### PR TITLE
Stop the transcript rebuilding what it already knows on every pass

### DIFF
--- a/Sources/Bloom/Design/BreathingMark.swift
+++ b/Sources/Bloom/Design/BreathingMark.swift
@@ -1,0 +1,151 @@
+import SwiftUI
+import AppKit
+import QuartzCore
+import BloomCore
+
+/// A mark that breathes on the window's heartbeat: the retrying turn's glyph, and anything else
+/// that has to say "still here" for minutes at a time.
+///
+/// # Why it is a layer and not a `keyframeAnimator`
+///
+/// The same argument `PulsingDot` carries, applied to the one repeating SwiftUI animation left in
+/// the transcript. A `keyframeAnimator(repeating: true)` is not handed to the render server:
+/// SwiftUI interpolates it on the main thread and re-renders the hosting view's display list every
+/// frame, so the bill is set by the size of the window rather than by the size of the mark.
+/// `BusyPulse`'s header carries the measurement, taken on this app: 320,971 view graph updates for
+/// 12 body evaluations over 12.3 seconds, with `RootGeometry` and `LayoutChildGeometries`
+/// recomputed 239.6 times a second. A retry runs for as long as somebody else's outage lasts, which
+/// is minutes.
+///
+/// **It keeps moving when the window is behind another app, and that is deliberate.** `0142c5f`
+/// removed every frontmost gate in Bloom: a mark that says "this is still going" is at its most
+/// useful in a window somebody has put to one side, and a `CAAnimation` is interpolated in the
+/// render server on the display's own clock, so parking it saves nothing. `Reduce Motion` is the
+/// one thing that holds it still, and it is read by `BusyPulseDriver` in one place. See `BusyPulse`.
+///
+/// # Why it hosts the mark rather than drawing it
+///
+/// The figure stays a SwiftUI view and only the opacity moves to a layer. An AppKit redrawing of an
+/// SF Symbol would have to match `TranscriptGlyph`'s point size, weight and scale by hand, and a
+/// mark half a point out of the column it shares with every other row in the transcript is a worse
+/// outcome than the animation it was trying to make cheaper. The hosting view is a subview rather
+/// than the animated layer itself, so the animation lives on a layer SwiftUI does not own and
+/// cannot reset from inside.
+struct BreathingMark<Content: View>: View {
+    /// False for a mark that is present but still: the snapshot run, and `Reduce Motion`.
+    var isMoving = true
+
+    @ViewBuilder var content: () -> Content
+
+    private var pulse: BusyPulse { .shared }
+
+    var body: some View {
+        if isMoving && pulse.isTicking {
+            BreathingMarkHost(epoch: pulse.epoch, content: content())
+        } else {
+            // Deliberately not the layer. Only the moving state has anything to gain from Core
+            // Animation, and keeping the still one in SwiftUI is what lets `ImageRenderer`
+            // photograph a mark that is not breathing: it cannot draw an `NSViewRepresentable` at
+            // all, and paints one as a yellow placeholder. See `Snapshot`.
+            content()
+        }
+    }
+}
+
+private struct BreathingMarkHost<Content: View>: NSViewRepresentable {
+    /// The heartbeat's start, which is the only thing that decides where in its breath the mark is.
+    /// See `BusyPulse.epoch`.
+    var epoch: CFTimeInterval
+
+    var content: Content
+
+    func makeNSView(context: Context) -> BreathingMarkView<Content> {
+        let view = BreathingMarkView(content: content)
+        view.configure(epoch: epoch, content: content)
+        return view
+    }
+
+    func updateNSView(_ view: BreathingMarkView<Content>, context: Context) {
+        view.configure(epoch: epoch, content: content)
+    }
+
+    func sizeThatFits(
+        _ proposal: ProposedViewSize, nsView: BreathingMarkView<Content>, context: Context
+    ) -> CGSize? {
+        nsView.fittingSize
+    }
+}
+
+/// The hosted mark, under a repeating fade.
+final class BreathingMarkView<Content: View>: BusyPulseLayerView {
+    private let hosting: NSHostingView<Content>
+    private var epoch: CFTimeInterval = 0
+
+    init(content: Content) {
+        hosting = NSHostingView(rootView: content)
+        super.init(frame: .zero)
+        // A glyph is drawn inside its own column and does not grow, but a mark that overflowed its
+        // box would be flattened against the edge rather than clipped politely, and rasterising a
+        // sixteen point box to find out is a cost nobody asked for.
+        layer?.masksToBounds = false
+        hosting.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(hosting)
+        NSLayoutConstraint.activate([
+            hosting.leadingAnchor.constraint(equalTo: leadingAnchor),
+            hosting.trailingAnchor.constraint(equalTo: trailingAnchor),
+            hosting.topAnchor.constraint(equalTo: topAnchor),
+            hosting.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("not used") }
+
+    override var intrinsicContentSize: NSSize { hosting.intrinsicContentSize }
+
+    /// Guarded, because `updateNSView` runs whenever the view around it is rebuilt, and a retry row
+    /// is rebuilt on every announcement. Reinstalling an animation that is already correct would
+    /// reset its phase, and the phase is what puts this mark on the window's one heartbeat.
+    func configure(epoch: CFTimeInterval, content: Content) {
+        hosting.rootView = content
+        guard epoch != self.epoch else { return }
+        self.epoch = epoch
+        install()
+    }
+
+    private func install() {
+        // The model value is the resting figure, so a layer whose animation has not arrived yet
+        // draws the mark at the strength it would rest at. Written with actions off, or AppKit
+        // interpolates its way there.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        layer?.opacity = Float(BusyBreath.restingOpacity)
+        CATransaction.commit()
+
+        guard let layer else { return }
+        install(breath(), on: layer, key: "breathe", beginAt: epoch)
+    }
+
+    /// One whole breath, sampled.
+    ///
+    /// Keyframes rather than a timing function, because the envelope's two eased stretches are
+    /// power curves and Core Animation's timing functions are cubic beziers: fitting them would be
+    /// an approximation of an approximation. `BusyBreath` is where the shape lives and where it is
+    /// tested, and it hands out the samples for exactly this.
+    ///
+    /// Capped at the frame rate `PulsingDot` measured for its own fade: this is a fade with no
+    /// position in it, over three seconds, so twelve frames a second moves it about a fiftieth of
+    /// its range per frame.
+    private func breath() -> CAKeyframeAnimation {
+        let samples = BusyBreath.opacitySamples(count: 24)
+        let animation = CAKeyframeAnimation(keyPath: "opacity")
+        animation.values = samples
+        animation.keyTimes = (0..<samples.count).map {
+            NSNumber(value: Double($0) / Double(samples.count - 1))
+        }
+        animation.calculationMode = .linear
+        animation.duration = BusyBreath.period
+        animation.preferredFrameRateRange = CAFrameRateRange(minimum: 8, maximum: 15, preferred: 12)
+        return animation
+    }
+}

--- a/Sources/Bloom/Design/PermissionSnapshotGallery.swift
+++ b/Sources/Bloom/Design/PermissionSnapshotGallery.swift
@@ -63,11 +63,10 @@ struct PermissionSnapshotGallery: View {
     }
 
     private func toolRow(_ id: String, name: String, file: String) -> some View {
-        ToolRowView(
-            use: AgentToolUse(
-                id: id, name: name,
-                input: .object(["file_path": .string(file)])
-            ),
+        let use = AgentToolUse(id: id, name: name, input: .object(["file_path": .string(file)]))
+        return ToolRowView(
+            use: use,
+            presentation: TranscriptPresenter.present(use),
             workspace: workspace,
             result: nil,
             isError: false,

--- a/Sources/Bloom/Design/ToolRowSnapshotGallery.swift
+++ b/Sources/Bloom/Design/ToolRowSnapshotGallery.swift
@@ -45,8 +45,10 @@ struct ToolRowSnapshotGallery: View {
         _ input: [String: JSONValue],
         isExpanded: Bool = false
     ) -> some View {
-        ToolRowView(
-            use: AgentToolUse(id: id, name: name, input: .object(input)),
+        let use = AgentToolUse(id: id, name: name, input: .object(input))
+        return ToolRowView(
+            use: use,
+            presentation: TranscriptPresenter.present(use),
             workspace: workspace,
             result: nil,
             isError: false,

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -159,7 +159,10 @@ final class WorkspaceModel {
     var localWork: LocalWork?
 
     // Setup.
-    var setupOutput: String = ""
+    /// Written here and nowhere else, which `private(set)` is what keeps true: the timeline below
+    /// is memoised against it, and a writer outside this class would leave the memo standing over
+    /// a log that had moved. See `timeline(isRunningSetup:)`.
+    private(set) var setupOutput: String = ""
     var isRunningSetup = false
     /// Things Bloom did to this workspace that are worth a line in the transcript: a merge, and
     /// whatever follows it.
@@ -180,15 +183,74 @@ final class WorkspaceModel {
 
     /// What the transcript draws above its rows: the setup line, derived from the workspace's own
     /// stored state, then everything Bloom has recorded since, in the order it happened.
+    ///
+    /// **Memoised, because this is asked from a view body rather than when the log moves.**
+    /// `WorkspaceEventsView` sits at the top of the transcript's own `LazyVStack`, so its body runs
+    /// on every pass of that list, which during a window or sidebar drag is once a frame. Building
+    /// the event is not cheap: `WorkspaceEvent.setup` counts the lines of a log that
+    /// `Workspace.setupLogLimit` allows to be two hundred thousand characters, and does it twice
+    /// for a run that succeeded, and for a run that failed `SetupDiagnosis.read` copies and splits
+    /// the whole of it on top of that.
+    ///
+    /// This partly undoes `dfe734b`, which moved the count into `WorkspaceEvent`'s initialiser so
+    /// it was "counted once at construction". That was true and it did not help, because
+    /// construction is what happens every pass: the count moved rather than went away. What makes
+    /// it go away is not constructing the event again when nothing it is built from has changed.
+    ///
+    /// Every field of the key is read on every call, and that is load-bearing rather than
+    /// wasteful: reading them is what registers this view's observation of them, so a memo that
+    /// answered without touching `setupOutput` would leave the transcript never hearing that the
+    /// log had moved. `utf8.count` is O(1) on a native Swift string.
     func timeline(isRunningSetup running: Bool) -> [WorkspaceEvent] {
+        let key = TimelineKey(
+            isRunning: running,
+            setupState: workspace.setupState,
+            logBytes: setupOutput.utf8.count,
+            logWrites: setupLogWrites,
+            durationMS: setupDurationMS,
+            exitStatus: setupExitStatus,
+            recorded: events
+        )
+        if let timelineMemo, timelineMemo.key == key { return timelineMemo.events }
+
         let setup = WorkspaceEvent.setup(
             state: running ? .running : workspace.setupState,
             log: setupOutput,
             durationMS: setupDurationMS,
             status: setupExitStatus
         )
-        return [setup].compactMap { $0 } + events
+        let built = [setup].compactMap { $0 } + events
+        timelineMemo = (key, built)
+        return built
     }
+
+    /// Everything the timeline is derived from, in the cheapest form that can tell two of them
+    /// apart.
+    ///
+    /// The log is in here twice, and neither is the log. Its byte count is what registers the
+    /// observation and catches every ordinary flush; the write count is what catches the one case
+    /// a length cannot, which is a log already at `Workspace.setupLogLimit` having a batch appended
+    /// and the same number of characters dropped off its front.
+    ///
+    /// The recorded events are compared whole rather than counted, and that is not the expensive
+    /// option it looks: the two sides are the same array buffer on every pass that has not appended
+    /// to it, which `Array.==` answers on identity alone. None of these carries a log.
+    private struct TimelineKey: Equatable {
+        var isRunning: Bool
+        var setupState: SetupState
+        var logBytes: Int
+        var logWrites: Int
+        var durationMS: Int?
+        var exitStatus: Int?
+        var recorded: [WorkspaceEvent]
+    }
+
+    /// The last timeline built, and what it was built from. Not observed: nothing draws it, the
+    /// values it is derived from are all observed already, and a view body is where it is written.
+    @ObservationIgnored private var timelineMemo: (key: TimelineKey, events: [WorkspaceEvent])?
+
+    /// How many times `setupOutput` has been written this launch. See `TimelineKey`.
+    @ObservationIgnored private var setupLogWrites = 0
 
     /// When the run now in flight started, and what the last finished one cost.
     ///
@@ -637,6 +699,7 @@ final class WorkspaceModel {
         setupDurationMS = nil
         setupExitStatus = nil
         setupOutput = ""
+        setupLogWrites += 1
         // A machine with no free block left is not a reason to refuse to run setup. The script
         // simply gets no port to bind, which it can decide for itself what to do about.
         await ensurePort()
@@ -756,6 +819,7 @@ final class WorkspaceModel {
     func appendSetupOutput(_ lines: [String]) {
         guard !lines.isEmpty else { return }
         setupOutput += lines.joined(separator: "\n") + "\n"
+        setupLogWrites += 1
         // The same cap the row is written under, so the transcript and the stored log agree
         // about how much of a long setup survives. See `Workspace.setupLogLimit`.
         if setupOutput.count > Workspace.setupLogLimit {

--- a/Sources/Bloom/Views/Markdown/MarkdownView.swift
+++ b/Sources/Bloom/Views/Markdown/MarkdownView.swift
@@ -2,11 +2,27 @@ import SwiftUI
 import AppKit
 import BloomCore
 
+/// A parsed answer, and everything derived from the parse that a caller would otherwise derive
+/// again on every pass.
 private final class MarkdownBlockBox: NSObject {
     let blocks: [MarkdownBlock]
 
-    init(_ blocks: [MarkdownBlock]) {
+    /// Every address the answer holds, in order and without repeats.
+    ///
+    /// Found once, here, because `LinkPolicy.addresses(in:)` walks the whole block tree and every
+    /// inline run inside it, and `MarkdownView.body` asked for it in front of blocks that were
+    /// already cached: the parse was kept and the walk over its result was not, so a settled row
+    /// paid for it on every pass of the transcript's list. It is a pure function of the blocks, and
+    /// the blocks are what this box exists to hold.
+    let addresses: [String]
+
+    init(_ blocks: [MarkdownBlock], addresses: [String]) {
         self.blocks = blocks
+        self.addresses = addresses
+    }
+
+    convenience init(_ blocks: [MarkdownBlock]) {
+        self.init(blocks, addresses: LinkPolicy.addresses(in: blocks))
     }
 }
 
@@ -19,12 +35,12 @@ private enum MarkdownParseCache {
         return cache
     }()
 
-    static func blocks(for text: String) -> [MarkdownBlock] {
+    static func parsed(for text: String) -> MarkdownBlockBox {
         let key = text as NSString
-        if let cached = values.object(forKey: key) { return cached.blocks }
-        let blocks = MarkdownParser.parse(text)
-        values.setObject(MarkdownBlockBox(blocks), forKey: key, cost: text.utf8.count)
-        return blocks
+        if let cached = values.object(forKey: key) { return cached }
+        let box = MarkdownBlockBox(MarkdownParser.parse(text))
+        values.setObject(box, forKey: key, cost: text.utf8.count)
+        return box
     }
 
     /// The live tail gets a cache of exactly one entry rather than a share of the one above.
@@ -34,13 +50,17 @@ private enum MarkdownParseCache {
     /// streamed answer would evict every finished row in it and leave the visible transcript
     /// re-parsing settled prose on its next redraw. One entry is still worth keeping, because
     /// SwiftUI is free to evaluate a body more than once for the same value.
-    private static var streamed: (text: String, blocks: [MarkdownBlock])?
+    ///
+    /// The addresses in this one are always empty, and that is not an omission: a run that is
+    /// still arriving offers none, so there is nothing for the walk to find and nothing yet worth
+    /// finding. See `MarkdownView.body`.
+    private static var streamed: (text: String, box: MarkdownBlockBox)?
 
-    static func streamingBlocks(for text: String) -> [MarkdownBlock] {
-        if let streamed, streamed.text == text { return streamed.blocks }
-        let blocks = MarkdownParser.parse(text)
-        streamed = (text, blocks)
-        return blocks
+    static func streamingParsed(for text: String) -> MarkdownBlockBox {
+        if let streamed, streamed.text == text { return streamed.box }
+        let box = MarkdownBlockBox(MarkdownParser.parse(text), addresses: [])
+        streamed = (text, box)
+        return box
     }
 }
 
@@ -51,28 +71,29 @@ public struct MarkdownView: View {
 
     /// - Parameter isStreaming: whether this text is still being written. It changes nothing about
     ///   what is drawn, only which cache the parse goes through. See
-    ///   `MarkdownParseCache.streamingBlocks(for:)`.
+    ///   `MarkdownParseCache.streamingParsed(for:)`.
     public init(_ text: String, isStreaming: Bool = false) {
         self.text = text
         self.isStreaming = isStreaming
     }
 
     public var body: some View {
-        let blocks = isStreaming
-            ? MarkdownParseCache.streamingBlocks(for: text)
-            : MarkdownParseCache.blocks(for: text)
         // Which addresses may be opened, and which may not, is `LinkPolicy.opens`. It is not
         // a rule about this view: the user's own bubble is drawn by a different one and goes
-        // through the same door.
-        let addresses = isStreaming ? [] : LinkPolicy.addresses(in: blocks)
-        MarkdownBlocksView(blocks: blocks)
+        // through the same door. The walk that finds them happens where the parse does, so a
+        // settled answer pays for neither twice. See `MarkdownBlockBox.addresses`.
+        //
+        // Not while it is still being written. A menu rebuilt on every token would be work done
+        // for a reader who is not there yet, and there is nothing to copy until the sentence
+        // carrying the address has finished arriving, so the streaming slot holds none.
+        let parsed = isStreaming
+            ? MarkdownParseCache.streamingParsed(for: text)
+            : MarkdownParseCache.parsed(for: text)
+        MarkdownBlocksView(blocks: parsed.blocks)
             .environment(\.markdownIsStreaming, isStreaming)
             .opensTranscriptLinks()
-            // Not while it is still being written. A menu rebuilt on every token would be work
-            // done for a reader who is not there yet, and there is nothing to copy until the
-            // sentence carrying the address has finished arriving. One walk for both takers.
-            .transcriptLinkMenu(addresses)
-            .transcriptLinkActions(addresses)
+            .transcriptLinkMenu(parsed.addresses)
+            .transcriptLinkActions(parsed.addresses)
     }
 }
 
@@ -103,8 +124,11 @@ private struct MarkdownBlocksView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: MarkdownMetrics.blockGap) {
-            ForEach(Array(blocks.enumerated()), id: \.offset) { offset, block in
-                MarkdownBlockView(block: block, foreground: foreground, isFirst: offset == 0)
+            // Over the indices rather than over `Array(blocks.enumerated())`, which allocates a
+            // second array of pairs every pass to draw the same blocks. The same change is made
+            // everywhere below it, and the identity is what it always was: a block's position.
+            ForEach(blocks.indices, id: \.self) { offset in
+                MarkdownBlockView(block: blocks[offset], foreground: foreground, isFirst: offset == 0)
             }
         }
     }
@@ -229,12 +253,12 @@ private struct MarkdownBlockView: View {
         // A tight list at zero read as one paragraph with dots in it, and a loose one at four was
         // tighter than the gap between the marker and its own text.
         VStack(alignment: .leading, spacing: tight ? Metrics.spacingTight : Metrics.spacing) {
-            ForEach(Array(items.enumerated()), id: \.offset) { offset, item in
+            ForEach(items.indices, id: \.self) { offset in
                 // Baseline, not top: this is the alignment the task list beside it already used,
                 // and top alignment sat the marker a fraction above the line it marks.
                 HStack(alignment: .firstTextBaseline, spacing: Metrics.spacingSmall) {
                     marker(start.map { "\($0 + offset)." } ?? "\u{2022}")
-                    MarkdownBlocksView(blocks: item, foreground: foreground)
+                    MarkdownBlocksView(blocks: items[offset], foreground: foreground)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
@@ -243,7 +267,8 @@ private struct MarkdownBlockView: View {
 
     private func taskList(_ items: [(checked: Bool, inline: [MarkdownInline])]) -> some View {
         VStack(alignment: .leading, spacing: Metrics.spacingTight) {
-            ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+            ForEach(items.indices, id: \.self) { index in
+                let item = items[index]
                 HStack(alignment: .firstTextBaseline, spacing: Metrics.spacingSmall) {
                     Image(systemName: item.checked ? "checkmark.square.fill" : "square")
                         .font(Typo.body)
@@ -260,11 +285,11 @@ private struct MarkdownBlockView: View {
         ScrollView(.horizontal) {
             Grid(horizontalSpacing: 0, verticalSpacing: 0) {
                 GridRow {
-                    ForEach(Array(headers.enumerated()), id: \.offset) { column, header in
+                    ForEach(headers.indices, id: \.self) { column in
                         // A header set a rung below the cells under it was the wrong way round.
                         // Same size, heavier, on a fill: that is what makes it read as a header.
                         tableCell(
-                            header,
+                            headers[column],
                             rung: Typo.bodyEmphasis,
                             alignment: alignment(at: column, in: alignments),
                             isLastColumn: column == headers.count - 1,
@@ -273,11 +298,12 @@ private struct MarkdownBlockView: View {
                         .background(Palette.surfaceSunken)
                     }
                 }
-                ForEach(Array(rows.enumerated()), id: \.offset) { index, row in
+                ForEach(rows.indices, id: \.self) { index in
+                    let row = rows[index]
                     GridRow {
-                        ForEach(Array(row.enumerated()), id: \.offset) { column, cell in
+                        ForEach(row.indices, id: \.self) { column in
                             tableCell(
-                                cell,
+                                row[column],
                                 rung: Typo.body,
                                 alignment: alignment(at: column, in: alignments),
                                 isLastColumn: column == row.count - 1,
@@ -438,12 +464,65 @@ private final class InlineAttributesKey: NSObject {
         self.font = font
         self.code = code
         self.color = color
+        cachedHash = Self.hash(of: inline, font: font, code: code, color: color)
+    }
+
+    /// **A weak hash, on purpose, and the equality below is unchanged.**
+    ///
+    /// This was `hasher.combine(inline)`, which walks the recursive tree and SipHashes every string
+    /// in it, so looking a cached paragraph up cost a pass over the whole paragraph. What it was
+    /// guarding is `isEqual`'s `inline == other.inline`, and that comparison almost never walks
+    /// anything: the blocks come out of `MarkdownParseCache`, so both sides are the same array
+    /// buffer and `Array.==` answers on identity alone. The lookup was paying the full price of the
+    /// comparison it exists to avoid.
+    ///
+    /// So the hash is the paragraph's shape rather than its contents: how many runs it has, what
+    /// the first and last of them are, and the presentation. Two paragraphs that agree on all of
+    /// that land in one bucket and are told apart by `isEqual`, which is exact. A weaker hash can
+    /// only cost bucket collisions; it cannot return the wrong string.
+    private static func hash(of inline: [MarkdownInline], font: Font, code: Font, color: Color) -> Int {
         var hasher = Hasher()
-        hasher.combine(inline)
+        hasher.combine(inline.count)
+        if let first = inline.first { combine(first, into: &hasher) }
+        if let last = inline.last, inline.count > 1 { combine(last, into: &hasher) }
         hasher.combine(font)
         hasher.combine(code)
         hasher.combine(color)
-        cachedHash = hasher.finalize()
+        return hasher.finalize()
+    }
+
+    /// How much of a run's text is looked at. Long enough that two paragraphs opening on the same
+    /// few words are still told apart, short enough that the walk is bounded.
+    private static let sample = 24
+
+    /// One run, as a case tag and a bounded amount of what is in it.
+    private static func combine(_ value: MarkdownInline, into hasher: inout Hasher) {
+        switch value {
+        case let .text(text):
+            hasher.combine(0)
+            hasher.combine(text.utf8.count)
+            hasher.combine(text.prefix(sample))
+        case let .code(text):
+            hasher.combine(1)
+            hasher.combine(text.utf8.count)
+            hasher.combine(text.prefix(sample))
+        case let .emphasis(children):
+            hasher.combine(2)
+            hasher.combine(children.count)
+        case let .strong(children):
+            hasher.combine(3)
+            hasher.combine(children.count)
+        case let .strikethrough(children):
+            hasher.combine(4)
+            hasher.combine(children.count)
+        case let .link(text, url):
+            hasher.combine(5)
+            hasher.combine(text.count)
+            hasher.combine(url.utf8.count)
+            hasher.combine(url.prefix(sample))
+        case .lineBreak:
+            hasher.combine(6)
+        }
     }
 
     override var hash: Int { cachedHash }

--- a/Sources/Bloom/Views/Transcript/AgentQuestionCard.swift
+++ b/Sources/Bloom/Views/Transcript/AgentQuestionCard.swift
@@ -33,7 +33,9 @@ struct AgentQuestionCard: View {
     @State private var isWritingOther: Set<String> = []
     @FocusState private var otherFocus: String?
 
-    private var questions: [AgentQuestion] { AgentQuestionnaire.questions(in: ask.input) }
+    /// The questions this card is about. See `AgentQuestionCache`, which is why asking for them
+    /// six or eight times in one pass is not six or eight parses.
+    private var questions: [AgentQuestion] { AgentQuestionCache.questions(in: ask) }
 
     private var isOpen: Bool { decision == nil }
 
@@ -460,4 +462,43 @@ private struct QuestionOptionStyle: ButtonStyle {
             return .clear
         }
     }
+}
+
+/// The questions inside an ask, parsed once per request rather than once per read.
+///
+/// `AgentQuestionnaire.questions(in:)` walks the tool input and builds a question and its options
+/// out of it, and the card asks for the answer from `body`, from its header, from the completeness
+/// check, from the answers it would send and from the debug capture: six to eight reads in a pass.
+/// The card also holds three pieces of `@State`, so typing a word into an Other row re-runs all of
+/// them per keystroke.
+///
+/// Keyed on the request id, which is what the CLI uses to identify one control request and what the
+/// answer is posted back against. The input behind a given id is what the agent sent once; nothing
+/// rewrites it.
+@MainActor
+private enum AgentQuestionCache {
+    /// A transcript holds few of these, and a card that has scrolled away can afford to parse
+    /// again if it comes back after a hundred others.
+    private static let values: NSCache<NSString, AgentQuestionsBox> = {
+        let cache = NSCache<NSString, AgentQuestionsBox>()
+        cache.countLimit = 64
+        return cache
+    }()
+
+    static func questions(in ask: PermissionAsk) -> [AgentQuestion] {
+        let key = ask.requestID as NSString
+        if let cached = values.object(forKey: key) { return cached.value }
+
+        let value = AgentQuestionnaire.questions(in: ask.input)
+        values.setObject(AgentQuestionsBox(value), forKey: key)
+        return value
+    }
+}
+
+/// `NSCache` cannot hold a value type. See `TranscriptEventCache`, which keeps its boxes beside it
+/// for the same reason.
+private final class AgentQuestionsBox {
+    let value: [AgentQuestion]
+
+    init(_ value: [AgentQuestion]) { self.value = value }
 }

--- a/Sources/Bloom/Views/Transcript/AgentQuestionCard.swift
+++ b/Sources/Bloom/Views/Transcript/AgentQuestionCard.swift
@@ -472,9 +472,11 @@ private struct QuestionOptionStyle: ButtonStyle {
 /// The card also holds three pieces of `@State`, so typing a word into an Other row re-runs all of
 /// them per keystroke.
 ///
-/// Keyed on the request id, which is what the CLI uses to identify one control request and what the
-/// answer is posted back against. The input behind a given id is what the agent sent once; nothing
-/// rewrites it.
+/// Keyed on the request id and the call it is about, which is what the CLI uses to identify one
+/// control request and what the answer is posted back against. The input behind that pair is what
+/// the agent sent once; nothing rewrites it. Both halves, because a request id is only promised to
+/// be unique within the session that issued it and a window holds several sessions at once, where a
+/// `tool_use` id is minted per call.
 @MainActor
 private enum AgentQuestionCache {
     /// A transcript holds few of these, and a card that has scrolled away can afford to parse
@@ -486,7 +488,8 @@ private enum AgentQuestionCache {
     }()
 
     static func questions(in ask: PermissionAsk) -> [AgentQuestion] {
-        let key = ask.requestID as NSString
+        // A separator no id can hold, so two pairs cannot be spelled the same way round.
+        let key = "\(ask.requestID)\u{1}\(ask.toolUseID)" as NSString
         if let cached = values.object(forKey: key) { return cached.value }
 
         let value = AgentQuestionnaire.questions(in: ask.input)

--- a/Sources/Bloom/Views/Transcript/RetryRowView.swift
+++ b/Sources/Bloom/Views/Transcript/RetryRowView.swift
@@ -90,8 +90,11 @@ struct RetryRowView: View {
 
     private var header: some View {
         HStack(spacing: TranscriptLayout.glyphGap) {
-            TranscriptGlyph(symbol: "arrow.trianglehead.clockwise", tint: tint)
-                .modifier(BreathingOpacity(isActive: !isStill && !reduceMotion))
+            // The breath is a `CAAnimation` on a layer rather than a repeating SwiftUI animation,
+            // and it keeps moving when the window is behind another app. See `BreathingMark`.
+            BreathingMark(isMoving: !isStill && !reduceMotion) {
+                TranscriptGlyph(symbol: "arrow.trianglehead.clockwise", tint: tint)
+            }
 
             Text(retry.headline)
                 .font(Typo.label)
@@ -149,34 +152,5 @@ struct RetryRowView: View {
         }
         .frame(height: Metrics.hairline * 2)
         .frame(maxWidth: TranscriptLayout.proseMeasure, alignment: .leading)
-    }
-}
-
-/// The glyph breathing on the window's heartbeat, so a retrying turn reads as alive.
-///
-/// `BusyBreath`'s envelope rather than a sine, and on a period that is a whole number of the busy
-/// dot's pulses, so a workspace that is retrying breathes against the window's own rhythm rather
-/// than at some rate of its own. Opacity only: the glyph must not change
-/// size, because a symbol that grows and shrinks at this size reads as a focus problem.
-private struct BreathingOpacity: ViewModifier {
-    var isActive: Bool
-
-    func body(content: Content) -> some View {
-        if isActive {
-            content.keyframeAnimator(
-                initialValue: 1.0,
-                repeating: true
-            ) { view, value in
-                view.opacity(value)
-            } keyframes: { _ in
-                KeyframeTrack {
-                    for sample in BusyBreath.samples(count: 12) {
-                        LinearKeyframe(0.45 + 0.55 * sample, duration: BusyBreath.period / 12)
-                    }
-                }
-            }
-        } else {
-            content
-        }
     }
 }

--- a/Sources/Bloom/Views/Transcript/ToolRowHeader.swift
+++ b/Sources/Bloom/Views/Transcript/ToolRowHeader.swift
@@ -108,7 +108,11 @@ struct ToolRowHeader: View {
     }
 
     var body: some View {
-        HStack(spacing: TranscriptLayout.glyphGap) {
+        // Read once for the pass. Working it out punctuates a sentence and joins two more, and the
+        // glyph's tint at the top of this stack and the word near the bottom of it both need it.
+        let outcome = outcome
+
+        return HStack(spacing: TranscriptLayout.glyphGap) {
             TranscriptGlyph(
                 symbol: presentation.glyph,
                 // The outcome's colour wins where there is one, and the presentation's role
@@ -155,8 +159,8 @@ struct ToolRowHeader: View {
             // refuses to give ground is cut in half at a narrow pane width rather than
             // truncated. `Chip` already holds itself to one line, and the detail beside it
             // carries the higher layout priority, so the chip only gives ground last.
-            ForEach(Array(presentation.chips.enumerated()), id: \.offset) { _, chip in
-                switch chip {
+            ForEach(presentation.chips.indices, id: \.self) { index in
+                switch presentation.chips[index] {
                 case .code(let text):
                     Chip(text: text, monospaced: true)
                 case .file(let path):

--- a/Sources/Bloom/Views/Transcript/ToolRowView.swift
+++ b/Sources/Bloom/Views/Transcript/ToolRowView.swift
@@ -4,6 +4,15 @@ import BloomCore
 /// One tool call: a line that says what happened, and everything behind it when opened.
 struct ToolRowView: View {
     var use: AgentToolUse
+    /// How the header draws this call: its glyph, its label, its detail and its chips.
+    ///
+    /// Handed down rather than worked out here, and that is a performance decision. This view holds
+    /// its own `isHovered`, so its body runs twice for a pointer crossing the row and again on
+    /// every pass of the transcript's list, and `TranscriptPresenter.present` is a full
+    /// `CodexItem.decode` for a Codex call and a line count over a whole written file for a
+    /// `Write`. The row that knows this row's identity is the one that can keep the answer. See
+    /// `TranscriptPresentationCache`.
+    var presentation: ToolPresentation
     /// Which worktree the call's paths are relative to, so a file chip in the header knows where
     /// it opens.
     var workspace: Workspace
@@ -24,7 +33,7 @@ struct ToolRowView: View {
         VStack(alignment: .leading, spacing: 0) {
             ExpandableRowHeader(isExpanded: isExpanded, onToggle: onToggle) {
                 ToolRowHeader(
-                    presentation: TranscriptPresenter.present(use),
+                    presentation: presentation,
                     workspace: workspace,
                     isError: isError,
                     refusal: refusal,

--- a/Sources/Bloom/Views/Transcript/TranscriptEventCache.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptEventCache.swift
@@ -61,11 +61,20 @@ final class TranscriptPayloadKey: NSObject {
 
     override var hash: Int { cachedHash }
 
+    /// The lengths rather than the bytes, and the hash above is what makes that safe.
+    ///
+    /// Two keys reach this having already agreed on a SipHash of the whole payload and on the row
+    /// id. `Data.==` then memcmp'd the payload again, in full, on every cache hit: 1.6MB across
+    /// 189 rows in a real session, on the main thread, on every pass that decodes a row. That is
+    /// the same measurement `TranscriptRowView.==` records for the comparison it refuses to make,
+    /// and the same answer: what identifies a stored row is its id, and its payload is written once
+    /// and never rewritten. The length is kept as the cheap half of the guard the byte comparison
+    /// was, for a row that somehow is rewritten into something of a different size.
     override func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? TranscriptPayloadKey else { return false }
         return cachedHash == other.cachedHash
             && rowID == other.rowID
-            && payload == other.payload
+            && payload.count == other.payload.count
     }
 }
 

--- a/Sources/Bloom/Views/Transcript/TranscriptLink.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptLink.swift
@@ -75,6 +75,53 @@ enum TranscriptLink {
     /// The addresses are scanned per run of words rather than over the whole turn, because a range
     /// found in the turn would name the wrong characters once the paths in front of it had each
     /// collapsed to a single character.
+    /// The same, from the turn's own words, and held.
+    ///
+    /// **This is the second uncached attributed string builder in the transcript.** `dfe734b` put
+    /// `InlineNSAttributes.make` behind a cache and called itself the last one; a sent bubble was
+    /// building a fresh `NSAttributedString` on every pass, which means segmenting the sentence,
+    /// scanning each run of it for addresses and laying out a text attachment per file in it, and
+    /// then handing the result to an `NSTextView` that relays the whole run out on being given a
+    /// new string. A bubble is a minority of the rows in a transcript, which is why this came last
+    /// rather than not at all.
+    ///
+    /// Keyed on everything the drawing depends on, the way `InlineAttributesKey` is: the words, the
+    /// two faces of them (size and colour), the leading and which ground the chips are drawn for.
+    /// A sent turn is never rewritten, so the entry cannot go stale under its key.
+    @MainActor
+    static func attributedString(
+        sent text: String,
+        font: NSFont,
+        color: NSColor,
+        lineSpacing: CGFloat,
+        chipGround: AttachmentChipCell.Ground
+    ) -> NSAttributedString {
+        let key = SentTurnKey(
+            text: text, font: font, color: color, lineSpacing: lineSpacing, ground: chipGround
+        )
+        if let cached = sentTurns.object(forKey: key) { return cached }
+
+        let value = attributedString(
+            FileMention.segments(in: text),
+            font: font,
+            color: color,
+            lineSpacing: lineSpacing,
+            chipGround: chipGround
+        )
+        sentTurns.setObject(value, forKey: key, cost: text.utf8.count)
+        return value
+    }
+
+    /// One screenful of bubbles and then some. A turn is a sentence and a few chips, so the cost
+    /// limit is over the words rather than over anything that could be large.
+    @MainActor
+    private static let sentTurns: NSCache<SentTurnKey, NSAttributedString> = {
+        let cache = NSCache<SentTurnKey, NSAttributedString>()
+        cache.countLimit = 200
+        cache.totalCostLimit = 2 * 1_024 * 1_024
+        return cache
+    }()
+
     @MainActor
     static func attributedString(
         _ segments: [AttachmentDraft.Segment],
@@ -192,7 +239,8 @@ extension View {
             self
         } else {
             contextMenu {
-                ForEach(Array(addresses.enumerated()), id: \.offset) { _, address in
+                ForEach(addresses.indices, id: \.self) { index in
+                    let address = addresses[index]
                     Button(addresses.count == 1 ? "Copy Link" : "Copy \(LinkPolicy.shortened(address))") {
                         TranscriptLink.copy(address)
                     }
@@ -212,7 +260,8 @@ extension View {
             self
         } else {
             accessibilityActions {
-                ForEach(Array(addresses.enumerated()), id: \.offset) { _, address in
+                ForEach(addresses.indices, id: \.self) { index in
+                    let address = addresses[index]
                     Button(addresses.count == 1 ? "Open Link" : "Open \(LinkPolicy.shortened(address))") {
                         guard let url = URL(string: address), LinkPolicy.opens(url) else { return }
                         NSWorkspace.shared.open(url)
@@ -220,5 +269,45 @@ extension View {
                 }
             }
         }
+    }
+}
+
+/// `NSCache` predates generics over value types, so the key has to be a class. It is an
+/// implementation detail of `TranscriptLink.attributedString(sent:...)` and lives with it.
+private final class SentTurnKey: NSObject {
+    let text: String
+    let font: NSFont
+    let color: NSColor
+    let lineSpacing: CGFloat
+    let ground: AttachmentChipCell.Ground
+    private let cachedHash: Int
+
+    init(text: String, font: NSFont, color: NSColor, lineSpacing: CGFloat, ground: AttachmentChipCell.Ground) {
+        self.text = text
+        self.font = font
+        self.color = color
+        self.lineSpacing = lineSpacing
+        self.ground = ground
+        var hasher = Hasher()
+        hasher.combine(text)
+        hasher.combine(font)
+        hasher.combine(color)
+        hasher.combine(lineSpacing)
+        // The plate alone. There are two grounds in the app, both of them `static let`s, and their
+        // three colours move together; the equality below is still on the whole of it.
+        hasher.combine(ground.plate)
+        cachedHash = hasher.finalize()
+    }
+
+    override var hash: Int { cachedHash }
+
+    override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? SentTurnKey else { return false }
+        return cachedHash == other.cachedHash
+            && text == other.text
+            && font == other.font
+            && color == other.color
+            && lineSpacing == other.lineSpacing
+            && ground == other.ground
     }
 }

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -26,8 +26,15 @@ struct TranscriptListView: View {
     /// re-runs this body. See `TranscriptHoverHost`.
     @State private var hoverHost = TranscriptHoverHost()
 
-    /// Only to reach the workspace's model, which is what a link opened in a browser tab needs.
-    /// Nothing in `body` reads anything else off it.
+    /// Two things, and the comment used to claim one.
+    ///
+    /// `linkActions` reaches the workspace's model, which is what a link opened in a browser tab
+    /// needs, and `existingModel` reads nothing observable to answer. `visibleRows` reads
+    /// `pendingTranscriptTarget`, and that one is a real subscription: this body runs again when
+    /// a transcript search sets it and again when the arrival clears it. It stays, because it is
+    /// what keeps a session that was opened on a searched row from drawing a tail the row is not
+    /// in, and two passes per search is not a cost worth moving anything for. What must not
+    /// appear here is a read of anything that moves while a turn runs.
     @Environment(AppModel.self) private var app
 
     /// Every programmatic move to the live end goes through this: opening a session on its end,
@@ -141,13 +148,20 @@ struct TranscriptListView: View {
     private var showsPlaceholder: Bool {
         transcript.isLoaded
             && !transcript.isRunning
-            && !transcript.isStreaming
             && !showsSetup
             // A workspace whose opening prompt is still queued, or whose first message is on its
             // way out, has nothing in its session and a bubble at the bottom of it. An empty state
             // centred over the pane would be drawn straight across the one thing on screen, which
             // is the same mistake `showsSetup` above is here to avoid.
             && transcript.hasNothingToShow
+            // Last, and the position is the point rather than a tidying. `isStreaming` reads the
+            // per-token buffers that `StreamingTailView` exists to keep out of this body: reading
+            // one here subscribes the whole list to it, and every delta of every answer would run
+            // a pass over every realised row. `&&` short-circuits, so a term that is only reached
+            // when a session is loaded, idle, without a setup row and with nothing at all in it is
+            // a term that is never reached while an answer is streaming. It used to sit second,
+            // where the same short circuit saved it by accident.
+            && !transcript.isStreaming
     }
 
     /// The rows this pass draws, which is every row of the session except on the frame that
@@ -169,7 +183,10 @@ struct TranscriptListView: View {
         let rows = transcript.rows
         guard drawnInFull != transcript.session.id else { return rows[...] }
 
-        let start = TranscriptTail.start(in: rows.map(\.kind))
+        // Lazily, so the kinds are read through the rows rather than copied out of them. This is
+        // asked on every pass, inside the arrival window the tail exists to protect, and the walk
+        // reads at most twice the tail's length of them however long the session is.
+        let start = TranscriptTail.start(in: rows.lazy.map(\.kind))
         guard start > 0 else { return rows[...] }
         // A session opens on the first thing the user has not read, and a scroll can only find a
         // row the list is drawing. Anything unread above the tail and there is no tail: opening in
@@ -232,6 +249,12 @@ struct TranscriptListView: View {
                             showSetupLogEnd(proxy, wasAsked: wasAsked)
                         }
                     )
+                    // On the values, because the two closures above are rebuilt on every pass of
+                    // this body and a struct holding a function can never compare equal to itself.
+                    // Without this the feed re-ran its own body every time this list did, and that
+                    // body rebuilds the setup timeline from a log that may be two hundred thousand
+                    // characters long. See `WorkspaceEventsView.==`.
+                    .equatable()
 
                     ForEach(visibleRows) { row in
                         if TranscriptNoise.isHidden(row) {

--- a/Sources/Bloom/Views/Transcript/TranscriptPresentationCache.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptPresentationCache.swift
@@ -1,0 +1,47 @@
+import Foundation
+import BloomCore
+
+/// How a tool call is drawn, worked out once per row rather than once per pass.
+///
+/// `TranscriptPresenter.present` is a pure function of a call's name and input, and it is not free.
+/// For a Codex workspace it starts with `CodexItem.decode`, which parses the whole item out of the
+/// call's input; for a `Write` it counts the lines of the entire file the agent wrote. It was being
+/// asked from `ToolRowView.body`, which holds the row's own `isHovered`, so the pointer crossing a
+/// row ran it twice, and every pass of the transcript's list ran it again for every realised row.
+///
+/// Keyed on the row's id alone, and that is the same argument `TranscriptEventCache`'s doc makes
+/// about payload identity turned the right way up: a stored row's payload is written once and never
+/// rewritten, so a presentation derived from it cannot go stale. A row whose payload really did
+/// change would be a row nothing else in this transcript could redraw correctly either.
+///
+/// The cost limit the event cache carries has no equivalent here. A `ToolPresentation` is a glyph
+/// name, two short strings and a handful of chips, all of them already truncated to a line, so the
+/// count limit is the whole of what needs bounding.
+@MainActor
+enum TranscriptPresentationCache {
+    /// Comfortably more than a screen of rows, and the same figure `TranscriptEventCache` holds.
+    private static let limit = 256
+
+    private static let values: NSCache<NSNumber, ToolPresentationBox> = {
+        let cache = NSCache<NSNumber, ToolPresentationBox>()
+        cache.countLimit = limit
+        return cache
+    }()
+
+    static func presentation(rowID: Int64, use: AgentToolUse) -> ToolPresentation {
+        let key = NSNumber(value: rowID)
+        if let cached = values.object(forKey: key) { return cached.value }
+
+        let value = TranscriptPresenter.present(use)
+        values.setObject(ToolPresentationBox(value), forKey: key)
+        return value
+    }
+}
+
+/// `NSCache` cannot hold a value type. See `TranscriptEventCache`, which keeps its boxes beside it
+/// for the same reason.
+private final class ToolPresentationBox {
+    let value: ToolPresentation
+
+    init(_ value: ToolPresentation) { self.value = value }
+}

--- a/Sources/Bloom/Views/Transcript/TranscriptRowView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptRowView.swift
@@ -87,10 +87,14 @@ struct TranscriptRowView: View, Equatable {
     private var content: some View {
         switch row.kind {
         case .user:
+            // Read once for the row. It walks the stored request's content blocks and joins them,
+            // and both branches below need it: the second used to reach it through `userTurn`, so
+            // an ordinary bubble built the same string twice per pass.
+            let typed = userText
             // A review turn first: its message is mostly scaffolding the reader never typed, so
             // it renders as the typed words plus a chip per comment. `split` is strict and
             // returns nil for everything else, which falls through to the ordinary bubble.
-            if let review = ReviewTurn.split(userText) {
+            if let review = ReviewTurn.split(typed) {
                 UserTurnRowView(
                     text: review.message,
                     reviewChips: review.chips,
@@ -98,9 +102,16 @@ struct TranscriptRowView: View, Equatable {
                     maxWidth: maxBubbleWidth
                 )
             } else {
+                // Attachments reach the agent as paths in the prompt text, which is the only
+                // reference every agent can follow, so this is the point where they are taken back
+                // out of the sentence and handed to the row as files. `AttachmentTrailer.split`
+                // returns the text untouched at the first thing that is not exactly the shape the
+                // composer writes, so a message that merely talks about attached files is never
+                // edited.
+                let turn = AttachmentTrailer.split(typed)
                 UserTurnRowView(
-                    text: userTurn.body,
-                    attachments: userTurn.paths,
+                    text: turn.body,
+                    attachments: turn.paths,
                     workspace: workspace,
                     maxWidth: maxBubbleWidth
                 )
@@ -120,6 +131,7 @@ struct TranscriptRowView: View, Equatable {
             if let use = toolUse {
                 ToolRowView(
                     use: use,
+                    presentation: TranscriptPresentationCache.presentation(rowID: row.id, use: use),
                     workspace: workspace,
                     result: toolResult,
                     isError: row.isError,
@@ -228,17 +240,6 @@ struct TranscriptRowView: View, Equatable {
               case .toolResult(let result)? = TranscriptEventCache.event(rowID: row.id, payload: payload)
         else { return nil }
         return result
-    }
-
-    /// What the user typed, and what they attached to it.
-    ///
-    /// Attachments reach the agent as paths in the prompt text, which is the only reference every
-    /// agent can follow, so this is the point where they are taken back out of the sentence and
-    /// handed to the row as files. `AttachmentTrailer.split` returns the text untouched at the
-    /// first thing that is not exactly the shape the composer writes, so a message that merely
-    /// talks about attached files is never edited.
-    private var userTurn: (body: String, paths: [String]) {
-        AttachmentTrailer.split(userText)
     }
 
     /// A user turn is the line Bloom itself wrote to stdin, so it is read straight out of the

--- a/Sources/Bloom/Views/Transcript/TranscriptTextView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTextView.swift
@@ -157,7 +157,13 @@ struct TranscriptTextView: NSViewRepresentable {
         }
         let proposed = proposal.width.map(Double.init)
         let width = TranscriptTextMeasure.layoutWidth(proposed: proposed)
-        container.containerSize = CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+        // Only when it has actually moved. Whether TextKit throws its layout away on being handed
+        // the size it already has is not documented either way, and this is the resize path: every
+        // frame of a divider drag asks every realised row for its size, several times, and the
+        // proposals a `.textSelection(.enabled)` block generates repeat the same widths. Not
+        // depending on the answer costs one comparison.
+        let wanted = CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+        if container.containerSize != wanted { container.containerSize = wanted }
         layout.ensureLayout(for: container)
         let used = layout.usedRect(for: container)
         let size = TranscriptTextMeasure.size(

--- a/Sources/Bloom/Views/Transcript/TurnFooterView.swift
+++ b/Sources/Bloom/Views/Transcript/TurnFooterView.swift
@@ -34,7 +34,25 @@ struct TurnFooterView: View {
     @State private var files: [TurnFile] = []
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        // Read once for the pass, and handed down.
+        //
+        // Every one of these is derived from the turn's result payload, which is one of the larger
+        // ones in the file, and the decode in front of it went through `TranscriptEventCache`
+        // precisely because the footer asks for it more than once. It asked about ten times: the
+        // glyph, its tint, the accessible label, the duration, the copy button's text, the menu's
+        // three items, the note under the row and the failure block under that. Cached or not, a
+        // decode is a dictionary lookup and an enum match per ask, and `outcome` and `appearance`
+        // were rebuilt on top of each one.
+        let result = result
+        let outcome = TurnEnding.of(
+            wasStopped: wasStopped,
+            succeeded: result?.succeeded != false,
+            denials: result?.permissionDenials ?? 0
+        )
+        let appearance = Self.appearance(of: outcome)
+        let summaryText = result?.summary ?? ""
+
+        return VStack(alignment: .leading, spacing: 0) {
             // Inset to the column the footer's own contents start on, rather than to the pane.
             // A rule that stops six points short of the text under it looks like a mistake, and
             // this one closes a turn, so it has to read as drawn on purpose.
@@ -59,7 +77,7 @@ struct TurnFooterView: View {
                     .foregroundStyle(appearance.tint)
                     .accessibilityLabel(outcome.label)
 
-                Text(TurnDuration.format(durationMS))
+                Text(TurnDuration.format(row.durationMS ?? result?.durationMS ?? 0))
                     .font(Typo.caption)
                     .foregroundStyle(Palette.textSecondary)
                     .monospacedDigit()
@@ -76,9 +94,21 @@ struct TurnFooterView: View {
                 // only thing in this row that can be dropped, and the alternative was every one of
                 // them being squeezed to an empty rounded rectangle while the duration and the
                 // two buttons kept their width.
+                //
+                // The second rung is where the ladder narrows rather than a fixed three, because
+                // `ViewThatFits` builds and measures every candidate it is offered until one fits.
+                // A turn that touched two or three files was offering the identical row of all of
+                // them twice before it got anywhere: two full sets of chips built and measured to
+                // draw one, on a turn shape that is most turns.
+                //
+                // Not a condition around the candidate, which is the obvious form and is wrong: an
+                // absent branch is an empty view, an empty view always fits, and the footer would
+                // draw nothing where it used to fall through to the count. The rung below is still
+                // offered when the two agree, and a candidate that has already failed fails again,
+                // so what is drawn is what was drawn before in every case.
                 ViewThatFits(in: .horizontal) {
                     fileChips(limit: Self.visibleFileLimit)
-                    fileChips(limit: 3)
+                    fileChips(limit: files.count > 3 ? 3 : 1)
                     fileChips(limit: 1)
                     countChip
                     Color.clear.frame(width: 0, height: 0)
@@ -124,7 +154,7 @@ struct TurnFooterView: View {
 
             // A turn that failed used to draw a red mark, a duration and nothing at all, with the
             // CLI's own explanation parked behind the copy menu. See `TurnFailure`.
-            if let failure {
+            if outcome == .failed, let result, let failure = TurnFailure.of(result) {
                 VStack(alignment: .leading, spacing: TranscriptLayout.tight) {
                     if let lead = failure.lead {
                         Text(lead)
@@ -160,8 +190,25 @@ struct TurnFooterView: View {
 
     // MARK: Turn facts
 
-    /// Read through the same cache the rows use. The footer asks for the result three times in one
-    /// pass, and a result payload is one of the larger ones in the file.
+    /// Read through the same cache the rows use, once per pass, in `body`. This used to say three
+    /// times, which was a count of the asks rather than a decision about them, and by the time the
+    /// failure block and the copy menu had been added it was about ten. The payload is one of the
+    /// larger ones in the file, and a cached decode is still a lookup and an enum match per ask.
+    ///
+    /// What was built on top of each of those asks is where the rest of the cost was. Four endings
+    /// and their drawing were three computed properties reading each other, so every read of the
+    /// last one decoded the first. `body` now takes the result once, works out the ending once,
+    /// and hands both down.
+    ///
+    /// A turn that failed shows what the CLI said for itself, and only when it really failed. Not
+    /// for a turn somebody stopped: the CLI reports its own SIGTERM as an error, and `TurnEnding`
+    /// already refuses to call that a failure. Quoting the CLI's account of a button press would
+    /// put the same mistake back one line lower.
+    ///
+    /// The denials `TurnEnding` is handed are the calls the CLI declined during the turn, reported
+    /// on the `result` line, which is otherwise a plain success: a turn in which every shell call
+    /// was denied ends with `is_error` false and `subtype` "success", so without them the footer
+    /// put a green tick under an agent that had been stopped at every door.
     private var result: AgentResult? {
         guard case .result(let value)? = TranscriptEventCache.event(rowID: row.id, payload: row.payload) else {
             return nil
@@ -169,33 +216,10 @@ struct TurnFooterView: View {
         return value
     }
 
-    private var succeeded: Bool { result?.succeeded != false }
-
-    /// What a failed turn has to say for itself, or nothing.
-    ///
-    /// Not drawn for a turn somebody stopped: the CLI reports its own SIGTERM as an error, and
-    /// `TurnEnding` already refuses to call that a failure. Quoting the CLI's account of a button
-    /// press would put the same mistake back one line lower.
-    private var failure: TurnFailure? {
-        guard outcome == .failed, let result else { return nil }
-        return TurnFailure.of(result)
-    }
-
-    /// How many calls the CLI declined during the turn. Reported on the `result` line, which is
-    /// otherwise a plain success: a turn in which every shell call was denied ends with
-    /// `is_error` false and `subtype` "success", so without this the footer put a green tick under
-    /// an agent that had been stopped at every door.
-    private var denials: Int { result?.permissionDenials ?? 0 }
-
-    /// Which of the four endings this was, and the sentence it carries. See `TurnEnding`.
-    private var outcome: TurnEnding {
-        TurnEnding.of(wasStopped: wasStopped, succeeded: succeeded, denials: denials)
-    }
-
-    /// The drawing of it. A stop is not a failure and must not borrow the failure's red: it is the
-    /// one ending nothing went wrong in, so it is drawn in the ink an ordinary caption uses, with
-    /// the Stop button's own symbol in the ring the other three endings use.
-    private var appearance: (glyph: String, tint: Color) {
+    /// The drawing of an ending. A stop is not a failure and must not borrow the failure's red: it
+    /// is the one ending nothing went wrong in, so it is drawn in the ink an ordinary caption uses,
+    /// with the Stop button's own symbol in the ring the other three endings use.
+    private static func appearance(of outcome: TurnEnding) -> (glyph: String, tint: Color) {
         switch outcome {
         case .finished: ("checkmark.circle", Palette.positive)
         case .denied: ("hand.raised.circle", Palette.warning)
@@ -204,18 +228,24 @@ struct TurnFooterView: View {
         }
     }
 
-    private var durationMS: Int { row.durationMS ?? result?.durationMS ?? 0 }
-
-    private var summaryText: String { result?.summary ?? "" }
-
     // MARK: Actions
 
     /// Off the main actor: a long turn means decoding every tool call in it, and that must not land
     /// on the frame that scrolled the footer into view.
+    ///
+    /// And only once per turn. This hangs off a `.task`, which runs on every realisation of the
+    /// row, and a `LazyVStack` re-realises a footer every time it is scrolled past: each of those
+    /// was a walk back over up to four hundred rows, decoding every one of them. See
+    /// `TurnScanCache` for why the answer can be kept.
     private func scanFiles() async {
+        if let known = TurnScanCache.files(rowID: row.id) {
+            files = known
+            return
+        }
         let scanned = await Task.detached(priority: .utility) { [rows, seq = row.seq] in
             TurnScan.files(rows: rows, endingAt: seq)
         }.value
+        TurnScanCache.remember(scanned, rowID: row.id)
         files = scanned
     }
 

--- a/Sources/Bloom/Views/Transcript/TurnScan.swift
+++ b/Sources/Bloom/Views/Transcript/TurnScan.swift
@@ -112,3 +112,48 @@ enum TurnScan {
         return nil
     }
 }
+
+/// What a turn wrote, kept for as long as the footer that asked is likely to come back.
+///
+/// The scan is a walk backwards over up to four hundred rows, decoding the payload of every tool
+/// call among them, and it hangs off a `.task` on the footer. A `LazyVStack` realises a row when it
+/// approaches the viewport and drops it when it leaves, so scrolling through a long session re-ran
+/// the whole scan for every footer that went past, each time to arrive at the answer it arrived at
+/// last time.
+///
+/// **Keyed on the result row's own id, and that is safe for the reason `TranscriptEventCache` gives
+/// for the payloads it holds.** A turn's rows are the stored messages between the previous result
+/// row and this one; they are written once as they arrive and never rewritten, and a result row is
+/// the last of them, so a turn that has one has stopped changing. Nothing that arrives afterwards
+/// belongs to it.
+///
+/// `@MainActor` because that is where a footer asks and where the answer is assigned. The scan
+/// itself still runs off the actor.
+@MainActor
+enum TurnScanCache {
+    /// Roughly the footers a long scroll passes through, and a turn's file list is a handful of
+    /// paths and two integers each.
+    private static let limit = 512
+
+    private static let values: NSCache<NSNumber, TurnFilesBox> = {
+        let cache = NSCache<NSNumber, TurnFilesBox>()
+        cache.countLimit = limit
+        return cache
+    }()
+
+    static func files(rowID: Int64) -> [TurnFile]? {
+        values.object(forKey: NSNumber(value: rowID))?.value
+    }
+
+    static func remember(_ files: [TurnFile], rowID: Int64) {
+        values.setObject(TurnFilesBox(files), forKey: NSNumber(value: rowID))
+    }
+}
+
+/// `NSCache` cannot hold a value type. See `TranscriptEventCache`, which keeps its boxes beside it
+/// for the same reason.
+private final class TurnFilesBox {
+    let value: [TurnFile]
+
+    init(_ value: [TurnFile]) { self.value = value }
+}

--- a/Sources/Bloom/Views/Transcript/UserTurnRowView.swift
+++ b/Sources/Bloom/Views/Transcript/UserTurnRowView.swift
@@ -134,7 +134,7 @@ struct UserTurnRowView: View {
                 // nothing at all. See the note on that type.
                 TranscriptTextView(
                     text: TranscriptLink.attributedString(
-                        FileMention.segments(in: text),
+                        sent: text,
                         font: Typo.body.resolvedNSFont(scale: fontScale, face: chatFont),
                         // White, the same ink a selected row uses on the same fill. Measured 5.2
                         // to 1 on Spatie Blue, which passes AA for body text in both appearances.

--- a/Sources/Bloom/Views/Transcript/WorkspaceEventsView.swift
+++ b/Sources/Bloom/Views/Transcript/WorkspaceEventsView.swift
@@ -9,7 +9,29 @@ import BloomCore
 /// a tidy one: a setup script flushes new output several times a second, and if the list's own body
 /// read it, every flush would re-run the `ForEach` over every row in the session. Nothing above
 /// this view reads the log, so a running setup redraws these rows and nothing else.
-struct WorkspaceEventsView: View {
+struct WorkspaceEventsView: View, Equatable {
+    /// The feed redraws when the workspace, the run or the pane changes, and not because the two
+    /// closures beside them are new closures.
+    ///
+    /// Functions are never equal to one another, and both of these are built fresh in
+    /// `TranscriptListView.body`, so without this SwiftUI has to assume the feed differs from the
+    /// one it drew a moment ago and re-runs this body on every pass of the transcript's own list.
+    /// That body reads the setup timeline, which is the whole of what the note above is about:
+    /// the read was kept out of the list so a flush redraws these rows and nothing else, and a
+    /// comparison that always fails put the list's passes back on top of it.
+    ///
+    /// **The closures are ignored, and `workspaceID` is what makes that safe.** A view kept by an
+    /// equal comparison keeps the closure it was built with, so what matters is what a stale one
+    /// could still capture. Both close over `TranscriptListView` itself: its `@State` reaches
+    /// through a storage box and is never stale, and the one stored value they reach, the
+    /// transcript, cannot change without the workspace changing, which is compared here.
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.workspaceID == rhs.workspaceID
+            && lhs.isRunning == rhs.isRunning
+            && lhs.isFirstThing == rhs.isFirstThing
+            && lhs.paneHeight == rhs.paneHeight
+    }
+
     var workspaceID: WorkspaceID
     /// Whether a setup run is in flight, as the pane above already knows it. The stored state
     /// catches up a moment later, when the workspace row is next read.
@@ -158,6 +180,11 @@ struct WorkspaceEventRow: View {
     private static let expandedTail = TextCap.lineCap
 
     var body: some View {
+        // Read once for the pass. `tail` walks the log backwards from its end, and it was asked
+        // for three times: here, to decide whether there is a block at all, and then again by the
+        // block and by the text inside it.
+        let tail = tail
+
         VStack(alignment: .leading, spacing: 0) {
             if canExpand {
                 ExpandableRowHeader(isExpanded: isExpanded, onToggle: { isExpanded.toggle() }) {
@@ -168,7 +195,7 @@ struct WorkspaceEventRow: View {
             }
 
             if !tail.isEmpty {
-                logBlock
+                logBlock(tail)
             }
 
             if !note.isEmpty {
@@ -290,8 +317,12 @@ struct WorkspaceEventRow: View {
     /// from becoming two hundred views. Those are also the three cases that may wrap: they are
     /// read, so nothing in them may be cut off, and none of them is moving while it is read.
     @ViewBuilder
-    private var tailText: some View {
+    private func tailText(_ tail: String) -> some View {
         if event.isRunning, !isExpanded {
+            // Once per pass rather than twice: the stack draws them and the settle below is keyed
+            // on them, and working them out is a walk over the window and a walk over the log's
+            // trailing newlines.
+            let lines = SetupTailLine.lines(of: tail, endingAt: event.log)
             VStack(alignment: .leading, spacing: 0) {
                 ForEach(lines) { line in
                     Text(line.text)
@@ -342,7 +373,7 @@ struct WorkspaceEventRow: View {
             .clipped()
             .animation(reduceMotion ? nil : Self.settle, value: lines)
         } else {
-            Text(marked)
+            Text(marked(tail))
         }
     }
 
@@ -356,7 +387,7 @@ struct WorkspaceEventRow: View {
     ///
     /// One `AttributedString` rather than a `Text` per line, so a selection still runs across the
     /// whole block and an expanded log stays one view however long it is.
-    private var marked: AttributedString {
+    private func marked(_ tail: String) -> AttributedString {
         guard event.isFailure, !event.failureSummary.isEmpty else { return AttributedString(tail) }
 
         var output = AttributedString()
@@ -369,23 +400,9 @@ struct WorkspaceEventRow: View {
         return output
     }
 
-    private var lines: [SetupTailLine] {
-        SetupTailLine.lines(of: tail, endingAt: event.log)
-    }
-
-    /// How tall one line of the tail is.
-    ///
-    /// Asked of AppKit rather than written down, because it has to be the height SwiftUI actually
-    /// lays a line of this face out on: a number a point out is a window that clips its last line
-    /// or leaves a gap under it, and the conversation can be set at any size. `Typo.code` is the
-    /// callout rung in monospace, and `ScaledFont` rounds the scaled size to a whole point before
-    /// asking for a face, so both steps are repeated here. The same question `ComposerTextEditor`
-    /// asks to size its own rows.
-    private var lineHeight: CGFloat {
-        let size = (NSFont.preferredFont(forTextStyle: .callout).pointSize * fontScale).rounded()
-        let font = NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
-        return NSLayoutManager().defaultLineHeight(for: font)
-    }
+    /// How tall one line of the tail is. See `SetupLineHeight`, which is where it is worked out
+    /// and where it is held.
+    private var lineHeight: CGFloat { SetupLineHeight.height(fontScale: fontScale) }
 
     /// One line of travel, and it is over before the next line is due.
     ///
@@ -398,9 +415,9 @@ struct WorkspaceEventRow: View {
 
     /// The same quoted block a tool result is drawn in, rule down the left and all, because it is
     /// the same thing: output from something that ran.
-    private var logBlock: some View {
+    private func logBlock(_ tail: String) -> some View {
         VStack(alignment: .leading, spacing: TranscriptLayout.tight) {
-            tailText
+            tailText(tail)
                 .font(Typo.code)
                 // Every line starts as ordinary output. The failure colours itself, in `marked`,
                 // and nothing else in the block is entitled to the alarm colour.
@@ -555,5 +572,34 @@ struct SetupTailLine: Identifiable, Equatable {
         }
         result.append(SetupTailLine(id: start, text: text))
         return result
+    }
+}
+
+/// How tall one line of a setup log is, at the size the conversation is set to.
+///
+/// Asked of AppKit rather than written down, because it has to be the height SwiftUI actually lays
+/// a line of this face out on: a number a point out is a window that clips its last line or leaves
+/// a gap under it, and the conversation can be set at any size. `Typo.code` is the callout rung in
+/// monospace, and `ScaledFont` rounds the scaled size to a whole point before asking for a face, so
+/// both steps are repeated here. The same question `ComposerTextEditor` asks to size its own rows.
+///
+/// **Held rather than asked, because the row asks it per line per pass.** A running tail draws one
+/// `Text` per line and states each one's height, the block states its own, and `tailCap` divides
+/// the pane by it, so an `NSLayoutManager` was being allocated a dozen times per pass of a row that
+/// redraws several times a second while a script runs. It is a pure function of the text size:
+/// `fontScale` is the app's own setting, and the callout rung it multiplies does not move on macOS,
+/// which has no Dynamic Type for it to track.
+@MainActor
+enum SetupLineHeight {
+    private static var memo: (scale: CGFloat, height: CGFloat)?
+
+    static func height(fontScale: CGFloat) -> CGFloat {
+        if let memo, memo.scale == fontScale { return memo.height }
+
+        let size = (NSFont.preferredFont(forTextStyle: .callout).pointSize * fontScale).rounded()
+        let font = NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
+        let height = NSLayoutManager().defaultLineHeight(for: font)
+        memo = (fontScale, height)
+        return height
     }
 }

--- a/Sources/BloomCore/BusyBreath.swift
+++ b/Sources/BloomCore/BusyBreath.swift
@@ -64,6 +64,28 @@ public enum BusyBreath {
         return 0
     }
 
+    /// What the mark holds at the bottom of the breath.
+    ///
+    /// Not nothing, for the reason `BusyDot` gives for its own floor: a glyph that reaches zero is
+    /// absent for part of every cycle, and a thirteen point symbol in a reading column is glanced
+    /// at rather than watched. A mark that disappears and comes back reads as a fault.
+    public static let restingOpacity = 0.45
+
+    /// The opacity a breathing mark is drawn at, at a fraction of the period.
+    ///
+    /// The envelope is here rather than at the mark for the reason the rest of this type is: the
+    /// retry glyph used to hold these two numbers itself, inside a `keyframeAnimator`, where
+    /// nothing could ask what they were.
+    public static func opacity(atPhase phase: Double) -> Double {
+        restingOpacity + (1 - restingOpacity) * value(atPhase: phase)
+    }
+
+    /// The opacities of one whole breath, for a `CAKeyframeAnimation` that interpolates between
+    /// them. The last repeats the first, so the animation closes on itself.
+    public static func opacitySamples(count: Int = 48) -> [Double] {
+        samples(count: count).map { restingOpacity + (1 - restingOpacity) * $0 }
+    }
+
     /// The breath sampled evenly across one period, for a keyframe animation.
     ///
     /// Sampled rather than expressed as four keyframes with timing functions, because the two eased

--- a/Sources/BloomCore/LogTail.swift
+++ b/Sources/BloomCore/LogTail.swift
@@ -69,25 +69,45 @@ public enum LogTail {
     /// U+2028, U+2029) are deliberately not counted. A setup script's output does not contain
     /// them, and `SetupDiagnosis.split`, which decides what a LINE of a log actually is, has never
     /// recognised them either: counting them here would have this disagree with what is drawn.
+    /// Walked over the string's own UTF-8 view rather than over `Array(text.utf8)`, which is the
+    /// second half of the same measurement. The byte scan was the cheap part; the copy in front of
+    /// it was not. A log of two hundred thousand characters allocates and fills two hundred
+    /// thousand bytes before a single one of them is looked at, and this is asked from a view body.
+    ///
+    /// One forward pass, because a `String.UTF8View` walks forwards cheaply and backwards through
+    /// its index arithmetic. The trailing newlines the old walk trimmed first are dropped at the
+    /// end instead: separators are counted as they are seen, and the run of them that no content
+    /// follows is taken off the total. That is the same answer, arrived at without knowing where
+    /// the end of the content is until the end is reached.
     public static func lineCount(_ text: String) -> Int {
-        let bytes = Array(text.utf8)
-        var end = bytes.count
-        while end > 0, bytes[end - 1] == 0x0A || bytes[end - 1] == 0x0D { end -= 1 }
-        guard end > 0 else { return 0 }
+        let bytes = text.utf8
+        let end = bytes.endIndex
 
-        var count = 1
-        var index = 0
+        var total = 0
+        /// Separators seen since the last byte that was not one, which at the end of the walk is
+        /// exactly the trailing run the old code trimmed before counting.
+        var sinceContent = 0
+        var sawContent = false
+
+        var index = bytes.startIndex
         while index < end {
             let byte = bytes[index]
+            index = bytes.index(after: index)
             if byte == 0x0D {
-                count += 1
+                total += 1
+                sinceContent += 1
                 // A CRLF is one separator, and one `Character`.
-                index += (index + 1 < end && bytes[index + 1] == 0x0A) ? 2 : 1
+                if index < end, bytes[index] == 0x0A { index = bytes.index(after: index) }
+            } else if byte == 0x0A {
+                total += 1
+                sinceContent += 1
             } else {
-                if byte == 0x0A { count += 1 }
-                index += 1
+                sawContent = true
+                sinceContent = 0
             }
         }
-        return count
+
+        guard sawContent else { return 0 }
+        return 1 + total - sinceContent
     }
 }

--- a/Sources/BloomCore/TranscriptTail.swift
+++ b/Sources/BloomCore/TranscriptTail.swift
@@ -34,15 +34,27 @@ public enum TranscriptTail {
     /// whole number of turns rather than the back half of one. Only as far as the tail's own length
     /// again: a single turn longer than that is not worth doubling the arrival frame for, and the
     /// history is on its way regardless.
-    public static func start(in kinds: [MessageKind], length: Int = length) -> Int {
-        guard length > 0, kinds.count > length else { return 0 }
+    /// Over any collection of kinds rather than over an array of them, and that is the caller's
+    /// allocation rather than a generality for its own sake. `TranscriptListView` asks this on
+    /// every pass, inside the arrival window the whole mechanism exists to protect, and
+    /// `rows.map(\.kind)` built an array holding every kind in the session to answer a question
+    /// that reads at most twice the tail's length of them. `rows.lazy.map(\.kind)` reads the same
+    /// rows through the same subscript and allocates nothing.
+    ///
+    /// The answer is an offset from the start of the collection, which is what it has always been.
+    public static func start<Kinds: RandomAccessCollection>(
+        in kinds: Kinds, length: Int = length
+    ) -> Int where Kinds.Element == MessageKind, Kinds.Index == Int {
+        let count = kinds.count
+        guard length > 0, count > length else { return 0 }
 
-        let cut = kinds.count - length
+        let first = kinds.startIndex
+        let cut = count - length
         let reach = max(0, cut - length)
         var index = cut
         while index > reach {
             // A turn ends on its result row, so the row after one begins the next turn.
-            if kinds[index - 1] == .result { return index }
+            if kinds[first + index - 1] == .result { return index }
             index -= 1
         }
         return cut

--- a/Tests/BloomCoreTests/BusyBreathTests.swift
+++ b/Tests/BloomCoreTests/BusyBreathTests.swift
@@ -75,6 +75,28 @@ struct BusyBreathTests {
         #expect(biggestStep < 0.2)
     }
 
+    /// The retry glyph is a layer now, and what it is handed is these numbers. A mark that reaches
+    /// nothing is absent for part of every cycle, which is the failure the floor exists to prevent.
+    @Test("the breathing mark never goes out, and arrives at full strength")
+    func opacityStaysOnScreen() {
+        #expect(BusyBreath.opacity(atPhase: 0) == BusyBreath.restingOpacity)
+        #expect(abs(BusyBreath.opacity(atPhase: BusyBreath.inhale) - 1) < 1e-12)
+
+        for step in 0...1_000 {
+            let value = BusyBreath.opacity(atPhase: Double(step) / 1_000)
+            #expect(value >= BusyBreath.restingOpacity)
+            #expect(value <= 1)
+        }
+    }
+
+    @Test("the opacity samples close on themselves")
+    func opacitySamplesClose() {
+        let samples = BusyBreath.opacitySamples(count: 12)
+        #expect(samples.count == 13)
+        #expect(samples.first == samples.last)
+        #expect(samples.max() == 1)
+    }
+
     /// The period is not free: every moving mark in the window is phased off one instant, and that
     /// only keeps them together while the periods share whole multiples. The rule crosses in
     /// `BusyPulse.pass`, which is three seconds.

--- a/Tests/BloomCoreTests/LogTailTests.swift
+++ b/Tests/BloomCoreTests/LogTailTests.swift
@@ -48,6 +48,21 @@ struct LogTailTests {
         #expect(LogTail.lineCount("a\n\nb\n") == 3)
     }
 
+    /// The count is a forward walk over the UTF-8 view now, where it used to trim the trailing
+    /// newlines off a copied byte array before counting. These are the cases the two shapes could
+    /// disagree on: a blank line in front of everything, which counts, against a run of them at
+    /// the end, which does not.
+    @Test("counting agrees at both ends of the log")
+    func countsAtTheEnds() {
+        #expect(LogTail.lineCount("\n\na") == 3)
+        #expect(LogTail.lineCount("\n\na\n\n\n") == 3)
+        #expect(LogTail.lineCount("a\r\nb\r\n") == 2)
+        #expect(LogTail.lineCount("a\rb") == 2)
+        #expect(LogTail.lineCount("a\r") == 1)
+        #expect(LogTail.lineCount("\r\n") == 0)
+        #expect(LogTail.lineCount("\r\n\r\na") == 3)
+    }
+
     @Test("a log of real size is walked from the end rather than copied")
     func handlesALargeLog() {
         let big = (0..<20_000).map { "line \($0)" }.joined(separator: "\n")

--- a/Tests/BloomCoreTests/TranscriptTailTests.swift
+++ b/Tests/BloomCoreTests/TranscriptTailTests.swift
@@ -60,4 +60,12 @@ struct TranscriptTailTests {
     func zeroLengthDrawsEverything() {
         #expect(TranscriptTail.start(in: session(count: 500, turn: 10), length: 0) == 0)
     }
+
+    /// The list asks this over `rows.lazy.map(\.kind)` rather than over an array it built, so the
+    /// answer has to be the same read through a view of the rows as it is read off a copy of them.
+    @Test("a lazy view of the kinds answers what an array of them does")
+    func lazyKindsAgree() {
+        let kinds = session(count: 500, turn: 10)
+        #expect(TranscriptTail.start(in: kinds.lazy.map { $0 }) == TranscriptTail.start(in: kinds))
+    }
 }


### PR DESCRIPTION
Twenty findings from a read-only performance report, worked in order and verified against the code first.

The setup timeline was rebuilt from a log that may be 200,000 characters on every pass of the transcript's list, because the feed's two closures made it compare unequal to itself. It is memoised on `WorkspaceModel` against the four things it is derived from, `LogTail.lineCount` walks the string's UTF-8 view instead of `Array(text.utf8)`, and `WorkspaceEventsView` compares on its values.

The turn footer decoded its result about ten times a pass and rescanned its turn on every realisation. A tool row asked `TranscriptPresenter` for its own drawing twice per pointer pass, which for a Codex row is a full `CodexItem.decode`. A prose row walked its whole parsed answer for addresses in front of a cache that already held the parse. `WorkspaceEventRow` allocated an `NSLayoutManager` per tail line per pass. All of those are answered once and kept, keyed on ids that name a row written once and never rewritten.

The retry glyph is a `CAAnimation` on a layer phased off `BusyPulse.epoch` rather than a `keyframeAnimator(repeating:)`, so a retry that runs for minutes during an upstream outage does not interpolate on the main thread. It keeps breathing when the window is behind another app, which is what `0142c5f` established for every other busy mark; the report's suggestion of a frontmost gate is stale and was not taken. Reduce Motion still holds it still.

The rest is smaller: `InlineAttributesKey` hashes the paragraph's shape rather than SipHashing every string in it, `TranscriptEventCache` stops memcmping the full payload after the hash and the row id have already matched, `TurnScan` is cached on the result row, `ViewThatFits` is no longer offered identical chip rows, `Array(x.enumerated())` becomes `x.indices` in the markdown and link builders, and `TranscriptTail.start` reads the kinds lazily.

Three decisions moved or stayed in BloomCore with tests: the line count's walk, the tail's start over any collection, and the breath's opacity envelope. Everything else is caching and hoisting, which no test in this package can reach; behaviour is argued in the comments beside each one.

Two findings turned out to be wrong. `ToolPresenter.lineCount` is `Git.countLines`, a `reduce` over characters, not the `Array(text.utf8)` the report claimed; the cache still pays for itself. `TranscriptListView`'s claim that nothing in `body` reads `AppModel` is false for `pendingTranscriptTarget`, and that read is correct where it is, so the comment was fixed rather than the code.