### PR TITLE
Follow the live end instead of teleporting to it

### DIFF
--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -50,6 +50,18 @@ struct TranscriptListView: View {
     /// scroll there in place of the `withAnimation` this used to be one line of.
     @State private var scroller = TranscriptLiveEndScroller()
 
+    /// What keeps the view with the newest row while a turn runs, and turns the last of that
+    /// travel into something the eye can follow. See `TranscriptLiveEndFollower`, which is where
+    /// the rules about whose view it may move are, and `TranscriptFollow`, where the arithmetic
+    /// is. Nothing in this body reads it, on purpose: it writes no SwiftUI state, so following a
+    /// turn costs no pass over this list.
+    @State private var follower = TranscriptLiveEndFollower()
+
+    /// Whether this window is the one in front, which is the whole of what the follower needs it
+    /// for: a display link in a backgrounded app is the battery cost `ActivityDot` carries the
+    /// measurement for, and there is nobody watching the travel.
+    @Environment(\.controlActiveState) private var activeState
+
     /// The unanimated second half of a glide to the live end, if one is owed. See `goToLiveEnd`.
     @State private var catchUp: Task<Void, Never>?
 
@@ -64,6 +76,21 @@ struct TranscriptListView: View {
     /// turning up in front of the reader: it is the pane being pointed somewhere else. See
     /// `trackArrivals` and the `task` below, which is where a session stops arriving.
     @State private var arrivalSession: SessionID?
+
+    /// Where this session was opened, so the reveal can put it back there once the history has
+    /// landed under it. See `position` and the reveal in `task`.
+    ///
+    /// Three openings and only one of them is the live end: a session opened on an unread mark or
+    /// on a row somebody searched for was opened where the reader asked to be, and putting it back
+    /// means putting it back THERE. The reveal used to say the live end whatever had been chosen,
+    /// which was wrong for two of the three and did nothing at all for the third.
+    private enum Opening: Equatable {
+        case liveEnd
+        /// A row, and where in the pane it was put.
+        case row(Int, UnitPoint)
+    }
+
+    @State private var opening: Opening?
 
     /// The session whose history has been put back, if any. See `visibleRows`.
     ///
@@ -311,7 +338,10 @@ struct TranscriptListView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 // Inside the content, so the scroll view behind the transcript can be found by
                 // walking up from it. See `TranscriptScrollBridge`.
-                .background(TranscriptScrollBridge(scroller: scroller).frame(width: 0, height: 0))
+                .background(
+                    TranscriptScrollBridge(scroller: scroller, follower: follower)
+                        .frame(width: 0, height: 0)
+                )
             }
             // A conversation shorter than the pane starts at the top of it, and only once there is
             // more of it than fits does the view sit at the live end.
@@ -329,16 +359,25 @@ struct TranscriptListView: View {
             // is longer than the pane, which is the case this one never sees.
             .defaultScrollAnchor(.top, for: .alignment)
             .scrollPosition($scrollPosition)
-            // What keeps the view at the live end while a turn runs, and it replaces a `scrollTo`
-            // that used to be issued on every row that arrived. Any scroll that names a position
-            // inside a `LazyVStack` has to build and measure every row between the viewport and
-            // that position, so following a turn re-rendered the entire transcript per row. An
-            // anchor asks for none of that.
+            // Held for the reader who has scrolled away, and not for the following.
             //
-            // Nil while the user has scrolled away, which is the whole of the rule that scroll
-            // used to enforce by hand. Yanking someone back down as they read something further up
-            // is the single most irritating thing a live log can do, and an absent anchor leaves
-            // them exactly where they are.
+            // This was put here as what keeps the view at the live end while a turn runs, in place
+            // of a `scrollTo` issued on every row that arrived: any scroll that names a position
+            // inside a `LazyVStack` has to build and measure every row between the viewport and
+            // that position, so following a turn re-rendered the entire transcript per row, and an
+            // anchor asks for none of that. The argument holds. What does not is that the anchor
+            // is what does the following. Measured on macOS 27.0 against a hosted `ScrollView` of
+            // four thousand rows, with a `.scrollPosition` and without one, over a lazy stack and
+            // an eager one, forced to `.bottom` and left to the flag below: appending a row moved
+            // the content and never the offset, in any of the eight. What actually holds the view
+            // at the end is the `ScrollPosition` above standing at `.bottom`, which does it in the
+            // same layout pass that grows the content, and `TranscriptLiveEndFollower`, which
+            // turns the last of that into something the eye can follow.
+            //
+            // It stays because it says the right thing and costs nothing: nil while the user has
+            // scrolled away, which is the rule the per-row scroll used to enforce by hand. Yanking
+            // someone back down as they read something further up is the single most irritating
+            // thing a live log can do.
             .defaultScrollAnchor(geometry.isNearBottom ? .bottom : nil, for: .sizeChanges)
             .onScrollGeometryChange(for: TranscriptGeometry.self, of: Self.measure) { _, new in
                 geometry = new
@@ -366,6 +405,21 @@ struct TranscriptListView: View {
             .onChange(of: transcript.rows.count, initial: true) { _, _ in
                 position(proxy)
                 trackArrivals()
+                // A row has landed, so the end of the content has moved. Between rows the tail
+                // grows without any of this being told, which is what `isStreaming` below is for.
+                follower.nudge()
+            }
+            // The three things that decide whether the follower may move anything, said out loud
+            // rather than read from a body: it writes no state and reads none, so nothing else
+            // would ever tell it. See `TranscriptLiveEndFollower`.
+            .onChange(of: transcript.isStreaming, initial: true) { _, streaming in
+                follower.isStreaming = streaming
+            }
+            .onChange(of: activeState, initial: true) { _, state in
+                follower.isFrontmost = state != .inactive
+            }
+            .onChange(of: reduceMotion, initial: true) { _, reduced in
+                follower.travels = TranscriptFollow.travels(reduceMotion: reduced)
             }
             // Asked for by the jump pill, and an edge rather than a row on purpose: the list is
             // drawing the end of the session and may not be holding the row a seq names yet.
@@ -375,8 +429,10 @@ struct TranscriptListView: View {
             .onChange(of: transcript.session.id) { _, _ in
                 // Nothing owed to a conversation the pane has left.
                 scroller.stop()
+                follower.stop()
                 catchUp?.cancel()
                 didPosition = false
+                opening = nil
                 expanded.removeAll()
                 // A session opens at its live end whatever the one being left was scrolled to,
                 // and the anchor is read before the new rows arrive.
@@ -397,6 +453,16 @@ struct TranscriptListView: View {
                 arrivalSession = nil
             }
             .task(id: transcript.session.id) {
+                // Said before anything is awaited, because the first row can land inside the load
+                // below. See `TranscriptLiveEndFollower.onRest`: the first frame the follower
+                // steps takes SwiftUI's own hold on the live end down, and this is what gives it
+                // back when the travel is over.
+                //
+                // The scroll position's own box rather than `settleAtLiveEnd`, which would be one
+                // character shorter and would capture this view. The view holds the follower, the
+                // follower would hold the closure, and a pane torn down mid turn would leave both
+                // of them behind. A `State` box is not a view and closes no circle.
+                follower.onRest = { [box = _scrollPosition] in box.wrappedValue.scrollTo(edge: .bottom) }
                 await transcript.load()
                 // Whatever the session arrived with, taken in without a fade. This runs whether
                 // or not the row count changed, which matters: two sessions can hold the same
@@ -423,24 +489,45 @@ struct TranscriptListView: View {
                 try? await Task.sleep(for: .milliseconds(100))
                 guard !Task.isCancelled else { return }
                 drawnInFull = transcript.session.id
-                // And the live end again, in the same breath.
+                // Not an arrival. See `TranscriptLiveEndFollower.forget`.
+                follower.forget()
+                // And the live end again, in two calls, in two passes.
                 //
-                // The size-change anchor is what holds the view still while the history lands,
-                // and it is only in force while `isNearBottom` says the user is following along.
-                // On the first visit of a launch that is not reliably true at this instant: the
-                // rows arrive into a scroll view that is already on screen and already empty, so
-                // there is a pass where the content is tall and the offset is still zero, the
-                // measurement says the user is a long way from the end, and the anchor is dropped
-                // for exactly as long as it takes the arrival to scroll itself down. Growing the
-                // content by four thousand rows with no anchor moved the viewport into a part of
-                // the stack that is not realised, and the transcript went blank and stayed blank.
-                // Filmed: rendered at 620ms, gone at 700ms, still gone three seconds later.
+                // **This is the "the chat text is gone" bug, and it is a fact about
+                // `ScrollPosition` rather than about anchors.** Growing the content by four
+                // thousand rows leaves the viewport where the tail's own end was, which is now a
+                // couple of per cent down a document twenty-five times taller, over rows the lazy
+                // stack has not realised: the transcript goes blank and stays blank. Filmed at the
+                // time: rendered at 620ms, gone at 700ms, still gone three seconds later. The line
+                // that was here to fix it, one `scrollTo(edge: .bottom)`, could not: a
+                // `ScrollPosition` is a VALUE, and asking it for the edge it already names is not
+                // a change, so SwiftUI has nothing to apply.
                 //
-                // A session that has just been arrived at is at its live end by construction, so
-                // saying so again costs nothing and cannot be wrong. It is not a second walk over
-                // the rows either: the anchor has already moved the viewport, and this only names
-                // the edge it is already on.
-                scrollPosition.scrollTo(edge: .bottom)
+                // Which is why it looked fixed. Arriving from another workspace, the position had
+                // been moved off `.bottom` by the session being left, so the reassert was a real
+                // change and landed. Coming back to a chat tab from an All changes tab, the pane
+                // is built from nothing, the state starts at `ScrollPosition(edge: .bottom)` from
+                // its own initialiser and is never moved off it, and the same line does nothing at
+                // all. That is the "sometimes".
+                //
+                // Measured on a hosted `ScrollView` of four thousand rows, driven through exactly
+                // this sequence: `scrollTo(edge: .bottom)` alone left the offset at the tail's
+                // 4,100 of 239,300; a point named first and the edge named in the NEXT update
+                // landed on 239,300 every time. Two updates, because both calls in one pass net
+                // out to the same value and change nothing. The point itself moves nothing: it is
+                // resolved against the content as it was before this pass, so it names where the
+                // view already is, and it exists only to stop the edge being the value the state
+                // already held.
+                //
+                // A row needs none of that, because `ScrollViewProxy.scrollTo` is a call rather
+                // than a value and always acts, which is why the two openings are said through
+                // one place that knows the difference. See `open`.
+                if opening == .liveEnd {
+                    scrollPosition.scrollTo(y: .greatestFiniteMagnitude)
+                    await Task.yield()
+                    guard !Task.isCancelled else { return }
+                }
+                open(opening, with: proxy)
                 // The session has finished arriving, so from here on a row that turns up is a row
                 // the reader is watching turn up. The history that just landed is not one of them:
                 // it was never absorbed, so every one of those rows latches at full opacity on the
@@ -476,6 +563,12 @@ struct TranscriptListView: View {
                     scroller.stop()
                     catchUp?.cancel()
                 }
+                // The follower is paused rather than stopped, and for deceleration too: a flick
+                // that lands near the live end is still the reader's own movement, and something
+                // pulling the last few points out from under the momentum is the same
+                // interruption a drag would be. `.animating` is this app's own travel, which is
+                // the one phase that is not somebody taking hold.
+                follower.isPaused = phase != .idle && phase != .animating
             }
             .overlay {
                 if showsPlaceholder {
@@ -650,7 +743,8 @@ struct TranscriptListView: View {
     ///
     /// Both of these resolve a position inside a `LazyVStack`, which is the expensive kind of
     /// scroll: it realises every row it passes. So it happens once per session rather than once
-    /// per row that arrives, and keeping up with a running turn is the size-change anchor's job.
+    /// per row that arrives, and keeping up with a running turn is `TranscriptLiveEndFollower`'s
+    /// job.
     private func position(_ proxy: ScrollViewProxy) {
         guard !transcript.rows.isEmpty, !didPosition else { return }
         didPosition = true
@@ -659,14 +753,36 @@ struct TranscriptListView: View {
         // screen asked for that line, and taking them to their unread mark or to the live end
         // instead would be the app finding the answer and then hiding it again. Centred rather
         // than at the top, because the sentence usually needs the turn around it to make sense.
+        //
+        // Which of the three it was is written down as it is chosen, because the history landing
+        // behind this a moment later moves everything on screen and the view has to be put back
+        // where it was put. See the reveal in `task`.
         if let target = app.takeTranscriptTarget(for: transcript.workspace.id) {
-            proxy.scrollTo(target.seq, anchor: .center)
+            opening = .row(target.seq, .center)
         } else if let unread = transcript.firstUnreadSeq, unread != transcript.rows.first?.seq {
-            proxy.scrollTo(unread, anchor: .top)
+            opening = .row(unread, .top)
         } else {
-            scrollPosition.scrollTo(edge: .bottom)
+            opening = .liveEnd
         }
+        open(opening, with: proxy)
         Task { await transcript.markAllRead() }
+    }
+
+    /// Puts the view where the session was opened.
+    ///
+    /// Said twice: once as the session arrives, and once more when its history has gone back in
+    /// behind the tail, because that grows the content above the viewport and leaves it looking at
+    /// something else entirely. See the reveal in `task` for why the live end takes two calls to
+    /// say and a row takes one.
+    private func open(_ opening: Opening?, with proxy: ScrollViewProxy) {
+        switch opening {
+        case .row(let seq, let anchor):
+            proxy.scrollTo(seq, anchor: anchor)
+        case .liveEnd:
+            scrollPosition.scrollTo(edge: .bottom)
+        case nil:
+            break
+        }
     }
 
     // MARK: Arrivals

--- a/Sources/Bloom/Views/Transcript/TranscriptLiveEndFollow.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptLiveEndFollow.swift
@@ -1,0 +1,215 @@
+import AppKit
+import BloomCore
+import QuartzCore
+import SwiftUI
+
+/// Keeps the transcript with the newest row while a turn runs, and makes the last of that travel
+/// something the eye can follow instead of a jolt.
+///
+/// **The rules are `TranscriptFollow`'s and the frames are here.** What this file owns is when the
+/// following is on at all, and one measurement about SwiftUI that the shape of it depends on.
+///
+/// ## Why this is not a `withAnimation` on the scroll position
+///
+/// For the same reason `TranscriptLiveEndScroller` is not, and that file carries the frame timings
+/// that settled it: on a long transcript SwiftUI's own animated scroll delivered a fifth of the
+/// frames the display wanted at six times the main-thread cost of stepping the clip view by hand.
+/// This one has a second reason on top of that. It runs while a turn streams, which is many
+/// content changes a second, and a state write per frame would re-run the list's body and rebuild
+/// every realised row with it. Nothing here writes any SwiftUI state at all: it reads two heights
+/// off AppKit and sets an origin, and `onScrollGeometryChange` picks the result up as if the
+/// reader had scrolled there themselves, so the jump pill and the size-change anchor keep working
+/// off exactly the numbers they already did.
+///
+/// ## The take-back, and why it is the shape of the thing
+///
+/// A `ScrollPosition` standing at `.bottom` keeps the view pinned to the end as the content grows,
+/// in the same layout pass that grows it. There is nothing to animate after that: by the time any
+/// frame is drawn the view is already at the end. So the travel has to be made rather than
+/// intercepted, and that is what `TranscriptFollow.start` is: on the frame that sees the content
+/// grow, the view is put back by what arrived, capped, and then travels forward to the end again.
+/// One frame of the pinned position may be shown before the take-back lands, which at 120Hz is
+/// eight milliseconds and has no visible width.
+///
+/// It costs nothing when SwiftUI does not pin. Then the view is simply behind the end by what
+/// arrived, `start` leaves it there, and the same approach carries it forward. Both worlds end up
+/// travelling the same distance at the same rate.
+///
+/// ## What turns it off
+///
+/// Reduce Motion, which drops the travel rather than slowing it, the way every other movement in
+/// this app does, and which is `TranscriptFollow.travels` rather than a reading of the setting
+/// taken here. A window that is not in front, because a display link in a backgrounded app is
+/// the battery bug `ActivityDot` carries the measurement for and there is nobody watching the
+/// travel anyway. A hand on the wheel, because a view that goes on dragging somebody somewhere
+/// after they have taken hold of it is the worst thing this file could do. And a quiet transcript:
+/// the link is only up while a turn is streaming or for a moment after a row lands, so a session
+/// nobody is running costs nothing at all.
+@MainActor
+final class TranscriptLiveEndFollower {
+    /// Weak, because the scroll view belongs to the view hierarchy and holding it here would keep
+    /// a pane's worth of realised rows alive after the pane has gone. See `TranscriptScrollBridge`.
+    weak var scrollView: NSScrollView? {
+        didSet { if scrollView !== oldValue { lastHeight = 0 } }
+    }
+
+    /// Whether a turn is streaming into this transcript. The tail grows without any row landing,
+    /// so this is what keeps the link up between rows.
+    var isStreaming = false { didSet { refresh() } }
+
+    /// Whether this window is the one in front. See the header.
+    var isFrontmost = true { didSet { refresh() } }
+
+    /// Whether the reader has hold of the view. Anything that is not an idle scroll phase.
+    var isPaused = false { didSet { refresh() } }
+
+    /// Whether there is a travel to make at all, which is `TranscriptFollow.travels` and is about
+    /// Reduce Motion. False leaves the transcript with the instant pin it has always had.
+    var travels = true { didSet { refresh() } }
+
+    /// Called when the following stops with the view at the end, so the caller can hand SwiftUI
+    /// its standing instruction back.
+    ///
+    /// **This is not tidiness, it is what stops the transcript falling behind when the following
+    /// is off.** Measured against a hosted `ScrollView` whose `ScrollPosition` was standing at
+    /// `.bottom`: content growing kept the view at the end, to the point, until the clip view was
+    /// moved by hand, and from that moment on it never kept it again. SwiftUI takes a position it
+    /// did not make as the reader having scrolled, which is exactly right and is why the pill
+    /// works, but it means the first frame this follower steps also puts SwiftUI's own following
+    /// down. So when the travel is over, whoever owns the scroll position says the edge again, and
+    /// the instant pin is back for the window that is behind another app, the reader who has asked
+    /// for less movement, and the quiet transcript nobody is running.
+    ///
+    /// Only at the end, and never mid travel: naming the edge from anywhere else is a jump, and
+    /// the reader who has just taken hold of the view is precisely who must not be given one.
+    var onRest: (@MainActor () -> Void)?
+
+    /// How long a row landing keeps the link up on its own.
+    ///
+    /// Long enough for the travel it started to finish, which `TranscriptFollow` settles in about
+    /// a quarter of a second, plus room for the next row of the same turn to land into the same
+    /// link rather than starting another. The cost of being generous is a few frames of reading
+    /// two numbers.
+    private static let grace: Double = 0.5
+
+    private var link: CADisplayLink?
+    private var deadline: CFTimeInterval = 0
+    private var lastFrame: CFTimeInterval = 0
+    /// The document height the last frame saw, which is how growth is noticed without anything
+    /// having to report it. Nought means "not measured yet", so the first frame after attaching
+    /// to a scroll view never reads a pane's worth of content as an arrival.
+    private var lastHeight: CGFloat = 0
+
+    /// A row has landed. Keeps the following up for a moment even if nothing is streaming.
+    func nudge() {
+        deadline = CACurrentMediaTime() + Self.grace
+        refresh()
+    }
+
+    /// Ends the following and forgets what it had measured. What a session change calls: the next
+    /// transcript's first frame must not read the difference between two conversations as content
+    /// arriving.
+    func stop() {
+        deadline = 0
+        forget()
+        // Without the handback: a conversation the pane has left is owed nothing, and naming an
+        // edge on the way out would land on whichever session arrives next.
+        dropLink()
+    }
+
+    /// Forgets the height it had measured, without ending anything.
+    ///
+    /// What the history reveal calls. Putting a session's whole history back behind its tail grows
+    /// the document by everything above the viewport in one pass, and that is the pane being
+    /// filled in rather than a line arriving in front of the reader. Re-baselining on the next
+    /// frame is the difference between that landing silently, which is the intention, and the
+    /// arrival of a workspace ending on a settle nobody asked for.
+    func forget() {
+        lastHeight = 0
+    }
+
+    // MARK: - The link
+
+    private var wants: Bool {
+        guard travels, isFrontmost, !isPaused, scrollView != nil else { return false }
+        return isStreaming || CACurrentMediaTime() < deadline
+    }
+
+    private func refresh() {
+        if wants { startLink() } else { endLink() }
+    }
+
+    private func startLink() {
+        guard link == nil, let scrollView else { return }
+        lastFrame = 0
+        let created = scrollView.contentView.displayLink(target: self, selector: #selector(step))
+        created.add(to: .main, forMode: .common)
+        link = created
+    }
+
+    /// Ends the link and, if the view is sitting at the end, hands SwiftUI its standing bottom
+    /// edge back. See `onRest`.
+    private func endLink() {
+        guard dropLink(), isAtEnd else { return }
+        onRest?()
+    }
+
+    /// Takes the link down, and says whether there was one. Nothing else.
+    @discardableResult
+    private func dropLink() -> Bool {
+        guard link != nil else { return false }
+        link?.invalidate()
+        link = nil
+        return true
+    }
+
+    private var isAtEnd: Bool {
+        guard let scrollView, let document = scrollView.documentView else { return false }
+        let clip = scrollView.contentView
+        return document.bounds.height - clip.bounds.height - clip.bounds.origin.y
+            <= TranscriptFollow.arrived
+    }
+
+    @objc private func step(_ sender: CADisplayLink) {
+        MainActor.assumeIsolated {
+            guard wants, let scrollView, let document = scrollView.documentView else { return endLink() }
+            // Flipped is what every scroll view in this app is, SwiftUI's included, but it is
+            // asked rather than assumed: unflipped, the end of the document is at the origin and
+            // everything below would be aimed the wrong way. See `TranscriptLiveEndScroller`.
+            guard document.isFlipped else { return endLink() }
+
+            let clip = scrollView.contentView
+            let now = CACurrentMediaTime()
+            let frame = lastFrame > 0 ? now - lastFrame : 0
+            lastFrame = now
+
+            // The clip view's own height, not the scroll view's frame: an inset or a ruler makes
+            // those different, and the one that decides how far the document can go is the area
+            // showing it.
+            let height = document.bounds.height
+            let end = height - clip.bounds.height
+            var offset = clip.bounds.origin.y
+
+            if lastHeight > 0, height > lastHeight {
+                offset = TranscriptFollow.start(offset: offset, end: end, grew: height - lastHeight)
+            }
+            lastHeight = height
+
+            switch TranscriptFollow.step(offset: offset, end: end, frame: frame) {
+            case .rest:
+                // The take-back still has to land even on a frame with no travel left in it,
+                // which is the frame a row lands on when the display link is running late.
+                if offset != clip.bounds.origin.y { put(offset, in: clip, of: scrollView) }
+            case .settle(let next):
+                put(next, in: clip, of: scrollView)
+            }
+
+            if !isStreaming, now >= deadline { endLink() }
+        }
+    }
+
+    private func put(_ y: CGFloat, in clip: NSClipView, of scrollView: NSScrollView) {
+        clip.setBoundsOrigin(NSPoint(x: clip.bounds.origin.x, y: y))
+        scrollView.reflectScrolledClipView(clip)
+    }
+}

--- a/Sources/Bloom/Views/Transcript/TranscriptLiveEndScroll.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptLiveEndScroll.swift
@@ -118,6 +118,10 @@ final class TranscriptLiveEndScroller {
 /// than a descendant of it, so it would answer nil, or find the composer's.
 struct TranscriptScrollBridge: NSViewRepresentable {
     let scroller: TranscriptLiveEndScroller
+    /// The other thing that moves this scroll view: what keeps up with a running turn. Fed from
+    /// here rather than from a bridge of its own, so there is one view planted in the content and
+    /// one answer about which scroll view the transcript is in.
+    let follower: TranscriptLiveEndFollower
 
     func makeNSView(context: Context) -> NSView {
         let view = NSView(frame: .zero)
@@ -129,7 +133,14 @@ struct TranscriptScrollBridge: NSViewRepresentable {
         // Every layout pass rather than once on attach. The pane is reused for every workspace the
         // window visits and SwiftUI is free to rebuild the hosting scroll view underneath it, so a
         // reference taken once goes stale in exactly the case that matters.
+        //
+        // It is also the only chance either of these gets. Measured against a bare hosted
+        // `ScrollView`, `enclosingScrollView` is nil on the first update, because the
+        // representable's view is created before it is put in the hierarchy: the scroll view is
+        // there from the second update on. Anything that took the reference once, on attach, would
+        // hold nil for ever and every travel below would silently fall back to a jump.
         let found = nsView.enclosingScrollView
         if scroller.scrollView !== found { scroller.scrollView = found }
+        if follower.scrollView !== found { follower.scrollView = found }
     }
 }

--- a/Sources/BloomCore/TranscriptFollow.swift
+++ b/Sources/BloomCore/TranscriptFollow.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// How the transcript keeps up with content arriving at the live end.
+///
+/// **This is about the reader who is already at the end.** Somebody who has scrolled up to read
+/// something is nobody's business but their own: `ScrollEnd` says who is at the end, the jump pill
+/// says there is more below, and nothing here ever moves a view that is further from the end than
+/// `ScrollEnd.threshold`. That one rule is what makes the rest of this safe.
+///
+/// ## Why a settle rather than a step per row
+///
+/// A line landing under a reader who is at the end used to put the view at the end in a single
+/// frame, and what that reads as is the whole conversation jolting upwards by a row. The eye is
+/// mid sentence and the sentence moves. A short travel over the same distance says the same thing
+/// and lets the eye ride it.
+///
+/// ## Why an exponential approach rather than a curve with a length
+///
+/// Because the target moves. A delta is a handful of characters arriving many times a second, and
+/// an animation with a start, an end and a duration has to be restarted every time the end of the
+/// content moves, which is an animation that never arrives. An exponential approach has no
+/// duration to restart: it is a rule about this frame only, so a growth that lands mid travel
+/// simply moves the target and the same travel carries on towards the new one. That is the whole
+/// of the coalescing, and there is no window to tune.
+///
+/// The lag it settles at is worth stating, because it is what stops this needing a rate limit of
+/// its own. Content growing steadily at `r` points a second leaves the view `r * timeConstant`
+/// points behind, so at a fifth of a second per line of prose the view trails by a couple of
+/// points, and it would take growth of well over a thousand points a second to trail by the
+/// `ScrollEnd.threshold` that would put the jump pill up. Nothing an agent prints does that.
+public enum TranscriptFollow {
+    /// How far back the view is put when content lands under a reader who is at the end, in
+    /// points, and therefore how much travel there is to watch.
+    ///
+    /// **Three quarters of `ScrollEnd.threshold`, and it is a ceiling rather than a distance.** A
+    /// row is put back by its own height so that what the eye was reading stays where it was, but
+    /// a tool result unfolding or a forty line answer landing whole would otherwise put the reader
+    /// most of a pane behind and then drag them through it, which is a tour rather than a settle.
+    /// Capped here, the far end of a tall row's arrival is what gets travelled and the rest of it
+    /// is simply where it lands.
+    ///
+    /// Under the threshold rather than at it, because the pill is drawn from a measurement that
+    /// can be a frame stale: at exactly the threshold a full take-back would read as "not at the
+    /// end" for as long as it took to travel, and the offer to jump to the newest row would blink
+    /// on every line that arrived.
+    public static let takeBack: Double = ScrollEnd.threshold * 0.75
+
+    /// How quickly the view closes the gap, as the time constant of the approach.
+    ///
+    /// A twentieth of a second, which puts a full `takeBack` within half a point of the end in
+    /// about a quarter of a second: the same quarter of a second `TranscriptMotion.glideCeiling`
+    /// gives the jump pill's travel, so a line arriving and a press of the pill settle at the same
+    /// pace. Shorter and there is nothing to see; longer and the view is visibly behind the words.
+    public static let timeConstant: Double = 0.05
+
+    /// Within this many points the travel is over. Half a point is under a pixel on every display
+    /// this app runs on, so the last of the approach is spent rather than watched.
+    public static let arrived: Double = 0.5
+
+    /// The smallest step worth taking, in points.
+    ///
+    /// **A device pixel, because a step smaller than one is not a step.** The offset this hands
+    /// back is written to a clip view whose origin is snapped to the backing store, and read back
+    /// on the next frame it is the same number it was: an exponential approach spends its last
+    /// point and a half in steps of a fifth of one, every one of which snaps back to where it
+    /// started. Measured against a real hosted scroll view, the travel stopped a point and a half
+    /// short and stayed there for as long as the link was up, which also means it never reported
+    /// itself as arrived and never handed the live end back.
+    ///
+    /// Never more than what is left, so this cannot overshoot the end.
+    public static let smallestStep: Double = 1
+
+    /// The longest frame this will integrate over.
+    ///
+    /// A display link that has been starved, by a layout pass over a long transcript or by the
+    /// machine being busy, hands back the whole of the gap since the last frame. Integrating that
+    /// literally would jump most of the remaining distance in one step, which is the teleport this
+    /// exists to replace, so a late frame is treated as an ordinary one.
+    public static let longestFrame: Double = 1.0 / 30
+
+    /// Whether this travel is owed at all.
+    ///
+    /// Reduce Motion drops it rather than slowing it, which is what `TranscriptMotion` does with
+    /// every other movement in this app and for the same reason: the setting is about movement,
+    /// and there is no slower version of following a turn worth having. With the travel dropped
+    /// the transcript keeps the instant pin it has always had, which is not a degraded answer.
+    public static func travels(reduceMotion: Bool) -> Bool {
+        !reduceMotion
+    }
+
+    /// What to do with the view this frame.
+    public enum Move: Equatable, Sendable {
+        /// Nothing. Either the view is at the end already, or the reader is somewhere else and it
+        /// is not this type's business.
+        case rest
+        /// Put the view's offset here.
+        case settle(Double)
+    }
+
+    /// Where the travel starts from, when content has just grown under a reader at the end.
+    ///
+    /// Called with what the view grew by since the last frame. A reader who is anywhere but at the
+    /// end is left exactly where they are, which is the same rule `step` follows and is why this
+    /// cannot yank anybody: growth is only ever taken back from somebody who was watching the end
+    /// of it.
+    ///
+    /// It returns the offset unchanged rather than an optional so that a caller cannot honour the
+    /// take-back and skip the guard.
+    public static func start(offset: Double, end: Double, grew: Double) -> Double {
+        guard grew > 0, end > 0 else { return offset }
+        // Only somebody the content has just been pinned under. Mid travel the gap is already
+        // open, and taking it back again would be a second bite of the same arrival.
+        guard end - offset <= arrived else { return offset }
+        return max(0, end - min(grew, takeBack))
+    }
+
+    /// This frame's offset, or `rest`.
+    ///
+    /// `frame` is the time since the last one, in seconds.
+    public static func step(offset: Double, end: Double, frame: Double) -> Move {
+        guard end > 0 else { return .rest }
+        let gap = end - offset
+
+        // Below the end, which is content that has shrunk under the view: a row folded up, a
+        // streaming block replaced by a shorter stored one. There is nothing to watch travelling
+        // backwards, so it is simply put right.
+        guard gap > -arrived else { return .settle(end) }
+        guard gap > arrived else { return .rest }
+        // Somebody reading further up. Not ours, at any distance, ever.
+        guard gap <= ScrollEnd.threshold else { return .rest }
+
+        let elapsed = min(max(frame, 0), longestFrame)
+        guard elapsed > 0 else { return .rest }
+        let travelled = max(gap * (1 - exp(-elapsed / timeConstant)), min(gap, smallestStep))
+        let next = offset + travelled
+        // The last half point is spent rather than watched, and this is also what stops the
+        // approach from asymptoting forever and holding the display link open.
+        return end - next <= arrived ? .settle(end) : .settle(next)
+    }
+}

--- a/Sources/BloomCore/TranscriptMotion.swift
+++ b/Sources/BloomCore/TranscriptMotion.swift
@@ -16,6 +16,10 @@ import Foundation
 /// would be replacing. So the fade belongs to the block rather than to the text, and there is
 /// nothing here to decide per delta: see `StreamingRowView`.
 ///
+/// **Keeping up with the end of a running turn is `TranscriptFollow`**, which is a fourth thing
+/// and is not here: it is a rule about where the view sits rather than about how a row is drawn,
+/// and it has to answer per frame rather than per arrival.
+///
 /// **A session's history does not fade at all.** Eighty rows fading up as a window opens reads as
 /// the app being slow rather than as anything arriving, and it is not work turning up in front of
 /// the reader, it is the pane being pointed somewhere else. That rule is `RowArrival.adopt` and

--- a/Tests/BloomCoreTests/TranscriptFollowTests.swift
+++ b/Tests/BloomCoreTests/TranscriptFollowTests.swift
@@ -1,0 +1,222 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+@Suite("Following the live end")
+struct TranscriptFollowTests {
+    // MARK: - Who this is allowed to move
+
+    /// The whole safety of the mechanism. A reader further from the end than the pill's own
+    /// threshold is reading something, and nothing here may touch them however much arrives.
+    @Test("a reader who has scrolled up is never moved")
+    func leavesAReaderAlone() {
+        let end = 10_000.0
+        for gap in [ScrollEnd.threshold + 1, 200, 3_000, 9_000] {
+            #expect(TranscriptFollow.step(offset: end - gap, end: end, frame: 1 / 60) == .rest)
+        }
+    }
+
+    @Test("a reader who has scrolled up keeps their place when content lands")
+    func doesNotTakeBackFromAReader() {
+        let offset = TranscriptFollow.start(offset: 5_000, end: 10_000, grew: 60)
+        #expect(offset == 5_000)
+    }
+
+    @Test("a view already at the end has nothing to do")
+    func restsAtTheEnd() {
+        #expect(TranscriptFollow.step(offset: 10_000, end: 10_000, frame: 1 / 60) == .rest)
+        #expect(TranscriptFollow.step(offset: 9_999.8, end: 10_000, frame: 1 / 60) == .rest)
+    }
+
+    /// A row folding up, or a streamed block replaced by a shorter stored one. There is nothing
+    /// to watch about travelling backwards.
+    @Test("content that shrinks under the view is put right at once")
+    func snapsBackFromBeyondTheEnd() {
+        #expect(TranscriptFollow.step(offset: 10_400, end: 10_000, frame: 1 / 60) == .settle(10_000))
+    }
+
+    @Test("a pane with nothing to scroll is left alone")
+    func nothingToScroll() {
+        #expect(TranscriptFollow.step(offset: 0, end: 0, frame: 1 / 60) == .rest)
+        #expect(TranscriptFollow.start(offset: 0, end: 0, grew: 60) == 0)
+    }
+
+    /// Dropped rather than slowed, like every other movement in this app. What is left is the
+    /// instant pin the transcript has always had, which is a whole answer rather than a degraded
+    /// one, so this is a Bool and not an absent settle the way `TranscriptMotion.arrival` is.
+    @Test("Reduce Motion is owed no travel")
+    func reduceMotion() {
+        #expect(TranscriptFollow.travels(reduceMotion: false))
+        #expect(!TranscriptFollow.travels(reduceMotion: true))
+    }
+
+    // MARK: - Where the travel starts
+
+    @Test("a row landing under a reader at the end is put back by its own height")
+    func takesBackTheRow() {
+        #expect(TranscriptFollow.start(offset: 10_000, end: 10_000, grew: 22) == 9_978)
+    }
+
+    /// A tool result unfolding, or a long answer landing whole. Travelling all of that would be a
+    /// tour of what just arrived rather than a settle onto it.
+    @Test("a tall arrival is capped rather than travelled in full")
+    func capsTheTakeBack() {
+        let offset = TranscriptFollow.start(offset: 10_000, end: 10_000, grew: 4_000)
+        #expect(offset == 10_000 - TranscriptFollow.takeBack)
+    }
+
+    /// The pill is drawn from a measurement that can be a frame stale, so a full take-back has to
+    /// still read as being at the end by the same rule the pill uses.
+    @Test("a full take-back still counts as being at the end")
+    func takeBackStaysBelowTheThreshold() {
+        let end = 10_000.0
+        let offset = TranscriptFollow.start(offset: end, end: end, grew: 5_000)
+        #expect(
+            ScrollEnd.isAtEnd(contentHeight: end + 700, viewportHeight: 700, offset: offset)
+        )
+    }
+
+    @Test("nothing arriving is nothing to take back")
+    func noGrowthNoTakeBack() {
+        #expect(TranscriptFollow.start(offset: 10_000, end: 10_000, grew: 0) == 10_000)
+    }
+
+    /// The coalescing rule, and the reason this is an approach rather than an animation with a
+    /// length: a second arrival mid travel moves the target and leaves the travel alone.
+    @Test("an arrival mid travel does not start the travel again")
+    func doesNotRestartMidTravel() {
+        let end = 10_000.0
+        let midTravel = end - 40
+        #expect(TranscriptFollow.start(offset: midTravel, end: end, grew: 22) == midTravel)
+    }
+
+    // MARK: - The travel itself
+
+    @Test("the gap closes, monotonically, and arrives")
+    func closesTheGap() {
+        var offset = 10_000 - TranscriptFollow.takeBack
+        let end = 10_000.0
+        var frames = 0
+        var last = offset
+
+        while frames < 240 {
+            guard case .settle(let next) = TranscriptFollow.step(offset: offset, end: end, frame: 1 / 120)
+            else { break }
+            #expect(next > last || next == end)
+            last = next
+            offset = next
+            frames += 1
+            if offset == end { break }
+        }
+
+        #expect(offset == end)
+        // A quarter of a second at 120Hz is thirty frames, and this is the same quarter of a
+        // second the jump pill's travel takes. Generous on both sides: what is being held down is
+        // that it is neither instant nor an effect.
+        #expect(frames > 4)
+        #expect(frames < 60)
+    }
+
+    /// Most of the movement early and the rest of it arriving, which is what makes a short travel
+    /// read as a settle rather than as a slide.
+    @Test("most of the distance goes in the first third")
+    func frontLoaded() {
+        let end = 10_000.0
+        var offset = end - TranscriptFollow.takeBack
+        // A twelfth of a second, which is a third of the quarter second the whole travel takes.
+        for _ in 0..<10 {
+            guard case .settle(let next) = TranscriptFollow.step(offset: offset, end: end, frame: 1 / 120)
+            else { break }
+            offset = next
+        }
+        let covered = (offset - (end - TranscriptFollow.takeBack)) / TranscriptFollow.takeBack
+        #expect(covered > 0.5)
+    }
+
+    /// A display link starved by a layout pass over a long transcript hands back the whole gap
+    /// since the last frame. Integrating that literally is the teleport this exists to replace.
+    @Test("a late frame is not a licence to teleport")
+    func clampsALateFrame() {
+        let end = 10_000.0
+        let offset = end - TranscriptFollow.takeBack
+        guard case .settle(let next) = TranscriptFollow.step(offset: offset, end: end, frame: 4)
+        else {
+            Issue.record("a late frame should still move the view")
+            return
+        }
+        let sameAsAnOrdinaryLongFrame = TranscriptFollow.step(
+            offset: offset, end: end, frame: TranscriptFollow.longestFrame
+        )
+        #expect(sameAsAnOrdinaryLongFrame == .settle(next))
+        #expect(next < end)
+    }
+
+    /// The offset goes to a clip view whose origin is snapped to the backing store, so a step
+    /// under a pixel is read back as no step at all and the same step is computed again for ever.
+    /// Filmed against a real scroll view: the travel sat a point and a half short and stayed
+    /// there. Every step from here to the end has to be worth at least a pixel.
+    @Test("the last point closes rather than halving forever")
+    func closesTheLastPoint() {
+        let end = 10_000.0
+        var offset = end - 1.5
+        var steps = 0
+
+        while steps < 10 {
+            guard case .settle(let next) = TranscriptFollow.step(offset: offset, end: end, frame: 1 / 120)
+            else { break }
+            #expect(next - offset >= min(end - offset, TranscriptFollow.smallestStep) - 0.000_1)
+            offset = next
+            steps += 1
+            if offset == end { break }
+        }
+
+        #expect(offset == end)
+        #expect(steps <= 2)
+    }
+
+    @Test("a step never carries the view past the end")
+    func neverOvershoots() {
+        let end = 10_000.0
+        for gap in stride(from: 0.6, through: TranscriptFollow.takeBack, by: 0.3) {
+            guard case .settle(let next) = TranscriptFollow.step(offset: end - gap, end: end, frame: 1 / 120)
+            else { continue }
+            #expect(next <= end)
+        }
+    }
+
+    @Test("a frame of no time at all moves nothing")
+    func zeroFrame() {
+        let end = 10_000.0
+        #expect(TranscriptFollow.step(offset: end - 40, end: end, frame: 0) == .rest)
+        #expect(TranscriptFollow.step(offset: end - 40, end: end, frame: -1) == .rest)
+    }
+
+    /// The lag a steadily growing tail settles at is `rate * timeConstant`, and it has to stay
+    /// under the threshold that puts the jump pill up, or following a turn would offer to take
+    /// the reader to where they already are.
+    @Test("a streaming tail is followed without ever looking scrolled away")
+    func steadyGrowthStaysAtTheEnd() {
+        var end = 10_000.0
+        var offset = end
+        let frame = 1.0 / 120
+        // Six hundred points a second is faster than any agent prints: about a line of prose
+        // every thirty milliseconds.
+        let rate = 600.0
+
+        for _ in 0..<600 {
+            let grew = rate * frame
+            end += grew
+            offset = TranscriptFollow.start(offset: offset, end: end, grew: grew)
+            if case .settle(let next) = TranscriptFollow.step(offset: offset, end: end, frame: frame) {
+                offset = next
+            }
+            #expect(
+                ScrollEnd.isAtEnd(contentHeight: end + 700, viewportHeight: 700, offset: offset)
+            )
+        }
+
+        // And it is genuinely following rather than sitting still: the lag settles at about
+        // `rate * timeConstant` and never runs away.
+        #expect(end - offset < TranscriptFollow.takeBack)
+    }
+}


### PR DESCRIPTION
The transcript follows a running turn instead of snapping to the end, and coming back to a chat tab no longer loses the conversation.

A line landing under a reader who is at the end used to put the view at the end in the same layout pass that grew the content. Now the view is put back by what arrived, capped at three quarters of `ScrollEnd.threshold`, and travels forward on an exponential approach with a time constant of a twentieth of a second. An approach rather than an animation with a length, because a delta arrives many times a second and a curve with a duration would restart on every one of them and never arrive: the target simply moves and the same travel carries on. The lag it settles at is rate times the time constant, which stays inside the threshold the jump pill is drawn from for growth far faster than an agent prints. `TranscriptFollow` in the core, with tests; `TranscriptLiveEndFollower` runs the frames off AppKit and writes no SwiftUI state, so following a turn costs no pass over the list.

Nobody who has scrolled up is moved, at any distance. Reduce Motion drops the travel and keeps the instant pin, and so does a window that is not in front.

The lost chat text is a fact about `ScrollPosition` rather than about anchors. Switching to a tool tab tears the chat pane down, so it comes back with fresh state, draws the tail and puts the history back behind it a tenth of a second later. That growth strands the viewport over rows the lazy stack has not realised, and the reassert meant to fix it was a no-op: a `ScrollPosition` is a value, and asking it for the edge it already names is not a change. It worked when arriving from another workspace, where the value had moved, and never on a rebuild, where it has not. Measured on a hosted `ScrollView` of four thousand rows: the reassert alone left the offset at 4,100 of 239,300; naming a point first and the edge in the next update landed on 239,300 every time. The same run says the size-change anchor never moved the offset in any of eight variations, so the comment claiming it is what follows a turn now says what does.

The reveal also puts a session back where it was opened rather than at the live end whatever was chosen, which was wrong for an unread mark and for a searched-for row.

The fade needed no change: every stored row already goes through `arrivingRow`.
