### PR TITLE
Stop the inspector redrawing itself, and lex each line once

### DIFF
--- a/Sources/Bloom/Design/HoverRow.swift
+++ b/Sources/Bloom/Design/HoverRow.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// A row that owns its own hover, wrapped around a row that cannot.
+///
+/// Hover used to be one `@State` on the list: `hoveredPath` in `ChangedFileList` and `hovered` in
+/// `FileTreeView`. Crossing a single row boundary is two writes to it, the leave and the enter,
+/// and every write re-ran the whole list's body and rebuilt every row the lazy stack had realised.
+/// Dragging the pointer down a list of forty changed files is eighty full list passes.
+///
+/// The obvious fix is a `@State` inside the row, and it does not work here. Those rows read
+/// `\.isOnEmphasizedSelection` out of their PARENT's environment to invert the marks that carry
+/// meaning (see `ChangedFileRow`), and `RowBackground` puts that value into the environment of the
+/// content it is applied to, so a row that applied `.rowBackground` to itself would be the one
+/// view in the window that could not see it. The state moves one level up instead, into this
+/// wrapper, which paints the fill and tracks the pointer with the row inside it.
+///
+/// Selection stays on the list, where it belongs: one row at a time is selected and the list is
+/// what knows which. Only hover comes down here, because hover is the one that moves per frame.
+struct HoverRow<Content: View>: View {
+    var isSelected: Bool
+    /// Whether the list this row belongs to has keyboard focus. See `RowBackground`.
+    var isFocused: Bool = false
+    /// Held as a value rather than as a closure, so a redraw caused by the pointer arriving
+    /// re-applies the fill to the row it already has instead of building a new one. A row that is
+    /// `Equatable` then costs nothing at all on a hover.
+    var content: Content
+
+    @State private var isHovered = false
+
+    init(isSelected: Bool, isFocused: Bool = false, @ViewBuilder content: () -> Content) {
+        self.isSelected = isSelected
+        self.isFocused = isFocused
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .rowBackground(isSelected: isSelected, isHovered: isHovered, isFocused: isFocused)
+            .onHover { isHovered = $0 }
+    }
+}

--- a/Sources/Bloom/Design/Theme.swift
+++ b/Sources/Bloom/Design/Theme.swift
@@ -876,17 +876,33 @@ struct DiffStatLabel: View {
         .monospacedDigit()
     }
 
+    /// The three styles the counts are set in, composed once rather than per call.
+    ///
+    /// This label draws two numbers for every changed file in the inspector, and a running agent
+    /// rewrites that list every six seconds, so `abbreviate` runs a few hundred times a minute
+    /// while nothing the reader can see has moved.
+    ///
+    /// Not `String(value)` for the plain case, which is what it looks like it could be: `formatted`
+    /// is what makes the digits the reader's own, and a locale that does not use Western digits
+    /// would get Western ones out of the shortcut.
+    private static let plainStyle = IntegerFormatStyle<Int>.number.grouping(.never)
+    private static let thousandsStyle = FloatingPointFormatStyle<Double>.number
+        .precision(.fractionLength(1))
+    private static let wholeThousandsStyle = FloatingPointFormatStyle<Double>.number
+        .precision(.fractionLength(0))
+        .grouping(.never)
+
     /// 2.8k rather than 2793, because the sidebar has no room for the exact number.
     ///
     /// `formatted` rather than `String(format:)`, which is not locale aware: the composer's token
     /// gauge a few inches away already used `formatted`, so on a machine set to a comma decimal
     /// separator one number in this window read `174,0k` and the other `2.8k`.
     static func abbreviate(_ value: Int) -> String {
-        if value < 1_000 { return value.formatted(.number.grouping(.never)) }
+        if value < 1_000 { return value.formatted(plainStyle) }
         let thousands = Double(value) / 1_000
         return thousands < 10
-            ? "\(thousands.formatted(.number.precision(.fractionLength(1))))k"
-            : "\(thousands.formatted(.number.precision(.fractionLength(0)).grouping(.never)))k"
+            ? "\(thousands.formatted(thousandsStyle))k"
+            : "\(thousands.formatted(wholeThousandsStyle))k"
     }
 }
 

--- a/Sources/Bloom/State/ReviewTextHost.swift
+++ b/Sources/Bloom/State/ReviewTextHost.swift
@@ -1,0 +1,32 @@
+import Observation
+import BloomCore
+
+/// Every character being typed into a review, kept away from everything that decides where those
+/// characters are drawn.
+///
+/// The draft and the in-place edits used to be the text and the placement together, on
+/// `WorkspaceModel`: `reviewDrafts[path]` held the spot, the anchor and the sentence so far, and
+/// `reviewEdits[id]` held the rewritten body. Observation is per stored property and not per key,
+/// so a keystroke invalidated every view that had read either dictionary for any reason.
+/// `DiffView.body` reads both, for the spot the editor follows and for whether a band is open, so
+/// each character typed re-ran the whole diff's body and rebuilt every row the lazy stack had
+/// realised. On a diff of a few hundred visible lines that is a redraw per keystroke.
+///
+/// Split, the model keeps what `body` has to ask (which spot the editor is on, which comments are
+/// open) and this object keeps what only the editor row itself reads. Typing now invalidates the
+/// one text view it is being typed into.
+///
+/// It is an object rather than more state on the model for the reason `TranscriptHoverHost` is:
+/// reaching it through a `let` registers no observation at all, so a view that only passes it on
+/// pays nothing, and only the view that reads a key is invalidated when that key changes.
+@MainActor
+@Observable
+final class ReviewTextHost {
+    /// The comment being written on each file's diff, keyed by file path. Where it will attach is
+    /// `WorkspaceModel.reviewDrafts`, and why either outlives the view is written down there.
+    var drafts: [String: String] = [:]
+
+    /// The text of every comment being edited in place, keyed by the comment it belongs to. Which
+    /// ones are open is `WorkspaceModel.reviewEdits`.
+    var edits: [ReviewCommentID: String] = [:]
+}

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -937,18 +937,31 @@ final class WorkspaceModel {
     /// find those four words already committed as a review comment. A draft only joins the
     /// review through Return or the Comment button; until then it waits here, and the editor
     /// reopens holding it when its file is opened again.
+    ///
+    /// Only where it will attach, not what is being typed into it. That is `reviewText`, because
+    /// `DiffView.body` reads this for every pass it makes over the diff and a keystroke must not
+    /// be a reason to make one.
     var reviewDrafts: [String: ReviewDraft] = [:]
 
-    /// The text of every comment currently being edited in place, keyed by the comment it belongs
-    /// to. Here for the same reason `reviewDrafts` is, and the reason is not hypothetical for an
-    /// edit either: the band being edited sits in the same lazy stack, so scrolling it out of
-    /// sight destroys it, and `ReviewPaneView` keys the whole diff by path, so glancing at another
-    /// file destroys it again. An edit held as view state would lose the rewritten sentence to
-    /// either, without a keystroke from the person who typed it.
+    /// Which comments are open for editing in place. Here for the same reason `reviewDrafts` is,
+    /// and the reason is not hypothetical for an edit either: the band being edited sits in the
+    /// same lazy stack, so scrolling it out of sight destroys it, and `ReviewPaneView` keys the
+    /// whole diff by path, so glancing at another file destroys it again. An edit held as view
+    /// state would lose the rewritten sentence to either, without a keystroke from the person who
+    /// typed it.
     ///
-    /// Keyed by id rather than by path because two comments on one file can be open at once, and
-    /// closing one must not take the other's text with it.
-    var reviewEdits: [ReviewCommentID: String] = [:]
+    /// By id rather than by path because two comments on one file can be open at once, and closing
+    /// one must not take the other's text with it.
+    ///
+    /// Which ones are open, not what is in them: the text is `reviewText`, for the reason given on
+    /// `reviewDrafts` above. `DiffView.body` asks this question of every band it lays out.
+    var reviewEdits: Set<ReviewCommentID> = []
+
+    /// What is being typed into the draft and into every open edit. See `ReviewTextHost`.
+    ///
+    /// A `let`, so reading it registers no observation and only the editor row that reads a key
+    /// out of it is invalidated when that key changes.
+    let reviewText = ReviewTextHost()
 
     func reloadReviewComments() async {
         guard let store else { return }
@@ -1015,7 +1028,8 @@ final class WorkspaceModel {
         // A comment that no longer exists cannot be being edited. Left behind, the buffer would
         // be a dictionary that grows for the life of the workspace and, worse, would put the old
         // text back into an editor if the same id were ever seen again.
-        reviewEdits[id] = nil
+        reviewEdits.remove(id)
+        reviewText.edits[id] = nil
     }
 
     /// One alert however many rows were refused, because a database that will not take a delete
@@ -1046,7 +1060,10 @@ final class WorkspaceModel {
         }
         let sent = Set(removed)
         reviewComments.removeAll { sent.contains($0.id) }
-        for id in removed { reviewEdits[id] = nil }
+        for id in removed {
+            reviewEdits.remove(id)
+            reviewText.edits[id] = nil
+        }
         if let refusal { report(refused: refusal) }
     }
 
@@ -1498,11 +1515,10 @@ final class LineBuffer: Sendable {
     }
 }
 
-/// A review comment mid-composition: where it will attach, the evidence captured when its
-/// editor opened, and the text so far. See `WorkspaceModel.reviewDrafts` for why it outlives
-/// the diff view that is editing it.
+/// A review comment mid-composition: where it will attach and the evidence captured when its
+/// editor opened. See `WorkspaceModel.reviewDrafts` for why it outlives the diff view that is
+/// editing it, and `ReviewTextHost` for why the text it is being given is not in here.
 struct ReviewDraft: Hashable {
     var spot: ReviewSpot
     var anchor: ReviewCommentAnchor
-    var text: String = ""
 }

--- a/Sources/Bloom/Views/Center/ReviewPaneView.swift
+++ b/Sources/Bloom/Views/Center/ReviewPaneView.swift
@@ -24,11 +24,22 @@ struct ReviewPaneView: View {
         model.changedFiles.first { $0.path == tab.path }
     }
 
-    private var exists: Bool {
-        !tab.path.isEmpty
-            && FileManager.default.fileExists(
-                atPath: (model.workspace.path as NSString).appendingPathComponent(tab.path)
-            )
+    /// Whether the file is still on disk. Resolved when the path or the changes poll moves, and
+    /// never from `body`: this was a computed property calling `FileManager.fileExists`, and
+    /// `body` runs on every frame of a window resize because `.onGeometryChange` writes
+    /// `paneHeight` as the pane grows. That is a `stat` per frame, on the main thread, for the
+    /// whole of a drag.
+    ///
+    /// Nil until the first answer arrives, and read as "assume it is there", so opening a file
+    /// draws it on the frame it was clicked rather than flashing the sentence that says it is
+    /// gone. A file that really has gone says so a frame later.
+    @State private var exists: Bool?
+
+    private var isPresent: Bool { exists ?? true }
+
+    private struct ExistsID: Hashable {
+        var path: String
+        var generation: Int
     }
 
     /// How tall the whole pane is, which caps how far the composer's divider can be dragged.
@@ -66,6 +77,16 @@ struct ReviewPaneView: View {
             guard let session = model.activeSession else { return }
             model.prepareTranscript(for: session.id)
         }
+        // Keyed on the poll as well as the path, because a file can be deleted underneath a reader
+        // who has not moved: the changes generation is what says the worktree has been looked at
+        // again.
+        .task(id: ExistsID(path: tab.path, generation: model.changesGeneration)) {
+            let path = tab.path
+            let absolute = (model.workspace.path as NSString).appendingPathComponent(path)
+            exists = await Task.detached(priority: .userInitiated) {
+                !path.isEmpty && FileManager.default.fileExists(atPath: absolute)
+            }.value
+        }
     }
 
     /// The conversation a turn sent from here joins: the active session's, which already falls
@@ -83,16 +104,9 @@ struct ReviewPaneView: View {
             // the new file's defaults key.
             DiffView(model: model, file: changed)
                 .id(changed.path)
-        } else if exists, FileMediaView.isMedia(path: tab.path) {
-            // An image, a PDF, a video. `FilePreview` reads a file as text and would say there is
-            // nothing to show, which for the screenshot somebody just attached is both wrong and
-            // the whole reason they clicked.
-            FileMediaView(worktree: model.workspace.path, path: tab.path)
-                .id(tab.path)
-        } else if exists {
-            FilePreview(model: model, path: tab.path)
-                .id(tab.path)
         } else if tab.path.isEmpty {
+            // Asked before the two branches below, because with no path there is nothing to look
+            // for and `isPresent` answers optimistically until the first look comes back.
             EmptyStateView(
                 glyph: "doc.text",
                 title: "No file open",
@@ -100,6 +114,15 @@ struct ReviewPaneView: View {
                     ? "Nothing in this worktree differs from \(model.workspace.baseBranch) yet."
                     : "Pick a file in the inspector to read it here."
             )
+        } else if isPresent, FileMediaView.isMedia(path: tab.path) {
+            // An image, a PDF, a video. `FilePreview` reads a file as text and would say there is
+            // nothing to show, which for the screenshot somebody just attached is both wrong and
+            // the whole reason they clicked.
+            FileMediaView(worktree: model.workspace.path, path: tab.path)
+                .id(tab.path)
+        } else if isPresent {
+            FilePreview(model: model, path: tab.path)
+                .id(tab.path)
         } else {
             // A file the agent deleted, or one that was reverted and then removed. Said plainly
             // rather than left as an empty rectangle, which reads as a failure to load.

--- a/Sources/Bloom/Views/Inspector/ChangedFileGroup.swift
+++ b/Sources/Bloom/Views/Inspector/ChangedFileGroup.swift
@@ -12,12 +12,19 @@ struct ChangedFileGroup: Identifiable {
     var id: String { directory }
 
     /// The directory said once, dimmed, with its files under it in name order.
+    ///
+    /// The names are taken once and sorted beside their files rather than read inside the
+    /// comparator. `ChangedFile.filename` bridges the path to `NSString` on every access, and a
+    /// comparator reads it O(n log n) times, on a list a running agent rewrites every six seconds.
     static func build(from files: [ChangedFile]) -> [ChangedFileGroup] {
         Dictionary(grouping: files, by: \.directory)
             .map { directory, files in
-                ChangedFileGroup(
+                let named = files.map { (name: $0.filename, file: $0) }
+                return ChangedFileGroup(
                     directory: directory,
-                    files: files.sorted { $0.filename.localizedStandardCompare($1.filename) == .orderedAscending }
+                    files: named
+                        .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+                        .map(\.file)
                 )
             }
             .sorted { $0.directory.localizedStandardCompare($1.directory) == .orderedAscending }

--- a/Sources/Bloom/Views/Inspector/ChangedFileList.swift
+++ b/Sources/Bloom/Views/Inspector/ChangedFileList.swift
@@ -14,7 +14,6 @@ import BloomCore
 struct ChangedFileList: View {
     let model: WorkspaceModel
 
-    @State private var hoveredPath: String?
     @State private var pendingRevert: ChangedFile?
     /// A revert that failed, so the user hears about it. It used to be a `try?` that threw the
     /// error away and refreshed the list, which left a file that had not been reverted looking
@@ -174,43 +173,49 @@ struct ChangedFileList: View {
         if let file = item.node.file {
             row(file, depth: item.depth)
         } else {
-            ChangedFolderRow(
-                name: item.node.name,
-                path: item.node.path,
-                isExpanded: !collapsed.contains(item.node.path),
-                depth: item.depth,
-                fullPath: fullPath(item.node.path),
-                action: { toggle(item.node.path) }
-            )
-            .rowBackground(isSelected: false, isHovered: hoveredPath == item.node.path)
+            // The hover is the row's own, and the fill is painted by the wrapper rather than by
+            // the row, for the two reasons `HoverRow` gives.
+            HoverRow(isSelected: false) {
+                ChangedFolderRow(
+                    name: item.node.name,
+                    path: item.node.path,
+                    isExpanded: !collapsed.contains(item.node.path),
+                    depth: item.depth,
+                    fullPath: fullPath(item.node.path),
+                    action: { toggle(item.node.path) }
+                )
+                .equatable()
+            }
             .padding(.horizontal, Metrics.spacingSmall)
-            .onHoverChange { hovering in hover(item.node.path, hovering) }
         }
     }
 
     private func row(_ file: ChangedFile, depth: Int = 0) -> some View {
         let isSelected = model.selectedFilePath == file.path
 
-        return ChangedFileRow(
-            file: file,
-            isSelected: isSelected,
-            fullPath: fullPath(file.path),
-            depth: depth,
-            // Always a selection, never a toggle. Clicking the open row used to close the diff
-            // under the list; there is no diff under the list any more, and a click that
-            // deselected would now close nothing while making the row you just aimed at go quiet.
-            onSelect: {
-                model.selectedFilePath = file.path
-                FileReview.open(path: file.path, in: model)
-                quickLookArm += 1
-            },
-            onRevert: { pendingRevert = file }
-        )
-        // The fill is applied here rather than inside the row so that the row's own body can read
-        // the selection out of the environment and invert its status letter accordingly.
-        .rowBackground(isSelected: isSelected, isHovered: hoveredPath == file.path)
+        // The fill is applied outside the row rather than inside it, so that the row's own body
+        // can read the selection out of the environment and invert its status letter accordingly.
+        // That is also why the hover cannot simply be state on the row: see `HoverRow`.
+        return HoverRow(isSelected: isSelected) {
+            ChangedFileRow(
+                file: file,
+                isSelected: isSelected,
+                fullPath: fullPath(file.path),
+                depth: depth,
+                // Always a selection, never a toggle. Clicking the open row used to close the diff
+                // under the list; there is no diff under the list any more, and a click that
+                // deselected would now close nothing while making the row you just aimed at go
+                // quiet.
+                onSelect: {
+                    model.selectedFilePath = file.path
+                    FileReview.open(path: file.path, in: model)
+                    quickLookArm += 1
+                },
+                onRevert: { pendingRevert = file }
+            )
+            .equatable()
+        }
         .padding(.horizontal, Metrics.spacingSmall)
-        .onHoverChange { hovering in hover(file.path, hovering) }
     }
 
     // MARK: - Actions
@@ -237,10 +242,6 @@ struct ChangedFileList: View {
             collapsed.insert(path)
         }
         rebuild()
-    }
-
-    private func hover(_ path: String, _ hovering: Bool) {
-        hoveredPath = hovering ? path : (hoveredPath == path ? nil : hoveredPath)
     }
 
     private func fullPath(_ relative: String) -> String {

--- a/Sources/Bloom/Views/Inspector/ChangedFileRow.swift
+++ b/Sources/Bloom/Views/Inspector/ChangedFileRow.swift
@@ -7,7 +7,23 @@ import BloomCore
 /// The selection and hover fill is painted by the list, not here, so this row can read
 /// `isOnEmphasizedSelection` and flip the colours that carry meaning. A row that sets the fill on
 /// itself only puts that value into its own children's environment, never into its own body.
-struct ChangedFileRow: View {
+struct ChangedFileRow: View, Equatable {
+    /// A row redraws when what it holds changes, and not because the closures beside it are new
+    /// closures. Both are written at the call site as `{ ... }`, so they are freshly allocated on
+    /// every pass over the list, and functions are never equal to one another: without this
+    /// SwiftUI has to assume every row differs from the one it drew a moment ago, and the whole
+    /// realised list is rebuilt whenever anything above it moves.
+    ///
+    /// Compared on the values, which is everything this row draws from. What the closures do is
+    /// decided by the list from the same `file`, so two of them can never disagree about a row
+    /// they both belong to.
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.file == rhs.file
+            && lhs.isSelected == rhs.isSelected
+            && lhs.fullPath == rhs.fullPath
+            && lhs.depth == rhs.depth
+    }
+
     var file: ChangedFile
     var isSelected: Bool
     /// The file's location in the worktree, for the menu items that hand it to another app.

--- a/Sources/Bloom/Views/Inspector/ChangedFolderRow.swift
+++ b/Sources/Bloom/Views/Inspector/ChangedFolderRow.swift
@@ -11,7 +11,17 @@ import AppKit
 /// Deliberately laid out exactly like `FileTreeRow`, the other tree in the same pane: one glyph
 /// box, then the name. The two used to disagree about the glyph, the gap and the type size, which
 /// made switching tabs look like switching apps.
-struct ChangedFolderRow: View {
+struct ChangedFolderRow: View, Equatable {
+    /// On the values, not on `action`, which is a fresh closure on every pass over the tree. See
+    /// `ChangedFileRow` for the whole of the reason.
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.name == rhs.name
+            && lhs.path == rhs.path
+            && lhs.isExpanded == rhs.isExpanded
+            && lhs.depth == rhs.depth
+            && lhs.fullPath == rhs.fullPath
+    }
+
     var name: String
     var path: String
     var isExpanded: Bool

--- a/Sources/Bloom/Views/Inspector/DiffLineView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffLineView.swift
@@ -5,7 +5,30 @@ import BloomCore
 ///
 /// The same view serves both layouts. Unified asks for both number columns, side by side asks for
 /// one and is given an explicit width so the two panes stay aligned even when a line is empty.
-struct DiffLineView: View {
+struct DiffLineView: View, Equatable {
+    /// A row redraws when what it holds changes, and not because the closure beside it is a new
+    /// closure. `onComment` is written at the call site as `{ beginDraft(at: $0) }`, so it is a
+    /// freshly allocated function on every pass over the diff, and functions are never equal to
+    /// one another: without this SwiftUI has to assume every row differs from the one it drew a
+    /// moment ago, and a diff of a few hundred realised rows rebuilds all of them whenever
+    /// anything at all moves in the view above.
+    ///
+    /// `onComment` is not among the fields compared, and cannot be. Conforming to `View` makes
+    /// this type main actor isolated, `Equatable.==` is a nonisolated requirement, and a function
+    /// type is not `Sendable`, so a `nonisolated ==` may not so much as ask whether the closure is
+    /// nil. It does not need to: whether the `+` is offered at all is decided by `offeredSpot`
+    /// from `line` and `numbers`, both of which are compared, and the two call sites that ask for
+    /// this comparison are the two halves of one diff and always hand it the same kind of closure.
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.line == rhs.line
+            && lhs.language == rhs.language
+            && lhs.carry == rhs.carry
+            && lhs.emphasis == rhs.emphasis
+            && lhs.numbers == rhs.numbers
+            && lhs.width == rhs.width
+            && lhs.isCommented == rhs.isCommented
+    }
+
     /// Which gutters this row shows. Side by side shows one, unified shows both.
     enum Numbers {
         case both

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -32,6 +32,16 @@ struct DiffView: View {
     /// Where every pending comment on this file draws, recomputed by `rebuild` so the bands and
     /// the rows they sit under always come from the same pass. See `ReviewPlacements`.
     @State private var placements: [ReviewPlacement] = []
+    /// Which printed lines wear a comment or the open editor, for the row tint. Assigned in the
+    /// same pass as `placements` above, which is the invariant that pass exists to hold. It was a
+    /// computed property building a `Set` out of `placements`, and `isCommented` reads it once per
+    /// rendered row and twice per row in the split layout, so the set was rebuilt from scratch for
+    /// every line of the diff on every pass.
+    @State private var commentedSpots: Set<ReviewSpot> = []
+    /// Highlighting for the top of the diff, warmed off the main thread. Cancelled when another
+    /// file is presented, because those lines are not the ones anybody is about to read. See
+    /// `prime`.
+    @State private var priming: Task<Void, Never>?
     /// The comment being written on this file, read through the model rather than held as view
     /// state, because everything that edits it outlives this view and this view does not: the
     /// editor row sits in a lazy stack and is destroyed when scrolled away, and the whole view is
@@ -118,6 +128,7 @@ struct DiffView: View {
         .onChange(of: isEditable) { _, editable in
             if !editable { mode = .diff }
         }
+        .onDisappear { priming?.cancel() }
         .alert(
             "Could not revert \(file.filename)",
             isPresented: $revertProblem.isPresent(),
@@ -161,6 +172,7 @@ struct DiffView: View {
     // MARK: Loading
 
     private func load() async {
+        priming?.cancel()
         phase = .loading
         rows = []
         expandedRuns = []
@@ -259,6 +271,33 @@ struct DiffView: View {
         fileLines = model.contents(of: path).map(ReviewCommentAnchor.split)
         phase = .ready(document)
         rebuild()
+        prime(document)
+    }
+
+    /// How much of a diff is highlighted before anybody scrolls to it. Several screens, which is
+    /// what a reader gets through before the cache is warm anyway, and far short of the four
+    /// thousand lines `SyntaxCache` holds across every open file: priming a whole large diff would
+    /// evict what it had just put in, and a diff between that limit and `largeDiffLimit` can
+    /// already thrash it by being scrolled.
+    private static let primeLimit = 600
+
+    /// Highlight the top of the diff off the main thread, so the rows a reader actually reaches
+    /// are a lookup rather than a lex.
+    ///
+    /// Every line was lexed twice. `DiffDocument.prepare` walks the file to thread the carry state
+    /// and throws the tokens away, and then `SyntaxCache` lexed the same line again, on the main
+    /// actor, the first time each row was built. The cache is an `NSCache` and documented thread
+    /// safe for exactly this, so the second pass can happen before the first row is asked for.
+    private func prime(_ document: DiffDocument) {
+        let language = document.language
+        let lines = document.linesToPrime(limit: Self.primeLimit)
+        priming?.cancel()
+        priming = Task.detached(priority: .utility) {
+            for line in lines {
+                guard !Task.isCancelled else { return }
+                _ = SyntaxCache.attributed(line: line.text, language: language, carry: line.carry)
+            }
+        }
     }
 
     /// Quiet explanations for the changes that have no lines to show.
@@ -387,6 +426,10 @@ struct DiffView: View {
                 isCommented: isCommented(line, numbers: .both),
                 onComment: { beginDraft(at: $0) }
             )
+            // Every pass over this diff rebuilds every row the stack has already realised, and a
+            // long file realises hundreds. Comparing the row's own values first is what keeps a
+            // second pass free, and the closure above is why it has to be said: see `DiffLineView`.
+            .equatable()
 
         case let .commentBand(placement):
             ReviewCommentBandView(
@@ -404,9 +447,12 @@ struct DiffView: View {
 
         case .commentEditor:
             ReviewCommentEditorView(
+                // Read out of `reviewText` rather than off the draft, so a keystroke invalidates
+                // this one editor instead of everything that had to ask where the editor is. See
+                // `ReviewTextHost`.
                 text: Binding(
-                    get: { model.reviewDrafts[file.path]?.text ?? "" },
-                    set: { model.reviewDrafts[file.path]?.text = $0 }
+                    get: { model.reviewText.drafts[file.path] ?? "" },
+                    set: { model.reviewText.drafts[file.path] = $0 }
                 ),
                 width: width,
                 onCommit: commitDraft,
@@ -441,6 +487,9 @@ struct DiffView: View {
             isCommented: isCommented(line, numbers: numbers),
             onComment: { beginDraft(at: $0) }
         )
+        // For the reason given at the unified call site above, and twice as much of it: the split
+        // layout builds two of these per row.
+        .equatable()
     }
 
     // MARK: - Review comments
@@ -448,13 +497,6 @@ struct DiffView: View {
     /// The pending comments on this one file, which is all a diff of it can place.
     private var fileComments: [ReviewComment] {
         model.reviewComments.filter { $0.filePath == file.path }
-    }
-
-    /// Every printed line wearing a comment or the open editor, for the row tint.
-    private var commentedSpots: Set<ReviewSpot> {
-        var spots = Set(placements.compactMap(\.spot))
-        if let draftSpot { spots.insert(draftSpot) }
-        return spots
     }
 
     /// The spots one rendered row answers for, filtered the way `DiffLineView.offeredSpot` is,
@@ -490,21 +532,19 @@ struct DiffView: View {
         else { return }
         // A second press while text is pending moves the editor, and the text moves with it:
         // clearing it here would be the same silent loss the model-held draft exists to prevent.
-        model.reviewDrafts[file.path] = ReviewDraft(
-            spot: spot,
-            anchor: anchor,
-            text: draft?.text ?? ""
-        )
+        model.reviewDrafts[file.path] = ReviewDraft(spot: spot, anchor: anchor)
     }
 
     private func cancelDraft() {
         model.reviewDrafts[file.path] = nil
+        model.reviewText.drafts[file.path] = nil
     }
 
     /// Return or the Comment button, and nothing else.
     private func commitDraft() {
         guard let draft else { return }
-        let body = draft.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let body = (model.reviewText.drafts[file.path] ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !body.isEmpty else {
             cancelDraft()
             return
@@ -526,10 +566,13 @@ struct DiffView: View {
     /// scrolling away from it and by walking to another file, and neither is a reason to lose a
     /// rewritten sentence.
     private func editBinding(for id: ReviewCommentID) -> Binding<String>? {
-        guard model.reviewEdits[id] != nil else { return nil }
+        guard model.reviewEdits.contains(id) else { return nil }
+        // Whether the band is open comes off the model, which changes twice per edit; what is in
+        // it comes out of `ReviewTextHost`, which changes on every character. Asking one question
+        // used to answer both, and the answer to the first was rebuilt on every keystroke.
         return Binding(
-            get: { model.reviewEdits[id] ?? "" },
-            set: { model.reviewEdits[id] = $0 }
+            get: { model.reviewText.edits[id] ?? "" },
+            set: { model.reviewText.edits[id] = $0 }
         )
     }
 
@@ -537,14 +580,16 @@ struct DiffView: View {
     /// is in it: the pencil is a point away from the text, and a stray click on it must not be
     /// the thing that resets a paragraph somebody has been rewriting.
     private func beginEdit(of comment: ReviewComment) {
-        guard model.reviewEdits[comment.id] == nil else { return }
-        model.reviewEdits[comment.id] = comment.body
+        guard !model.reviewEdits.contains(comment.id) else { return }
+        model.reviewText.edits[comment.id] = comment.body
+        model.reviewEdits.insert(comment.id)
     }
 
     /// Escape and Cancel. The typed text goes; the comment keeps the body it had. Discarding is
     /// safe here in a way it is not on a click elsewhere, because this is somebody saying so.
     private func cancelEdit(of id: ReviewCommentID) {
-        model.reviewEdits[id] = nil
+        model.reviewEdits.remove(id)
+        model.reviewText.edits[id] = nil
     }
 
     /// Return and Save. What the three answers mean is `ReviewCommentEdit`'s, and a refusal
@@ -552,7 +597,7 @@ struct DiffView: View {
     /// an emptied field is a mistake far more often than it is a request to delete, and the
     /// remove control is right there for when it is not.
     private func commitEdit(of comment: ReviewComment) {
-        guard let typed = model.reviewEdits[comment.id] else { return }
+        guard let typed = model.reviewText.edits[comment.id] else { return }
         switch ReviewCommentEdit.outcome(typed: typed, replacing: comment.body) {
         case .refused:
             return
@@ -632,6 +677,8 @@ struct DiffView: View {
     private func rebuild() {
         guard case let .ready(document) = phase else {
             rows = []
+            placements = []
+            commentedSpots = []
             return
         }
         // Placed in the same pass that lays the rows out, so a band can never survive the row it
@@ -643,6 +690,9 @@ struct DiffView: View {
             currentLines: fileLines,
             revealedNewLines: revealedContextLines(document)
         )
+        var spots = Set(placements.compactMap(\.spot))
+        if let draftSpot { spots.insert(draftSpot) }
+        commentedSpots = spots
         rows = isSideBySide ? splitRows(document) : unifiedRows(document)
 
         // The editor follows its line, and a rebuild can take that line off the screen: a reload

--- a/Sources/Bloom/Views/Inspector/FileHeaderBar.swift
+++ b/Sources/Bloom/Views/Inspector/FileHeaderBar.swift
@@ -34,11 +34,8 @@ struct FileHeaderBar: View {
     /// apportioned, so it dropped the folder while there was still most of a pane to spare.
     @State private var width: CGFloat = 0
 
-    /// Below this the bar keeps the filename and the controls and drops the folder beside it.
-    /// A readable filename, the collapsed control cluster and the pane's own insets, with just
-    /// enough left for a folder worth reading.
-    private static let folderThreshold: CGFloat = 340
-
+    /// Whether this file is holding unsaved edits. Read where the dialog below is built, never
+    /// from `body`: see `UnsavedEditsDot` for what reading it here used to cost.
     private var isDirty: Bool { session.isDirty(absolutePath) }
 
     private var absolutePath: String {
@@ -49,8 +46,9 @@ struct FileHeaderBar: View {
         HStack(spacing: InspectorLayout.gap) {
             FilePathChip(
                 file: file,
-                hasUnsavedEdits: isDirty,
-                showsDirectory: width >= Self.folderThreshold
+                session: session,
+                absolutePath: absolutePath,
+                showsDirectory: FileBarLayout.showsDirectory(width: width)
             )
 
             // Lower priority than the name beside it, so a wide bar spends its slack on

--- a/Sources/Bloom/Views/Inspector/FilePathChip.swift
+++ b/Sources/Bloom/Views/Inspector/FilePathChip.swift
@@ -12,8 +12,12 @@ import BloomCore
 /// costs the row the space a readable folder would have.
 struct FilePathChip: View {
     var file: ChangedFile
-    /// Shown when Edit mode is holding changes that are not on disk yet.
-    var hasUnsavedEdits: Bool
+    /// Where the dot after the name asks whether Edit mode is holding changes that are not on disk
+    /// yet. The question is asked by `UnsavedEditsDot` rather than answered here, so a keystroke
+    /// invalidates the dot instead of the bar this chip sits in.
+    var session: FileEditSession
+    /// The file's absolute path, which is what `FileEditSession` keys on.
+    var absolutePath: String
 
     /// Whether there is room for the folder at all. The bar knows its own width; this view only
     /// ever sees the share of it the layout has already decided to give away.
@@ -39,13 +43,7 @@ struct FilePathChip: View {
                 .lineLimit(1)
                 .truncationMode(.middle)
 
-            if hasUnsavedEdits {
-                Circle()
-                    .fill(Palette.accent)
-                    .frame(width: Metrics.dot, height: Metrics.dot)
-                    .help("Unsaved changes")
-                    .accessibilityLabel("Unsaved changes")
-            }
+            UnsavedEditsDot(session: session, path: absolutePath)
         }
         .help(file.path)
         .accessibilityElement(children: .combine)

--- a/Sources/Bloom/Views/Inspector/FilePreview.swift
+++ b/Sources/Bloom/Views/Inspector/FilePreview.swift
@@ -21,11 +21,6 @@ struct FilePreview: View {
     /// The same cap `FilePathChip` puts on the folder above a diff.
     private static let chipWidth: CGFloat = 170
 
-    /// Below this the bar keeps the filename and the controls and drops the folder beside it.
-    /// The same rule and the same number as `FileHeaderBar`, so the two bars give the folder up at
-    /// the same pane width rather than a few points apart.
-    private static let folderThreshold: CGFloat = 340
-
     @State private var lines: [String] = []
     @State private var carries: [LexState] = []
     @State private var language: Language = .plainText
@@ -115,7 +110,7 @@ struct FilePreview: View {
     /// to say: nothing here has a diff, a revert or two layouts to choose between.
     private var header: some View {
         HStack(spacing: InspectorLayout.gap) {
-            if width >= Self.folderThreshold, !directory.isEmpty {
+            if FileBarLayout.showsDirectory(width: width), !directory.isEmpty {
                 Chip(text: directory)
                     .frame(maxWidth: Self.chipWidth, alignment: .leading)
                     .layoutPriority(-1)
@@ -131,13 +126,7 @@ struct FilePreview: View {
             // holds its text in `FileEditSession` rather than on this view: switching to View,
             // to another file or to another workspace keeps the typing, and the dot is the only
             // thing that says so.
-            if isDirty {
-                Circle()
-                    .fill(Palette.accent)
-                    .frame(width: Metrics.dot, height: Metrics.dot)
-                    .help("Unsaved changes")
-                    .accessibilityLabel("Unsaved changes")
-            }
+            UnsavedEditsDot(session: session, path: absolutePath)
 
             Spacer(minLength: InspectorLayout.tight)
 
@@ -209,8 +198,6 @@ struct FilePreview: View {
                     + "\(FileEditor.sizeLimit / 1_048_576) MB."
         )
     }
-
-    private var isDirty: Bool { session.isDirty(absolutePath) }
 
     private var filename: String { (path as NSString).lastPathComponent }
 
@@ -304,29 +291,54 @@ struct FilePreview: View {
 
         guard !Task.isCancelled else { return }
 
-        let source = model.contents(of: path)
         let detected = Language.detect(path: path)
+        let lineLimit = Self.lineLimit
+        let columnLimit = Self.columnLimit
 
-        guard let source else {
+        // Reading the file, splitting it and measuring its widest line all happen here, in one hop
+        // and off the main actor. The read is the whole file off disk, the split walks all of it,
+        // and the width is a per-character loop over up to five thousand lines: on a large file
+        // that is the window held still for the length of all three. Only the carry pass used to
+        // be moved off, and on a file with no lexer at all that is the one of the four that costs
+        // nothing.
+        let prepared = await Task.detached(priority: .userInitiated) { () -> Prepared? in
+            guard let source = try? String(contentsOfFile: absolute, encoding: .utf8) else {
+                return nil
+            }
+            let all = source.components(separatedBy: "\n")
+            let truncated = all.count > lineLimit
+            let kept = truncated ? Array(all.prefix(lineLimit)) : all
+            return Prepared(
+                lines: kept,
+                carries: CarryPass.states(for: kept, language: detected),
+                maxColumns: min(
+                    kept.reduce(0) { max($0, CodeMetrics.columns(of: $1)) }, columnLimit
+                ),
+                isTruncated: truncated
+            )
+        }.value
+
+        guard !Task.isCancelled else { return }
+
+        guard let prepared else {
             lines = []
             isLoading = false
             return
         }
 
-        let all = source.components(separatedBy: "\n")
-        let truncated = all.count > Self.lineLimit
-        let kept = truncated ? Array(all.prefix(Self.lineLimit)) : all
-
-        let states = await Task.detached(priority: .userInitiated) {
-            CarryPass.states(for: kept, language: detected)
-        }.value
-
-        guard !Task.isCancelled else { return }
-        lines = kept
-        carries = states
+        lines = prepared.lines
+        carries = prepared.carries
         language = detected
-        isTruncated = truncated
-        maxColumns = min(kept.reduce(0) { max($0, CodeMetrics.columns(of: $1)) }, Self.columnLimit)
+        isTruncated = prepared.isTruncated
+        maxColumns = prepared.maxColumns
         isLoading = false
+    }
+
+    /// Everything the reader needs about a file, so the whole of the reading is one hop.
+    private struct Prepared: Sendable {
+        var lines: [String]
+        var carries: [LexState]
+        var maxColumns: Int
+        var isTruncated: Bool
     }
 }

--- a/Sources/Bloom/Views/Inspector/FileTreeRow.swift
+++ b/Sources/Bloom/Views/Inspector/FileTreeRow.swift
@@ -6,7 +6,17 @@ import AppKit
 ///
 /// As with `ChangedFileRow`, the tree paints the selection fill and this row reads it back out of
 /// the environment, which is the only way its own body can invert the marks that carry meaning.
-struct FileTreeRow: View {
+struct FileTreeRow: View, Equatable {
+    /// On the values, not on `action`, which is a fresh closure on every pass over the tree. See
+    /// `ChangedFileRow` for the whole of the reason.
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.item.node == rhs.item.node
+            && lhs.item.depth == rhs.item.depth
+            && lhs.isExpanded == rhs.isExpanded
+            && lhs.isChanged == rhs.isChanged
+            && lhs.fullPath == rhs.fullPath
+    }
+
     var item: FileTreeRowItem
     var isExpanded: Bool
     var isChanged: Bool

--- a/Sources/Bloom/Views/Inspector/FileTreeView.swift
+++ b/Sources/Bloom/Views/Inspector/FileTreeView.swift
@@ -13,7 +13,6 @@ struct FileTreeView: View {
     /// `WorkspaceModel.fileTree`, and the note there for why it cannot live in this view.
     @State private var expanded: Set<String> = []
     @State private var selection: String?
-    @State private var hovered: String?
 
     /// The flattened row list, rebuilt when the listing loads or a folder opens rather than on
     /// every redraw. Walking the index inside `body` meant re-walking it for every layout pass.
@@ -80,20 +79,20 @@ struct FileTreeView: View {
     private func row(_ item: FileTreeRowItem) -> some View {
         let path = item.node.path
 
-        return FileTreeRow(
-            item: item,
-            isExpanded: expanded.contains(path),
-            isChanged: changedPaths.contains(path),
-            fullPath: fullPath(path),
-            action: { activate(item.node) }
-        )
-        // Applied here rather than inside the row, so the row can read the selection back out of
-        // the environment and invert the dot that marks a changed file.
-        .rowBackground(isSelected: selection == path, isHovered: hovered == path)
-        .padding(.horizontal, Metrics.spacingSmall)
-        .onHoverChange { hovering in
-            hovered = hovering ? path : (hovered == path ? nil : hovered)
+        // The fill is applied outside the row rather than inside it, so the row can read the
+        // selection back out of the environment and invert the dot that marks a changed file. That
+        // is also why the hover cannot simply be state on the row: see `HoverRow`.
+        return HoverRow(isSelected: selection == path) {
+            FileTreeRow(
+                item: item,
+                isExpanded: expanded.contains(path),
+                isChanged: changedPaths.contains(path),
+                fullPath: fullPath(path),
+                action: { activate(item.node) }
+            )
+            .equatable()
         }
+        .padding(.horizontal, Metrics.spacingSmall)
     }
 
     // MARK: - Actions

--- a/Sources/Bloom/Views/Inspector/UnsavedEditsDot.swift
+++ b/Sources/Bloom/Views/Inspector/UnsavedEditsDot.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// The dot that says Edit mode is holding text the disk has not got.
+///
+/// Its own view, and it asks the session itself rather than being handed the answer, because
+/// `FileEditSession.drafts` is one `@Observable` dictionary and observation is per stored property
+/// rather than per key. A bar that read `isDirty` from its own body was invalidated by every
+/// keystroke in the editor beside it, which is written down in `SharedDiff` as the reason the
+/// share text is rendered on export. `FileHeaderBar` is the bar in question and it holds a
+/// `ViewThatFits` over three clusters of seven controls, so every character typed measured all
+/// three of them. Asked here, a keystroke redraws a five point circle.
+struct UnsavedEditsDot: View {
+    var session: FileEditSession
+    /// The file's absolute path, which is what `FileEditSession` keys on.
+    var path: String
+
+    var body: some View {
+        if session.isDirty(path) {
+            Circle()
+                .fill(Palette.accent)
+                .frame(width: Metrics.dot, height: Metrics.dot)
+                .help("Unsaved changes")
+                .accessibilityLabel("Unsaved changes")
+        }
+    }
+}

--- a/Sources/BloomCore/DiffDocument.swift
+++ b/Sources/BloomCore/DiffDocument.swift
@@ -101,4 +101,29 @@ public struct DiffDocument: Sendable {
             maxColumns: min(maxColumns, columnLimit)
         )
     }
+
+    /// The printed lines a renderer should highlight before anybody asks for them, each with the
+    /// lexer state it begins in.
+    ///
+    /// Every line of a diff was lexed twice. `prepare` above walks the whole file to thread the
+    /// carry state and throws the tokens away, and then the first time a row was built the view's
+    /// own highlight cache lexed the same line again, on the main thread, while the reader was
+    /// waiting to see it. Handing this list to that cache from a background task turns the first
+    /// draw of every row it covers into a lookup.
+    ///
+    /// Bounded, and deliberately from the top: a reader arrives at the first hunk, and the cache
+    /// this feeds holds a few thousand lines in total across every open file, so priming a whole
+    /// large diff would only evict what it had just put in.
+    public func linesToPrime(limit: Int) -> [(text: String, carry: LexState)] {
+        guard limit > 0 else { return [] }
+        var result: [(text: String, carry: LexState)] = []
+        result.reserveCapacity(limit)
+        for hunk in file.hunks {
+            for line in hunk.lines where line.kind != .noNewline {
+                result.append((line.text, carries[line.index] ?? LexState()))
+                if result.count == limit { return result }
+            }
+        }
+        return result
+    }
 }

--- a/Sources/BloomCore/FileBarLayout.swift
+++ b/Sources/BloomCore/FileBarLayout.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Shared geometry for the bar above an open file, so the two bars that draw it cannot drift.
+///
+/// `FileHeaderBar` sits over a changed file and `FilePreview` draws its own over one nobody
+/// changed, and the reader walks between them by clicking around a single column. The folder
+/// threshold was written out as a `private static let` in each, with a comment in the second
+/// asking whoever changed one to remember the other, which is the arrangement that ends with two
+/// bars giving the folder up a few points apart.
+public enum FileBarLayout {
+    /// Below this the bar keeps the filename and the controls and drops the folder beside it.
+    /// A readable filename, the collapsed control cluster and the pane's own insets, with just
+    /// enough left over for a folder worth reading.
+    public static let folderThreshold: CGFloat = 340
+
+    /// Whether there is room for the containing folder beside the filename.
+    ///
+    /// Asked of the bar's own measured width, never of a `ViewThatFits`: the layout has already
+    /// apportioned the row by the time a fitting view is offered a share of it, so the folder was
+    /// dropped while there was still most of a pane to spare.
+    public static func showsDirectory(width: CGFloat) -> Bool {
+        width >= folderThreshold
+    }
+}

--- a/Sources/BloomCore/SyntaxHighlighter.swift
+++ b/Sources/BloomCore/SyntaxHighlighter.swift
@@ -142,6 +142,10 @@ public enum SyntaxHighlighter {
 private struct Lexer {
     private let units: [UInt16]
     private let language: Language
+    /// Looked up once per line rather than once per identifier. This was a computed property
+    /// returning a freshly built `Set` of up to forty-five strings, read one to three times for
+    /// every identifier scanned, so a thousand line diff rebuilt it tens of thousands of times.
+    private let keywords: Set<String>
     fileprivate var state: LexState
     private var cursor = 0
     private var tokens: [Token] = []
@@ -149,6 +153,7 @@ private struct Lexer {
     init(line: String, language: Language, state: LexState) {
         units = Array(line.utf16)
         self.language = language
+        keywords = Words.keywords(for: language)
         self.state = state
     }
 
@@ -206,7 +211,7 @@ private struct Lexer {
         }
 
         if let multiline = state.multilineString {
-            let delimiter = multiline == .swiftTriple ? ascii("\"\"\"") : ascii("`")
+            let delimiter = multiline == .swiftTriple ? Needles.tripleQuote : Needles.backtick
             if let found = find(delimiter, from: 0) {
                 let end = found + delimiter.count
                 scanInterpolatedBody(
@@ -241,16 +246,16 @@ private struct Lexer {
     private mutating func scanComment() -> Bool {
         let start = cursor
 
-        if language == .blade, matches("{{--", at: cursor) {
+        if language == .blade, matches(Needles.bladeCommentOpen, at: cursor) {
             return scanBlockComment(start: start, openerLength: 4, end: "--}}")
         }
-        if [.html, .xml, .vue, .blade].contains(language), matches("<!--", at: cursor) {
+        if isHTMLLike, matches(Needles.htmlCommentOpen, at: cursor) {
             return scanBlockComment(start: start, openerLength: 4, end: "-->")
         }
-        if supportsSlashComments, matches("/*", at: cursor) {
+        if supportsSlashComments, matches(Needles.blockCommentOpen, at: cursor) {
             return scanBlockComment(start: start, openerLength: 2, end: "*/")
         }
-        if supportsSlashComments, matches("//", at: cursor) {
+        if supportsSlashComments, matches(Needles.lineCommentOpen, at: cursor) {
             cursor = units.count
             add(.comment, start, cursor)
             return true
@@ -261,12 +266,12 @@ private struct Lexer {
             add(.comment, start, cursor)
             return true
         }
-        if language == .sql, matches("--", at: cursor) {
+        if language == .sql, matches(Needles.sqlCommentOpen, at: cursor) {
             cursor = units.count
             add(.comment, start, cursor)
             return true
         }
-        if language == .markdown, matches("[//]:", at: cursor) {
+        if language == .markdown, matches(Needles.markdownCommentOpen, at: cursor) {
             cursor = units.count
             add(.comment, start, cursor)
             return true
@@ -289,20 +294,20 @@ private struct Lexer {
     private mutating func scanLanguageSpecial() -> Bool {
         let start = cursor
 
-        if language == .php, matches("<?php", at: cursor) {
+        if language == .php, matches(Needles.phpOpen, at: cursor) {
             cursor += 5
             add(.punctuation, start, cursor)
             return true
         }
-        if language == .php, matches("<?=", at: cursor) {
+        if language == .php, matches(Needles.phpEchoOpen, at: cursor) {
             cursor += 3
             add(.punctuation, start, cursor)
             return true
         }
-        if language == .php, matches("<<<", at: cursor) {
+        if language == .php, matches(Needles.heredocOpen, at: cursor) {
             return scanHeredoc()
         }
-        if language == .php, matches("#[", at: cursor) {
+        if language == .php, matches(Needles.phpAttributeOpen, at: cursor) {
             cursor += 2
             add(.attribute, start, cursor)
             return true
@@ -313,7 +318,7 @@ private struct Lexer {
             add(.attribute, start, cursor)
             return true
         }
-        if [.swift, .java, .kotlin].contains(language), unit(at: cursor) == 64,
+        if annotationsUseAt, unit(at: cursor) == 64,
            isIdentifierStart(at: cursor + 1) {
             cursor += 2
             while isIdentifierContinue(at: cursor) { cursor += 1 }
@@ -327,10 +332,10 @@ private struct Lexer {
             add(.variable, start, cursor)
             return true
         }
-        if [.php, .blade, .shell].contains(language), unit(at: cursor) == 36 {
+        if variablesUseDollar, unit(at: cursor) == 36 {
             return scanDollarVariable()
         }
-        if language == .markdown, matches("```", at: cursor) {
+        if language == .markdown, matches(Needles.fence, at: cursor) {
             cursor = units.count
             add(.punctuation, start, cursor)
             return true
@@ -389,9 +394,9 @@ private struct Lexer {
     private mutating func scanString() -> Bool {
         let start = cursor
 
-        if language == .swift, matches("\"\"\"", at: cursor) {
+        if language == .swift, matches(Needles.tripleQuote, at: cursor) {
             cursor += 3
-            if let found = find(ascii("\"\"\""), from: cursor) {
+            if let found = find(Needles.tripleQuote, from: cursor) {
                 cursor = found + 3
                 scanInterpolatedBody(from: start, to: cursor, style: .swift)
             } else {
@@ -411,7 +416,7 @@ private struct Lexer {
                 return true
             }
         }
-        if [.javascript, .typescript].contains(language), unit(at: cursor) == 96 {
+        if isJavaScriptLike, unit(at: cursor) == 96 {
             cursor += 1
             if let found = findUnescaped(96, from: cursor) {
                 cursor = found + 1
@@ -461,6 +466,13 @@ private struct Lexer {
     }
 
     private mutating func scanInterpolatedBody(from start: Int, to end: Int, style: InterpolationStyle) {
+        // Composed once for the body rather than inside the loop, which used to build the marker
+        // string and convert it to UTF-16 again for every character of every raw string.
+        let rawMarker: [UInt16]? = if case let .swiftRaw(hashes) = style {
+            ascii("\\" + String(repeating: "#", count: hashes) + "(")
+        } else {
+            nil
+        }
         var part = start
         var index = start
         while index < end {
@@ -471,19 +483,18 @@ private struct Lexer {
                     variableEnd = dollarEnd(at: index, limit: end)
                 }
             case .bracedDollar:
-                if matches("${", at: index) {
+                if matches(Needles.bracedDollarOpen, at: index) {
                     var candidate = index + 2
                     while candidate < end, unit(at: candidate) != 125 { candidate += 1 }
                     variableEnd = candidate < end ? candidate + 1 : end
                 }
             case .swift:
-                if matches("\\(", at: index) {
+                if matches(Needles.swiftInterpolationOpen, at: index) {
                     variableEnd = closingParenthesis(from: index + 2, limit: end)
                 }
-            case let .swiftRaw(hashes):
-                let marker = "\\" + String(repeating: "#", count: hashes) + "("
-                if matches(marker, at: index) {
-                    variableEnd = closingParenthesis(from: index + marker.utf16.count, limit: end)
+            case .swiftRaw:
+                if let rawMarker, matches(rawMarker, at: index) {
+                    variableEnd = closingParenthesis(from: index + rawMarker.count, limit: end)
                 }
             case .none:
                 break
@@ -559,9 +570,9 @@ private struct Lexer {
 
         if keywords.contains(lower) {
             kind = .keyword
-        } else if constants.contains(lower) {
+        } else if Words.constants.contains(lower) {
             kind = .constant
-        } else if types.contains(lower) || word.first?.isUppercase == true {
+        } else if Words.types.contains(lower) || word.first?.isUppercase == true {
             kind = .type
         } else if nextNonWhitespace(after: cursor) == 40 {
             kind = .function
@@ -570,7 +581,7 @@ private struct Lexer {
             kind = .variable
         } else if isHTMLLike, isInsideHTMLTag(at: start) {
             kind = isHTMLTagName(at: start) ? .type : .attribute
-        } else if [.yaml, .toml, .json, .css].contains(language),
+        } else if colonNamesAttribute,
                   nextNonWhitespace(after: cursor) == 58 || nextNonWhitespace(after: cursor) == 61 {
             kind = .attribute
         } else {
@@ -582,22 +593,22 @@ private struct Lexer {
 
     private mutating func scanOperatorOrPunctuation() -> Bool {
         let start = cursor
-        if [.javascript, .typescript].contains(language), unit(at: cursor) == 47,
+        if isJavaScriptLike, unit(at: cursor) == 47,
            shouldStartRegex(), let end = regexEnd(from: cursor) {
             cursor = end
             add(.regex, start, cursor)
             return true
         }
 
-        for text in ["<=>", "===", "!==", "...", "??=", "->", "::", "=>", "==", "!=", "<=", ">=", "&&", "||", "??", "?.", "++", "--", "**", "<<", ">>", "{{", "}}", "{!!", "!!}"] {
-            if matches(text, at: cursor) {
-                cursor += text.utf16.count
+        let value = unit(at: cursor)
+        if operatorNeedleHeads.contains(value) {
+            for needle in operatorNeedles where matches(needle, at: cursor) {
+                cursor += needle.count
                 add(.operator, start, cursor)
                 return true
             }
         }
 
-        let value = unit(at: cursor)
         if asciiOperators.contains(value) {
             cursor += 1
             add(.operator, start, cursor)
@@ -617,10 +628,12 @@ private struct Lexer {
         var index = cursor - 1
         while index >= 0, isWhitespace(at: index) { index -= 1 }
         if index < 0 { return true }
-        if ascii("=(:,![{;?").contains(unit(at: index)) { return true }
+        if regexLeadingUnits.contains(unit(at: index)) { return true }
         let prefix = decode(0, index + 1)
-        let lastWord = prefix.split { !$0.isLetter }.last?.lowercased()
-        return ["return", "case", "throw", "typeof", "delete", "void", "yield"].contains(lastWord)
+        guard let lastWord = prefix.split(whereSeparator: { !$0.isLetter }).last?.lowercased() else {
+            return false
+        }
+        return regexLeadingWords.contains(lastWord)
     }
 
     private func regexEnd(from start: Int) -> Int? {
@@ -644,16 +657,57 @@ private struct Lexer {
         return nil
     }
 
+    // A `switch` rather than a membership test against an array literal, because these are read
+    // once per token and every one of those literals was an allocation.
     private var supportsSlashComments: Bool {
-        ![.python, .ruby, .yaml, .toml, .shell, .sql, .markdown, .plainText].contains(language)
+        switch language {
+        case .python, .ruby, .yaml, .toml, .shell, .sql, .markdown, .plainText: false
+        default: true
+        }
     }
 
     private var hashStartsComment: Bool {
-        [.php, .python, .ruby, .yaml, .toml, .shell].contains(language)
+        switch language {
+        case .php, .python, .ruby, .yaml, .toml, .shell: true
+        default: false
+        }
     }
 
     private var isHTMLLike: Bool {
-        [.html, .xml, .vue, .blade].contains(language)
+        switch language {
+        case .html, .xml, .vue, .blade: true
+        default: false
+        }
+    }
+
+    private var isJavaScriptLike: Bool {
+        switch language {
+        case .javascript, .typescript: true
+        default: false
+        }
+    }
+
+    /// Languages where `@name` introduces an annotation rather than an ordinary operator.
+    private var annotationsUseAt: Bool {
+        switch language {
+        case .swift, .java, .kotlin: true
+        default: false
+        }
+    }
+
+    private var variablesUseDollar: Bool {
+        switch language {
+        case .php, .blade, .shell: true
+        default: false
+        }
+    }
+
+    /// Languages where an identifier followed by `:` or `=` is naming a key.
+    private var colonNamesAttribute: Bool {
+        switch language {
+        case .yaml, .toml, .json, .css: true
+        default: false
+        }
     }
 
     private func isInsideHTMLTag(at index: Int) -> Bool {
@@ -673,38 +727,6 @@ private struct Lexer {
         return unit(at: position) == 47 && unit(at: position - 1) == 60
     }
 
-    private var keywords: Set<String> {
-        switch language {
-        case .php, .blade:
-            ["abstract", "as", "break", "case", "catch", "class", "clone", "const", "continue", "declare", "default", "do", "echo", "else", "elseif", "enum", "extends", "final", "finally", "fn", "for", "foreach", "function", "global", "if", "implements", "include", "instanceof", "interface", "match", "namespace", "new", "private", "protected", "public", "readonly", "require", "return", "static", "throw", "trait", "try", "use", "while", "yield"]
-        case .swift:
-            ["actor", "as", "associatedtype", "async", "await", "break", "case", "catch", "class", "continue", "default", "defer", "do", "else", "enum", "extension", "fallthrough", "for", "func", "guard", "if", "import", "in", "inout", "is", "let", "nonisolated", "private", "protocol", "public", "repeat", "return", "some", "static", "struct", "switch", "throw", "throws", "try", "var", "where", "while"]
-        case .javascript, .typescript:
-            ["async", "await", "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete", "do", "else", "export", "extends", "finally", "for", "from", "function", "if", "import", "in", "instanceof", "interface", "let", "new", "of", "return", "static", "switch", "throw", "try", "typeof", "var", "void", "while", "with", "yield"]
-        case .sql:
-            ["alter", "and", "as", "asc", "begin", "between", "by", "case", "create", "delete", "desc", "distinct", "drop", "else", "end", "exists", "from", "group", "having", "in", "index", "inner", "insert", "into", "is", "join", "left", "like", "limit", "not", "null", "on", "or", "order", "outer", "right", "select", "set", "table", "then", "union", "update", "values", "when", "where"]
-        case .python:
-            ["and", "as", "assert", "async", "await", "break", "class", "continue", "def", "del", "elif", "else", "except", "finally", "for", "from", "global", "if", "import", "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try", "while", "with", "yield"]
-        case .ruby:
-            ["begin", "break", "case", "class", "def", "defined", "do", "else", "elsif", "end", "ensure", "for", "if", "in", "module", "next", "redo", "rescue", "retry", "return", "self", "super", "then", "unless", "until", "when", "while", "yield"]
-        // Control flow and the builtins that declare something, not every command a shell knows.
-        // `echo`, `cd` and `git` are ordinary commands: colouring them would mark most of the
-        // lines in a setup script and tell the reader nothing about which ones branch.
-        case .shell:
-            ["alias", "break", "case", "continue", "declare", "do", "done", "elif", "else", "esac", "eval", "exec", "exit", "export", "fi", "for", "function", "if", "in", "local", "readonly", "return", "select", "set", "shift", "source", "then", "trap", "typeset", "unalias", "unset", "until", "while"]
-        default:
-            ["break", "case", "catch", "class", "const", "continue", "default", "else", "enum", "extends", "false", "final", "for", "fun", "func", "if", "import", "interface", "let", "new", "package", "private", "protected", "public", "return", "static", "struct", "switch", "throw", "true", "try", "var", "void", "while"]
-        }
-    }
-
-    private var types: Set<String> {
-        ["array", "bool", "boolean", "char", "double", "float", "int", "integer", "mixed", "never", "number", "object", "self", "string", "void", "any", "some"]
-    }
-
-    private var constants: Set<String> {
-        ["true", "false", "null", "nil", "none", "undefined", "nan", "inf"]
-    }
-
     private mutating func add(_ kind: TokenKind, _ start: Int, _ end: Int) {
         guard start < end else { return }
         if let last = tokens.last, kind != .plain, last.kind == kind, last.range.upperBound == start {
@@ -717,10 +739,6 @@ private struct Lexer {
     private func unit(at index: Int) -> UInt16 {
         guard index >= 0, index < units.count else { return 0 }
         return units[index]
-    }
-
-    private func matches(_ text: String, at index: Int) -> Bool {
-        matches(ascii(text), at: index)
     }
 
     private func matches(_ needle: [UInt16], at index: Int) -> Bool {
@@ -799,6 +817,79 @@ private enum InterpolationStyle {
     case swift
     case swiftRaw(Int)
 }
+
+/// One `Set` per language, built once. Every lookup below used to run off a computed property that
+/// rebuilt its literal on each read, and `scanIdentifier` reads all three for every identifier it
+/// scans.
+private enum Words {
+    static func keywords(for language: Language) -> Set<String> {
+        switch language {
+        case .php, .blade:
+            ["abstract", "as", "break", "case", "catch", "class", "clone", "const", "continue", "declare", "default", "do", "echo", "else", "elseif", "enum", "extends", "final", "finally", "fn", "for", "foreach", "function", "global", "if", "implements", "include", "instanceof", "interface", "match", "namespace", "new", "private", "protected", "public", "readonly", "require", "return", "static", "throw", "trait", "try", "use", "while", "yield"]
+        case .swift:
+            ["actor", "as", "associatedtype", "async", "await", "break", "case", "catch", "class", "continue", "default", "defer", "do", "else", "enum", "extension", "fallthrough", "for", "func", "guard", "if", "import", "in", "inout", "is", "let", "nonisolated", "private", "protocol", "public", "repeat", "return", "some", "static", "struct", "switch", "throw", "throws", "try", "var", "where", "while"]
+        case .javascript, .typescript:
+            ["async", "await", "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete", "do", "else", "export", "extends", "finally", "for", "from", "function", "if", "import", "in", "instanceof", "interface", "let", "new", "of", "return", "static", "switch", "throw", "try", "typeof", "var", "void", "while", "with", "yield"]
+        case .sql:
+            ["alter", "and", "as", "asc", "begin", "between", "by", "case", "create", "delete", "desc", "distinct", "drop", "else", "end", "exists", "from", "group", "having", "in", "index", "inner", "insert", "into", "is", "join", "left", "like", "limit", "not", "null", "on", "or", "order", "outer", "right", "select", "set", "table", "then", "union", "update", "values", "when", "where"]
+        case .python:
+            ["and", "as", "assert", "async", "await", "break", "class", "continue", "def", "del", "elif", "else", "except", "finally", "for", "from", "global", "if", "import", "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try", "while", "with", "yield"]
+        case .ruby:
+            ["begin", "break", "case", "class", "def", "defined", "do", "else", "elsif", "end", "ensure", "for", "if", "in", "module", "next", "redo", "rescue", "retry", "return", "self", "super", "then", "unless", "until", "when", "while", "yield"]
+        // Control flow and the builtins that declare something, not every command a shell knows.
+        // `echo`, `cd` and `git` are ordinary commands: colouring them would mark most of the
+        // lines in a setup script and tell the reader nothing about which ones branch.
+        case .shell:
+            ["alias", "break", "case", "continue", "declare", "do", "done", "elif", "else", "esac", "eval", "exec", "exit", "export", "fi", "for", "function", "if", "in", "local", "readonly", "return", "select", "set", "shift", "source", "then", "trap", "typeset", "unalias", "unset", "until", "while"]
+        default:
+            ["break", "case", "catch", "class", "const", "continue", "default", "else", "enum", "extends", "false", "final", "for", "fun", "func", "if", "import", "interface", "let", "new", "package", "private", "protected", "public", "return", "static", "struct", "switch", "throw", "true", "try", "var", "void", "while"]
+        }
+    }
+
+    static let types: Set<String> = ["array", "bool", "boolean", "char", "double", "float", "int", "integer", "mixed", "never", "number", "object", "self", "string", "void", "any", "some"]
+
+    static let constants: Set<String> = ["true", "false", "null", "nil", "none", "undefined", "nan", "inf"]
+}
+
+/// Needles the scanner compares against, held as UTF-16 so the comparison costs nothing. These
+/// were `String` literals passed to a `matches(_:String,at:)` overload that called
+/// `Array(string.utf16)` on every call, which is a heap allocation for every character of every
+/// line the scanner walked past.
+private enum Needles {
+    static let bladeCommentOpen = ascii("{{--")
+    static let htmlCommentOpen = ascii("<!--")
+    static let blockCommentOpen = ascii("/*")
+    static let lineCommentOpen = ascii("//")
+    static let sqlCommentOpen = ascii("--")
+    static let markdownCommentOpen = ascii("[//]:")
+    static let phpOpen = ascii("<?php")
+    static let phpEchoOpen = ascii("<?=")
+    static let heredocOpen = ascii("<<<")
+    static let phpAttributeOpen = ascii("#[")
+    static let fence = ascii("```")
+    static let tripleQuote = ascii("\"\"\"")
+    static let backtick = ascii("`")
+    static let bracedDollarOpen = ascii("${")
+    static let swiftInterpolationOpen = ascii("\\(")
+}
+
+/// Ordered longest first, because the scanner takes the first match: `<=>` has to be tried before
+/// `<=`, and `===` before `==`.
+private let operatorNeedles: [[UInt16]] = [
+    "<=>", "===", "!==", "...", "??=", "->", "::", "=>", "==", "!=", "<=", ">=", "&&", "||", "??",
+    "?.", "++", "--", "**", "<<", ">>", "{{", "}}", "{!!", "!!}",
+].map(ascii)
+
+/// The loop over those needles is entered only when the unit under the cursor can begin one, which
+/// one set lookup settles for most of a line.
+private let operatorNeedleHeads: Set<UInt16> = Set(operatorNeedles.compactMap(\.first))
+
+/// Punctuation a slash may follow and still open a regular expression, and the words that do the
+/// same. Both were rebuilt on every call to `shouldStartRegex`.
+private let regexLeadingUnits: Set<UInt16> = Set(ascii("=(:,![{;?"))
+private let regexLeadingWords: Set<String> = [
+    "return", "case", "throw", "typeof", "delete", "void", "yield",
+]
 
 private let asciiOperators = Set(ascii("+-*/%=!<>?&|^~"))
 private let asciiPunctuation = Set(ascii("()[]{}.,;:@#\\"))

--- a/Tests/BloomCoreTests/DiffDocumentTests.swift
+++ b/Tests/BloomCoreTests/DiffDocumentTests.swift
@@ -178,6 +178,59 @@ struct DiffDocumentTests {
 
         #expect(document.maxColumns == 800)
     }
+
+    // MARK: Priming
+
+    @Test("the lines offered for priming are the first printed ones, with their carry")
+    func primesFromTheTop() {
+        let document = DiffDocument.prepare(
+            file: file([
+                line(.context, "/* opened", index: 0),
+                line(.deletion, "gone", index: 1),
+                line(.addition, "here", index: 2),
+                line(.noNewline, "\\ No newline at end of file", index: 3),
+            ]),
+            path: "Sources/Thing.swift"
+        )
+
+        let primed = document.linesToPrime(limit: 3)
+        #expect(primed.map(\.text) == ["/* opened", "gone", "here"])
+        // The carry is the state the line BEGINS in, so the first line of an open block comment
+        // still carries the clean state and the two after it do not.
+        #expect(primed[0].carry == LexState())
+        #expect(primed[1].carry != LexState())
+        #expect(primed[2].carry != LexState())
+    }
+
+    @Test("priming stops at the limit and skips the no-newline marker")
+    func primingIsBounded() {
+        let document = DiffDocument.prepare(
+            file: file([
+                line(.addition, "one", index: 0),
+                line(.addition, "two", index: 1),
+                line(.noNewline, "\\ No newline at end of file", index: 2),
+            ]),
+            path: "Sources/Thing.swift"
+        )
+
+        #expect(document.linesToPrime(limit: 1).map(\.text) == ["one"])
+        #expect(document.linesToPrime(limit: 99).map(\.text) == ["one", "two"])
+        #expect(document.linesToPrime(limit: 0).isEmpty)
+    }
+}
+
+/// One number, asked by both of the bars that draw a file's name, which is why it is in the core
+/// rather than written out as a private constant in each of them.
+@Suite("File bar layout")
+struct FileBarLayoutTests {
+    @Test("the folder is kept above the threshold and dropped below it")
+    func folderFollowsTheWidth() {
+        #expect(FileBarLayout.showsDirectory(width: FileBarLayout.folderThreshold))
+        #expect(FileBarLayout.showsDirectory(width: FileBarLayout.folderThreshold + 1))
+        #expect(!FileBarLayout.showsDirectory(width: FileBarLayout.folderThreshold - 1))
+        // A bar that has not been measured yet has room for nothing.
+        #expect(!FileBarLayout.showsDirectory(width: 0))
+    }
 }
 
 @Suite("Code columns")

--- a/Tests/BloomCoreTests/SyntaxHighlighterGoldenTests.swift
+++ b/Tests/BloomCoreTests/SyntaxHighlighterGoldenTests.swift
@@ -1,0 +1,604 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// The whole token stream for a sample of every language the highlighter knows, recorded once and
+/// compared whole. The scanner was rewritten for speed (hoisted word sets, hoisted UTF-16 needles,
+/// a `switch` in place of membership tests against array literals) and the entire point of that
+/// work was that nothing observable changes, which no assertion about one construct at a time can
+/// show. A failure here prints the two dumps, so the line and the token that moved are readable
+/// from the diff. Re-record it only when a highlighting change is intended.
+@Suite("Syntax highlighter goldens", .tags(.agentProtocol))
+struct SyntaxHighlighterGoldenTests {
+    @Test("tokenizes every language exactly as recorded")
+    func matchesTheRecordedTokens() {
+        #expect(dumpTokens() == goldenTokens)
+    }
+}
+
+/// `kind:text` per token, pipe separated, one line per source line, grouped by language.
+private func dumpTokens() -> String {
+    var out = ""
+    for language in Language.allCases.sorted(by: { $0.rawValue < $1.rawValue }) {
+        guard let source = samples[language] else {
+            out += "== \(language.rawValue)\nno sample\n"
+            continue
+        }
+        out += "== \(language.rawValue)\n"
+        let lines = source.components(separatedBy: "\n")
+        for (index, tokens) in SyntaxHighlighter.tokenize(source: source, language: language).enumerated() {
+            let units = Array(lines[index].utf16)
+            let described = tokens.map {
+                "\($0.kind.rawValue):\(String(decoding: units[$0.range], as: UTF16.self))"
+            }
+            out += "\(index)|\(described.joined(separator: "|"))\n"
+        }
+    }
+    return out.trimmingCharacters(in: .newlines)
+}
+
+private let samples: [Language: String] = [
+    .php: """
+    <?php
+
+    namespace App\\Services;
+
+    #[Attribute]
+    final class Report implements Contract
+    {
+        public const LIMIT = 1_000;
+        private ?string $name = null;
+
+        public function build(array $rows = [], int $depth = 0x1f): string
+        {
+            // a line comment
+            /* a block
+               comment */
+            $out = <<<SQL
+                select * from things where id = $id
+            SQL;
+            $sql = <<<'RAW'
+                literal $notInterpolated
+            RAW;
+            return match (true) {
+                $depth <= 0 => "empty {$this->name} \\n",
+                default => 'plain' . self::LIMIT,
+            };
+        }
+    }
+    """,
+    .blade: """
+    {{-- a blade comment --}}
+    <div class="card" @click="go">
+        @foreach ($items as $item)
+            {{ $item->name }}
+            {!! $item->html !!}
+        @endforeach
+        <!-- html comment -->
+    </div>
+    """,
+    .swift: """
+    import Foundation
+
+    @MainActor
+    public struct Widget: Sendable {
+        // one line
+        /* block */
+        private let count: Int = 0b1010
+        var name: String { "x" }
+
+        func run() async throws -> [String] {
+            let text = \"\"\"
+            multi \\(name) line
+            \"\"\"
+            let raw = #\"not \\(interpolated)\"#
+            guard count != 0, count >= 1 else { return [] }
+            return [text, "a\\u{1F600}b"]
+        }
+    }
+    """,
+    .javascript: """
+    import { thing } from './thing.js';
+
+    export default async function run(a = 1, ...rest) {
+      // comment
+      const re = /^a[b/c]+$/gi;
+      const div = a / 2;
+      const t = `hey ${a + 1} there`;
+      if (a === 1 && rest?.length > 0) return null;
+      return { a, b: true, c: undefined };
+    }
+    """,
+    .typescript: """
+    interface Shape<T extends object> {
+      readonly kind: 'circle' | 'square';
+      area(): number;
+    }
+
+    export const make = <T,>(x: T): Shape<T> => ({ kind: 'circle', area: () => 1.5e3 });
+    """,
+    .python: """
+    from __future__ import annotations
+
+    class Thing:
+        # a comment
+        def __init__(self, name: str = "x") -> None:
+            self.name = name
+            self.items = [1, 2, 3]
+
+        async def run(self, *args, **kwargs):
+            if self.name is None or not args:
+                raise ValueError(f"bad {self.name!r}")
+            return {k: v for k, v in kwargs.items()}
+    """,
+    .ruby: """
+    module Reporting
+      class Report < Base
+        # a comment
+        def initialize(name:, limit: 10)
+          @name = name
+          @limit = limit
+        end
+
+        def to_s
+          "#{@name} (#{@limit})"
+        end
+      end
+    end
+    """,
+    .go: """
+    package main
+
+    import "fmt"
+
+    type Report struct {
+        Name  string
+        Limit int
+    }
+
+    func (r *Report) String() string {
+        // comment
+        if r.Limit == 0 {
+            return ""
+        }
+        return fmt.Sprintf("%s/%d", r.Name, r.Limit)
+    }
+    """,
+    .rust: """
+    use std::collections::HashMap;
+
+    #[derive(Debug, Clone)]
+    pub struct Report<'a> {
+        pub name: &'a str,
+        pub limit: u32,
+    }
+
+    impl<'a> Report<'a> {
+        pub fn new(name: &'a str) -> Self {
+            // comment
+            Self { name, limit: 0xff }
+        }
+    }
+    """,
+    .java: """
+    package com.example;
+
+    import java.util.List;
+
+    @Override
+    public final class Report {
+        private static final int LIMIT = 1000;
+
+        public String build(List<String> rows) {
+            /* block */
+            if (rows.isEmpty()) return "";
+            return String.join(",", rows);
+        }
+    }
+    """,
+    .kotlin: """
+    package com.example
+
+    import kotlin.math.max
+
+    data class Report(val name: String, val limit: Int = 10) {
+        fun build(rows: List<String>): String {
+            // comment
+            if (rows.isEmpty()) return ""
+            return rows.joinToString(",") { it.trim() }
+        }
+    }
+    """,
+    .css: """
+    /* a comment */
+    :root {
+      --brand: #ff8800;
+      font-size: 14px;
+    }
+
+    .card > .title:hover {
+      color: var(--brand);
+      margin: 0 auto !important;
+    }
+    """,
+    .html: """
+    <!doctype html>
+    <html lang="en">
+      <!-- a comment -->
+      <head>
+        <meta charset="utf-8" />
+        <title>Bloom</title>
+      </head>
+      <body class="dark" data-x='1'>
+        <p>Hello &amp; welcome</p>
+      </body>
+    </html>
+    """,
+    .json: """
+    {
+      "name": "bloom",
+      "version": "0.3.0",
+      "nested": { "a": [1, 2.5, true, false, null] },
+      "escaped": "a \\"b\\" c"
+    }
+    """,
+    .yaml: """
+    # a comment
+    name: bloom
+    on:
+      push:
+        branches: [main]
+    jobs:
+      test:
+        runs-on: macos-26
+        steps:
+          - uses: actions/checkout@v4
+          - run: |
+              make test
+    """,
+    .toml: """
+    # a comment
+    [package]
+    name = "bloom"
+    version = "0.3.0"
+
+    [dependencies]
+    serde = { version = "1.0", features = ["derive"] }
+    """,
+    .markdown: """
+    # Title
+
+    Some *emphasis* and `code` and a [link](https://example.com).
+
+    ```swift
+    let x = 1
+    ```
+
+    [//]: # (a comment)
+
+    - one
+    - two
+    """,
+    .shell: """
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # a comment
+    NAME="${1:-bloom}"
+    for file in "$@"; do
+      if [[ -f "$file" ]]; then
+        echo "found $file"
+      else
+        exit 1
+      fi
+    done
+    """,
+    .sql: """
+    -- a comment
+    select t.id, count(*) as total
+    from things t
+    inner join owners o on o.id = t.owner_id
+    where t.created_at >= '2024-01-01'
+      and t.name like '%bloom%'
+    group by t.id
+    order by total desc
+    limit 10;
+    """,
+    .vue: """
+    <template>
+      <!-- comment -->
+      <div class="card" :title="name" @click="go">{{ name }}</div>
+    </template>
+
+    <script setup>
+    import { ref } from 'vue';
+    const name = ref('bloom');
+    </script>
+    """,
+    .xml: """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!-- a comment -->
+    <plist version="1.0">
+      <dict>
+        <key>CFBundleName</key>
+        <string>Bloom</string>
+      </dict>
+    </plist>
+    """,
+    .plainText: """
+    Just some words, 1234 and a "quote" plus (brackets).
+    A second line -> with an arrow.
+    """,
+]
+
+private let goldenTokens = #"""
+== blade
+0|comment:{{-- a blade comment --}}
+1|operator:<|type:div|plain: |keyword:class|operator:=|string:"card"|plain: |attribute:@click|operator:=|string:"go"|operator:>
+2|plain:    |attribute:@foreach|plain: |punctuation:(|variable:$items|plain: |keyword:as|plain: |variable:$item|punctuation:)
+3|plain:        |operator:{{|plain: |variable:$item|operator:->|plain:name|plain: |operator:}}
+4|plain:        |operator:{!!|plain: |variable:$item|operator:->|plain:html|plain: |operator:!!}
+5|plain:    |attribute:@endforeach
+6|plain:    |comment:<!-- html comment -->
+7|operator:</|type:div|operator:>
+== css
+0|comment:/* a comment */
+1|punctuation::|plain:root|plain: |punctuation:{
+2|plain:  |operator:--|attribute:brand|punctuation::|plain: |punctuation:#|plain:ff8800|punctuation:;
+3|plain:  |plain:font|operator:-|attribute:size|punctuation::|plain: |number:14|plain:px|punctuation:;
+4|punctuation:}
+5|
+6|punctuation:.|plain:card|plain: |operator:>|plain: |punctuation:.|attribute:title|punctuation::|plain:hover|plain: |punctuation:{
+7|plain:  |attribute:color|punctuation::|plain: |keyword:var|punctuation:(|operator:--|plain:brand|punctuation:);
+8|plain:  |attribute:margin|punctuation::|plain: |number:0|plain: |plain:auto|plain: |operator:!|plain:important|punctuation:;
+9|punctuation:}
+== go
+0|keyword:package|plain: |plain:main
+1|
+2|keyword:import|plain: |string:"fmt"
+3|
+4|plain:type|plain: |type:Report|plain: |keyword:struct|plain: |punctuation:{
+5|plain:    |type:Name|plain:  |type:string
+6|plain:    |type:Limit|plain: |type:int
+7|punctuation:}
+8|
+9|keyword:func|plain: |punctuation:(|plain:r|plain: |operator:*|type:Report|punctuation:)|plain: |type:String|punctuation:()|plain: |type:string|plain: |punctuation:{
+10|plain:    |comment:// comment
+11|plain:    |keyword:if|plain: |plain:r|punctuation:.|type:Limit|plain: |operator:==|plain: |number:0|plain: |punctuation:{
+12|plain:        |keyword:return|plain: |string:""
+13|plain:    |punctuation:}
+14|plain:    |keyword:return|plain: |plain:fmt|punctuation:.|type:Sprintf|punctuation:(|string:"%s/%d"|punctuation:,|plain: |plain:r|punctuation:.|type:Name|punctuation:,|plain: |plain:r|punctuation:.|type:Limit|punctuation:)
+15|punctuation:}
+== html
+0|operator:<!|attribute:doctype|plain: |attribute:html|operator:>
+1|operator:<|type:html|plain: |attribute:lang|operator:=|string:"en"|operator:>
+2|plain:  |comment:<!-- a comment -->
+3|plain:  |operator:<|type:head|operator:>
+4|plain:    |operator:<|type:meta|plain: |attribute:charset|operator:=|string:"utf-8"|plain: |operator:/>
+5|plain:    |operator:<|type:title|operator:>|type:Bloom|operator:</|type:title|operator:>
+6|plain:  |operator:</|type:head|operator:>
+7|plain:  |operator:<|type:body|plain: |keyword:class|operator:=|string:"dark"|plain: |attribute:data|operator:-|attribute:x|operator:=|string:'1'|operator:>
+8|plain:    |operator:<|type:p|operator:>|type:Hello|plain: |operator:&|plain:amp|punctuation:;|plain: |plain:welcome|operator:</|type:p|operator:>
+9|plain:  |operator:</|type:body|operator:>
+10|operator:</|type:html|operator:>
+== java
+0|keyword:package|plain: |plain:com|punctuation:.|plain:example|punctuation:;
+1|
+2|keyword:import|plain: |plain:java|punctuation:.|plain:util|punctuation:.|type:List|punctuation:;
+3|
+4|attribute:@Override
+5|keyword:public|plain: |keyword:final|plain: |keyword:class|plain: |type:Report|plain: |punctuation:{
+6|plain:    |keyword:private|plain: |keyword:static|plain: |keyword:final|plain: |type:int|plain: |type:LIMIT|plain: |operator:=|plain: |number:1000|punctuation:;
+7|
+8|plain:    |keyword:public|plain: |type:String|plain: |function:build|punctuation:(|type:List|operator:<|type:String|operator:>|plain: |plain:rows|punctuation:)|plain: |punctuation:{
+9|plain:        |comment:/* block */
+10|plain:        |keyword:if|plain: |punctuation:(|plain:rows|punctuation:.|function:isEmpty|punctuation:())|plain: |keyword:return|plain: |string:""|punctuation:;
+11|plain:        |keyword:return|plain: |type:String|punctuation:.|function:join|punctuation:(|string:","|punctuation:,|plain: |plain:rows|punctuation:);
+12|plain:    |punctuation:}
+13|punctuation:}
+== javascript
+0|keyword:import|plain: |punctuation:{|plain: |plain:thing|plain: |punctuation:}|plain: |keyword:from|plain: |string:'./thing.js'|punctuation:;
+1|
+2|keyword:export|plain: |keyword:default|plain: |keyword:async|plain: |keyword:function|plain: |function:run|punctuation:(|plain:a|plain: |operator:=|plain: |number:1|punctuation:,|plain: |operator:...|plain:rest|punctuation:)|plain: |punctuation:{
+3|plain:  |comment:// comment
+4|plain:  |keyword:const|plain: |plain:re|plain: |operator:=|plain: |regex:/^a[b/c]+$/gi|punctuation:;
+5|plain:  |keyword:const|plain: |plain:div|plain: |operator:=|plain: |plain:a|plain: |operator:/|plain: |number:2|punctuation:;
+6|plain:  |keyword:const|plain: |plain:t|plain: |operator:=|plain: |string:`hey |variable:${a + 1}|string: there`|punctuation:;
+7|plain:  |keyword:if|plain: |punctuation:(|plain:a|plain: |operator:===|plain: |number:1|plain: |operator:&&|plain: |plain:rest|operator:?.|plain:length|plain: |operator:>|plain: |number:0|punctuation:)|plain: |keyword:return|plain: |constant:null|punctuation:;
+8|plain:  |keyword:return|plain: |punctuation:{|plain: |plain:a|punctuation:,|plain: |plain:b|punctuation::|plain: |constant:true|punctuation:,|plain: |plain:c|punctuation::|plain: |constant:undefined|plain: |punctuation:};
+9|punctuation:}
+== json
+0|punctuation:{
+1|plain:  |string:"name"|punctuation::|plain: |string:"bloom"|punctuation:,
+2|plain:  |string:"version"|punctuation::|plain: |string:"0.3.0"|punctuation:,
+3|plain:  |string:"nested"|punctuation::|plain: |punctuation:{|plain: |string:"a"|punctuation::|plain: |punctuation:[|number:1|punctuation:,|plain: |number:2.5|punctuation:,|plain: |keyword:true|punctuation:,|plain: |keyword:false|punctuation:,|plain: |constant:null|punctuation:]|plain: |punctuation:},
+4|plain:  |string:"escaped"|punctuation::|plain: |string:"a \"b\" c"
+5|punctuation:}
+== kotlin
+0|keyword:package|plain: |plain:com|punctuation:.|plain:example
+1|
+2|keyword:import|plain: |plain:kotlin|punctuation:.|plain:math|punctuation:.|plain:max
+3|
+4|plain:data|plain: |keyword:class|plain: |type:Report|punctuation:(|plain:val|plain: |plain:name|punctuation::|plain: |type:String|punctuation:,|plain: |plain:val|plain: |plain:limit|punctuation::|plain: |type:Int|plain: |operator:=|plain: |number:10|punctuation:)|plain: |punctuation:{
+5|plain:    |keyword:fun|plain: |function:build|punctuation:(|plain:rows|punctuation::|plain: |type:List|operator:<|type:String|operator:>|punctuation:):|plain: |type:String|plain: |punctuation:{
+6|plain:        |comment:// comment
+7|plain:        |keyword:if|plain: |punctuation:(|plain:rows|punctuation:.|function:isEmpty|punctuation:())|plain: |keyword:return|plain: |string:""
+8|plain:        |keyword:return|plain: |plain:rows|punctuation:.|function:joinToString|punctuation:(|string:","|punctuation:)|plain: |punctuation:{|plain: |plain:it|punctuation:.|function:trim|punctuation:()|plain: |punctuation:}
+9|plain:    |punctuation:}
+10|punctuation:}
+== markdown
+0|punctuation:#|plain: |type:Title
+1|
+2|type:Some|plain: |operator:*|plain:emphasis|operator:*|plain: |plain:and|plain: |plain:`|plain:code|plain:`|plain: |plain:and|plain: |plain:a|plain: |punctuation:[|plain:link|punctuation:](|plain:https|punctuation::|operator://|plain:example|punctuation:.|plain:com|punctuation:).
+3|
+4|punctuation:```swift
+5|keyword:let|plain: |plain:x|plain: |operator:=|plain: |number:1
+6|punctuation:```
+7|
+8|comment:[//]: # (a comment)
+9|
+10|operator:-|plain: |plain:one
+11|operator:-|plain: |plain:two
+== php
+0|punctuation:<?php
+1|
+2|keyword:namespace|plain: |type:App|punctuation:\|type:Services|punctuation:;
+3|
+4|attribute:#[|type:Attribute|punctuation:]
+5|keyword:final|plain: |keyword:class|plain: |type:Report|plain: |keyword:implements|plain: |type:Contract
+6|punctuation:{
+7|plain:    |keyword:public|plain: |keyword:const|plain: |type:LIMIT|plain: |operator:=|plain: |number:1_000|punctuation:;
+8|plain:    |keyword:private|plain: |operator:?|type:string|plain: |variable:$name|plain: |operator:=|plain: |constant:null|punctuation:;
+9|
+10|plain:    |keyword:public|plain: |keyword:function|plain: |function:build|punctuation:(|type:array|plain: |variable:$rows|plain: |operator:=|plain: |punctuation:[],|plain: |type:int|plain: |variable:$depth|plain: |operator:=|plain: |number:0x1f|punctuation:):|plain: |type:string
+11|plain:    |punctuation:{
+12|plain:        |comment:// a line comment
+13|plain:        |comment:/* a block
+14|comment:           comment */
+15|plain:        |variable:$out|plain: |operator:=|plain: |string:<<<SQL
+16|string:            select * from things where id = |variable:$id
+17|string:        SQL;
+18|plain:        |variable:$sql|plain: |operator:=|plain: |string:<<<'RAW'
+19|string:            literal $notInterpolated
+20|string:        RAW;
+21|plain:        |keyword:return|plain: |keyword:match|plain: |punctuation:(|constant:true|punctuation:)|plain: |punctuation:{
+22|plain:            |variable:$depth|plain: |operator:<=|plain: |number:0|plain: |operator:=>|plain: |string:"empty {|variable:$this|string:->name} \n"|punctuation:,
+23|plain:            |keyword:default|plain: |operator:=>|plain: |string:'plain'|plain: |punctuation:.|plain: |type:self|operator:::|type:LIMIT|punctuation:,
+24|plain:        |punctuation:};
+25|plain:    |punctuation:}
+26|punctuation:}
+== plainText
+0|type:Just|plain: |type:some|plain: |plain:words|punctuation:,|plain: |number:1234|plain: |plain:and|plain: |plain:a|plain: |string:"quote"|plain: |function:plus|plain: |punctuation:(|plain:brackets|punctuation:).
+1|type:A|plain: |plain:second|plain: |plain:line|plain: |operator:->|plain: |plain:with|plain: |plain:an|plain: |plain:arrow|punctuation:.
+== python
+0|keyword:from|plain: |plain:__future__|plain: |keyword:import|plain: |plain:annotations
+1|
+2|keyword:class|plain: |type:Thing|punctuation::
+3|plain:    |comment:# a comment
+4|plain:    |keyword:def|plain: |function:__init__|punctuation:(|type:self|punctuation:,|plain: |plain:name|punctuation::|plain: |plain:str|plain: |operator:=|plain: |string:"x"|punctuation:)|plain: |operator:->|plain: |constant:None|punctuation::
+5|plain:        |type:self|punctuation:.|plain:name|plain: |operator:=|plain: |plain:name
+6|plain:        |type:self|punctuation:.|plain:items|plain: |operator:=|plain: |punctuation:[|number:1|punctuation:,|plain: |number:2|punctuation:,|plain: |number:3|punctuation:]
+7|
+8|plain:    |keyword:async|plain: |keyword:def|plain: |function:run|punctuation:(|type:self|punctuation:,|plain: |operator:*|plain:args|punctuation:,|plain: |operator:**|plain:kwargs|punctuation:):
+9|plain:        |keyword:if|plain: |type:self|punctuation:.|plain:name|plain: |keyword:is|plain: |constant:None|plain: |keyword:or|plain: |keyword:not|plain: |plain:args|punctuation::
+10|plain:            |keyword:raise|plain: |type:ValueError|punctuation:(|plain:f|string:"bad {self.name!r}"|punctuation:)
+11|plain:        |keyword:return|plain: |punctuation:{|plain:k|punctuation::|plain: |plain:v|plain: |keyword:for|plain: |plain:k|punctuation:,|plain: |plain:v|plain: |keyword:in|plain: |plain:kwargs|punctuation:.|function:items|punctuation:()}
+== ruby
+0|keyword:module|plain: |type:Reporting
+1|plain:  |keyword:class|plain: |type:Report|plain: |operator:<|plain: |type:Base
+2|plain:    |comment:# a comment
+3|plain:    |keyword:def|plain: |function:initialize|punctuation:(|plain:name|punctuation::,|plain: |plain:limit|punctuation::|plain: |number:10|punctuation:)
+4|plain:      |punctuation:@|plain:name|plain: |operator:=|plain: |plain:name
+5|plain:      |punctuation:@|plain:limit|plain: |operator:=|plain: |plain:limit
+6|plain:    |keyword:end
+7|
+8|plain:    |keyword:def|plain: |plain:to_s
+9|plain:      |string:"#{@name} (#{@limit})"
+10|plain:    |keyword:end
+11|plain:  |keyword:end
+12|keyword:end
+== rust
+0|plain:use|plain: |plain:std|operator:::|plain:collections|operator:::|type:HashMap|punctuation:;
+1|
+2|punctuation:#[|function:derive|punctuation:(|type:Debug|punctuation:,|plain: |type:Clone|punctuation:)]
+3|plain:pub|plain: |keyword:struct|plain: |type:Report|operator:<|string:'a> {
+4|plain:    |plain:pub|plain: |plain:name|punctuation::|plain: |operator:&|string:'a str,
+5|plain:    |plain:pub|plain: |plain:limit|punctuation::|plain: |plain:u32|punctuation:,
+6|punctuation:}
+7|
+8|plain:impl|operator:<|string:'a> Report<'|plain:a|operator:>|plain: |punctuation:{
+9|plain:    |plain:pub|plain: |plain:fn|plain: |keyword:new|punctuation:(|plain:name|punctuation::|plain: |operator:&|string:'a str) -> Self {
+10|plain:        |comment:// comment
+11|plain:        |type:Self|plain: |punctuation:{|plain: |plain:name|punctuation:,|plain: |plain:limit|punctuation::|plain: |number:0xff|plain: |punctuation:}
+12|plain:    |punctuation:}
+13|punctuation:}
+== shell
+0|comment:#!/usr/bin/env bash
+1|keyword:set|plain: |operator:-|plain:euo|plain: |plain:pipefail
+2|
+3|comment:# a comment
+4|type:NAME|operator:=|string:"|variable:${1:-bloom}|string:"
+5|keyword:for|plain: |plain:file|plain: |keyword:in|plain: |string:"$@"|punctuation:;|plain: |keyword:do
+6|plain:  |keyword:if|plain: |punctuation:[[|plain: |operator:-|plain:f|plain: |string:"|variable:$file|string:"|plain: |punctuation:]];|plain: |keyword:then
+7|plain:    |plain:echo|plain: |string:"found |variable:$file|string:"
+8|plain:  |keyword:else
+9|plain:    |keyword:exit|plain: |number:1
+10|plain:  |keyword:fi
+11|keyword:done
+== sql
+0|comment:-- a comment
+1|keyword:select|plain: |plain:t|punctuation:.|plain:id|punctuation:,|plain: |function:count|punctuation:(|operator:*|punctuation:)|plain: |keyword:as|plain: |plain:total
+2|keyword:from|plain: |plain:things|plain: |plain:t
+3|keyword:inner|plain: |keyword:join|plain: |plain:owners|plain: |plain:o|plain: |keyword:on|plain: |plain:o|punctuation:.|plain:id|plain: |operator:=|plain: |plain:t|punctuation:.|plain:owner_id
+4|keyword:where|plain: |plain:t|punctuation:.|plain:created_at|plain: |operator:>=|plain: |string:'2024-01-01'
+5|plain:  |keyword:and|plain: |plain:t|punctuation:.|plain:name|plain: |keyword:like|plain: |string:'%bloom%'
+6|keyword:group|plain: |keyword:by|plain: |plain:t|punctuation:.|plain:id
+7|keyword:order|plain: |keyword:by|plain: |plain:total|plain: |keyword:desc
+8|keyword:limit|plain: |number:10|punctuation:;
+== swift
+0|keyword:import|plain: |type:Foundation
+1|
+2|attribute:@MainActor
+3|keyword:public|plain: |keyword:struct|plain: |type:Widget|punctuation::|plain: |type:Sendable|plain: |punctuation:{
+4|plain:    |comment:// one line
+5|plain:    |comment:/* block */
+6|plain:    |keyword:private|plain: |keyword:let|plain: |plain:count|punctuation::|plain: |type:Int|plain: |operator:=|plain: |number:0b1010
+7|plain:    |keyword:var|plain: |plain:name|punctuation::|plain: |type:String|plain: |punctuation:{|plain: |string:"x"|plain: |punctuation:}
+8|
+9|plain:    |keyword:func|plain: |function:run|punctuation:()|plain: |keyword:async|plain: |keyword:throws|plain: |operator:->|plain: |punctuation:[|type:String|punctuation:]|plain: |punctuation:{
+10|plain:        |keyword:let|plain: |plain:text|plain: |operator:=|plain: |string:"""
+11|string:        multi |variable:\(name)|string: line
+12|string:        """
+13|plain:        |keyword:let|plain: |plain:raw|plain: |operator:=|plain: |string:#"not \(interpolated)"#
+14|plain:        |keyword:guard|plain: |plain:count|plain: |operator:!=|plain: |number:0|punctuation:,|plain: |plain:count|plain: |operator:>=|plain: |number:1|plain: |keyword:else|plain: |punctuation:{|plain: |keyword:return|plain: |punctuation:[]|plain: |punctuation:}
+15|plain:        |keyword:return|plain: |punctuation:[|plain:text|punctuation:,|plain: |string:"a\u{1F600}b"|punctuation:]
+16|plain:    |punctuation:}
+17|punctuation:}
+== toml
+0|comment:# a comment
+1|punctuation:[|keyword:package|punctuation:]
+2|attribute:name|plain: |operator:=|plain: |string:"bloom"
+3|attribute:version|plain: |operator:=|plain: |string:"0.3.0"
+4|
+5|punctuation:[|plain:dependencies|punctuation:]
+6|attribute:serde|plain: |operator:=|plain: |punctuation:{|plain: |attribute:version|plain: |operator:=|plain: |string:"1.0"|punctuation:,|plain: |attribute:features|plain: |operator:=|plain: |punctuation:[|string:"derive"|punctuation:]|plain: |punctuation:}
+== typescript
+0|keyword:interface|plain: |type:Shape|operator:<|type:T|plain: |keyword:extends|plain: |type:object|operator:>|plain: |punctuation:{
+1|plain:  |plain:readonly|plain: |plain:kind|punctuation::|plain: |string:'circle'|plain: |operator:||plain: |string:'square'|punctuation:;
+2|plain:  |function:area|punctuation:():|plain: |type:number|punctuation:;
+3|punctuation:}
+4|
+5|keyword:export|plain: |keyword:const|plain: |plain:make|plain: |operator:=|plain: |operator:<|type:T|punctuation:,|operator:>|punctuation:(|plain:x|punctuation::|plain: |type:T|punctuation:):|plain: |type:Shape|operator:<|type:T|operator:>|plain: |operator:=>|plain: |punctuation:({|plain: |plain:kind|punctuation::|plain: |string:'circle'|punctuation:,|plain: |plain:area|punctuation::|plain: |punctuation:()|plain: |operator:=>|plain: |number:1.5e3|plain: |punctuation:});
+== vue
+0|operator:<|type:template|operator:>
+1|plain:  |comment:<!-- comment -->
+2|plain:  |operator:<|type:div|plain: |keyword:class|operator:=|string:"card"|plain: |punctuation::|attribute:title|operator:=|string:"name"|plain: |punctuation:@|attribute:click|operator:=|string:"go"|operator:>{{|plain: |plain:name|plain: |operator:}}</|type:div|operator:>
+3|operator:</|type:template|operator:>
+4|
+5|operator:<|type:script|plain: |attribute:setup|operator:>
+6|keyword:import|plain: |punctuation:{|plain: |plain:ref|plain: |punctuation:}|plain: |plain:from|plain: |string:'vue'|punctuation:;
+7|keyword:const|plain: |plain:name|plain: |operator:=|plain: |function:ref|punctuation:(|string:'bloom'|punctuation:);
+8|operator:</|type:script|operator:>
+== xml
+0|operator:<?|attribute:xml|plain: |attribute:version|operator:=|string:"1.0"|plain: |attribute:encoding|operator:=|string:"UTF-8"|operator:?>
+1|comment:<!-- a comment -->
+2|operator:<|type:plist|plain: |attribute:version|operator:=|string:"1.0"|operator:>
+3|plain:  |operator:<|type:dict|operator:>
+4|plain:    |operator:<|type:key|operator:>|type:CFBundleName|operator:</|type:key|operator:>
+5|plain:    |operator:<|type:string|operator:>|type:Bloom|operator:</|type:string|operator:>
+6|plain:  |operator:</|type:dict|operator:>
+7|operator:</|type:plist|operator:>
+== yaml
+0|comment:# a comment
+1|attribute:name|punctuation::|plain: |plain:bloom
+2|attribute:on|punctuation::
+3|plain:  |attribute:push|punctuation::
+4|plain:    |attribute:branches|punctuation::|plain: |punctuation:[|plain:main|punctuation:]
+5|attribute:jobs|punctuation::
+6|plain:  |attribute:test|punctuation::
+7|plain:    |plain:runs|operator:-|attribute:on|punctuation::|plain: |plain:macos|operator:-|number:26
+8|plain:    |attribute:steps|punctuation::
+9|plain:      |operator:-|plain: |attribute:uses|punctuation::|plain: |plain:actions|operator:/|plain:checkout|punctuation:@|plain:v4
+10|plain:      |operator:-|plain: |attribute:run|punctuation::|plain: |operator:|
+11|plain:          |plain:make|plain: |plain:test
+"""#


### PR DESCRIPTION
Nine findings from a read-only performance report, worked through and verified against the code.

The syntax highlighter allocated its way through every line: `keywords`, `types` and `constants` were computed properties rebuilding a `Set` per identifier, `matches(_:at:)` converted a `String` to UTF-16 on every call, and the operator scan looped 18 of those per operator. All hoisted. Same tokens out: a golden dump of a sample of all 22 languages is byte for byte what the old scanner produced, and it is a test now. Measured on Store.swift, 2,604 lines, 40 passes, -O: 430ms to 136ms.

The rest stops the inspector rebuilding itself for nothing. A review comment's text moves out of `WorkspaceModel` into `ReviewTextHost`, so typing no longer invalidates the whole visible diff. `commentedSpots` is assigned in the same pass as `placements` instead of being a `Set` rebuilt per row. `DiffLineView`, `ChangedFileRow`, `FileTreeRow` and `ChangedFolderRow` are `Equatable` on their values, so the freshly allocated closure beside each one stops invalidating it. Hover moves off the two lists into `HoverRow`, which owns it per row and still paints the fill from outside the row (these rows read `isOnEmphasizedSelection` out of their parent's environment, so the state cannot simply move down).

`DiffView` primes `SyntaxCache` off the main thread for the first 600 lines, which were being lexed a second time on the main actor as each row first drew. `FilePreview` reads, splits and measures a file in one hop off the main actor rather than doing all three on it. `ReviewPaneView` no longer calls `fileExists` from `body`, which was once a frame for the length of a window resize.

Two of the findings did not hold up:

- Finding 9 asked for `ViewThatFits` in `FileHeaderBar` to be replaced by width thresholds. The thresholds cannot be derived from the source and a wrong one clips a segmented control, which is what that type's own doc comment says it is there to prevent. The cost it was named for is real and is fixed at its cause instead: the bar read `FileEditSession.drafts` from its own body, so a keystroke in the editor beside it remeasured three clusters of seven controls. That read is now `UnsavedEditsDot`, and a keystroke redraws a five point circle.
- Attaching `DiffLineView`'s hover conditionally buys nothing: both of the only two call sites pass a non-nil `onComment`. Its `.contentShape(Rectangle())` is left alone as asked.

Also here: one folder threshold in `FileBarLayout` instead of the same number written out in two bars, the changed file sort decorated so `filename` bridges to `NSString` once per file rather than once per comparison, and `DiffStatLabel`'s format styles composed once.
