### PR TITLE
Tighten the test workflow and add the quality checks

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# actionlint ships a list of the runner labels GitHub offers and warns about any
+# label it does not know. Its list is a snapshot taken when it was released, and
+# macos-26 arrived after 1.7.7 did, so both workflows here would be flagged for
+# naming a runner that exists. This says the label is real.
+self-hosted-runner:
+  labels:
+    - macos-26

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,183 @@
+name: Nightly
+
+# The checks worth running, but not worth running fifty times a day.
+#
+# test.yml is what a push has to survive, so everything in it has to be fast
+# enough that nobody minds waiting. These three are not. They answer questions
+# that change slowly: is there a data race, how much of the core is covered, and
+# how much of the code is not used by anything. A night is a fine resolution for
+# all three.
+#
+# Nothing here gates anything. No push is blocked by this workflow and no branch
+# is protected by it. It reports, in the run summary, and a red mark in the
+# Actions tab is how you find out.
+
+on:
+  schedule:
+    # 03:00 UTC, which is the small hours in Brussels and the cheapest time to
+    # be holding three macOS runners.
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never two of these at once, and if one is somehow still running when the
+  # next night comes round, the older one is the one to keep: it is nearly done.
+  group: bloom-nightly
+  cancel-in-progress: false
+
+jobs:
+  # Thread Sanitizer over the core suite. This app is an actor holding a
+  # database, a JSON-RPC client, git running in the background and an
+  # NSTextView, which is exactly the shape of program TSan was written for. It
+  # makes the suite two to four times slower, which is why it is here and not on
+  # every push.
+  races:
+    runs-on: macos-26
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # The same reason test.yml has it: about thirty tests make a real commit,
+      # and git refuses to commit without a name and an address.
+      - name: Give the runner a git identity
+        run: |
+          set -euo pipefail
+          git config --global user.email "ci@bloom.local"
+          git config --global user.name "Bloom CI"
+
+      - name: Run the core tests under Thread Sanitizer
+        env:
+          BLOOM_TEST_SWIFT_ARGS: --sanitize=thread
+          # Report every race and keep going, rather than stopping at the first
+          # one. One night should produce the whole list.
+          TSAN_OPTIONS: halt_on_error=0
+        run: ./test-core.sh
+
+  # How much of BloomCore the suite actually touches. Information, not a gate:
+  # there is no threshold here to argue with and nothing fails on a number going
+  # down. It is in the summary so the trend is visible.
+  coverage:
+    runs-on: macos-26
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Give the runner a git identity
+        run: |
+          set -euo pipefail
+          git config --global user.email "ci@bloom.local"
+          git config --global user.name "Bloom CI"
+
+      # TMPDIR is pinned so the step below knows where test-core.sh put the
+      # build. It derives both directories from TMPDIR and BLOOM_TEST_ID, so
+      # fixing those two is what makes the profile findable afterwards.
+      - name: Run the core tests with coverage
+        env:
+          TMPDIR: ${{ runner.temp }}
+          BLOOM_TEST_ID: coverage
+          BLOOM_TEST_SWIFT_ARGS: --enable-code-coverage
+        run: ./test-core.sh
+
+      - name: Report the coverage
+        if: ${{ !cancelled() }}
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          build="$TMPDIR/bloom-core-build-coverage/debug"
+          profile="$build/codecov/default.profdata"
+          bundle="$build/BloomCoreOnlyPackageTests.xctest"
+          binary="$bundle/Contents/MacOS/BloomCoreOnlyPackageTests"
+          if [ ! -f "$profile" ] || [ ! -f "$binary" ]; then
+            echo "No coverage profile at $profile. Did the suite run?"
+            echo "The coverage run produced no profile." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          # The test sources and the checked out dependencies are not what is
+          # being measured, and leaving them in moves the total for no reason.
+          xcrun llvm-cov report "$binary" \
+            -instr-profile "$profile" \
+            -ignore-filename-regex='.*(Tests|checkouts)/.*' > coverage.txt
+          {
+            echo "### Core coverage"
+            echo
+            echo '```'
+            tail -1 coverage.txt
+            echo '```'
+            echo
+            echo "<details><summary>Every file</summary>"
+            echo
+            echo '```'
+            cat coverage.txt
+            echo '```'
+            echo
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Unused declarations. Swift will not tell you that a function, an enum case
+  # or a protocol member is dead, because from the compiler's point of view an
+  # internal declaration nobody calls is perfectly legal. Periphery indexes the
+  # whole package and says which ones nothing reaches.
+  #
+  # Advisory, and it will be for a while: the first run found 382 things, which
+  # is a reading list rather than a build failure. It also has a false positive
+  # class worth knowing about, notably `static var description` on every App
+  # Intent, which the framework reads and our code never does.
+  unused:
+    runs-on: macos-26
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check the toolchain
+        run: |
+          set -euo pipefail
+          xcodebuild -version
+          swift --version
+
+      # The release binary rather than brew, which would install a tap and a
+      # toolchain to build it. Pinned, because this is a binary from the
+      # internet that then reads all of our source.
+      - name: Fetch periphery
+        env:
+          PERIPHERY_VERSION: 3.8.0
+        run: |
+          set -euo pipefail
+          url="https://github.com/peripheryapp/periphery/releases/download/${PERIPHERY_VERSION}/periphery-${PERIPHERY_VERSION}.zip"
+          curl -sSfL -o periphery.zip "$url"
+          unzip -q periphery.zip -d periphery-bin
+          ./periphery-bin/periphery version
+
+      # Timed on purpose. If this turns out to cost about a minute it belongs on
+      # every push instead of here, and the number in the log is what decides
+      # that.
+      - name: Scan for unused code
+        run: |
+          set -euo pipefail
+          start=$SECONDS
+          ./periphery-bin/periphery scan --quiet --format json > periphery.json
+          echo "periphery took $((SECONDS - start))s"
+          echo "PERIPHERY_SECONDS=$((SECONDS - start))" >> "$GITHUB_ENV"
+
+      # A summary rather than a wall. The full list is the artifact, the counts
+      # are what tells you whether it is ten things or four hundred.
+      - name: Summarise what it found
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          python3 Tools/periphery-summary.py periphery.json "${PERIPHERY_SECONDS:-0}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Keep the full list
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: periphery
+          path: periphery.json
+          retention-days: 30
+          if-no-files-found: warn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,12 @@ name: Test
 # so until this existed nothing compiled the app or ran a test in reaction to a
 # commit, and a branch could look fine right up to the moment somebody built it.
 #
-# Two things happen here, and they fail for different reasons.
+# Two things happen on every run, and they fail for different reasons.
 #
 #   swift build      compiles the app target, Sources/Bloom included.
 #                    test-core.sh mirrors only BloomCore into a throwaway
 #                    package with no app target, so a view that stops compiling
-#                    leaves the whole suite green. That has broken main three
+#                    leaves the whole suite green. That has broken main four
 #                    times in a single day: widen an enum, leave a switch
 #                    non-exhaustive, tests pass, app does not build.
 #   ./test-core.sh   the BloomCore suite, around 1600 tests.
@@ -17,31 +17,103 @@ name: Test
 # Both run even when the other has already failed, because one push should tell
 # you everything that is wrong with it rather than one thing at a time.
 #
+# A bundle is only built when somebody asks for one by hand, from the Actions
+# tab. It used to be built on every push, which proved the app can be assembled
+# on a runner. That is proven, and release.yml is what builds the copies people
+# actually install, so paying for a zip nobody downloads on every commit was
+# space and macOS minutes spent on a question already answered.
+#
 # The runner image and the toolchain check are copied from release.yml on
 # purpose. If the two ever disagree about which Xcode builds Bloom, the release
 # is the one that finds out, and it finds out at the worst moment.
-#
-# Warnings do not fail this build. The app compiles with 16 of them today; once
-# those are gone, adding -warnings-as-errors here is what keeps them gone.
 
 on:
+  # Push on main only, pull request for everything else. Running on both for
+  # every branch meant a branch with a pull request open was built twice for
+  # one commit, and a macOS minute on a private repository bills at ten times
+  # the rate of a Linux one. The consequence to know about: a branch with no
+  # pull request open is not built until it lands on main.
   push:
+    branches: [main]
   pull_request:
+  # The manual build. Run this workflow from the Actions tab, on any branch, to
+  # get a Bloom.app out of it without cutting a release.
+  workflow_dispatch:
 
 permissions:
-  # Nothing is written. The artifact goes through the actions API, not contents.
+  # Nothing is written. The artifact, on the runs that make one, goes through
+  # the actions API rather than contents.
   contents: read
 
 concurrency:
   # A second push to a branch makes the first one's answer stale, so the older
-  # run is dropped rather than left to occupy a macOS runner.
-  group: bloom-test-${{ github.workflow }}-${{ github.ref }}
+  # run is dropped rather than left to occupy a macOS runner. The event is part
+  # of the group so that a push does not cancel a manual build of the same
+  # branch: that run was asked for by a person who wants the zip at the end.
+  group: bloom-test-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Everything that does not need a Mac, on a runner that bills at a tenth of
+  # the rate of one. It runs beside the build rather than in front of it, so a
+  # spelling mistake and a failing test are reported by the same run.
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Workflow files are only ever executed by GitHub, so a mistake in one is
+      # found by pushing it and waiting. actionlint reads them here instead: it
+      # knows the schema, the expression syntax and which contexts exist in
+      # which place. Pinned, because this is a binary from the internet.
+      - name: Lint the workflows
+        env:
+          ACTIONLINT_VERSION: 1.7.7
+        run: |
+          set -euo pipefail
+          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
+          curl -sSfL "$url/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | tar xz actionlint
+          # SC2153 is ignored, and only SC2153. actionlint hands every `run:`
+          # block to shellcheck, which cannot see the step's `env:` block, so
+          # every value passed in the safe way, through the environment rather
+          # than interpolated into the script, looks to it like a misspelling of
+          # a nearby local variable. That is the house pattern in release.yml
+          # and it is not going to change.
+          ./actionlint -no-color -ignore 'SC2153' .github/workflows/*.yml
+
+      # Every script in this repository is zsh, and shellcheck refuses zsh
+      # outright: it parses sh, bash, dash and ksh and nothing else. Forcing it
+      # to read them as bash was tried and is worse than nothing. It cannot
+      # parse a glob qualifier, so `for art in Resources/*.pdf(N)` is four
+      # errors, and it does not know that zsh never word splits an unquoted
+      # parameter, so its advice on Tools/release/keychain.sh would break a
+      # working script. What zsh itself can do is parse them, which catches the
+      # unbalanced quote and the missing fi, and that is what runs here.
+      - name: Check the shell scripts parse
+        run: |
+          set -euo pipefail
+          command -v zsh >/dev/null || sudo apt-get install -y -qq zsh
+          command -v shellcheck >/dev/null || sudo apt-get install -y -qq shellcheck
+          # Any tracked script, so a new one is covered the day it is added.
+          git ls-files '*.sh' | while read -r script; do
+            case "$(head -1 "$script")" in
+              *zsh*) zsh -n "$script" ;;
+              *) shellcheck "$script" ;;
+            esac
+            echo "ok $script"
+          done
+
+      # The rules that are ours rather than the language's. See the script.
+      - name: Check the house rules
+        run: ./Tools/house-rules.sh
+
   test:
     runs-on: macos-26
-    timeout-minutes: 60
+    # A cold run is about six minutes. Anything past thirty is hung, and a hung
+    # job that is left alone bills for the full six hour default.
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v7
@@ -49,6 +121,8 @@ jobs:
       # Verbatim from release.yml. Swift 6 language mode, actool for the
       # layered icon and the App Intents metadata processor all come from Xcode,
       # and an older one would produce an app that builds with pieces missing.
+      # It costs a couple of seconds and turns "the image changed its default
+      # Xcode" from a wall of unrelated compiler errors into one sentence.
       - name: Check the toolchain
         run: |
           set -euo pipefail
@@ -70,11 +144,24 @@ jobs:
           git config --global user.email "ci@bloom.local"
           git config --global user.name "Bloom CI"
 
-      # Release configuration, because build.sh -r below wants the same objects
-      # and there is no reason to compile everything twice. This step is the one
-      # that answers "does Sources/Bloom still build".
+      # Debug, because nothing downstream consumes these objects. The question
+      # this step answers is "does Sources/Bloom still compile", and a debug
+      # build answers it faster. The manual build below makes its own release
+      # build through build.sh.
+      #
+      # -warnings-as-errors lives here rather than in Package.swift so that a
+      # local build stays tolerant while a run of this workflow does not. The
+      # tree has been at zero warnings since a33e0c9 and this is what keeps it
+      # there. The flag reaches the dependencies as well as our own targets, so
+      # a warning in SwiftTerm would fail this build. That is acceptable
+      # because Package.resolved is committed: the versions are pinned, nothing
+      # moves on its own, and the only commit that can introduce a dependency
+      # warning is a deliberate bump, whose author is right here to see it. If
+      # that day comes and the warning is not ours to fix, move the flag into
+      # Package.swift behind an environment variable so it applies to the
+      # Bloom and BloomCore targets only.
       - name: Build the app target
-        run: swift build -c release
+        run: swift build -Xswiftc -warnings-as-errors
 
       # Even if the build above failed: the core suite does not depend on the
       # app target compiling, and a run that reports both is worth more.
@@ -82,25 +169,30 @@ jobs:
         if: ${{ !cancelled() }}
         run: ./test-core.sh
 
+      # Everything below only happens on a manual run.
+      #
       # Assembles Bloom.app: the icon, the App Intents metadata, the embedded
       # Sparkle framework, and an ad-hoc signature. No secrets are involved, and
       # none of the signing, notarisation or bucket steps in release.yml are
       # touched. The result is an app nobody has vouched for, which is the point
       # for now: it is here to be tried, not to be handed out.
       - name: Assemble the app bundle
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: ./build.sh -r
 
       - name: Zip the bundle
         id: zip
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           set -euo pipefail
           app="$(swift build -c release --show-bin-path)/Bloom.app"
           [ -d "$app" ] || { echo "No bundle at $app"; exit 1; }
           mkdir -p dist
           # ditto, never zip. Sparkle.framework inside the bundle is a versioned
-          # framework held together by symlinks, and the bundle carries extended
-          # attributes and a signature. zip flattens the symlinks and drops the
-          # rest, and what comes out the far end does not launch.
+          # framework held together by symlinks, nine of them, and the bundle
+          # carries extended attributes and a signature. zip flattens the
+          # symlinks and drops the rest, and what comes out the far end does
+          # not launch.
           /usr/bin/ditto -c -k --keepParent "$app" dist/Bloom.zip
           echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           echo "Zipped $(du -h dist/Bloom.zip | cut -f1)"
@@ -110,6 +202,7 @@ jobs:
       # A downloaded artifact is therefore a zip inside a zip, and the inner one
       # is the bundle ditto made.
       - name: Upload the app
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@v7
         with:
           name: Bloom-${{ steps.zip.outputs.sha }}
@@ -118,6 +211,7 @@ jobs:
           if-no-files-found: error
 
       - name: Say how to open it
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           {
             echo "### Bloom ${{ steps.zip.outputs.sha }}"

--- a/Tools/house-rules.sh
+++ b/Tools/house-rules.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# The conventions this repository has that no off the shelf linter knows about.
+#
+#   ./Tools/house-rules.sh
+#
+# Three rules, and every one of them is here because it has already been broken:
+#
+#   1. No em dashes and no en dashes. Anywhere. They arrive by the hundred from
+#      anything that writes prose for you, and once one is in a file the next
+#      writer copies the house style it thinks it sees.
+#   2. The app is Bloom. It was called Baton until it was renamed, and the old
+#      name still turns up in new text written from stale memory.
+#   3. British spelling. The tree is already at 69 greys to 1 gray and 74
+#      cancelleds to 1 canceled, so this is about keeping it that way.
+#
+# Exit status is 1 if anything was found, and every finding is printed with the
+# file and line so it can be opened. The word lists are deliberately narrow:
+# a rule that cries wolf gets switched off, so anything with a legitimate use in
+# this codebase either stays out of the list or is named in an exception below.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+findings=0
+
+report() {
+  findings=$((findings + 1))
+  echo "$1"
+}
+
+# The two characters this file is not allowed to contain, since it is scanned by
+# the rule it implements. Built from their UTF-8 bytes instead.
+em_dash="$(printf '\342\200\224')"
+en_dash="$(printf '\342\200\223')"
+
+echo "==> no em dashes or en dashes"
+# .claude holds agent skills written elsewhere and vendored in as they are, and
+# fixtures holds recorded sessions that have to stay byte for byte what the
+# agent actually emitted. Neither is house prose and neither may be rewritten.
+if hits="$(git grep -n -I -e "$em_dash" -e "$en_dash" -- ':!.claude' ':!fixtures' || true)" && [ -n "$hits" ]; then
+  echo "$hits" | while IFS= read -r line; do echo "  $line"; done
+  report "A dash that should be a comma, a full stop or a pair of brackets."
+fi
+
+echo "==> the app is called Bloom"
+# This file is exempt from the two rules below because it has to spell out what
+# it is looking for. The dash rule above does apply to it, which is why the two
+# characters are built from their bytes rather than typed.
+# This file is exempt from this rule and the spelling rule below, because it has
+# to spell out what it is looking for. The dash rule above does apply to it,
+# which is why those two characters are built from their bytes rather than typed.
+#
+# Every file that is allowed to say Baton, and why. This list should only ever
+# get shorter. A file not on it that mentions the old name is a new mistake.
+baton_allowed=(
+  'PROTOCOL.md'                                     # quotes a recorded session
+  'build.sh'                                        # BATON_CODESIGN_IDENTITY, kept working on purpose
+  'fixtures/'                                       # recorded sessions, byte for byte
+  'Sources/BloomCore/LegacyDatabase.swift'          # reads the old app's database
+  'Sources/BloomCore/LegacyDefaults.swift'          # reads the old app's preferences
+  'Sources/BloomCore/WorkspaceManager.swift'        # a comment about the old worktree home
+  'Tests/BloomCoreTests/AgentEventTests.swift'      # sample paths and recorded payloads
+  'Tests/BloomCoreTests/FilePathGuessTests.swift'   # sample paths
+  'Tests/BloomCoreTests/HomeListTests.swift'        # a sample repository name
+  'Tests/BloomCoreTests/InstallPingTests.swift'     # a sample path
+  'Tests/BloomCoreTests/LegacyMigrationTests.swift' # tests the migration off the old name
+  'Tests/BloomCoreTests/RepositoryStartPlanTests.swift' # sample folder names
+  'Tools/icon/lib9.py'                              # a sample path
+)
+for file in $(git grep -l -I -i baton -- ':!.claude' ':!Tools/house-rules.sh' || true); do
+  allowed=0
+  for prefix in "${baton_allowed[@]}"; do
+    case "$file" in "$prefix"*) allowed=1 ;; esac
+  done
+  if [ "$allowed" -eq 0 ]; then
+    git grep -n -I -i baton -- "$file" | while IFS= read -r line; do echo "  $line"; done
+    report "$file calls the app by its old name."
+  fi
+done
+# Not a finding, just housekeeping: an exception nobody needs any more.
+for prefix in "${baton_allowed[@]}"; do
+  case "$prefix" in */) continue ;; esac
+  if [ -f "$prefix" ] && ! git grep -q -I -i baton -- "$prefix"; then
+    echo "  note: $prefix no longer says Baton, so it can come off the list in $0."
+  fi
+done
+
+echo "==> British spelling"
+# Words with an American spelling that has no other job in this codebase.
+# Deliberately absent: colour, behaviour, centre, dialogue, catalogue and
+# licence, because Apple's own API is spelled the American way and the tree is
+# full of foregroundColor, scrollBehavior and NSTextAlignment.center.
+american=(defense offense fulfill fulfillment skeptical acknowledgment maneuver
+          labeled modeled traveled centered analyze analyzing paralyze
+          enrollment installment)
+# These three do have a job in code today: "Favorites" names a Finder sidebar
+# section, ToolRefusal parses the literal string "canceled" out of agent output,
+# and gray names a CoreGraphics colour space. In prose there is no such excuse.
+american_in_prose=(favorite favorites gray canceled)
+
+for word in "${american[@]}"; do
+  if hits="$(git grep -n -I -i -w "$word" -- ':!.claude' ':!fixtures' ':!Tools/house-rules.sh' || true)" && [ -n "$hits" ]; then
+    echo "$hits" | while IFS= read -r line; do echo "  $line"; done
+    report "American spelling: $word."
+  fi
+done
+for word in "${american_in_prose[@]}"; do
+  if hits="$(git grep -n -I -i -w "$word" -- '*.md' ':!.claude' ':!Tools/house-rules.sh' || true)" && [ -n "$hits" ]; then
+    echo "$hits" | while IFS= read -r line; do echo "  $line"; done
+    report "American spelling in prose: $word."
+  fi
+done
+
+if [ "$findings" -gt 0 ]; then
+  echo
+  echo "$findings house rule violations."
+  exit 1
+fi
+echo
+echo "House rules pass."

--- a/Tools/periphery-summary.py
+++ b/Tools/periphery-summary.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Turn a periphery JSON report into something readable in a run summary.
+
+    Tools/periphery-summary.py periphery.json [seconds]
+
+Periphery's own output is one line per finding, and there are several hundred of
+them, which is a wall nobody reads twice. What is worth knowing at a glance is
+how many there are, of which kind, and where they sit, so that is what this
+prints. The full report is kept as an artifact for anyone who wants to work
+through it.
+"""
+
+import collections
+import json
+import os
+import sys
+
+HINTS = {
+    "unused": "Nothing reaches this declaration",
+    "assignOnlyProperty": "Written, never read",
+    "redundantPublicAccessibility": "Public, but only used inside its own module",
+}
+
+
+def main() -> int:
+    path = sys.argv[1]
+    seconds = sys.argv[2] if len(sys.argv) > 2 else None
+    with open(path) as handle:
+        findings = json.load(handle)
+
+    root = os.getcwd() + "/"
+    by_hint = collections.Counter()
+    by_place = collections.Counter()
+    unused = []
+
+    for finding in findings:
+        hint = (finding.get("hints") or ["unknown"])[0]
+        by_hint[hint] += 1
+        where = finding["location"].replace(root, "")
+        by_place["/".join(where.split("/")[:2])] += 1
+        if hint == "unused":
+            unused.append((finding["kind"], finding["name"], where))
+
+    print("### Unused code")
+    print()
+    print(f"{len(findings)} findings" + (f", scanned in {seconds}s." if seconds else "."))
+    print()
+    print("| Kind | Count | Means |")
+    print("| --- | ---: | --- |")
+    for hint, count in by_hint.most_common():
+        print(f"| `{hint}` | {count} | {HINTS.get(hint, '')} |")
+    print()
+    print("| Where | Count |")
+    print("| --- | ---: |")
+    for place, count in by_place.most_common():
+        print(f"| `{place}` | {count} |")
+    print()
+    print("Not all of these are real. Anything a framework reads and our own code")
+    print("never does looks unused from here, `static var description` on every App")
+    print("Intent being the obvious case. The full report is attached to this run.")
+    print()
+    print("<details><summary>The first 40 unreachable declarations</summary>")
+    print()
+    for kind, name, where in unused[:40]:
+        print(f"- `{kind}` **{name}** in `{where}`")
+    print()
+    print("</details>")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test-core.sh
+++ b/test-core.sh
@@ -17,6 +17,10 @@
 #   BLOOM_LOCAL_AGENTS  =1 asserts which agent CLIs exist on this machine
 #   BLOOM_LOCAL_SETTINGS=1 parses the .conductor/settings.toml files on this machine
 #   BLOOM_LIVE          =1 drives the real `claude` binary. Costs money.
+#   BLOOM_TEST_SWIFT_ARGS  extra flags for `swift test`, split on spaces. For the runs that are
+#                       not the ordinary one: the nightly workflow passes --sanitize=thread and
+#                       --enable-code-coverage through here rather than reimplementing the
+#                       mirrored package it needs to avoid building the app target.
 #
 
 set -euo pipefail
@@ -63,6 +67,10 @@ for name in "$@"; do
   filters+=(--filter "$name")
 done
 
+# Split on spaces, which is what ${=...} is for. An unset variable leaves an empty array, and an
+# empty array in quotes expands to no words at all, so the ordinary run is unchanged.
+extra=(${=BLOOM_TEST_SWIFT_ARGS:-})
+
 cd "$WORK"
 runs="${BLOOM_TEST_RUNS:-1}"
 failed=0
@@ -70,7 +78,7 @@ for run in $(seq 1 "$runs"); do
   if [[ "$runs" -gt 1 ]]; then
     print -r -- "===> run $run of $runs"
   fi
-  if ! swift test --scratch-path "$SCRATCH" "${filters[@]}"; then
+  if ! swift test --scratch-path "$SCRATCH" "${extra[@]}" "${filters[@]}"; then
     failed=$((failed + 1))
   fi
 done


### PR DESCRIPTION
The artifact now comes from a manual run rather than every push. The compile check stays, in debug, with warnings as errors. Push on main only, pull request for the rest, and superseded runs are cancelled.

Alongside it: actionlint, a parse check over every shell script, and a house rules check (dashes, the old name, British spelling) on a Linux runner. A nightly workflow runs Thread Sanitizer, coverage and periphery, none of which gate anything.