### PR TITLE
Make the create sheet's source a searchable picker

### DIFF
--- a/Sources/Bloom/Views/Center/MenuSearchField.swift
+++ b/Sources/Bloom/Views/Center/MenuSearchField.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+import AppKit
+
+/// A one line field that types into a list rather than into a document: the arrow keys and Return
+/// belong to whatever it is filtering, and only the characters are its own.
+///
+/// An `NSTextField` rather than SwiftUI's `TextField`, for the reason `ComposerTextEditor` writes
+/// down about the composer: a focused `TextField` swallows Return and both arrows inside its field
+/// editor, so `onSubmit` and `onKeyPress` on the view around it never see the shape of the event.
+/// The field editor asks its delegate first through `doCommandBySelector`, which is the one place
+/// those keys can be taken before the caret moves, so that is where this sits. Nothing else here
+/// is AppKit's: the text is SwiftUI's binding and the field keeps no state of its own.
+struct MenuSearchField: NSViewRepresentable {
+    @Binding var text: String
+    var placeholder: String
+    /// The keys the list wants. Returning false hands the key back to the field editor, which is
+    /// what leaves Tab moving the focus and Return doing whatever a field does with it when the
+    /// list has nothing highlighted to press.
+    var onKey: @MainActor (ComposerKey) -> Bool
+
+    func makeNSView(context: Context) -> NSTextField {
+        let field = NSTextField()
+        field.delegate = context.coordinator
+        field.placeholderString = placeholder
+        field.isBordered = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.font = .systemFont(ofSize: NSFont.systemFontSize)
+        field.lineBreakMode = .byTruncatingTail
+        field.cell?.usesSingleLineMode = true
+        field.stringValue = text
+        context.coordinator.takeFocus(field)
+        return field
+    }
+
+    func updateNSView(_ field: NSTextField, context: Context) {
+        context.coordinator.onKey = onKey
+        context.coordinator.text = $text
+        // Only when it differs. Writing the value back on every pass would move the insertion
+        // point to the end of the field mid word.
+        if field.stringValue != text { field.stringValue = text }
+        // Asked for again here, and it is not belt and braces: the panel is made before its window
+        // exists, so the first attempt has nothing to be first responder in. The coordinator only
+        // ever succeeds once, so a field somebody has since tabbed out of is left alone.
+        context.coordinator.takeFocus(field)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text, onKey: onKey)
+    }
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var text: Binding<String>
+        var onKey: @MainActor (ComposerKey) -> Bool
+        /// Whether the keyboard has been claimed once already. The panel opens because somebody
+        /// clicked the control it hangs off and the next thing they do is type, so it is claimed;
+        /// claiming it again on a later pass would drag the caret back out of wherever they had
+        /// put it.
+        private var didFocus = false
+
+        init(text: Binding<String>, onKey: @escaping @MainActor (ComposerKey) -> Bool) {
+            self.text = text
+            self.onKey = onKey
+        }
+
+        /// On the next pass of the run loop, because a view being made or updated is not yet in
+        /// the window that would have to hand the keyboard over.
+        @MainActor
+        func takeFocus(_ field: NSTextField) {
+            guard !didFocus else { return }
+            DispatchQueue.main.async { [weak self] in
+                guard let self, !self.didFocus, let window = field.window else { return }
+                didFocus = window.makeFirstResponder(field)
+            }
+        }
+
+        func controlTextDidChange(_ notification: Notification) {
+            guard let field = notification.object as? NSTextField else { return }
+            text.wrappedValue = field.stringValue
+        }
+
+        func control(
+            _ control: NSControl, textView: NSTextView, doCommandBy selector: Selector
+        ) -> Bool {
+            let key: ComposerKey? = switch selector {
+            case #selector(NSResponder.moveUp(_:)): .up
+            case #selector(NSResponder.moveDown(_:)): .down
+            case #selector(NSResponder.insertNewline(_:)): .returnKey
+            case #selector(NSResponder.cancelOperation(_:)): .escape
+            case #selector(NSResponder.insertTab(_:)): .tab
+            default: nil
+            }
+            guard let key else { return false }
+            return onKey(key)
+        }
+    }
+}

--- a/Sources/Bloom/Views/Sidebar/CreateWorkspaceSheet.swift
+++ b/Sources/Bloom/Views/Sidebar/CreateWorkspaceSheet.swift
@@ -341,84 +341,18 @@ struct CreateWorkspaceSheet: View {
     /// three are answers to the same question and only ever one of them is in force. Visible
     /// rather than filed under the overflow menu for the reason the base branch always was: it is
     /// the setting here whose wrong value is expensive.
+    ///
+    /// Everything it draws is `WorkspaceSourcePicker`, including the search field a `Menu` could
+    /// not have held. What is left here is what the sheet owns: which project's lists these are,
+    /// and what happens to the one that gets picked.
     private var sourceControl: some View {
-        Menu {
-            Picker("Start from", selection: Binding(
-                get: { checkout == nil ? baseBranch : "" },
-                set: { branch in
-                    guard !branch.isEmpty else { return }
-                    checkout = nil
-                    baseBranch = branch
-                }
-            )) {
-                ForEach(branchOptions, id: \.self) { branch in
-                    Text("New branch from \(branch)").tag(branch)
-                }
-            }
-            .pickerStyle(.inline)
-
-            Section("Review a pull request") {
-                ForEach(checkoutOptions.pullRequests) { request in
-                    Button {
-                        choose(.pullRequest(request))
-                    } label: {
-                        Text(pullRequestLabel(request))
-                    }
-                }
-                if let sentence = pullRequestUnavailable {
-                    Text(sentence)
-                }
-                Button("Pull request by number or URL…") {
-                    referenceProblem = nil
-                    isEnteringReference = true
-                }
-            }
-
-            if !checkoutOptions.branches.isEmpty {
-                Section("Open an existing branch") {
-                    ForEach(checkoutOptions.branches) { branch in
-                        Button(branch.isLocal ? branch.name : "\(branch.name) (remote)") {
-                            choose(.branch(branch))
-                        }
-                    }
-                }
-            }
-        } label: {
-            ComposerControlLabel(
-                systemImage: sourceGlyph,
-                text: sourceLabel,
-                showsMenuIndicator: true
-            )
-        }
-        .menuStyle(.button)
-        .buttonStyle(.plain)
-        .menuIndicator(.hidden)
-        .fixedSize()
-        .help("Cut a new branch, or open a pull request or an existing branch")
-        .accessibilityLabel("Start from")
-        .accessibilityValue(sourceLabel)
-    }
-
-    private var sourceGlyph: String {
-        switch checkout {
-        case .pullRequest: "arrow.triangle.pull"
-        case .branch, .none: "arrow.triangle.branch"
-        }
-    }
-
-    private var sourceLabel: String {
-        switch checkout {
-        case .pullRequest(let request): "PR #\(request.number)"
-        case .branch(let branch): "on \(branch.name)"
-        case .none: "from \(baseBranch.isEmpty ? (repo?.defaultBranch ?? "") : baseBranch)"
-        }
-    }
-
-    private func pullRequestLabel(_ request: PullRequestListing) -> String {
-        let title = request.title.count > 52
-            ? String(request.title.prefix(52)) + "…"
-            : request.title
-        return "#\(request.number) \(title)" + (request.isDraft ? " (draft)" : "")
+        WorkspaceSourcePicker(
+            offering: offering,
+            checkout: checkout,
+            baseBranch: baseBranch.isEmpty ? (repo?.defaultBranch ?? "") : baseBranch,
+            unavailable: pullRequestUnavailable,
+            onPick: pick(_:)
+        )
     }
 
     /// Why the pull request section is empty, when it is. The three reasons need different
@@ -442,13 +376,13 @@ struct CreateWorkspaceSheet: View {
                 .textFieldStyle(.roundedBorder)
                 .font(Typo.body)
                 .focused($isReferenceFocused)
-                .onSubmit { resolveReference() }
+                .onSubmit { resolveReference(reference) }
                 .disabled(isResolvingReference)
 
             if isResolvingReference {
                 ProgressView().controlSize(.small)
             } else {
-                Button("Open", action: resolveReference)
+                Button("Open") { resolveReference(reference) }
                     .disabled(reference.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
 
@@ -854,6 +788,20 @@ struct CreateWorkspaceSheet: View {
         return WorkspaceStartContext.branchOptions(branches: branches, defaultBranch: repo.defaultBranch)
     }
 
+    /// The three lists the picker ranks, as one value.
+    ///
+    /// The base branches are this sheet's own listing rather than `checkoutOptions.branches`. The
+    /// two are different questions: what may be cut from includes the default branch and every
+    /// head a pull request speaks for, and what may be opened does not. See
+    /// `WorkspaceCheckoutPlan.offeredBranches`.
+    private var offering: WorkspaceSourceOffering {
+        WorkspaceSourceOffering(
+            pullRequests: checkoutOptions.pullRequests,
+            branches: checkoutOptions.branches,
+            baseBranches: branchOptions
+        )
+    }
+
     /// The same question `AppModel` will ask a moment from now, so the hint and what happens cannot
     /// disagree. See `WorkspaceNaming.shouldName` for what each condition rules out.
     ///
@@ -948,6 +896,41 @@ struct CreateWorkspaceSheet: View {
         )
     }
 
+    /// What a row in the source picker means here.
+    ///
+    /// The one that is not a choice about this sheet at all is a branch a live workspace already
+    /// has. Git refuses one branch in two worktrees, so "open it" cannot mean a second workspace;
+    /// it means the workspace that has it, and the sheet has nothing left to ask. That row used to
+    /// be missing from the list entirely, which answered the question by pretending the branch was
+    /// not there.
+    private func pick(_ source: WorkspaceSource) {
+        switch source {
+        case .newBranch(let ref):
+            checkout = nil
+            baseBranch = ref
+            focusTheBox()
+        case .existingBranch(let branch):
+            if let held = WorkspaceCheckoutPlan.workspaceHolding(
+                branch: branch.name, among: app.workspaces
+            ) {
+                app.selection = .workspace(held.id)
+                dismiss()
+                return
+            }
+            choose(.branch(branch))
+        case .pullRequest(.listed(let request)):
+            choose(.pullRequest(request))
+        case .pullRequest(.typed(_, let text)):
+            // A number or a URL, which nothing knows anything about until gh is asked. The box
+            // comes up carrying it so the wait, and any sentence about the wrong repository, have
+            // somewhere to be read.
+            reference = text
+            referenceProblem = nil
+            isEnteringReference = true
+            resolveReference(text)
+        }
+    }
+
     /// Takes a pull request or a branch as the source, and closes anything the choice answers.
     private func choose(_ chosen: WorkspaceCheckout) {
         checkout = chosen
@@ -965,9 +948,11 @@ struct CreateWorkspaceSheet: View {
 
     /// Resolves what was typed into the box. Everything but the drawing is in the core: the
     /// parsing, the repository check and the gh call are `WorkspaceCheckoutResolver`.
-    private func resolveReference() {
+    ///
+    /// The text is passed in rather than read back off `reference`, because the picker's typed row
+    /// writes it and calls this in the same breath.
+    private func resolveReference(_ text: String) {
         guard let repo, !isResolvingReference else { return }
-        let text = reference
         let path = repo.path
         isResolvingReference = true
         referenceProblem = nil
@@ -987,16 +972,25 @@ struct CreateWorkspaceSheet: View {
     /// run in separate tasks, so this one used to see an empty list every time and offer every
     /// branch as though it lived only on the remote. See `WorkspaceCheckoutOptions.load`.
     ///
-    /// Branches already checked out in a live workspace are left out: git refuses to have one
-    /// branch in two worktrees, so offering them would be offering a create that cannot succeed.
+    /// Branches already checked out in a live workspace are listed with the workspace that has
+    /// them named on the row, and selecting one goes there. They used to be left out, because git
+    /// refuses one branch in two worktrees and offering one is offering a create that cannot
+    /// succeed. That is true of the create and wrong about the list: the branch being looked for
+    /// is very often the one that is already open. See `WorkspaceCheckoutPlan.offeredBranches`.
     private func loadCheckouts() async {
         guard let repo else { return }
         isLoadingCheckouts = true
-        let taken = Set(app.workspaces.filter { $0.state == .active }.map(\.branch))
+        let inUse = Dictionary(
+            app.workspaces.filter { $0.state == .active }.map { ($0.branch, $0.name) },
+            // Two live workspaces cannot hold the same branch, so a duplicate here is a row that
+            // has not caught up with a worktree that has gone. The first is as good an answer as
+            // there is, and it is what `workspaceHolding` will find when the row is selected.
+            uniquingKeysWith: { first, _ in first }
+        )
         let options = await WorkspaceCheckoutOptions.load(
             repoPath: repo.path,
             defaultBranch: repo.defaultBranch,
-            takenBranches: taken
+            branchesInUse: inUse
         )
         guard !Task.isCancelled else { return }
         isLoadingCheckouts = false

--- a/Sources/Bloom/Views/Sidebar/WorkspaceSourcePicker.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspaceSourcePicker.swift
@@ -1,0 +1,220 @@
+import SwiftUI
+import BloomCore
+
+/// Where the work comes from: an open pull request, a branch somebody has already written on, or a
+/// fresh branch cut off a base.
+///
+/// It replaces a `Menu` that listed "New branch from <name>" for every branch in the project and
+/// filed "Open an existing branch" under all of them, with no way to search. A colleague's branch
+/// was picked out of the top of that list, which cut a new branch off their head, and the
+/// workspace came up empty with its Changes tab saying nothing differed. So the two verbs are
+/// drawn as two sections, one above the other, with the same branch in both: the choice is made
+/// with both answers in view rather than a screenful apart.
+///
+/// A `.popover` rather than a `Menu`, and not by preference. An `NSMenu` cannot contain a text
+/// field, so a menu with a search box in it is not a thing macOS has; the panel is the app's own
+/// filtered list instead, the one `FileMentionMenu` draws over the composer, with the same arrow
+/// keys, the same Return and the same empty line when nothing matches.
+struct WorkspaceSourcePicker: View {
+    var offering: WorkspaceSourceOffering
+    /// What is chosen now, which is what the button reports. Nil is the sheet's own route: a new
+    /// branch off `baseBranch`.
+    var checkout: WorkspaceCheckout?
+    var baseBranch: String
+    /// Why there are no pull requests, when there are none. Drawn at the foot of the panel rather
+    /// than as a row, because "Sign in with gh" is not something to arrow onto and press Return on.
+    var unavailable: String?
+    var onPick: @MainActor (WorkspaceSource) -> Void
+
+    @State private var isPresented = false
+    @State private var query = ""
+    /// The highlighted row, held as the row itself and never as an index into the list. A ranked
+    /// list reorders under every keystroke, so an index highlights whatever has since moved into
+    /// that slot and Return opens something other than what is drawn. `FileMentionMenu` carries
+    /// the same note over the same failure.
+    @State private var selected: WorkspaceSource?
+
+    /// Wide enough for a pull request title beside its author without either being cut, which is
+    /// what the old menu's 52 character truncation was working around.
+    private static let width: CGFloat = 460
+    /// Taller than `MenuLayout.maxHeight`, which is the cap a completion menu keeps because it
+    /// floats over the composer it is filtering. This one hangs off a control at the top of a
+    /// sheet with nothing underneath it worth reading, and it is a list people scan rather than a
+    /// glance, so it gets about eleven rows instead of eight.
+    private static let listHeight: CGFloat = 320
+
+    private var matches: WorkspaceSourceMatches {
+        offering.search(query: query)
+    }
+
+    private var label: String {
+        WorkspaceSource.label(for: checkout, baseBranch: baseBranch)
+    }
+
+    /// The same three marks the rows carry, so the control shows the row that was picked. Cutting
+    /// a new branch had the branch mark too, which left "from main" and "on main" telling the two
+    /// apart on one word and no other difference at all.
+    private var glyph: String {
+        switch checkout {
+        case .pullRequest: "arrow.triangle.pull"
+        case .branch: "arrow.triangle.branch"
+        case .none: "plus.circle"
+        }
+    }
+
+    var body: some View {
+        Button {
+            isPresented = true
+        } label: {
+            ComposerControlLabel(
+                systemImage: glyph,
+                text: label,
+                isActive: isPresented,
+                showsMenuIndicator: true
+            )
+        }
+        .buttonStyle(.plain)
+        .fixedSize()
+        .help("Open a pull request or a branch, or cut a new branch")
+        .accessibilityLabel("Start from")
+        .accessibilityValue(label)
+        .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+            panel
+        }
+    }
+
+    private var panel: some View {
+        // Ranked once for the whole pass, and everything below draws from that one value. The
+        // panel asks three questions of it (is there anything, what goes in each section) and a
+        // ranking run per question is the same list computed three times over a repository's worth
+        // of branches, on every keystroke.
+        let matches = self.matches
+        return VStack(alignment: .leading, spacing: 0) {
+            searchRow
+            Hairline()
+
+            if matches.isEmpty {
+                MenuEmptyRow(
+                    text: query.isEmpty
+                        ? "No branches or pull requests yet"
+                        : "Nothing matches \(query)"
+                )
+            } else {
+                list(matches)
+            }
+
+            if let unavailable {
+                Hairline()
+                Text(unavailable)
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textTertiary)
+                    .lineLimit(1)
+                    .padding(.horizontal, Metrics.gutter)
+                    .padding(.vertical, Metrics.spacingWide)
+            }
+        }
+        .frame(width: Self.width)
+        // A fresh query every time it opens. The panel is a way of finding one thing, not a filter
+        // somebody set and left, and reopening it onto yesterday's word would hide the list that
+        // has since loaded behind it.
+        .onAppear {
+            query = ""
+            selected = offering.search(query: "").ordered.first
+        }
+    }
+
+    private var searchRow: some View {
+        HStack(spacing: Metrics.spacing) {
+            Image(systemName: "magnifyingglass")
+                .imageScale(.small)
+                .foregroundStyle(Palette.textTertiary)
+
+            MenuSearchField(
+                text: $query,
+                placeholder: "Search branches and pull requests, or paste a pull request",
+                onKey: handle(key:)
+            )
+            .frame(height: Metrics.rowHeight)
+        }
+        .padding(.horizontal, Metrics.gutter)
+        .padding(.vertical, Metrics.spacingSmall)
+        .onChange(of: query) { _, _ in
+            // The highlight follows the list rather than staying where it was: a highlight left
+            // pointing at a row the new query filtered out is a Return that does nothing.
+            selected = matches.settled(after: selected)
+        }
+    }
+
+    private func list(_ matches: WorkspaceSourceMatches) -> some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    // The heading says what happens to the work that is already there, because
+                    // "Open" alone reads as "open a copy of". Carrying on somebody's branch is
+                    // what the sheet could not say before.
+                    section("Open, and carry on", rows: matches.open)
+                    section("New branch from", rows: matches.new)
+                }
+                .padding(Metrics.spacingSmall)
+            }
+            .frame(maxHeight: Self.listHeight)
+            .onChange(of: selected) { _, row in
+                guard let row else { return }
+                proxy.scrollTo(row.id)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func section(_ title: String, rows: [WorkspaceSource]) -> some View {
+        if !rows.isEmpty {
+            Text(title)
+                .font(Typo.caption)
+                .foregroundStyle(Palette.textTertiary)
+                .padding(.horizontal, Metrics.spacing)
+                .padding(.top, Metrics.spacingWide)
+                .padding(.bottom, Metrics.spacingTight)
+                .accessibilityAddTraits(.isHeader)
+
+            ForEach(rows) { row in
+                WorkspaceSourceRow(
+                    source: row,
+                    isSelected: row == selected,
+                    onPick: { pick(row) },
+                    onHover: { selected = row }
+                )
+                // Identity is the thing the row names, never its position. See `selected`.
+                .id(row.id)
+            }
+        }
+    }
+
+    // MARK: - Keys
+
+    /// The panel's whole keyboard. Where the highlight lands is `WorkspaceSourceMatches`, in the
+    /// core, because it is a decision and a decision taken in a view is one nothing can test.
+    private func handle(key: ComposerKey) -> Bool {
+        switch key {
+        case .up:
+            selected = matches.stepped(from: selected, by: -1)
+            return true
+        case .down:
+            selected = matches.stepped(from: selected, by: 1)
+            return true
+        case .returnKey, .commandReturn:
+            guard let selected else { return false }
+            pick(selected)
+            return true
+        case .escape:
+            isPresented = false
+            return true
+        case .tab:
+            return false
+        }
+    }
+
+    private func pick(_ source: WorkspaceSource) {
+        isPresented = false
+        onPick(source)
+    }
+}

--- a/Sources/Bloom/Views/Sidebar/WorkspaceSourceRow.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspaceSourceRow.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import BloomCore
+
+/// One row in the source picker: what it is, what it is called, and the note that says what
+/// selecting it will actually do.
+///
+/// The same shape as `FileMentionRow`, deliberately. The two panels are the same thing (a filtered
+/// floating list somebody arrows through), and a second shape for the second one is how a window
+/// grows two idioms for one job.
+struct WorkspaceSourceRow: View {
+    var source: WorkspaceSource
+    var isSelected: Bool
+    var onPick: @MainActor () -> Void
+    var onHover: @MainActor () -> Void
+
+    @Environment(\.controlActiveState) private var activeState
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onPick) {
+            HStack(spacing: Metrics.spacing) {
+                Image(systemName: glyph)
+                    .imageScale(.small)
+                    .foregroundStyle(isEmphasized ? Palette.selectedEmphasizedText : Palette.textTertiary)
+                    .frame(width: Metrics.glyph)
+
+                Text(source.name)
+                    .font(Typo.body)
+                    .foregroundStyle(nameColour)
+                    .lineLimit(1)
+                    .truncationMode(truncation)
+
+                Spacer(minLength: Metrics.spacingSmall)
+
+                if let note = source.note {
+                    Text(note)
+                        .font(Typo.caption)
+                        .foregroundStyle(
+                            isEmphasized
+                                ? Palette.selectedEmphasizedText.opacity(0.75)
+                                : Palette.textTertiary
+                        )
+                        .lineLimit(1)
+                }
+            }
+            .padding(.horizontal, Metrics.spacing)
+            .frame(height: Metrics.rowHeight)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        // The verb is spoken even where the section heading carries it on screen, because a reader
+        // arrowing down the list hears one row at a time and the heading is above all of them.
+        .accessibilityLabel("\(source.verb) \(source.name)")
+        .accessibilityValue(source.note ?? "")
+        // Focused, for the reason spelled out on `SlashCommandRow`.
+        .rowBackground(isSelected: isSelected, isHovered: isHovered, isFocused: true)
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering { onHover() }
+        }
+    }
+
+    /// Which end of a long name is dropped, and the two answers are opposite.
+    ///
+    /// A branch loses its front: `feature/` and a colleague's login are the part everybody shares,
+    /// and the end is what tells two of somebody's `patch-1`s apart. A pull request loses its
+    /// tail, because it opens with the number it is referred to by out loud.
+    private var truncation: Text.TruncationMode {
+        switch source {
+        case .pullRequest: .tail
+        case .newBranch, .existingBranch: .head
+        }
+    }
+
+    private var glyph: String {
+        switch source {
+        case .pullRequest: "arrow.triangle.pull"
+        case .existingBranch: "arrow.triangle.branch"
+        case .newBranch: "plus.circle"
+        }
+    }
+
+    /// A branch a workspace already has is drawn quieter than the rest, because selecting it does
+    /// something else: it goes to that workspace rather than making one. The note beside it says
+    /// which, and the two together are what a disabled row would have said while being unclickable
+    /// for no reason anybody could see.
+    private var nameColour: Color {
+        if isEmphasized { return Palette.selectedEmphasizedText }
+        return source.heldBy == nil ? Palette.textPrimary : Palette.textTertiary
+    }
+
+    /// Whether the row is about to be painted with the accent colour. Both labels set their own
+    /// colour, so the inverted foreground `rowBackground` installs never reaches them on its own.
+    private var isEmphasized: Bool {
+        isSelected && activeState != .inactive
+    }
+}

--- a/Sources/BloomCore/WorkspaceCheckout.swift
+++ b/Sources/BloomCore/WorkspaceCheckout.swift
@@ -55,12 +55,22 @@ public struct ExistingBranch: Sendable, Hashable, Identifiable, Codable {
     /// Whether there is a local `refs/heads` copy. False means the branch is only on the remote,
     /// which needs a tracking branch made for it rather than a plain checkout.
     public let isLocal: Bool
+    /// The live workspace already sitting on this branch, by name, or nil when it is free.
+    ///
+    /// Carried on the branch rather than worked out by the picker, because the picker used to be
+    /// handed a list these branches had been taken out of: git refuses one branch in two
+    /// worktrees, so an in-use branch was dropped, and the answer to "where is the branch I was
+    /// working on yesterday" was silence. It is listed and marked instead, and selecting it goes
+    /// to the workspace that has it. See `WorkspaceCheckoutPlan.workspaceHolding`, which is what
+    /// turns this name back into the row to select.
+    public let inUseBy: String?
 
     public var id: String { name }
 
-    public init(name: String, isLocal: Bool) {
+    public init(name: String, isLocal: Bool, inUseBy: String? = nil) {
         self.name = name
         self.isLocal = isLocal
+        self.inUseBy = inUseBy
     }
 }
 
@@ -174,11 +184,19 @@ public enum WorkspaceCheckoutPlan {
     /// against the project's default, the pull request entry against the ref the pull request
     /// actually targets. Offering both is offering a coin flip over what the Changes tab means,
     /// and the pull request is the one that knows the answer. See `heads(of:)`.
+    ///
+    /// A branch a live workspace is already sitting on is NOT dropped. It used to be, because git
+    /// refuses one branch in two worktrees and offering it would be offering a create that cannot
+    /// succeed. That reasoning is right about the create and wrong about the list: the branch
+    /// somebody is looking for is very often the one they were working on yesterday, and a picker
+    /// that answers by not mentioning it reads as a branch that has gone. It is listed with the
+    /// workspace holding it named on the row, and selecting it goes there instead of creating
+    /// anything. See `ExistingBranch.inUseBy`.
     public static func offeredBranches(
         local: [String],
         remote: [String],
         defaultBranch: String,
-        excluding taken: Set<String> = [],
+        inUse: [String: String] = [:],
         pullRequestHeads: Set<String> = []
     ) -> [ExistingBranch] {
         var byName: [String: Bool] = [:]
@@ -189,10 +207,9 @@ public enum WorkspaceCheckoutPlan {
             byName[name] = false
         }
         byName[defaultBranch] = nil
-        for name in taken { byName[name] = nil }
         for name in pullRequestHeads { byName[name] = nil }
         return byName
-            .map { ExistingBranch(name: $0.key, isLocal: $0.value) }
+            .map { ExistingBranch(name: $0.key, isLocal: $0.value, inUseBy: inUse[$0.key]) }
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
     }
 

--- a/Sources/BloomCore/WorkspaceSource.swift
+++ b/Sources/BloomCore/WorkspaceSource.swift
@@ -1,0 +1,283 @@
+import Foundation
+
+/// Where a pull request the picker offers came from.
+///
+/// Two ways in, and they cost different things. A listed one has already been fetched, so its
+/// title, its author and its head are on the row before anything is clicked. A typed one is a
+/// number or a URL somebody put in the search field, which is worth offering (a closed pull
+/// request, somebody else's, or the hundred and first of a busy repository is never in the list)
+/// but which nothing knows anything about until gh is asked.
+///
+/// The typed case carries the text as it was typed rather than the number alone, and that is the
+/// whole reason it is not a bare `Int`: `WorkspaceCheckoutResolver.problem` compares the
+/// repository half of a pasted URL against this project, and pasting another project's pull
+/// request into this sheet otherwise resolves quietly to whatever this repository has as number
+/// 42.
+public enum PullRequestOffer: Sendable, Hashable {
+    case listed(PullRequestListing)
+    case typed(PullRequestReference, text: String)
+}
+
+/// One row the source picker can offer, over the three verbs the picker exists to put side by
+/// side.
+///
+/// The bug that forced this: the create sheet's "Start from" menu listed "New branch from <name>"
+/// for every branch in the project and filed "Open an existing branch" underneath all of them,
+/// unsearchable. Picking a colleague's branch out of the top of that list cuts a fresh branch off
+/// their head, so the workspace opens empty and its Changes tab says nothing differs. The two
+/// verbs are one keystroke apart in intent and were a screenful apart on the menu, so the picker
+/// draws them as two sections with the same branch in both, and every row says which verb it is.
+public enum WorkspaceSource: Sendable, Hashable, Identifiable {
+    /// Cut a fresh branch off a named ref. What Bloom could always do.
+    case newBranch(from: String)
+    /// Check out a branch somebody has already written on.
+    case existingBranch(ExistingBranch)
+    case pullRequest(PullRequestOffer)
+
+    /// Identity is what the row names, never where it sits. See `WorkspaceSourcePicker`: a
+    /// selection pinned to a position in a list that reranks under an open panel selects whatever
+    /// has since moved into that slot. The prefix is what keeps a branch offered under both verbs
+    /// from being one row twice.
+    public var id: String {
+        switch self {
+        case .newBranch(let ref): "new:\(ref)"
+        case .existingBranch(let branch): "branch:\(branch.name)"
+        case .pullRequest(.listed(let request)): "pr:\(request.number)"
+        case .pullRequest(.typed(let reference, _)): "typed:\(reference.number)"
+        }
+    }
+
+    /// What this row will do, said in the row rather than only in the section heading. The
+    /// headings scroll; the verb is the thing that was wrong.
+    public var verb: String {
+        switch self {
+        case .newBranch: "New branch from"
+        case .existingBranch: "Open"
+        case .pullRequest: "Review"
+        }
+    }
+
+    /// The thing the row names, as it is written everywhere else in the app.
+    public var name: String {
+        switch self {
+        case .newBranch(let ref): ref
+        case .existingBranch(let branch): branch.name
+        case .pullRequest(.listed(let request)): "#\(request.number) \(request.title)"
+        case .pullRequest(.typed(let reference, _)): "#\(reference.number)"
+        }
+    }
+
+    /// What is worth saying after the name, or nothing.
+    ///
+    /// "In use by" wins over every other note. A branch git will refuse to check out twice is the
+    /// one fact on the row that changes what selecting it does, so it is never crowded out by an
+    /// author's login.
+    public var note: String? {
+        switch self {
+        case .newBranch:
+            return nil
+        case .existingBranch(let branch):
+            if let holder = branch.inUseBy { return "In use by \(holder)" }
+            return branch.isLocal ? nil : "remote"
+        case .pullRequest(.listed(let request)):
+            let author = request.author.isEmpty ? nil : request.author
+            return [request.isDraft ? "draft" : nil, author]
+                .compactMap { $0 }
+                .joined(separator: ", ")
+                .nonEmpty
+        case .pullRequest(.typed):
+            return "Look it up on GitHub"
+        }
+    }
+
+    /// The workspace already holding this branch, by name, when there is one.
+    ///
+    /// Selecting such a row does not create anything: git refuses one branch in two worktrees, so
+    /// the honest answer to "open this branch" is the workspace that already has it. These rows
+    /// used to be dropped from the list altogether, which answered the question by pretending the
+    /// branch did not exist.
+    public var heldBy: String? {
+        guard case .existingBranch(let branch) = self else { return nil }
+        return branch.inUseBy
+    }
+
+    /// What the sheet is being asked to open, or nil for the rows that are not a checkout: a new
+    /// branch, which is the sheet's own route, and a typed pull request, which has to be resolved
+    /// against gh before there is anything to open.
+    public var checkout: WorkspaceCheckout? {
+        switch self {
+        case .newBranch: nil
+        case .existingBranch(let branch): .branch(branch)
+        case .pullRequest(.listed(let request)): .pullRequest(request)
+        case .pullRequest(.typed): nil
+        }
+    }
+
+    /// Everything a query is matched against. A pull request is looked for by all four of the
+    /// things people remember about one: its number, its title, its author and the branch it is
+    /// on. The branch is in here because "the figma one" is how a head is recalled long after the
+    /// title has gone.
+    var searchText: String {
+        switch self {
+        case .newBranch(let ref): ref
+        case .existingBranch(let branch): branch.name
+        case .pullRequest(.listed(let request)):
+            "#\(request.number) \(request.title) \(request.author) \(request.headRefName)"
+        case .pullRequest(.typed(let reference, let text)): "#\(reference.number) \(text)"
+        }
+    }
+}
+
+public extension WorkspaceSource {
+    /// What the button that opens the picker says, and the other half of the fix.
+    ///
+    /// "on" against "from", because that is the distinction the old menu buried: a workspace that
+    /// sits on somebody else's branch and one that cuts a fresh branch off it are different jobs,
+    /// and the control that reports which was chosen has to be readable without opening anything.
+    /// A pull request reports its head rather than its number for the same reason. The number is
+    /// already on the heading above the box and on the chip under it, and neither of those says
+    /// whether the worktree lands on that head or beside it.
+    static func label(for checkout: WorkspaceCheckout?, baseBranch: String) -> String {
+        guard let checkout else { return "from \(baseBranch)" }
+        return "on \(checkout.preferredLocalBranch)"
+    }
+}
+
+/// Everything the picker has to offer, and the ranking over it.
+///
+/// A value rather than a function over three arrays, because the panel asks it the same question
+/// on every keystroke and the sections have to be built from one answer: a row that is in the
+/// drawn list and not in the list the arrow keys walk is a row that cannot be selected.
+public struct WorkspaceSourceOffering: Sendable, Hashable {
+    public let pullRequests: [PullRequestListing]
+    public let branches: [ExistingBranch]
+    /// What a new branch may be cut from. The project's branches, which is a different list from
+    /// `branches` above: that one has the default branch and the pull request heads taken out of
+    /// it, and both are perfectly good things to cut a branch from.
+    public let baseBranches: [String]
+
+    public init(
+        pullRequests: [PullRequestListing] = [],
+        branches: [ExistingBranch] = [],
+        baseBranches: [String] = []
+    ) {
+        self.pullRequests = pullRequests
+        self.branches = branches
+        self.baseBranches = baseBranches
+    }
+
+    /// The "Open, and carry on" section: what somebody else has already written.
+    ///
+    /// Pull requests first. A repository with anything open has one or two of them and a few
+    /// hundred branches, so a list that opened on branch names would need scrolling before the
+    /// thing most people came for was on screen.
+    public var openRows: [WorkspaceSource] {
+        pullRequests.map { .pullRequest(.listed($0)) } + branches.map { WorkspaceSource.existingBranch($0) }
+    }
+
+    /// The "New branch from" section: Bloom's original and still ordinary route.
+    public var newBranchRows: [WorkspaceSource] {
+        baseBranches.map { .newBranch(from: $0) }
+    }
+
+    /// Ranks the whole offering against what is in the search field.
+    ///
+    /// Pure and `nonisolated`, like `FileMatch.search` and for the same reason: it runs on every
+    /// keystroke, over a list that is a few hundred branches long in any repository worth the
+    /// name, and none of that belongs on the actor drawing the panel.
+    public nonisolated func search(query: String, limit: Int = 40) -> WorkspaceSourceMatches {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        return WorkspaceSourceMatches(
+            query: trimmed,
+            open: typedRows(for: trimmed) + Self.rank(openRows, query: trimmed, limit: limit),
+            new: Self.rank(newBranchRows, query: trimmed, limit: limit)
+        )
+    }
+
+    /// The row for a number or a URL that was typed rather than picked.
+    ///
+    /// Nothing is offered when the list already answers the number, because the listed row knows
+    /// the title, the author and the base, and an identical looking row that costs a gh call to
+    /// find that out is a coin flip nobody can see. The parsing is
+    /// `WorkspaceCheckoutPlan.parseReference`, which already knows every shape a pull request
+    /// arrives in.
+    private func typedRows(for query: String) -> [WorkspaceSource] {
+        guard let reference = WorkspaceCheckoutPlan.parseReference(query) else { return [] }
+        guard !pullRequests.contains(where: { $0.number == reference.number }) else { return [] }
+        return [.pullRequest(.typed(reference, text: query))]
+    }
+
+    /// The same shape of ranking `FileMatch.search` does: a hit anywhere keeps the row, a hit in
+    /// the name it is known by pushes it up. Ties keep the order they arrived in, which is newest
+    /// first for pull requests and alphabetical for branches, so an empty field reads as a list
+    /// rather than as a shuffle.
+    private nonisolated static func rank(
+        _ rows: [WorkspaceSource], query: String, limit: Int
+    ) -> [WorkspaceSource] {
+        guard !query.isEmpty else { return Array(rows.prefix(limit)) }
+
+        var scored: [(row: WorkspaceSource, score: Int, position: Int)] = []
+        scored.reserveCapacity(rows.count)
+        for (position, row) in rows.enumerated() {
+            guard let score = FuzzyMatch.score(row.searchText, query: query) else { continue }
+            let nameBonus = FuzzyMatch.score(row.name, query: query) ?? 0
+            scored.append((row, score + nameBonus, position))
+        }
+        scored.sort { lhs, rhs in
+            if lhs.score != rhs.score { return lhs.score > rhs.score }
+            return lhs.position < rhs.position
+        }
+        return scored.prefix(limit).map(\.row)
+    }
+}
+
+/// What the panel draws, in the order the arrow keys walk it.
+public struct WorkspaceSourceMatches: Sendable, Hashable {
+    /// What was searched for, so the empty state can say it rather than shrugging. See
+    /// `MenuEmptyRow`, which is where that sentence is drawn everywhere else in the app.
+    public let query: String
+    public let open: [WorkspaceSource]
+    public let new: [WorkspaceSource]
+
+    public init(query: String = "", open: [WorkspaceSource] = [], new: [WorkspaceSource] = []) {
+        self.query = query
+        self.open = open
+        self.new = new
+    }
+
+    public var isEmpty: Bool { open.isEmpty && new.isEmpty }
+
+    /// Both sections as one list, top to bottom.
+    ///
+    /// The keyboard walks this and the panel draws it in the same order, from the same value, so
+    /// Return cannot pick something other than the highlighted row.
+    public var ordered: [WorkspaceSource] { open + new }
+
+    /// Where the highlight lands after a step, given what is highlighted now.
+    ///
+    /// Here rather than in the panel because it is the whole of the keyboard's behaviour and a
+    /// decision taken in a view is a decision nothing can test. It wraps at both ends, which is
+    /// what every menu on the Mac does, and it answers with the first row when nothing is
+    /// highlighted yet, so the first press of Down after typing does not swallow itself.
+    public func stepped(from current: WorkspaceSource?, by step: Int) -> WorkspaceSource? {
+        let rows = ordered
+        guard !rows.isEmpty else { return nil }
+        guard let current, let index = rows.firstIndex(of: current) else {
+            return step < 0 ? rows.last : rows.first
+        }
+        let next = (index + step + rows.count) % rows.count
+        return rows[next]
+    }
+
+    /// What stays highlighted when the list changes under the field: the same row if it survived
+    /// the new query, otherwise the best one there is now. A highlight left pointing at a row that
+    /// has been filtered out is a Return that does nothing.
+    public func settled(after current: WorkspaceSource?) -> WorkspaceSource? {
+        guard let current, ordered.contains(current) else { return ordered.first }
+        return current
+    }
+}
+
+private extension String {
+    var nonEmpty: String? { isEmpty ? nil : self }
+}

--- a/Sources/BloomCore/WorkspaceStartContext.swift
+++ b/Sources/BloomCore/WorkspaceStartContext.swift
@@ -79,10 +79,13 @@ public struct WorkspaceCheckoutOptions: Sendable {
     /// and then checked out with `--track -b`, which git refuses when the local branch is already
     /// there. Reading it here costs one `for-each-ref`, which is what the sheet was paying anyway,
     /// and it runs beside the remote listing rather than after it.
+    ///
+    /// `branchesInUse` maps a branch to the live workspace sitting on it, which the picker draws
+    /// on the row rather than using to hide it. See `WorkspaceCheckoutPlan.offeredBranches`.
     public static func load(
         repoPath: String,
         defaultBranch: String,
-        takenBranches: Set<String> = []
+        branchesInUse: [String: String] = [:]
     ) async -> WorkspaceCheckoutOptions {
         async let localListing = Git.branches(of: repoPath)
         async let remoteListing = Git.remoteBranches(of: repoPath)
@@ -100,7 +103,7 @@ public struct WorkspaceCheckoutOptions: Sendable {
                     local: local,
                     remote: remote,
                     defaultBranch: defaultBranch,
-                    excluding: takenBranches,
+                    inUse: branchesInUse,
                     pullRequestHeads: WorkspaceCheckoutPlan.heads(of: pullRequests)
                 ),
                 access: access,

--- a/Tests/BloomCoreTests/WorkspaceCheckoutTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceCheckoutTests.swift
@@ -75,15 +75,20 @@ struct WorkspaceCheckoutTests {
         #expect(branches.first { $0.name == "theirs" }?.isLocal == false)
     }
 
-    @Test("A branch already checked out in a workspace is not offered, because git would refuse")
-    func skipsBranchesInUse() {
+    @Test("A branch a workspace is already on is still offered, wearing the workspace's name")
+    func marksBranchesInUse() {
+        // It used to be dropped, because git refuses one branch in two worktrees. That answered
+        // "where is the branch I was working on yesterday" with silence. The row is offered and
+        // marked instead; selecting it goes to the workspace rather than creating a second one.
         let branches = WorkspaceCheckoutPlan.offeredBranches(
             local: ["main", "wip", "review"],
             remote: [],
             defaultBranch: "main",
-            excluding: ["review"]
+            inUse: ["review": "Quiet Harbour"]
         )
-        #expect(branches.map(\.name) == ["wip"])
+        #expect(branches.map(\.name) == ["review", "wip"])
+        #expect(branches.first { $0.name == "review" }?.inUseBy == "Quiet Harbour")
+        #expect(branches.first { $0.name == "wip" }?.inUseBy == nil)
     }
 
     @Test("A head with a pull request open on it is offered as the pull request and not twice")
@@ -96,6 +101,19 @@ struct WorkspaceCheckoutTests {
             pullRequestHeads: WorkspaceCheckoutPlan.heads(of: requests)
         )
         #expect(branches.map(\.name) == ["wip"])
+    }
+
+    @Test("Being in use does not save a branch from the exclusions that are still right")
+    func keepsExcludingWhatAPullRequestSpeaksFor() {
+        let requests = [listing(number: 4, head: "figma-mcp-check")]
+        let branches = WorkspaceCheckoutPlan.offeredBranches(
+            local: ["main", "figma-mcp-check"],
+            remote: ["origin/HEAD"],
+            defaultBranch: "main",
+            inUse: ["figma-mcp-check": "Coral Bay", "main": "Coral Bay"],
+            pullRequestHeads: WorkspaceCheckoutPlan.heads(of: requests)
+        )
+        #expect(branches.isEmpty)
     }
 
     @Test("A fork's head does not hide a branch of this repository that shares its name")

--- a/Tests/BloomCoreTests/WorkspaceSourceTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceSourceTests.swift
@@ -1,0 +1,237 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// What the create sheet's source picker offers, how it ranks what was typed, and what the button
+/// that opens it says afterwards.
+///
+/// The bug behind the suite: "New branch from freekmurze/figma-mcp-check" was picked out of an
+/// unsearchable menu when what was wanted was that branch itself, and the workspace came up empty.
+/// Both verbs are offered here, and both the row and the button say which is which.
+@Suite("Workspace source picker")
+struct WorkspaceSourceTests {
+    private func listing(
+        number: Int = 12,
+        title: String = "Fix the parser",
+        author: String = "contributor",
+        head: String = "fix-parser",
+        isDraft: Bool = false
+    ) -> PullRequestListing {
+        PullRequestListing(
+            number: number,
+            title: title,
+            author: author,
+            headRefName: head,
+            baseRefName: "main",
+            isDraft: isDraft
+        )
+    }
+
+    private func offering(
+        pullRequests: [PullRequestListing] = [],
+        branches: [ExistingBranch] = [],
+        baseBranches: [String] = []
+    ) -> WorkspaceSourceOffering {
+        WorkspaceSourceOffering(
+            pullRequests: pullRequests, branches: branches, baseBranches: baseBranches
+        )
+    }
+
+    // MARK: - The two verbs
+
+    @Test("The same branch is offered under both verbs, which is the point of the picker")
+    func offersBothVerbs() {
+        let matches = offering(
+            branches: [ExistingBranch(name: "figma-mcp-check", isLocal: false)],
+            baseBranches: ["main", "figma-mcp-check"]
+        ).search(query: "figma")
+        #expect(matches.open.map(\.name) == ["figma-mcp-check"])
+        #expect(matches.new.map(\.name) == ["figma-mcp-check"])
+        #expect(matches.open.first?.verb == "Open")
+        #expect(matches.new.first?.verb == "New branch from")
+    }
+
+    @Test("Only the open verb is a checkout; a new branch is the sheet's own route")
+    func namesWhatIsBeingOpened() {
+        let branch = ExistingBranch(name: "wip", isLocal: true)
+        #expect(WorkspaceSource.existingBranch(branch).checkout == .branch(branch))
+        #expect(WorkspaceSource.newBranch(from: "wip").checkout == nil)
+        let request = listing()
+        #expect(WorkspaceSource.pullRequest(.listed(request)).checkout == .pullRequest(request))
+    }
+
+    @Test("Every row is identified by what it names, never by where it sits")
+    func identifiesRowsByName() {
+        #expect(WorkspaceSource.newBranch(from: "wip").id != WorkspaceSource.existingBranch(
+            ExistingBranch(name: "wip", isLocal: true)
+        ).id)
+    }
+
+    // MARK: - Ranking
+
+    @Test("A pull request is found by its number, its title, its author and its head")
+    func findsPullRequestsEveryWayTheyAreRemembered() {
+        let offered = offering(pullRequests: [
+            listing(number: 41, title: "Serialise the drains", author: "freekmurze", head: "drains"),
+            listing(number: 42, title: "Rename the sheet", author: "someone", head: "rename"),
+        ])
+        #expect(offered.search(query: "drains").open.first?.name.hasPrefix("#41") == true)
+        #expect(offered.search(query: "freekmurze").open.first?.name.hasPrefix("#41") == true)
+        #expect(offered.search(query: "rename").open.first?.name.hasPrefix("#42") == true)
+        #expect(offered.search(query: "serialise").open.first?.name.hasPrefix("#41") == true)
+    }
+
+    @Test("A branch nothing matches is gone, and so is the whole result when nothing matches")
+    func filters() {
+        let matches = offering(
+            branches: [ExistingBranch(name: "wip", isLocal: true)],
+            baseBranches: ["main"]
+        ).search(query: "zzz")
+        #expect(matches.isEmpty)
+        #expect(matches.query == "zzz")
+    }
+
+    @Test("An empty query offers everything, pull requests before branches")
+    func offersEverythingWhenNothingIsTyped() {
+        let matches = offering(
+            pullRequests: [listing(number: 7)],
+            branches: [ExistingBranch(name: "wip", isLocal: true)],
+            baseBranches: ["main", "wip"]
+        ).search(query: "  ")
+        #expect(matches.open.count == 2)
+        #expect(matches.open.first?.name.hasPrefix("#7") == true)
+        #expect(matches.new.map(\.name) == ["main", "wip"])
+    }
+
+    @Test("The list is capped, so a repository with a thousand branches is still a panel")
+    func capsEachSection() {
+        let many = (1...200).map { "branch-\($0)" }
+        let matches = offering(baseBranches: many).search(query: "", limit: 5)
+        #expect(matches.new.count == 5)
+    }
+
+    // MARK: - A number or a URL typed into the field
+
+    @Test("A typed number is offered as a pull request to look up")
+    func offersATypedNumber() {
+        let matches = offering(baseBranches: ["main"]).search(query: "1234")
+        #expect(matches.open.first?.name == "#1234")
+        guard case .pullRequest(.typed(let reference, let text)) = matches.open.first else {
+            Issue.record("the typed number was not offered as a pull request")
+            return
+        }
+        #expect(reference.number == 1234)
+        // The text as typed, not the number: the repository half of a pasted URL is what stops
+        // another project's #42 resolving quietly to this project's. See
+        // `WorkspaceCheckoutResolver.problem`.
+        #expect(text == "1234")
+    }
+
+    @Test("A pasted URL keeps the repository it named")
+    func offersATypedURL() {
+        let matches = offering().search(query: "https://github.com/spatie/ray/pull/7/files")
+        guard case .pullRequest(.typed(let reference, let text)) = matches.open.first else {
+            Issue.record("the pasted URL was not offered as a pull request")
+            return
+        }
+        #expect(reference.number == 7)
+        #expect(reference.repository == "spatie/ray")
+        #expect(text.contains("spatie/ray"))
+    }
+
+    @Test("A number the list already answers is not offered twice")
+    func prefersTheListedPullRequest() {
+        let matches = offering(pullRequests: [listing(number: 42)]).search(query: "42")
+        #expect(matches.open.count == 1)
+        #expect(matches.open.first?.checkout != nil)
+    }
+
+    @Test("A branch name is not a pull request number")
+    func doesNotOfferNonsenseAsAPullRequest() {
+        let matches = offering(baseBranches: ["main"]).search(query: "main")
+        #expect(matches.open.isEmpty)
+        #expect(matches.new.map(\.name) == ["main"])
+    }
+
+    // MARK: - A branch somebody else is already on
+
+    @Test("An in-use branch is listed, greyed by its note, and says which workspace has it")
+    func marksAnInUseBranch() {
+        let row = WorkspaceSource.existingBranch(
+            ExistingBranch(name: "review", isLocal: true, inUseBy: "Quiet Harbour")
+        )
+        #expect(row.heldBy == "Quiet Harbour")
+        #expect(row.note == "In use by Quiet Harbour")
+        // The note that would otherwise be there loses to it: what selecting the row does is the
+        // one fact on it that changes.
+        let remote = WorkspaceSource.existingBranch(
+            ExistingBranch(name: "review", isLocal: false, inUseBy: "Quiet Harbour")
+        )
+        #expect(remote.note == "In use by Quiet Harbour")
+        #expect(
+            WorkspaceSource.existingBranch(ExistingBranch(name: "review", isLocal: false)).note
+                == "remote"
+        )
+        #expect(WorkspaceSource.newBranch(from: "main").heldBy == nil)
+    }
+
+    @Test("A draft and its author are what a pull request row says after its title")
+    func notesADraft() {
+        #expect(
+            WorkspaceSource.pullRequest(.listed(listing(author: "freekmurze", isDraft: true))).note
+                == "draft, freekmurze"
+        )
+        #expect(
+            WorkspaceSource.pullRequest(.listed(listing(author: ""))).note == nil
+        )
+    }
+
+    // MARK: - The keyboard
+
+    @Test("Down and up walk both sections as one list, and wrap")
+    func stepsThroughBothSections() {
+        let matches = offering(
+            branches: [ExistingBranch(name: "wip", isLocal: true)],
+            baseBranches: ["main"]
+        ).search(query: "")
+        let first = matches.ordered.first
+        let last = matches.ordered.last
+        #expect(matches.stepped(from: nil, by: 1) == first)
+        #expect(matches.stepped(from: nil, by: -1) == last)
+        #expect(matches.stepped(from: first, by: 1) == last)
+        #expect(matches.stepped(from: last, by: 1) == first)
+        #expect(WorkspaceSourceMatches().stepped(from: nil, by: 1) == nil)
+    }
+
+    @Test("A highlight that the next keystroke filters away moves to the best row there is")
+    func settlesTheHighlight() {
+        let offered = offering(
+            branches: [ExistingBranch(name: "wip", isLocal: true)],
+            baseBranches: ["main", "wip"]
+        )
+        let held = WorkspaceSource.existingBranch(ExistingBranch(name: "wip", isLocal: true))
+        #expect(offered.search(query: "wip").settled(after: held) == held)
+        #expect(offered.search(query: "main").settled(after: held)?.name == "main")
+        #expect(WorkspaceSourceMatches().settled(after: held) == nil)
+    }
+
+    // MARK: - What the button says
+
+    @Test("The button says 'on' for a checkout and 'from' for a new branch")
+    func labelsTheButton() {
+        #expect(WorkspaceSource.label(for: nil, baseBranch: "main") == "from main")
+        #expect(
+            WorkspaceSource.label(
+                for: .branch(ExistingBranch(name: "figma-mcp-check", isLocal: false)),
+                baseBranch: "main"
+            ) == "on figma-mcp-check"
+        )
+        // A pull request sits on its head, so it reads the same way. The number is on the heading
+        // above the box and on the chip under it; neither of those says whether the worktree lands
+        // on that head or beside it, which is the thing this control has to answer.
+        #expect(
+            WorkspaceSource.label(for: .pullRequest(listing(head: "fix-parser")), baseBranch: "main")
+                == "on fix-parser"
+        )
+    }
+}


### PR DESCRIPTION
The "Start from" menu listed "New branch from <name>" for every branch and filed "Open an existing branch" under all of them, unsearchable. Picking a colleague's branch off the top of it cut a new branch from their head, so the workspace opened empty.

It is a searchable popover now (a `Menu` cannot hold a text field), with two sections: "Open, and carry on" for pull requests and existing branches, "New branch from" underneath. The same branch appears in both on purpose, so the two verbs are chosen with both in view. Arrow keys, Return and Escape, with the row's identity being the thing it names rather than its position.

A branch a live workspace already holds is no longer dropped from the list: it stays, greyed, saying "In use by <workspace>", and selecting it goes to that workspace. Typing or pasting a pull request number or URL offers a row for it.

The button that opens it says `on <branch>` when the workspace will sit on that branch and `from <branch>` when a new branch is cut off it.

The ranking, the offering, the keyboard's step and the button's wording are `WorkspaceSource` in BloomCore, with a suite.