### PR TITLE
Offer to fix merge conflicts instead of a merge that cannot happen

### DIFF
--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -1305,6 +1305,47 @@ final class WorkspaceModel {
         return text + "\n\n" + MergeInstructions.defaultMarkdown
     }
 
+    /// Asks the workspace's agent to bring the base branch in and resolve the conflicts.
+    ///
+    /// The state this answers used to be offered a Merge button, which could not work: GitHub had
+    /// already said the branch does not apply to its base, so the only thing that press could
+    /// produce was the agent running `gh pr merge` and reading the refusal back out.
+    ///
+    /// The same guard and the same route as the other three buttons in the strip, with two
+    /// differences that are both about what this turn does NOT do. There is no instructions file,
+    /// because nothing here acts on a server and the project's conventions for resolving a
+    /// conflict are already in front of the agent; and there is no confirmation in front of it,
+    /// for the reason written out at `PullRequestSummary.fixConflictsButton`.
+    ///
+    /// Returns nil on success, or the sentence to put in front of the user.
+    func requestFixConflicts(
+        _ pullRequest: PullRequest,
+        overrides: PromptOverrides = PromptOverrides()
+    ) async -> String? {
+        guard !isRunning else {
+            return "\(workspace.name) is still working. Wait for the turn to finish, then press "
+                + "Fix merge conflicts again."
+        }
+
+        guard let session = await sessionForPullRequest(titledIfNew: "Fix merge conflicts") else {
+            return "Could not open a session in \(workspace.name) to send the request to."
+        }
+
+        let context = FixConflictsPromptContext(
+            workspaceName: workspace.name,
+            number: pullRequest.number,
+            // The worktree's own branch rather than gh's `headRefName`. The sentence is about the
+            // branch the agent is standing on, and this is the one fact here Bloom holds itself.
+            branch: workspace.branch,
+            baseBranch: workspace.baseBranch
+        )
+        let render = context.render(template: overrides.template(for: .fixConflicts))
+
+        activeSessionID = session.id
+        await transcript(for: session).submit(render.text)
+        return nil
+    }
+
     /// The turn that goes down the wire, with the instructions named in it.
     ///
     /// The path goes in the sentence that asks for it, which is where every other file Bloom sends

--- a/Sources/Bloom/Views/Inspector/PullRequestBar.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestBar.swift
@@ -94,8 +94,10 @@ struct PullRequestBar: View {
                 worktree: model.workspace.path,
                 localWork: model.localWork,
                 isWorking: isWorking,
+                isAgentBusy: model.isRunning,
                 onMerge: merge,
                 onPush: push,
+                onFixConflicts: { fixConflicts(on: pullRequest) },
                 onContinue: { carryOn(after: pullRequest) },
                 onArchive: archive
             )
@@ -186,6 +188,26 @@ struct PullRequestBar: View {
         Task {
             defer { isWorking = false }
             if let refusal = await model.requestPush() {
+                report = PullRequestNotice(
+                    tone: .info, title: "Nothing was sent", message: refusal
+                )
+            }
+        }
+    }
+
+    /// Hands the conflict to the agent, the same way the other three buttons hand it their work.
+    ///
+    /// Nothing here runs git, and there is nothing to report on success either: what comes back is
+    /// an ordinary turn in the transcript, and the strip notices the resolved worktree on its next
+    /// refresh like any other change on this disk. The pull request stays conflicted on GitHub
+    /// until the reader presses Commit and push, which is the button the strip offers next.
+    private func fixConflicts(on pullRequest: PullRequest) {
+        isWorking = true
+        report = nil
+
+        Task {
+            defer { isWorking = false }
+            if let refusal = await model.requestFixConflicts(pullRequest) {
                 report = PullRequestNotice(
                     tone: .info, title: "Nothing was sent", message: refusal
                 )

--- a/Sources/Bloom/Views/Inspector/PullRequestCreator.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestCreator.swift
@@ -189,9 +189,10 @@ struct PullRequestCreator: View {
     }
 
     private var helpText: String {
-        if isAgentBusy {
-            return "The agent is working. The request is sent as a turn, so it has to wait for this one."
-        }
+        // The same sentence `PullRequestSummary` shows on the buttons it draws in this band once
+        // there is a pull request, from the one place it is written: it is a fact about how all
+        // five of these buttons work rather than about this one.
+        if isAgentBusy { return PullRequestStatus.agentBusyReason }
         // No path named. There are two, the project's own and Bloom's copy of the default, and
         // which one is in play is not something a tooltip should be teaching anybody.
         return "Ask this workspace's agent to push the branch and open a pull request against "

--- a/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
@@ -26,9 +26,16 @@ struct PullRequestSummary: View {
     /// still running, which is not the same as "nothing", and is drawn as nothing extra.
     var localWork: LocalWork?
     var isWorking: Bool
+    /// The workspace's agent is mid turn. Every button in this strip works by composing a turn and
+    /// sending it, and an agent runs one turn at a time, so none of them can do anything until
+    /// this one is over. `PullRequestCreator` takes the same fact for the same reason, and both
+    /// say it in the same words: `PullRequestStatus.agentBusyReason`.
+    var isAgentBusy: Bool
     var onMerge: (GitHub.MergeMethod) -> Void
     /// Hands the outstanding work to the workspace's agent to commit and push.
     var onPush: () -> Void
+    /// Asks the workspace's agent to bring the base branch in and resolve the conflicts with it.
+    var onFixConflicts: () -> Void
     /// Carries a merged workspace on to a fresh branch, in place. See `continueButton`.
     var onContinue: () -> Void
     /// Archives, through the app's ordinary archive with all its checks intact.
@@ -217,7 +224,7 @@ struct PullRequestSummary: View {
         } else if pullRequest.isOpen {
             HStack(spacing: Metrics.spacingTight) {
                 mergeMenu
-                if status.remedy == .merge { mergeButton } else { pushButton }
+                primaryButton
             }
             .fixedSize()
         } else if pullRequest.isMerged {
@@ -233,6 +240,22 @@ struct PullRequestSummary: View {
         // only place its commits live, and moving off it would be exactly the wrong offer. Archive
         // on its own would be a control that says "throw this away" over a branch nobody has
         // agreed to throw away.
+    }
+
+    /// Which of the three the open state's primary slot holds.
+    ///
+    /// A switch rather than a chain of conditions, and the reason is the failure this project has
+    /// had four times: the remedy is an enum in the core, and a case added to it has to stop
+    /// compiling here rather than quietly falling through to whichever branch happened to be last.
+    /// The decision itself is `PullRequest.status(local:)`, tested, because a decision taken in a
+    /// view is a decision nothing can test.
+    @ViewBuilder
+    private var primaryButton: some View {
+        switch status.remedy {
+        case .merge: mergeButton
+        case .fixConflicts: fixConflictsButton
+        case .commitAndPush, .push: pushButton
+        }
     }
 
     /// Carry this workspace on, on a new branch, without giving up the session.
@@ -351,15 +374,74 @@ struct PullRequestSummary: View {
             .buttonStyle(.borderedProminent)
             .tint(status.tone.fill)
             .controlSize(.regular)
+            .disabled(isAgentBusy)
             .help(
-                "Ask this workspace's agent to \(pushLabel.lowercased()) branch "
-                    + "\(pullRequest.branch.isEmpty ? "this branch" : pullRequest.branch), so "
-                    + "#\(pullRequest.number) is what is on this disk."
+                isAgentBusy
+                    ? PullRequestStatus.agentBusyReason
+                    : "Ask this workspace's agent to \(pushLabel.lowercased()) branch "
+                        + "\(pullRequest.branch.isEmpty ? "this branch" : pullRequest.branch), so "
+                        + "#\(pullRequest.number) is what is on this disk."
             )
     }
 
     private var pushLabel: String {
         status.remedy == .push ? "Push" : "Commit and push"
+    }
+
+    /// What stands where Merge stands, when merging is the one thing this state cannot do.
+    ///
+    /// GitHub has already said the branch does not apply to its base, so the Merge button that
+    /// used to sit here beside a red band could only ever produce a refusal read back out of `gh`.
+    /// The state has one remedy and this offers it: the same route as every other button in the
+    /// strip, a turn composed and sent to this workspace's agent, in the transcript, under the
+    /// permission mode the reader already set.
+    ///
+    /// **No confirmation, and that is a decision rather than an oversight.** Merge asks because it
+    /// is the one destructive, off-machine thing this app offers: it lands commits on somebody
+    /// else's branch and deletes a branch on the server, and none of that can be taken back from
+    /// here. This lands nothing anywhere. It brings the base into a worktree that is already the
+    /// disposable copy, commits the resolution locally, and is told to push nothing and merge
+    /// nothing, so what it can cost is a git operation in a worktree that exists to be thrown
+    /// away. Asking "are you sure?" about that is how confirmations stop being read, which is the
+    /// same argument `archiveButton` makes for the press above it.
+    ///
+    /// The sign in gate is skipped for the same reason: nothing in this turn talks to GitHub, so
+    /// a signed out `gh` has no bearing on whether it can work.
+    ///
+    /// Two forms, the way `pushButton` has two. "Fix merge conflicts" is longer than any other
+    /// label in the strip and the headline is the part that must not be what truncates.
+    private var fixConflictsButton: some View {
+        ViewThatFits(in: .horizontal) {
+            fixConflictsControl.labelStyle(.titleAndIcon)
+            fixConflictsControl.labelStyle(.iconOnly)
+        }
+        .fixedSize()
+    }
+
+    /// Tinted `status.tone.fill`, which in this state is red, and deliberately so.
+    ///
+    /// Red is the band's colour here and the rule the strip is built on is that the prominent
+    /// button carries the colour of the band it stands in: see `PullRequestStatus.Tone.fill`,
+    /// where that rule and the reason it is stated once are written out. It reads as the state
+    /// rather than as a warning about the press, which is what it already means over Checks
+    /// failing, where the same red button lands a branch on somebody's main.
+    ///
+    /// Tinted explicitly, like every prominent button in this app, because an untinted
+    /// `.borderedProminent` follows the system accent and comes out as whatever colour the Mac is
+    /// set to. `mergeButton` carries the measurement.
+    private var fixConflictsControl: some View {
+        Button("Fix merge conflicts", systemImage: "wrench.and.screwdriver", action: onFixConflicts)
+            .buttonStyle(.borderedProminent)
+            .tint(status.tone.fill)
+            .controlSize(.regular)
+            .disabled(isAgentBusy)
+            .help(
+                isAgentBusy
+                    ? PullRequestStatus.agentBusyReason
+                    : "Ask this workspace's agent to bring \(baseBranch) into this worktree and "
+                        + "resolve the conflicts here. Nothing is pushed and #\(pullRequest.number)"
+                        + " is not merged."
+            )
     }
 
     /// The other two merge methods, and while there is local work the way to merge at all.
@@ -379,8 +461,8 @@ struct PullRequestSummary: View {
         // reads as a stray control that wandered into the strip.
         .foregroundStyle(tint ?? Palette.accent)
         .controlSize(.small)
-        .disabled(!status.canMerge)
-        .help(status.blockedReason ?? "Merge #\(pullRequest.number), by whichever method")
+        .disabled(!status.canMerge || isAgentBusy)
+        .help(blockedReason ?? "Merge #\(pullRequest.number), by whichever method")
     }
 
     /// The one prominent control in the inspector, and the only solid colour in the strip.
@@ -412,13 +494,22 @@ struct PullRequestSummary: View {
             .buttonStyle(.borderedProminent)
             .tint(status.tone.fill)
             .controlSize(.regular)
-            .disabled(!status.canMerge)
+            .disabled(!status.canMerge || isAgentBusy)
             // Disabled controls do not explain themselves, and "why is this greyed out" is the
             // whole question a blocked pull request raises.
-            .help(status.blockedReason ?? "Squash and merge, or choose another method")
+            .help(blockedReason ?? "Squash and merge, or choose another method")
     }
 
     // MARK: - Text
+
+    /// Why nothing here can be pressed, or nil when something can.
+    ///
+    /// The busy turn comes first. It is true of every button in this strip rather than of one of
+    /// them, and it is the reason that goes away on its own, so a reader who hovers a grey button
+    /// while their agent is working is told to wait rather than told about a draft.
+    private var blockedReason: String? {
+        isAgentBusy ? PullRequestStatus.agentBusyReason : status.blockedReason
+    }
 
     /// The title belongs somewhere, and a tooltip on the state is where: it answers "which pull
     /// request is this" without spending any of the strip's width on an answer the reader already

--- a/Sources/BloomCore/FixConflictsPrompt.swift
+++ b/Sources/BloomCore/FixConflictsPrompt.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// The facts the fix-merge-conflicts prompt is rendered against.
+///
+/// A value rather than a lookup into the app's models, for the same reason `MergePromptContext` is
+/// one: the wording of what an agent is told to do to somebody's repository has to be checkable
+/// without a store, a worktree or GitHub.
+///
+/// It carries the branch as well as the base, and both are load bearing rather than decoration.
+/// The turn asks for the base to be brought INTO this worktree, so a sentence that named only one
+/// of the two would leave the direction of that merge to be guessed, and the wrong guess is the
+/// one that rewrites the base branch.
+public struct FixConflictsPromptContext: Sendable, Hashable {
+    /// What goes in the branch's place when there is no name to put there.
+    ///
+    /// The caller fills this from the workspace's own branch rather than from gh's `headRefName`,
+    /// because the sentence is about the branch the agent is standing on and Bloom knows that
+    /// without asking GitHub. It can still be empty, on a workspace whose branch was never
+    /// recorded, and "resolve the conflicts on " followed by nothing reads to an agent as an
+    /// instruction that was cut off. So it says the name is missing and that the worktree is the
+    /// answer, which is true: the agent is already standing on it.
+    public static let noBranch = "(the branch name is not recorded: it is whichever branch this "
+        + "worktree is already on, and do not switch away from it)"
+
+    public var workspaceName: String
+    public var number: Int
+    public var branch: String
+    public var baseBranch: String
+
+    public init(workspaceName: String, number: Int, branch: String, baseBranch: String) {
+        self.workspaceName = workspaceName
+        self.number = number
+        self.branch = branch
+        self.baseBranch = baseBranch
+    }
+
+    public var values: [String: String] {
+        [
+            PromptRegistry.FixConflicts.workspace: workspaceName,
+            PromptRegistry.FixConflicts.number: String(number),
+            PromptRegistry.FixConflicts.branch: branch.isEmpty ? Self.noBranch : branch,
+            PromptRegistry.FixConflicts.baseBranch: baseBranch,
+        ]
+    }
+
+    public func render(template: String) -> PromptRender {
+        PromptTemplate.render(template, values: values)
+    }
+}

--- a/Sources/BloomCore/PromptRegistry.swift
+++ b/Sources/BloomCore/PromptRegistry.swift
@@ -8,6 +8,7 @@ public enum PromptID: String, Sendable, Hashable, CaseIterable, Codable {
     case createPullRequest
     case pushLocalWork
     case mergePullRequest
+    case fixConflicts
     case continueAfterMerge
     case review
     case nameWorkspace
@@ -60,8 +61,8 @@ public struct PromptDefinition: Sendable, Hashable, Identifiable {
 /// none of that and can only fail.
 public enum PromptRegistry {
     public static let all: [PromptDefinition] = [
-        createPullRequest, pushLocalWork, mergePullRequest, continueAfterMerge, review,
-        nameWorkspace,
+        createPullRequest, pushLocalWork, mergePullRequest, fixConflicts, continueAfterMerge,
+        review, nameWorkspace,
     ]
 
     public static func definition(for id: PromptID) -> PromptDefinition {
@@ -100,6 +101,21 @@ public enum PromptRegistry {
         /// is read by a person editing it in Settings and then by an agent typing a command, and
         /// neither form is the right one for both readers.
         public static let methodFlag = "method_flag"
+    }
+
+    /// The names the fix-merge-conflicts prompt may use.
+    ///
+    /// Deliberately fewer than the merge prompt's. Nothing in this turn touches GitHub, so the
+    /// method and its flag would be two variables describing a command that is never run, and the
+    /// title says nothing a conflicted file does not say better.
+    public enum FixConflicts {
+        public static let workspace = "workspace"
+        public static let number = "number"
+        /// The branch the conflicts are resolved ON, which is the one this worktree is standing on.
+        public static let branch = "branch"
+        /// The branch that is brought IN. Both, because the direction of that merge is the one
+        /// thing in this prompt that must not be left to a guess.
+        public static let baseBranch = "base_branch"
     }
 
     /// The names the continue-after-merge prompt may use.
@@ -286,6 +302,66 @@ public enum PromptRegistry {
         defaultTemplate: """
         Merge pull request #{{number}} into {{base_branch}} as a {{method}}, which is \
         `{{method_flag}}`. It is on the branch {{branch}}.
+        """
+    )
+
+    /// Sent when the strip says the branch conflicts with its base.
+    ///
+    /// It exists because the button that used to stand there could not work. A conflicted pull
+    /// request drew the ordinary Merge button beside a red band, and pressing it asked the agent
+    /// to run `gh pr merge` on something GitHub had already refused to merge. The state has one
+    /// remedy, a person resolving the conflict, and the button now offers that instead.
+    ///
+    /// No instructions file, and that is the difference from the merge prompt rather than an
+    /// omission. `MergeInstructions` is a file because merging is policy about a server: which
+    /// flags are allowed, what to do when GitHub refuses, when the branch is deleted, and a
+    /// project that merges differently has to be able to say so once for everybody. Resolving a
+    /// conflict is ordinary work in this worktree, of the kind every other turn asks for, and the
+    /// conventions for it are already in front of the agent in the project's own instruction
+    /// files. A second file repeating them would be a second place to keep them right.
+    ///
+    /// The template pushes nothing and merges nothing on the server. What comes out is a resolved
+    /// worktree with a commit in it, which is exactly the state the strip's Commit and push button
+    /// is for, so the next press is the reader's rather than this turn's.
+    static let fixConflicts = PromptDefinition(
+        id: .fixConflicts,
+        title: "Fix merge conflicts",
+        summary: """
+        Sent to the workspace's agent when you press Fix merge conflicts, which is what the strip \
+        offers in place of Merge once GitHub reports that the branch conflicts with its base. It \
+        asks for the base branch to be brought into this worktree and the conflicts resolved \
+        here. Nothing is pushed and nothing is merged on GitHub: what you get back is a resolved \
+        worktree, and the strip then offers Commit and push in the ordinary way.
+        """,
+        variables: [
+            PromptVariable(name: FixConflicts.workspace, summary: "The workspace's name."),
+            PromptVariable(name: FixConflicts.number, summary: "The pull request's number."),
+            PromptVariable(
+                name: FixConflicts.branch,
+                summary: "The branch the conflicts are resolved on, which is this worktree's."
+            ),
+            PromptVariable(
+                name: FixConflicts.baseBranch,
+                summary: "The branch that conflicts with it, and that is brought in."
+            ),
+        ],
+        defaultTemplate: """
+        Pull request #{{number}} conflicts with {{base_branch}}, so GitHub will not merge it as it \
+        stands. Resolve that here, in this worktree, on {{branch}}.
+
+        Fetch {{base_branch}} first, so you are working against what is on the server rather than \
+        a stale copy of it, then bring it into this branch the way this project brings it in: \
+        merge it unless the project's own conventions say to rebase onto it. It goes into this \
+        branch and never the other way round.
+
+        Work through every conflicted file. Keep what this branch changed and what \
+        {{base_branch}} changed, and where the two genuinely disagree, read enough of the code \
+        around them to work out which is right instead of taking a side. Follow this project's \
+        conventions, and run whatever it uses to check itself before you call anything resolved.
+
+        Commit the resolution, with a message worded the way this project words one. Do not push \
+        it, and do not merge the pull request. Finish by saying which files conflicted, what you \
+        decided in each of them, and anything you are not sure about.
         """
     )
 

--- a/Sources/BloomCore/PullRequestStatus.swift
+++ b/Sources/BloomCore/PullRequestStatus.swift
@@ -54,7 +54,20 @@ public struct PullRequestStatus: Sendable, Hashable {
         /// depending on whether anything is uncommitted, and the label follows.
         case commitAndPush
         case push
+        /// Bring the base in and resolve the conflict, because merging is the one thing this state
+        /// cannot do. The strip used to draw Merge here, beside a red band saying the branch
+        /// conflicts, and pressing it asked the agent to run a command GitHub had already refused.
+        case fixConflicts
     }
+
+    /// Why the strip's buttons are dead while the workspace's agent is mid turn.
+    ///
+    /// Here rather than in the two views that say it, because it is one fact about how every one
+    /// of these buttons works: none of them does anything itself, they all compose a turn, and an
+    /// agent runs one turn at a time. `PullRequestCreator` and `PullRequestSummary` both show it,
+    /// and a sentence written out twice is a sentence that gets improved once.
+    public static let agentBusyReason =
+        "The agent is working. The request is sent as a turn, so it has to wait for this one."
 
     public init(
         tone: Tone,
@@ -210,7 +223,13 @@ public extension PullRequest {
                 text: "Merge conflicts",
                 detail: "This branch conflicts with the base branch",
                 canMerge: false,
-                blockedReason: "Resolve the conflicts with the base branch first."
+                blockedReason: "Resolve the conflicts with the base branch first.",
+                // The one state whose remedy is neither merging nor pushing. It is set here and
+                // not weighed against local work, because `status(local:)` hands a conflict
+                // straight back: a conflicted branch with uncommitted files still needs the
+                // conflict resolved first, and resolving it is going to make more local work
+                // rather than less.
+                remedy: .fixConflicts
             )
         }
         if isDraft {

--- a/Sources/BloomCore/WorkspaceListTool.swift
+++ b/Sources/BloomCore/WorkspaceListTool.swift
@@ -386,6 +386,7 @@ public struct WorkspaceListTool: BridgeToolHandling {
         case .merge: "merge"
         case .push: "push"
         case .commitAndPush: "commitAndPush"
+        case .fixConflicts: "fixConflicts"
         }
     }
 }

--- a/Tests/BloomCoreTests/FixConflictsPromptTests.swift
+++ b/Tests/BloomCoreTests/FixConflictsPromptTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// The strip used to draw Merge over a branch GitHub had already refused to merge, so the press
+/// could only ever produce a refusal read back out of `gh`. These are the two halves of the answer
+/// to that: the state says which button belongs there, and the prompt says what the press asks for.
+@Suite("Fix merge conflicts")
+struct FixConflictsPromptTests {
+    /// The decision that belongs in the core rather than in the view. A conflicted pull request is
+    /// the one open state whose remedy is neither merging nor pushing.
+    @Test("a conflicted pull request offers the fix rather than the merge")
+    func conflictsOfferTheFix() {
+        let status = conflicted().status
+
+        #expect(status.remedy == .fixConflicts)
+        #expect(status.text == "Merge conflicts")
+        // The button changes; what the menu beside it is allowed to do does not. GitHub has said
+        // this branch does not apply to its base, so merging stays blocked and stays explained.
+        #expect(!status.canMerge)
+        #expect(status.blockedReason != nil)
+    }
+
+    /// gh reports the same fact through two fields with different vocabularies, depending on which
+    /// version is installed, and the button has to follow both.
+    @Test("both of gh's words for a conflict reach the same button", arguments: [
+        "CONFLICTING", "DIRTY", "conflicting",
+    ])
+    func bothVocabularies(mergeable: String) {
+        #expect(conflicted(mergeable: mergeable).status.remedy == .fixConflicts)
+    }
+
+    /// Uncommitted work does not take this state's headline and must not take its button either.
+    /// Resolving a conflict is going to make more local work rather than less, so a strip pointing
+    /// at Commit and push here would be pointing at the second step.
+    @Test("local work does not move the conflicting state off the fix")
+    func localWorkDoesNotWin() {
+        let status = conflicted().status(local: LocalWork(modifiedFiles: 3, unpushedCommits: 1))
+
+        #expect(status.remedy == .fixConflicts)
+        #expect(status.text == "Merge conflicts")
+    }
+
+    /// Everything the state reports on its own keeps the button it had. A widened remedy that
+    /// leaked into a healthy pull request would put a wrench where Merge belongs.
+    @Test("nothing else in the strip gains the fix", arguments: [
+        "MERGEABLE", "UNKNOWN", "",
+    ])
+    func onlyConflictsGetIt(mergeable: String) {
+        #expect(conflicted(mergeable: mergeable).status.remedy == .merge)
+    }
+
+    @Test("the default prompt renders every fact it names")
+    func rendersFully() {
+        let definition = PromptRegistry.definition(for: .fixConflicts)
+        let render = context().render(template: definition.defaultTemplate)
+
+        #expect(render.unknown.isEmpty)
+        #expect(render.missing.isEmpty)
+        #expect(render.text.contains("#42"))
+        #expect(render.text.contains("main"))
+        #expect(render.text.contains("feature/glyphs"))
+    }
+
+    /// The two things this turn is not allowed to do, asserted rather than trusted. A prompt that
+    /// pushed would put a half resolved branch on the server, and one that merged would be the
+    /// button this whole change exists to remove.
+    @Test("the default prompt pushes nothing and merges nothing on GitHub")
+    func staysOnThisMachine() {
+        let text = PromptRegistry.definition(for: .fixConflicts).defaultTemplate
+
+        #expect(text.contains("Do not push"))
+        #expect(text.contains("do not merge the pull request"))
+        #expect(!text.contains("gh pr merge"))
+    }
+
+    /// The direction of the merge is the one thing in this prompt that must not be guessed, so
+    /// both branches are named and the sentence says which way round they go.
+    @Test("the default prompt brings the base in rather than the other way round")
+    func namesTheDirection() {
+        let render = context().render(
+            template: PromptRegistry.definition(for: .fixConflicts).defaultTemplate
+        )
+
+        #expect(render.text.contains("It goes into this branch and never the other way round."))
+    }
+
+    /// A workspace whose branch was never recorded still has a button to press, and a sentence
+    /// that stops after "on " reads to an agent as an instruction that was cut off.
+    @Test("a workspace with no branch name never renders a guess")
+    func missingBranchIsSaidRatherThanGuessed() {
+        var facts = context()
+        facts.branch = ""
+
+        let render = facts.render(template: "{{branch}}")
+
+        #expect(render.text == FixConflictsPromptContext.noBranch)
+        #expect(render.text.contains("this worktree is already on"))
+    }
+
+    private func conflicted(mergeable: String = "CONFLICTING") -> PullRequest {
+        PullRequest(
+            number: 42, title: "Draw the glyphs", url: "https://example/42", state: "OPEN",
+            isDraft: false, mergeable: mergeable, checks: .passing,
+            checksSummary: "12 of 12 checks passed", reviewDecision: nil, branch: "feature/glyphs"
+        )
+    }
+
+    private func context() -> FixConflictsPromptContext {
+        FixConflictsPromptContext(
+            workspaceName: "Glyphs",
+            number: 42,
+            branch: "feature/glyphs",
+            baseBranch: "main"
+        )
+    }
+}

--- a/Tests/BloomCoreTests/LocalWorkTests.swift
+++ b/Tests/BloomCoreTests/LocalWorkTests.swift
@@ -176,7 +176,9 @@ struct LocalWorkTests {
         #expect(status.text == "Merge conflicts")
         // The headline and the button are one decision. They came from two places once, and a
         // conflicted branch with uncommitted work drew "Merge conflicts" over Commit and push.
-        #expect(status.remedy == .merge)
+        // The button is no longer Merge either: GitHub has refused this branch, so the press that
+        // belongs here is the one that resolves the conflict. See `FixConflictsPromptTests`.
+        #expect(status.remedy == .fixConflicts)
     }
 
     @Test("the button offers the remedy the state actually calls for")


### PR DESCRIPTION
A conflicted pull request drew the ordinary Merge button beside the red band saying the branch conflicts, and pressing it asked the agent to run a command GitHub had already refused. That slot now holds Fix merge conflicts, which sends a turn asking the agent to fetch the base, bring it into this worktree, resolve the conflicts and commit them. It pushes nothing and merges nothing, so the strip offers Commit and push next, in the ordinary way.

Which button the slot holds is `PullRequestStatus.Remedy.fixConflicts`, decided in the core beside the headline it has to agree with, and the view switches on the enum so a case added later stops compiling instead of falling through.

No confirmation in front of it. Merge asks because it lands commits on somebody else's branch and deletes one on the server; this touches only the worktree, which is the disposable copy.

The prompt is editable in Settings like the other four, and carries no instructions file: resolving a conflict is ordinary work in the worktree and the project's conventions for it are already in front of the agent.
