### PR TITLE
Stop the centre column rebuilding itself on every frame and every keystroke

### DIFF
--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -87,6 +87,18 @@ final class TranscriptModel {
     private var storedIsAwaitingPermission = false
     private(set) var isLoaded = false
 
+    /// How full the model's context window is, as of the newest row that said anything about it.
+    ///
+    /// Stored for exactly the reason `isAwaitingPermission` is stored, and the composer is exactly
+    /// the reader that argument was written for. It used to be derived in the composer's own body
+    /// from `rows`, which is observed, so every row appended during a turn invalidated the whole
+    /// composer subtree: the box, the chips, the footer and its four menus, once per streamed
+    /// block. And the walk itself could not stop early when there was no answer to find, because
+    /// the limit only ever arrives on the line that closes a turn, so a session that had never
+    /// finished one walked the entire transcript on every pass to return nil. Keeping the answer
+    /// removes the walk and the dependency together. See `ContextWindowUsage.updated`.
+    private(set) var contextUsage: ContextWindowUsage?
+
     /// Text and thinking arriving live, before the completed block is persisted.
     private(set) var streamingText = ""
     private(set) var streamingThinking = ""
@@ -242,6 +254,10 @@ final class TranscriptModel {
         }
         rows = built
         indexByRefID = index
+        // The one place the whole list is walked, because it is also the one place there is a
+        // whole list to walk. Everything after this folds in what arrived. Nothing is held from
+        // before: this is a session being read from the start.
+        contextUsage = ContextWindowUsage.latest(in: built)
         SwitchTrace.mark("transcript.rows.built", workspace: workspace.id)
         SwitchTrace.markOnScreen("transcript.rows.built", workspace: workspace.id)
 
@@ -974,7 +990,19 @@ final class TranscriptModel {
         await loader.wait()
         let after = rows.map(\.seq).max() ?? -1
         let fresh = (try? await store.messages(sessionID: session.id, afterSeq: after)) ?? []
+        guard !fresh.isEmpty else { return }
+        let appendedFrom = rows.count
         for message in fresh { absorb(message) }
+        // Over what actually arrived, not over the transcript. A tool result folds onto a row that
+        // is already there rather than appending, so the slice can be empty, and an empty one
+        // leaves the held reading exactly where it was.
+        noteContextWindow(in: rows[min(appendedFrom, rows.count)...])
+    }
+
+    /// Folds what the newest rows say about the context window into the held reading.
+    private func noteContextWindow(in appended: ArraySlice<TranscriptRow>) {
+        let usage = ContextWindowUsage.updated(contextUsage, with: appended)
+        if usage != contextUsage { contextUsage = usage }
     }
 
     private func clearStreaming() {

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -108,6 +108,10 @@ final class WorkspaceModel {
     /// re-check their anchors against the worktree. Only that re-check reads this, so the tick
     /// invalidates one small view and not the tree.
     private(set) var changesGeneration = 0
+    /// Patches git has already produced for this worktree, so that returning to the review tab is
+    /// not another subprocess. Not observed: nothing draws it, and a write on every file opened
+    /// would invalidate every view watching this model. See `PatchCache`.
+    @ObservationIgnored private var patches = PatchCache()
     /// Why the last refresh could not answer. Non-nil means `changedFiles` is the last list git was
     /// able to produce, not what the worktree looks like now.
     var changesError: String?
@@ -1097,15 +1101,36 @@ final class WorkspaceModel {
         await task.value
     }
 
+    /// One file's diff, from the cache where the worktree has not been looked at since the last
+    /// one, and from git otherwise. See `PatchCache` for what makes an answer reusable and for the
+    /// bug this closes, which is that changing centre tab destroys the review pane and coming back
+    /// to it re-ran the same `git diff` on a worktree nothing had touched.
     func patch(for file: ChangedFile) async -> String {
         let path = workspace.path
         let base = workspace.baseBranch
         // The same scope the list was built with, or the pane opens a file the list narrowed and
         // shows it in full.
         let scope = diffScope
-        return await Task.detached(priority: .userInitiated) {
+        let key = PatchCache.Key(
+            worktree: path, base: base, file: file, scope: scope, generation: changesGeneration
+        )
+        if let held = patches.patch(for: key) { return held }
+
+        let patch = await Task.detached(priority: .userInitiated) {
             (try? await Git.patch(worktree: path, base: base, file: file, scope: scope)) ?? ""
         }.value
+
+        // Only an answer git actually gave. Empty is also what a failure comes back as, and
+        // holding one would turn a moment of git trouble into a file that reads as unchanged for
+        // as long as the generation lasts.
+        guard !patch.isEmpty else { return patch }
+        // Checked again on the way out, because a refresh can land while git is out. An answer
+        // measured before that refresh says nothing about the worktree after it, and filing it
+        // under the new generation would be a claim; filing it under the old one would sweep the
+        // new generation's entries out. So it is handed back and not kept.
+        guard changesGeneration == key.generation else { return patch }
+        patches.store(patch, for: key)
+        return patch
     }
 
     /// Full contents of a file in the worktree, for the All files tab.

--- a/Sources/Bloom/Views/Center/CenterPaneView.swift
+++ b/Sources/Bloom/Views/Center/CenterPaneView.swift
@@ -18,7 +18,13 @@ struct CenterPaneView: View {
     /// menu does not offer it.
     var isSplit: Bool
 
-    @State private var size: CGSize = .zero
+    /// How big the pane is, read by the two drop closures below and by nothing that is drawn.
+    ///
+    /// In a box rather than in `@State` for the reason `GeometryBox` sets out: the probe writes
+    /// this on every frame of a window or divider drag, and as `@State` every one of those frames
+    /// invalidated this body, and with it whichever transcript, terminal or page the pane is
+    /// holding, to store a number the body never reads.
+    @State private var size = GeometryBox(CGSize.zero)
     @State private var isTargeted = false
     /// Which part of this pane a tab being dragged is currently over, which is the part it would
     /// land in. Nil when no drag is over the pane at all.
@@ -41,7 +47,7 @@ struct CenterPaneView: View {
 
     var body: some View {
         content
-            .onGeometryChange(for: CGSize.self) { $0.size } action: { size = $0 }
+            .onGeometryChange(for: CGSize.self) { $0.size } action: { size.value = $0 }
             // Simultaneous rather than a plain tap: the transcript, the composer and the terminal
             // all want their own clicks, and this only needs to know that one happened.
             .simultaneousGesture(
@@ -58,7 +64,7 @@ struct CenterPaneView: View {
             }
             .onDropSessionUpdated { session in
                 switch session.phase {
-                case .entering, .active: landing = PaneRegion.at(session.location, in: size)
+                case .entering, .active: landing = PaneRegion.at(session.location, in: size.value)
                 default: landing = nil
                 }
             }
@@ -193,7 +199,7 @@ struct CenterPaneView: View {
         // `WorkspaceTabsStore.canAbsorb`.
         guard tabs.canAbsorb(dropped) else { return false }
 
-        guard let placement = PaneRegion.at(location, in: size).placement else {
+        guard let placement = PaneRegion.at(location, in: size.value).placement else {
             tabs.replace(pane: pane, of: tab, with: dropped, in: model)
             return true
         }

--- a/Sources/Bloom/Views/Center/ChatPaneView.swift
+++ b/Sources/Bloom/Views/Center/ChatPaneView.swift
@@ -24,6 +24,12 @@ struct ChatPaneView: View {
 
     /// What the transcript and the composer were given between them, which is what caps how far
     /// the divider between the two can be dragged.
+    ///
+    /// Rounded, and that is a performance decision rather than a tidiness one. Raw, it changed on
+    /// every pixel of a window or sidebar drag, which is once a frame, and every one of those
+    /// changes re-ran this body: the whole transcript subtree and the composer under it, rebuilt to
+    /// move a clamp by one point. See `PaneMeasure`, and `TranscriptGeometry` for the same decision
+    /// taken for the same reason one view down.
     @State private var conversationHeight: CGFloat = 0
 
     /// The conversation's text size, applied here because this pane is exactly what the setting is
@@ -67,7 +73,10 @@ struct ChatPaneView: View {
                 availableHeight: conversationHeight
             )
         }
-        .onGeometryChange(for: CGFloat.self) { $0.size.height } action: {
+        // Rounded inside the probe rather than after it, because `onGeometryChange` only calls
+        // the action when the value it is given has changed. Rounding here is what stops the
+        // action running at all for the frames that do not cross a step.
+        .onGeometryChange(for: CGFloat.self) { PaneMeasure.room($0.size.height) } action: {
             conversationHeight = $0
         }
         .background(Palette.windowBackground)

--- a/Sources/Bloom/Views/Center/ComposerContextGauge.swift
+++ b/Sources/Bloom/Views/Center/ComposerContextGauge.swift
@@ -6,6 +6,10 @@ import SwiftUI
 /// something about the next turn that the user may want to act on before sending it.
 struct ComposerContextGauge: View {
     var usage: ContextWindowUsage
+    /// The percentage and the spoken sentence, formatted by the footer. Passed in rather than
+    /// worked out here because this control is built two or three times per pass: see
+    /// `ContextWindowUsage.Reading`.
+    var reading: ContextWindowUsage.Reading
     /// Owned by the footer, not by this view, and the popover is attached there too.
     ///
     /// `ComposerFooterView` draws this row inside a `ViewThatFits` with three candidates, and two
@@ -33,7 +37,7 @@ struct ComposerContextGauge: View {
         } label: {
             HStack(spacing: Metrics.spacingSmall) {
                 bar
-                Text(ContextWindowUsage.percent(usage.fraction))
+                Text(reading.percent)
                     .monospacedDigit()
             }
             .font(Typo.label)
@@ -51,13 +55,7 @@ struct ComposerContextGauge: View {
         .fixedSize()
         .help("Context window")
         .accessibilityLabel("Context window")
-        // The crowded state is drawn as amber and as nothing else, so it has to be said here or
-        // a reader gets the number with no indication that the number is a problem.
-        .accessibilityValue(
-            "\(ContextWindowUsage.percent(usage.fraction)) used, "
-                + "\(ContextWindowUsage.format(usage.used)) of \(ContextWindowUsage.format(usage.limit)) tokens"
-                + (usage.isCrowded ? ", filling up" : "")
-        )
+        .accessibilityValue(reading.spoken)
     }
 
     private var bar: some View {

--- a/Sources/Bloom/Views/Center/ComposerFooterView.swift
+++ b/Sources/Bloom/Views/Center/ComposerFooterView.swift
@@ -41,10 +41,12 @@ struct ComposerFooterView: View {
     @State private var extraModels: [String] = []
     @State private var extraEfforts: [String] = []
 
-    /// The output styles this checkout offers. Held here rather than shared, unlike the model
-    /// catalogue below, because its answer depends on which repository the footer is pointing at
-    /// and one composer only ever points at one. `ViewThatFits` still gets a single copy, because
-    /// the three rows it builds are three renders of this one view.
+    /// The output styles this checkout offers.
+    ///
+    /// Shared per checkout, and swapped for the shared one in the task below rather than owned:
+    /// a footer that owned it re-read the disk every time the centre column changed tab, because
+    /// the pane and everything in it is built again on the way back. `ViewThatFits` gets a single
+    /// copy either way, because the three rows it builds are three renders of this one view.
     @State private var outputStyles = ComposerOutputStyleCatalog()
 
     /// Shared, because `ViewThatFits` below builds this row three times and three copies would be
@@ -57,6 +59,17 @@ struct ComposerFooterView: View {
     @State private var isShowingContextDetail = false
 
     var body: some View {
+        // Everything the row is built out of, worked out once.
+        //
+        // `ViewThatFits` builds each of its candidates in order to measure it, so `row` below runs
+        // three times per pass for the one row it draws. Left inside it, the model sections were
+        // assembled three times, the effort list three times, the output styles and their footnote
+        // three times, the permission modes three times, and the context reading formatted twice.
+        // None of that depends on the width, which is the only thing the three candidates differ
+        // in. This file had already hoisted three pieces of state out of the candidates for a
+        // related reason; the work they were doing stayed behind.
+        let choices = self.choices
+
         // The footer is a fixed row of controls in a pane whose width the user owns: the centre
         // column can be dragged to 420 points and then split in two, and at that width the full
         // row does not fit. Left to overflow it clipped from both edges at once, which took the
@@ -64,10 +77,10 @@ struct ComposerFooterView: View {
         // had no way to send. Each step drops the least load-bearing thing left: first the words
         // beside the picker glyphs, then the context reading, which is the one control here that
         // reports rather than does.
-        ViewThatFits(in: .horizontal) {
-            row(isCompact: false, showsContext: true)
-            row(isCompact: true, showsContext: true)
-            row(isCompact: true, showsContext: false)
+        return ViewThatFits(in: .horizontal) {
+            row(isCompact: false, showsContext: true, choices: choices)
+            row(isCompact: true, showsContext: true, choices: choices)
+            row(isCompact: true, showsContext: false, choices: choices)
         }
         // Outside the `ViewThatFits`, so narrowing the pane cannot take the presenter out of the
         // tree while the popover is up.
@@ -86,7 +99,10 @@ struct ComposerFooterView: View {
         // Re-run when the composer moves to another checkout, because a project's own styles are
         // that project's. The scan itself does nothing when the answer is already held and fresh.
         .task(id: project) {
-            if showsAgentControls { await outputStyles.refreshIfStale(project: project) }
+            guard showsAgentControls else { return }
+            let catalog = ComposerOutputStyleCatalog.shared(for: project)
+            outputStyles = catalog
+            await catalog.refreshIfStale(project: project)
         }
     }
 
@@ -96,7 +112,42 @@ struct ComposerFooterView: View {
         list.append(id)
     }
 
-    private func row(isCompact: Bool, showsContext: Bool) -> some View {
+    /// What the row's pickers offer, and what the gauge says. Built once above `ViewThatFits`,
+    /// because none of it depends on which candidate is being measured.
+    private struct Choices {
+        var models: [ComposerModelSection] = []
+        var efforts: [ComposerOption] = []
+        var outputStyles: [ComposerOption] = []
+        var outputStyleDetail: String?
+        var permissionModes: [ComposerOption] = []
+        var context: ContextWindowUsage.Reading?
+    }
+
+    private var choices: Choices {
+        guard showsAgentControls else {
+            // A terminal workspace has no agent, so the only control left is the send button and
+            // none of these lists is asked for.
+            return Choices(context: context?.reading)
+        }
+        return Choices(
+            models: catalog.sections(includingCurrent: controls.model, on: controls.agentKind),
+            efforts: ComposerOption.adding(extraEfforts, to: efforts),
+            // Only when the picker is drawn at all. Codex has no output styles, and scanning the
+            // list to build rows nothing will show is the same waste one level down.
+            outputStyles: controls.offersOutputStyle
+                ? outputStyles.options(includingCurrent: controls.outputStyle)
+                : [],
+            outputStyleDetail: controls.offersOutputStyle
+                ? outputStyles.detail(of: controls.outputStyle)
+                : nil,
+            permissionModes: controls.availablePermissionModes.map {
+                ComposerOption(id: $0.rawValue, label: $0.label)
+            },
+            context: context?.reading
+        )
+    }
+
+    private func row(isCompact: Bool, showsContext: Bool, choices: Choices) -> some View {
         HStack(spacing: Metrics.spacingTight) {
             if showsAgentControls {
                 ComposerOptionMenu(
@@ -104,7 +155,7 @@ struct ComposerFooterView: View {
                     // One section per backend that can run a chat. A flat list of five names says
                     // nothing about which agent each one belongs to, and picking a name here is
                     // picking an agent.
-                    sections: catalog.sections(includingCurrent: controls.model, on: controls.agentKind),
+                    sections: choices.models,
                     selection: controls.model,
                     // No heading. Opus 5 and Sonnet 5 are names, and the chip this opened from is
                     // showing one of them.
@@ -116,7 +167,7 @@ struct ComposerFooterView: View {
                 )
 
                 ComposerOptionMenu(
-                    options: ComposerOption.adding(extraEfforts, to: efforts),
+                    options: choices.efforts,
                     selection: controls.effort,
                     heading: "Reasoning effort",
                     systemImage: "chart.bar.fill",
@@ -131,10 +182,10 @@ struct ComposerFooterView: View {
                 // has no output styles: see `ComposerControls.offersOutputStyle`.
                 if controls.offersOutputStyle {
                     ComposerOptionMenu(
-                        options: outputStyles.options(includingCurrent: controls.outputStyle),
+                        options: choices.outputStyles,
                         // The selected style, in its own words. The CLI's own sentence for the
                         // four it compiles in, and the file's `description` for a custom one.
-                        footnote: outputStyles.detail(of: controls.outputStyle),
+                        footnote: choices.outputStyleDetail,
                         selection: controls.outputStyle,
                         heading: "Output style",
                         systemImage: "textformat",
@@ -145,9 +196,7 @@ struct ComposerFooterView: View {
                 }
 
                 ComposerOptionMenu(
-                    options: controls.availablePermissionModes.map {
-                        ComposerOption(id: $0.rawValue, label: $0.label)
-                    },
+                    options: choices.permissionModes,
                     footnote: controls.missingPermissionModeNote,
                     selection: controls.permissionMode.rawValue,
                     heading: "Permission mode",
@@ -169,8 +218,10 @@ struct ComposerFooterView: View {
 
             // On the far side of the spacer, away from the pickers. It is a reading rather than
             // something to choose, and among the three menus it read as a fourth one.
-            if let context, showsContext {
-                ComposerContextGauge(usage: context, isShowingDetail: $isShowingContextDetail)
+            if let context, let reading = choices.context, showsContext {
+                ComposerContextGauge(
+                    usage: context, reading: reading, isShowingDetail: $isShowingContextDetail
+                )
             }
 
             // A paperclip, not the plus that used to sit here: a plus already means "new session"

--- a/Sources/Bloom/Views/Center/ComposerOutputStyleCatalog.swift
+++ b/Sources/Bloom/Views/Center/ComposerOutputStyleCatalog.swift
@@ -29,6 +29,26 @@ final class ComposerOutputStyleCatalog {
     /// How long a list is taken on trust before opening the menu re-reads it.
     static let stalenessWindow: TimeInterval = 3
 
+    /// One catalogue per checkout, shared by every footer pointing at it.
+    ///
+    /// Held on the same terms as `SlashCommandCatalog.shared(for:)` and for the same bug: the
+    /// footer's own copy came and went with the pane, so switching tab threw away a list that had
+    /// just been read off disk and scanned for it again. `refreshIfStale` already declined to
+    /// re-read a list that was fresh; what it could not do was find one, because the object
+    /// holding it had been destroyed with the view.
+    ///
+    /// Keyed on the project, which can be nil in the create sheet, where there is no checkout yet
+    /// and the built in styles are the whole answer.
+    private static var byProject: [String: ComposerOutputStyleCatalog] = [:]
+
+    static func shared(for project: String?) -> ComposerOutputStyleCatalog {
+        let key = project ?? ""
+        if let held = byProject[key] { return held }
+        let made = ComposerOutputStyleCatalog()
+        byProject[key] = made
+        return made
+    }
+
     /// Re-reads only if the held list is for another checkout, or is old enough to have missed
     /// something. Cheap to call on every appearance, which is how the footer calls it.
     func refreshIfStale(project: String?, now: Date = Date()) async {

--- a/Sources/Bloom/Views/Center/ComposerPrompt.swift
+++ b/Sources/Bloom/Views/Center/ComposerPrompt.swift
@@ -77,6 +77,13 @@ struct ComposerPrompt<Footer: View>: View {
     /// the text system can undo rather than as a draft replaced behind its back.
     @State private var editor = ComposerEditorHandle()
 
+    /// The `/command` list for the checkout this composer points at.
+    ///
+    /// Swapped for the shared one in the task below rather than owned. A composer that owned its
+    /// catalogue re-scanned six directories every time the centre column changed tab, because the
+    /// pane and everything in it is built again on the way back. This starts as an empty one so
+    /// there is something to read on the pass before that task runs. See
+    /// `SlashCommandCatalog.shared(for:)`.
     @State private var slashCatalog = SlashCommandCatalog()
     /// Whether the pointer has settled on the command chip, which is what puts its card up.
     @State private var isCommandPreviewed = false
@@ -89,7 +96,32 @@ struct ComposerPrompt<Footer: View>: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Metrics.spacingWide) {
+        // Everything derived from the draft, worked out once at the top and threaded down.
+        //
+        // Both of these parse the whole draft. `SlashCommandDraft.parse` splits the leading
+        // `/command` off the prompt, and `ComposerMenu.resolve` takes the text before the caret
+        // and the token around it, which is three `NSString` copies of the draft per call. They
+        // were computed properties, and this body read them about fourteen times between the chip,
+        // the drop target, the three floating overlays, the placement rule they share and the four
+        // task ids underneath, on every keystroke.
+        //
+        // The local is named `draft` rather than `command` deliberately: the drop closure below
+        // reads `command.body` when a file is let go, which must be the draft as it is THEN and
+        // not as it was when this pass ran.
+        let draft = command
+        let menu = ComposerMenu.resolve(draft: draft.body, caret: caret)
+        // Escape only takes down the menu that was open. See `activeMenu`.
+        let openMenu = isMenuDismissed ? ComposerMenu.none : menu
+        // One lookup for the chip and its hover card, which are the same command.
+        let named = draft.name.flatMap { slashCatalog.command(named: $0) }
+        let attachments = self.attachments
+        // Shared by all three floating panels, so the menus and the hover cards cannot end up on
+        // different sides of the same box.
+        let typedLineBottom = typedLineBottom(hasCommand: draft.name != nil)
+        let placement = menuPlacement(typedLineBottom: typedLineBottom)
+        let guide = floatingGuide(isBelow: placement.isBelow, typedLineBottom: typedLineBottom)
+
+        return VStack(alignment: .leading, spacing: Metrics.spacingWide) {
             if !reviewComments.isEmpty {
                 ChipFlow(spacing: Metrics.spacingSmall, lineSpacing: Metrics.spacingSmall) {
                     ForEach(reviewComments) { comment in
@@ -102,10 +134,10 @@ struct ComposerPrompt<Footer: View>: View {
                 }
             }
 
-            if let name = command.name {
+            if let name = draft.name {
                 SlashCommandChip(
                     name: name,
-                    command: slashCatalog.command(named: name),
+                    command: named,
                     onRemove: removeCommand,
                     onHover: { isCommandPreviewed = $0 }
                 )
@@ -152,36 +184,38 @@ struct ComposerPrompt<Footer: View>: View {
             // same time as one of them: they would sit on top of each other, and a menu the user
             // is typing into outranks a preview they are only looking at.
             AttachmentCardOverlay(
-                attachment: activeMenu == .none ? hoveredAttachment : nil,
+                attachment: openMenu == .none
+                    ? hoveredAttachment(in: draft, among: attachments)
+                    : nil,
                 worktree: attachmentRoot,
                 availableWidth: boxWidth
             )
-            .alignmentGuide(.top, computeValue: floatingGuide)
+            .alignmentGuide(.top, computeValue: guide)
         }
         .overlay(alignment: .topLeading) {
             // Same place, same card, same rule as the attachment preview: a menu the user is
             // typing into outranks anything they are only looking at.
             SlashCommandCardOverlay(
-                name: activeMenu == .none && isCommandPreviewed ? command.name : nil,
-                command: command.name.flatMap { slashCatalog.command(named: $0) },
+                name: openMenu == .none && isCommandPreviewed ? draft.name : nil,
+                command: named,
                 availableWidth: boxWidth,
-                availableHeight: menuPlacement.room
+                availableHeight: placement.room
             )
-            .alignmentGuide(.top, computeValue: floatingGuide)
+            .alignmentGuide(.top, computeValue: guide)
         }
         .overlay(alignment: .topLeading) {
             ComposerMenuOverlay(
-                menu: activeMenu,
-                commands: slashResults,
+                menu: openMenu,
+                commands: slashResults(in: openMenu),
                 commandsAreLoaded: slashCatalog.isLoaded,
                 files: fileMatches,
                 selectedIndex: menuIndex,
-                maxHeight: menuPlacement.menuHeight,
+                maxHeight: placement.menuHeight,
                 onPickCommand: pick(command:),
                 onPickFile: pick(file:),
                 onHighlight: { menuIndex = $0 }
             )
-            .alignmentGuide(.top, computeValue: floatingGuide)
+            .alignmentGuide(.top, computeValue: guide)
         }
         // Keyed on the session rather than run on first appearance, because this view is not built
         // again for each one. An unsplit centre column is now the same pane in every workspace, so
@@ -194,15 +228,19 @@ struct ComposerPrompt<Footer: View>: View {
             applyCaptureDraft()
             applyCaptureAttachments()
         }
-        .task(id: mentionRoot) { await slashCatalog.load(workspacePath: mentionRoot) }
+        .task(id: mentionRoot) {
+            let catalog = SlashCommandCatalog.shared(for: mentionRoot)
+            slashCatalog = catalog
+            await catalog.load(workspacePath: mentionRoot)
+        }
         // Opening the menu is the only moment a stale list can be seen, so it is the only moment
         // worth re-reading one. A skill written in another window while Bloom stayed open is in
         // the list by the time the user has finished typing the slash.
-        .task(id: isSlashMenuOpen) {
-            guard isSlashMenuOpen else { return }
+        .task(id: openMenu.kind == .slash) {
+            guard openMenu.kind == .slash else { return }
             await slashCatalog.refreshIfStale(workspacePath: mentionRoot)
         }
-        .task(id: activeMenu.mention?.query) { await refreshFileMatches() }
+        .task(id: openMenu.mention?.query) { await refreshFileMatches() }
         .onChange(of: text) { _, _ in menuIndex = 0 }
         .onChange(of: menu) { old, new in
             menuIndex = 0
@@ -296,24 +334,25 @@ struct ComposerPrompt<Footer: View>: View {
     /// The hover card, once it has been checked against what the draft still says. A file that was
     /// typed out of the sentence, or that went with the turn, takes its card with it without
     /// anything having to remember to put it away.
-    private var hoveredAttachment: PromptAttachment? {
-        guard let hoveredPath, files.paths.contains(hoveredPath) else { return nil }
-        return attachment(for: hoveredPath)
-    }
-
-    /// The draft, split into what was typed and the files named in it.
     ///
-    /// Derived rather than stored, for the same reason `command` is: the text is the only record
-    /// that a file is attached, so nothing can disagree with it about whether one is. See
-    /// `AttachmentDraft`.
-    private var files: AttachmentDraft {
-        AttachmentDraft.parse(command.body, paths: attachments.map(\.path))
+    /// Handed the draft and the records the caller has already read, because the body has both to
+    /// hand and parsing the draft a second time to answer a question about the pointer is the cost
+    /// this whole pass was written to stop paying.
+    private func hoveredAttachment(
+        in draft: SlashCommandDraft, among attachments: [PromptAttachment]
+    ) -> PromptAttachment? {
+        guard let hoveredPath else { return nil }
+        let files = AttachmentDraft.parse(draft.body, paths: attachments.map(\.path))
+        guard files.paths.contains(hoveredPath) else { return nil }
+        return attachment(for: hoveredPath, among: attachments)
     }
 
     /// What is known about one of the paths in the draft. A path with no record beside it is
     /// still a file: it is drawn, opened and sent from the path alone, which is what makes a
     /// restored draft work when nothing else survived the relaunch.
-    private func attachment(for path: String) -> PromptAttachment {
+    private func attachment(
+        for path: String, among attachments: [PromptAttachment]
+    ) -> PromptAttachment {
         attachments.first { $0.path == path } ?? .sent(path: path)
     }
 
@@ -358,18 +397,14 @@ struct ComposerPrompt<Footer: View>: View {
 
     /// Only scored while the slash menu is actually on screen, so a keystroke in an ordinary draft
     /// costs nothing.
-    private var slashResults: [SlashCommandMatch] {
-        guard let token = activeMenu.slash else { return [] }
+    private func slashResults(in menu: ComposerMenu) -> [SlashCommandMatch] {
+        guard let token = menu.slash else { return [] }
         return slashCatalog.matches(token.query)
     }
 
-    /// Whether the slash menu is the one the draft is asking for, which is the moment the command
-    /// list is worth reading off disk again.
-    private var isSlashMenuOpen: Bool { activeMenu.kind == .slash }
-
     private var menuCount: Int {
         switch activeMenu {
-        case .slash: slashResults.count
+        case .slash: slashResults(in: activeMenu).count
         case .mention: fileMatches.count
         case .none: 0
         }
@@ -383,7 +418,7 @@ struct ComposerPrompt<Footer: View>: View {
     /// opened upwards there was clipped at the sheet's top edge: two arbitrary rows survived, the
     /// ranked ones, the selected one among them, were cut off, and the header controls were
     /// covered by what was left. See `MenuLayout.placement` for the rule.
-    private var menuPlacement: MenuLayout.Placement {
+    private func menuPlacement(typedLineBottom: CGFloat) -> MenuLayout.Placement {
         MenuLayout.placement(
             above: boxTop - Metrics.spacing * 2,
             below: windowHeight - boxTop - typedLineBottom - Metrics.spacing * 2
@@ -396,9 +431,9 @@ struct ComposerPrompt<Footer: View>: View {
     /// later line of a long draft can end up under the panel, and both menus can now be opened
     /// there, since a slash completes anywhere it begins a word. The filtering each menu does is
     /// the feedback for what is being typed, so a covered caret costs the reader nothing.
-    private var typedLineBottom: CGFloat {
+    private func typedLineBottom(hasCommand: Bool) -> CGFloat {
         Metrics.gutter
-            + (command.name == nil ? 0 : AttachmentChip.height + Metrics.spacingWide)
+            + (hasCommand ? AttachmentChip.height + Metrics.spacingWide : 0)
             + ComposerTextEditor.lineHeight
     }
 
@@ -409,8 +444,9 @@ struct ComposerPrompt<Footer: View>: View {
     /// A closure built here rather than a method passed by name, because `alignmentGuide` runs
     /// its closure during layout, off the main actor, and a main actor method cannot go there.
     /// The two numbers can: they are read while the body is being built.
-    private var floatingGuide: @Sendable (ViewDimensions) -> CGFloat {
-        let isBelow = menuPlacement.isBelow
+    private func floatingGuide(
+        isBelow: Bool, typedLineBottom: CGFloat
+    ) -> @Sendable (ViewDimensions) -> CGFloat {
         let drop = typedLineBottom + Metrics.spacing
         return { isBelow ? -drop : $0[.bottom] + Metrics.spacing }
     }
@@ -483,8 +519,9 @@ struct ComposerPrompt<Footer: View>: View {
     private func pickHighlighted() {
         switch activeMenu {
         case .slash:
-            guard slashResults.indices.contains(menuIndex) else { return }
-            pick(command: slashResults[menuIndex].command)
+            let results = slashResults(in: activeMenu)
+            guard results.indices.contains(menuIndex) else { return }
+            pick(command: results[menuIndex].command)
         case .mention:
             guard fileMatches.indices.contains(menuIndex) else { return }
             pick(file: fileMatches[menuIndex])
@@ -594,7 +631,7 @@ struct ComposerPrompt<Footer: View>: View {
 
     private func open(path: String) {
         hoveredPath = nil
-        onOpenAttachment(attachment(for: path))
+        onOpenAttachment(attachment(for: path, among: attachments))
     }
 
     private func attachFiles() {

--- a/Sources/Bloom/Views/Center/ComposerTextEditor.swift
+++ b/Sources/Bloom/Views/Center/ComposerTextEditor.swift
@@ -71,7 +71,29 @@ struct ComposerTextEditor: NSViewRepresentable {
     @Environment(\.chatFont) private var chatFont
 
     static var font: NSFont { NSFont.preferredFont(forTextStyle: .body) }
-    static var lineHeight: CGFloat { NSLayoutManager().defaultLineHeight(for: font) }
+
+    /// How tall one line of the composer's own face is.
+    ///
+    /// **Held, because working it out means building a whole TextKit layout manager.** There is no
+    /// cheaper way to ask: `NSLayoutManager.defaultLineHeight(for:)` is the only thing that answers
+    /// with the number the text system will actually lay a line out at, and the property that
+    /// wrapped it allocated one on every read. It is read to size the editor, to clamp the drag, to
+    /// place the completion menus and to seed four other views' state, eight to ten times per pass
+    /// of the composer's body.
+    ///
+    /// Keyed on the font itself rather than invalidated by a notification. A body font that has
+    /// changed, because the reader changed the system text size, is a different `NSFont` and misses
+    /// the cache on its own; a notification would be a second mechanism to keep in step with the
+    /// first, and the one that could be forgotten.
+    static var lineHeight: CGFloat {
+        let font = font
+        if let held = heldLineHeight, held.font == font { return held.height }
+        let height = NSLayoutManager().defaultLineHeight(for: font)
+        heldLineHeight = (font, height)
+        return height
+    }
+
+    private static var heldLineHeight: (font: NSFont, height: CGFloat)?
 
     /// How far the writing starts from the sides of the box.
     ///

--- a/Sources/Bloom/Views/Center/ComposerView.swift
+++ b/Sources/Bloom/Views/Center/ComposerView.swift
@@ -32,6 +32,12 @@ struct ComposerView: View {
     @State private var contentHeight = ComposerTextEditor.lineHeight
     /// Everything in the composer that is not the editor: the divider, the footer, the box and the
     /// padding. Measured rather than assumed, because the footer's height comes from its controls.
+    ///
+    /// Rounded, like the pane height it is taken off. This feeds `maxEditorHeight`, which feeds
+    /// `editorHeight`, which is the body: raw, a window resize wrote it once a frame and each
+    /// write re-ran this view and the footer under it. Up rather than down, because it is
+    /// subtracted from the room, so both roundings err on the side of leaving the transcript its
+    /// floor. See `PaneMeasure`.
     @State private var chromeHeight: CGFloat = 0
     /// The height the drag started from, and the marker for "a drag is under way".
     @State private var resizeOrigin: CGFloat?
@@ -60,8 +66,16 @@ struct ComposerView: View {
         .background(Palette.surface)
         // The chrome is whatever is left once the editor's share is taken off, so this settles on
         // the first pass and only moves again when the footer's controls change size.
+        //
+        // Rounded in the action rather than in the probe, unlike `ChatPaneView`: the number being
+        // measured is the whole composer and the number being kept is the difference between that
+        // and the editor, so a probe that quantised the total would put the rounding error into a
+        // subtraction instead of into the answer. The guard is what stops the write: a resize
+        // moves the total on every frame and leaves the chrome exactly where it was, and writing
+        // an unchanged value into `@State` still re-runs this body.
         .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { total in
-            chromeHeight = total - editorHeight
+            let chrome = PaneMeasure.chrome(total - editorHeight)
+            if chrome != chromeHeight { chromeHeight = chrome }
         }
     }
 
@@ -84,7 +98,7 @@ struct ComposerView: View {
             ComposerFooterView(
                 controls: controls,
                 onChange: apply(controls:),
-                context: ContextWindowUsage.latest(in: transcript.rows),
+                context: transcript.contextUsage,
                 isRunning: transcript.isRunning,
                 canSend: canSend,
                 project: transcript.workspace.path,
@@ -161,8 +175,13 @@ struct ComposerView: View {
         )
     }
 
+    /// Whether anything but whitespace has been typed.
+    ///
+    /// Asked rather than trimmed. `trimmingCharacters` allocates a copy of the whole draft to
+    /// settle a question the first non-space character settles, and this is read through `canSend`
+    /// on every pass of the composer's body.
     private var hasBody: Bool {
-        !transcript.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        transcript.draft.contains { !$0.isWhitespace }
     }
 
     private var attachments: [PromptAttachment] {

--- a/Sources/Bloom/Views/Center/ContextWindowUsage.swift
+++ b/Sources/Bloom/Views/Center/ContextWindowUsage.swift
@@ -42,16 +42,34 @@ struct ContextWindowUsage: Equatable {
     /// number and no indication that the number was a problem.
     var isCrowded: Bool { fraction >= Self.crowdedAt }
 
-    /// The most recent reading a transcript holds, or nil when the session has not run a turn yet
-    /// and so has never been told either number.
+    /// The most recent reading a whole transcript holds, or nil when the session has not run a
+    /// turn yet and so has never been told either number.
     ///
-    /// Walked backwards and stopped as soon as both numbers are in hand, because the answer is
-    /// almost always in the last few rows and this is read on every composer render.
+    /// For the one caller that has the whole list and nothing held: a session being read back off
+    /// disk. Everything after that goes through `updated(_:with:)` below, because this walk cannot
+    /// stop early when there is no answer to find.
+    @MainActor
+    static func latest(in rows: [TranscriptRow]) -> Self? {
+        updated(nil, with: rows)
+    }
+
+    /// What newly arrived rows say about the window, folded onto what was already known.
+    ///
+    /// **The two numbers arrive on different lines, and neither is on every line.** The limit only
+    /// appears on the line that closes a turn and what is in the window only on an assistant or
+    /// thinking block, so each is kept until something newer replaces it rather than being
+    /// recomputed from the whole transcript. Nought means "this line did not say", never "the
+    /// window is empty", which is why neither is ever overwritten with one.
+    ///
+    /// Walked backwards and stopped as soon as both numbers are in hand, because the answer is in
+    /// the last few rows of whatever it is handed.
     ///
     /// Rows from inside a subagent are skipped: the Agent tool runs its own conversation with its
     /// own window, and its usage says nothing about the one the composer is about to add to.
     @MainActor
-    static func latest(in rows: [TranscriptRow]) -> Self? {
+    static func updated(
+        _ held: Self?, with rows: some BidirectionalCollection<TranscriptRow>
+    ) -> Self? {
         var used = 0
         var limit = 0
 
@@ -76,6 +94,8 @@ struct ContextWindowUsage: Equatable {
             if used > 0, limit > 0 { break }
         }
 
+        if used == 0 { used = held?.used ?? 0 }
+        if limit == 0 { limit = held?.limit ?? 0 }
         guard used > 0, limit > 0 else { return nil }
         return Self(used: used, limit: limit)
     }
@@ -102,5 +122,30 @@ struct ContextWindowUsage: Equatable {
     /// do not have, since the next turn's prompt is not in them yet.
     static func percent(_ fraction: Double) -> String {
         (fraction).formatted(.percent.precision(.fractionLength(0)))
+    }
+
+    /// Everything the gauge puts into words: what it shows, and what it says to a reader who
+    /// cannot see it.
+    ///
+    /// Built once by the footer and handed down, rather than by the gauge's own body. The footer
+    /// draws its row inside a `ViewThatFits` with three candidates and two of them hold the gauge,
+    /// so a sentence assembled in that body cost four `FormatStyle` invocations twice over on
+    /// every pass, for one control that reports and does nothing.
+    struct Reading: Equatable {
+        /// What is drawn beside the bar.
+        var percent: String
+        /// The whole reading, spoken. The crowded state is drawn as amber and as nothing else, so
+        /// it has to be said here or a reader gets the number with no indication that the number
+        /// is a problem.
+        var spoken: String
+    }
+
+    var reading: Reading {
+        Reading(
+            percent: Self.percent(fraction),
+            spoken: "\(Self.percent(fraction)) used, "
+                + "\(Self.format(used)) of \(Self.format(limit)) tokens"
+                + (isCrowded ? ", filling up" : "")
+        )
     }
 }

--- a/Sources/Bloom/Views/Center/GeometryBox.swift
+++ b/Sources/Bloom/Views/Center/GeometryBox.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Somewhere to keep a measurement the body does not read.
+///
+/// **A geometry probe writes once a frame, and `@State` turns every one of those writes into a
+/// rebuild.** That is the right trade when the body actually draws the number, and it is pure
+/// waste when it does not: `CenterPaneView` measures its own size so a drop closure can say which
+/// quarter a tab was let go in, and `SessionTabsView` measures where each tab is centred so a drag
+/// can take a snapshot when it begins. Neither number is drawn by anything. Kept in `@State` they
+/// invalidated a pane, and a strip, on every frame of every window resize, for a value nobody was
+/// going to look at until the pointer went down.
+///
+/// A class held in `@State` is the fix, because SwiftUI tracks the STATE and not what it points
+/// at: the reference never changes, so writing through it is not a change SwiftUI can see. This is
+/// the same reasoning `TranscriptGeometry` writes down from the other side, where the number IS
+/// drawn and so is rounded instead. Reach for that one when the body reads the value and this one
+/// when it does not.
+///
+/// Not `@Observable`, deliberately, and not because it was forgotten: observation is exactly the
+/// thing being avoided here.
+@MainActor
+final class GeometryBox<Value> {
+    var value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+}

--- a/Sources/Bloom/Views/Center/PromptAttachmentStore.swift
+++ b/Sources/Bloom/Views/Center/PromptAttachmentStore.swift
@@ -18,21 +18,53 @@ import BloomCore
 final class PromptAttachmentStore {
     static let shared = PromptAttachmentStore()
 
-    private(set) var bySession: [String: [PromptAttachment]] = [:]
+    /// One session's list, in a box of its own.
+    ///
+    /// **A dictionary is one observed property however many sessions are in it.** Reading
+    /// `bySession[id]` from a composer's body registered a dependency on the whole map, so
+    /// attaching a file to one conversation, or reading another one's list back off disk on the
+    /// first visit to it, rebuilt every composer in the window. A box per session is the ordinary
+    /// answer: the map itself is not observed, and a body that read one session's list hears about
+    /// that session and no other.
+    ///
+    /// Nil means the list has not been read back from defaults yet, which is not the same as a
+    /// session with nothing attached. `load` is the only thing that tells the two apart, and it
+    /// has to, or every pass would re-read the defaults for a session that genuinely has none.
+    @Observable
+    final class SessionAttachments {
+        var list: [PromptAttachment]?
+    }
+
+    /// Not observed, deliberately: see `SessionAttachments`. Entries are only ever added, so a
+    /// reader that has a box keeps it.
+    @ObservationIgnored private var bySession: [String: SessionAttachments] = [:]
 
     private init() {}
 
     // MARK: - Reading
 
     func attachments(for sessionID: String) -> [PromptAttachment] {
-        bySession[sessionID] ?? []
+        box(for: sessionID).list ?? []
     }
 
     /// Reads a session's attachments back once per launch. Called from a task rather than from a
-    /// getter, because filling the map is a mutation and a view body may not cause one.
+    /// getter, because filling the list is a mutation and a view body may not cause one.
     func load(sessionID: String) {
-        guard bySession[sessionID] == nil else { return }
-        bySession[sessionID] = Self.restore(sessionID: sessionID)
+        let box = box(for: sessionID)
+        guard box.list == nil else { return }
+        box.list = Self.restore(sessionID: sessionID)
+    }
+
+    /// The box a session's list lives in, made on the spot if this is the first anyone has asked.
+    ///
+    /// Called from a body, and that is safe here in a way `load` above is not: the map is not
+    /// observed, so putting an empty box in it changes nothing anything is watching. What the body
+    /// then reads is the box's own list, which is what it has to observe.
+    private func box(for sessionID: String) -> SessionAttachments {
+        if let held = bySession[sessionID] { return held }
+        let made = SessionAttachments()
+        bySession[sessionID] = made
+        return made
     }
 
     // MARK: - Writing
@@ -209,7 +241,7 @@ final class PromptAttachmentStore {
     // MARK: - Persistence
 
     private func apply(_ attachments: [PromptAttachment], to sessionID: String) {
-        bySession[sessionID] = attachments
+        box(for: sessionID).list = attachments
         Self.persist(attachments, sessionID: sessionID)
     }
 

--- a/Sources/Bloom/Views/Center/SessionTabsView.swift
+++ b/Sources/Bloom/Views/Center/SessionTabsView.swift
@@ -27,7 +27,12 @@ struct SessionTabsView: View {
     @State private var drag: StripDrag?
     /// Where each tab is centred along the strip. Written continuously, read only as a snapshot at
     /// the start of a drag.
-    @State private var centres: [PaneContent: Double] = [:]
+    ///
+    /// In a box rather than in `@State`, for the reason `GeometryBox` sets out and because the
+    /// sentence above is the whole argument: nothing draws these numbers. Every tab's probe wrote
+    /// one on every frame of a window resize, and each of those writes rebuilt this strip and
+    /// every tab in it.
+    @State private var centres = GeometryBox([PaneContent: Double]())
     /// The namespace the selection fill matches across, so moving the selection slides one
     /// capsule between tabs instead of fading one out and another in. See `TabItemView`, which
     /// hangs its `matchedGeometryEffect` off this.
@@ -85,15 +90,38 @@ struct SessionTabsView: View {
         return drag.order
     }
 
-    /// Which tab the user is in. **One** answer, where `CenterPaneStore.isShowing` gave the strip
-    /// as many marks as the column had panes: a tab owns the panes now, so being in a tab is a
-    /// single fact about the workspace again.
-    private var selectedTab: PaneContent? {
-        store.selectedTab(in: model)
-    }
-
     var body: some View {
-        TabStrip(pane: Self.pane, selection: selectedID) {
+        // Derived once, at the top, and threaded down to everything that needs it.
+        //
+        // `entries` is not a stored list: it maps the sessions, reads the tool tab list, works out
+        // what the tabs have absorbed and lays the user's own order over the result. It used to be
+        // asked for again by the separator between every pair of tabs (twice each), by the pane
+        // edge test on every tab, by the scroll target, by the rule before the `+`, by every split
+        // menu, and once more inside the store on the way to the selection. That is about six full
+        // derivations per tab per pass for a list that cannot change while the pass is running.
+        //
+        // This is `SidebarRepoGroup`'s bug and `SidebarRepoGroup`'s fix: derive it once, pass it
+        // as a parameter, and let the helpers say what they need rather than reach for it.
+        let entries = self.entries
+        // **One** answer, where `CenterPaneStore.isShowing` gave the strip as many marks as the
+        // column had panes: a tab owns the panes now, so being in a tab is a single fact about the
+        // workspace again.
+        let selected = store.selectedTab(in: model, entries: entries)
+        // Which tab the strip scrolls into view, as a plain id rather than as `PaneContent`.
+        //
+        // Nil when the focused pane is showing something the strip does not have a tab for, which
+        // is the moment after a tab is closed: aiming a scroll at an id that is no longer laid out
+        // does nothing, and this says so rather than relying on that.
+        let selectedID = selected.flatMap { entries.contains($0) ? AnyHashable($0.id) : nil }
+        // Whichever tab the pane's leading edge runs through. This strip begins at that edge: it
+        // has no leading control, so its first tab starts where the centre column starts, drops
+        // the line and the corner down that side and lets the pane's own rule be its edge. Read
+        // off the whole order rather than off either kind's run, because a workspace whose
+        // conversations have all been closed opens with a terminal or a browser first. See
+        // `TabItemView.isAtPaneEdge`.
+        let leadingID = entries.first?.id
+
+        return TabStrip(pane: Self.pane, selection: selectedID) {
             HStack(spacing: 0) {
                 // One run over one list. A conversation and a terminal are two kinds of thing kept
                 // in two stores, which is why they used to be drawn by two `ForEach`es in that
@@ -102,17 +130,25 @@ struct SessionTabsView: View {
                 // drag the owner could actually make into a drag that could not be honoured.
                 ForEach(Array(entries.enumerated()), id: \.element) { index, entry in
                     if index > 0 {
-                        TabStripSeparator(isHidden: !isSeparated(at: index))
+                        TabStripSeparator(
+                            isHidden: !isSeparated(at: index, in: entries, selected: selected)
+                        )
                     }
 
                     switch entry {
                     case .chat(let id):
                         if let session = session(id) {
-                            sessionTab(session).id(id)
+                            sessionTab(
+                                session,
+                                selected: selected,
+                                isAtPaneEdge: leadingID == id.rawValue
+                            )
+                            .id(id)
                         }
                     case .tool(let id):
                         if let tab = tool(id) {
-                            toolTab(tab).id(id)
+                            toolTab(tab, selected: selected, isAtPaneEdge: leadingID == id)
+                                .id(id)
                         }
                     }
                 }
@@ -142,7 +178,7 @@ struct SessionTabsView: View {
             // own fill is its edge, and hidden again when there is no tab for it to come after.
             // A workspace whose conversations have all been closed would otherwise open with a
             // hairline standing against the rule down the edge of the pane.
-            TabStripSeparator(isHidden: order.last.map(isSelected) ?? true)
+            TabStripSeparator(isHidden: entries.last.map { $0 == selected } ?? true)
 
             newTabMenu
         } trailing: {
@@ -164,12 +200,6 @@ struct SessionTabsView: View {
     /// measurements that used to live here.
     private static let pane = TabPane.content
 
-    /// Every tab in the strip, in the order it is drawn. Identity and order only: a title that
-    /// changes must not make the strip move.
-    private var order: [String] {
-        entries.map(\.id)
-    }
-
     /// The conversation or the tool tab one entry of the strip stands for, and nil for an entry
     /// whose content has gone between the strip being derived and this being asked.
     private func session(_ id: SessionID) -> Session? {
@@ -180,64 +210,35 @@ struct SessionTabsView: View {
         tabs.tabs(for: model.workspace.id).first { $0.id == id }
     }
 
-    /// Whether a tab is the one the pane's leading edge runs through.
-    ///
-    /// This strip begins at that edge: it has no leading control, so its first tab starts where
-    /// the centre column starts. Whichever tab that is drops the line and the corner down that
-    /// side and lets the pane's own rule be its edge. See `TabItemView.isAtPaneEdge`.
-    ///
-    /// Asked of the strip's whole order rather than of either run on its own, because a workspace
-    /// whose conversations have all been closed opens with a terminal or a browser first.
-    private func isAtPaneEdge(_ id: String) -> Bool {
-        order.first == id
-    }
-
-    /// Which tab the strip scrolls into view, as a plain id rather than as `PaneContent`.
-    ///
-    /// Nil when the focused pane is showing something the strip does not have a tab for, which is
-    /// the moment after a tab is closed: aiming a scroll at an id that is no longer laid out does
-    /// nothing, and this says so rather than relying on that.
-    private var selectedID: AnyHashable? {
-        guard let selectedTab, entries.contains(selectedTab) else { return nil }
-        return AnyHashable(selectedTab.id)
-    }
-
-    private func isSelected(_ session: Session) -> Bool {
-        selectedTab == .chat(session.id)
-    }
-
-    private func isSelected(_ tab: CenterTab) -> Bool {
-        selectedTab == .tool(tab.id)
-    }
-
-    /// Whether a tab is selected, named by id alone, for the callers that have thrown away which
-    /// of the two kinds of thing it is. `order` is one such.
-    private func isSelected(_ id: String) -> Bool {
-        selectedTab?.id == id
-    }
-
     /// Whether the rule between two tabs is drawn.
     ///
     /// Hidden against the selected tab on either side, whose own fill is its edge. One rule for the
     /// whole strip now that the strip is one list: the pair of cases this used to need, "the last
     /// conversation before the first tool" and "the tool before this one", were the seam between
     /// two runs and there is no seam any more.
-    private func isSeparated(at index: Int) -> Bool {
+    ///
+    /// Handed the strip and the selection rather than reaching for either. It is asked once per
+    /// gap, so a version that derived the strip itself derived it twice per gap.
+    private func isSeparated(
+        at index: Int, in entries: [PaneContent], selected: PaneContent?
+    ) -> Bool {
         guard index > 0 else { return false }
-        return !isSelected(entries[index - 1].id) && !isSelected(entries[index].id)
+        return entries[index - 1] != selected && entries[index] != selected
     }
 
     // MARK: - Tabs
 
-    private func sessionTab(_ session: Session) -> some View {
+    private func sessionTab(
+        _ session: Session, selected: PaneContent?, isAtPaneEdge: Bool
+    ) -> some View {
         SessionTabView(
             session: session,
             agentGlyph: PaneGlyph.agentMark(
                 for: session.agentKind, among: model.sessions.map(\.agentKind)
             ),
-            isActive: isSelected(session),
+            isActive: selected == .chat(session.id),
             isRunning: model.isRunning(session),
-            isAtPaneEdge: isAtPaneEdge(session.id.rawValue),
+            isAtPaneEdge: isAtPaneEdge,
             isRenaming: renamingID == session.id.rawValue,
             // Always. The workspace's last conversation IS closable, and hiding the cross was the
             // only thing pretending otherwise: "Close Session" in the File menu holds Cmd+W and has
@@ -249,26 +250,28 @@ struct SessionTabsView: View {
             onCommitRename: { commitRename(session, to: $0) },
             onCancelRename: { renamingID = nil },
             onClose: { close(session) },
-            onSplitRight: splitAction(.chat(session.id), axis: .horizontal),
-            onSplitDown: splitAction(.chat(session.id), axis: .vertical),
+            onSplitRight: splitAction(.chat(session.id), axis: .horizontal, selected: selected),
+            onSplitDown: splitAction(.chat(session.id), axis: .vertical, selected: selected),
             namespace: selection
         )
         .draggable(session.id.rawValue)
         .modifier(StripDragTracking(
             content: .chat(session.id),
             space: Self.stripSpace,
-            onMeasure: { centres[.chat(session.id)] = $0 },
+            onMeasure: { centres.value[.chat(session.id)] = $0 },
             onBegin: { begin(.chat(session.id)) },
             onEnd: { finish(taken: $0) }
         ))
     }
 
-    private func toolTab(_ tab: CenterTab) -> some View {
+    private func toolTab(
+        _ tab: CenterTab, selected: PaneContent?, isAtPaneEdge: Bool
+    ) -> some View {
         TabItemView(
             title: tabs.displayTitle(of: tab, in: model),
             icon: tab.icon,
-            isActive: isSelected(tab),
-            isAtPaneEdge: isAtPaneEdge(tab.id),
+            isActive: selected == .tool(tab.id),
+            isAtPaneEdge: isAtPaneEdge,
             surface: Self.pane.surface,
             isRenaming: renamingID == tab.id,
             // What is on the tab, not what the tab is filed under. A browser showing "Spatie"
@@ -287,15 +290,15 @@ struct SessionTabsView: View {
             },
             onCancelRename: { renamingID = nil },
             onClose: { Task { await tabs.close(tab) } },
-            onSplitRight: splitAction(.tool(tab.id), axis: .horizontal),
-            onSplitDown: splitAction(.tool(tab.id), axis: .vertical),
+            onSplitRight: splitAction(.tool(tab.id), axis: .horizontal, selected: selected),
+            onSplitDown: splitAction(.tool(tab.id), axis: .vertical, selected: selected),
             namespace: selection
         )
         .draggable(tab.id)
         .modifier(StripDragTracking(
             content: .tool(tab.id),
             space: Self.stripSpace,
-            onMeasure: { centres[.tool(tab.id)] = $0 },
+            onMeasure: { centres.value[.tool(tab.id)] = $0 },
             onBegin: { begin(.tool(tab.id)) },
             onEnd: { finish(taken: $0) }
         ))
@@ -388,15 +391,15 @@ struct SessionTabsView: View {
     /// Also false for the review asked of itself, which has no second copy to make: a workspace
     /// has exactly one of it by design. See `PaneDuplicate`.
     private func splitAction(
-        _ content: PaneContent, axis: SplitAxis
+        _ content: PaneContent, axis: SplitAxis, selected: PaneContent?
     ) -> (@MainActor () -> Void)? {
-        guard canSplit(content) else { return nil }
+        guard canSplit(content, selected: selected) else { return nil }
         return { split(content, axis: axis) }
     }
 
-    private func canSplit(_ content: PaneContent) -> Bool {
-        guard let selectedTab else { return false }
-        guard content != selectedTab else { return duplicable(content) }
+    private func canSplit(_ content: PaneContent, selected: PaneContent?) -> Bool {
+        guard let selected else { return false }
+        guard content != selected else { return duplicable(content) }
         return store.canAbsorb(content)
     }
 
@@ -414,7 +417,7 @@ struct SessionTabsView: View {
     /// the strip as an entry of its own. Asking this of the tab you are already in is asking for
     /// the same thing twice, which is `PaneDuplicate`'s question rather than this one's.
     private func split(_ content: PaneContent, axis: SplitAxis) {
-        guard let tab = selectedTab else { return }
+        guard let tab = store.selectedTab(in: model) else { return }
         let pane = store.focusedPane(of: tab)
 
         guard content != tab else {
@@ -488,7 +491,7 @@ struct SessionTabsView: View {
         guard drag?.tab != tab else { return }
         let run = stored
         guard run.count > 1, run.contains(tab) else { return }
-        drag = StripDrag(tab: tab, run: run, centres: centres, order: run)
+        drag = StripDrag(tab: tab, run: run, centres: centres.value, order: run)
     }
 
     /// The pointer has moved. Nothing else about the strip is touched: this is the only thing that
@@ -519,7 +522,7 @@ struct SessionTabsView: View {
         guard run.count > 1, run.contains(tab) else { return drag = nil }
 
         settle(drag?.order ?? TabDragOrder.live(
-            run, moving: tab, centres: drag?.centres ?? centres, to: pointer
+            run, moving: tab, centres: drag?.centres ?? centres.value, to: pointer
         ))
     }
 

--- a/Sources/Bloom/Views/Center/SlashCommandCatalog.swift
+++ b/Sources/Bloom/Views/Center/SlashCommandCatalog.swift
@@ -21,6 +21,10 @@ final class SlashCommandCatalog {
 
     private var loadedPath: String?
     private var loadedAt: Date?
+    /// `commands` by name, for the lookup the composer does on every pass. Observed like the list
+    /// it indexes, because the chip's description is drawn from it and has to arrive when the scan
+    /// does.
+    private var byName: [String: SlashCommand] = [:]
     /// The scan that is already running, and the checkout it is running for, so a second caller
     /// joins it rather than starting a duplicate walk of the same directories.
     private var running: Task<[SlashCommand], Never>?
@@ -28,6 +32,27 @@ final class SlashCommandCatalog {
 
     /// How long a list is taken on trust before opening the menu re-reads it.
     static let stalenessWindow: TimeInterval = 3
+
+    /// One catalogue per checkout, shared by every composer pointing at it.
+    ///
+    /// **A composer used to hold its own, and that turned a tab switch into a disk scan.** The
+    /// centre pane is destroyed and rebuilt when the column changes tab, so the fresh catalogue
+    /// that came with it had `loadedPath == nil` and walked six directories to depth six, up to
+    /// five hundred entries each, reading the front of every file it found, for a list the last
+    /// composer had already built. The walk is off the main actor, so what it cost was disk
+    /// contention during the switch and a slash menu that showed its loading state again.
+    ///
+    /// Held for the life of the launch, like `ComposerModelCatalog.shared` and `FileIndex.shared`.
+    /// One entry per checkout the window has visited, each a list of tens of commands, so there is
+    /// nothing here worth evicting.
+    private static var byPath: [String: SlashCommandCatalog] = [:]
+
+    static func shared(for workspacePath: String) -> SlashCommandCatalog {
+        if let held = byPath[workspacePath] { return held }
+        let made = SlashCommandCatalog()
+        byPath[workspacePath] = made
+        return made
+    }
 
     /// Builds the list for a checkout, and does nothing at all if it is already the one held.
     func load(workspacePath: String) async {
@@ -56,8 +81,12 @@ final class SlashCommandCatalog {
     /// Nothing is a real answer and not an error: a draft restored from another machine, or a
     /// mistyped name, still leads with something the CLI will be handed, and the chip that draws
     /// it says only what it can stand behind.
+    ///
+    /// Indexed rather than searched. The composer asks this for the chip and for the chip's hover
+    /// card on every pass, and a scan of every command and skill on the machine is a strange price
+    /// for a lookup by name.
     func command(named name: String) -> SlashCommand? {
-        commands.first { $0.name == name }
+        byName[name]
     }
 
     /// Ranks the list against the text typed after the `/`.
@@ -94,6 +123,11 @@ final class SlashCommandCatalog {
         isLoaded = true
         // Assigning an identical list would still invalidate every view observing it, and this
         // runs every few seconds while a menu is open.
-        if found != commands { commands = found }
+        guard found != commands else { return }
+        commands = found
+        // The FIRST definition of a name wins, which is what the linear search this replaced did.
+        // Two files can define one name, and which of them the chip described is not a thing to
+        // change while making the lookup cheaper.
+        byName = Dictionary(found.map { ($0.name, $0) }, uniquingKeysWith: { first, _ in first })
     }
 }

--- a/Sources/Bloom/Views/Center/WorkspaceTabsStore.swift
+++ b/Sources/Bloom/Views/Center/WorkspaceTabsStore.swift
@@ -203,7 +203,17 @@ final class WorkspaceTabsStore {
     /// deliberately does not write the answer back: a view body asks this, and a body may not
     /// mutate observed state.
     func selectedTab(in model: WorkspaceModel) -> PaneContent? {
-        let entries = entries(in: model)
+        selectedTab(in: model, entries: entries(in: model))
+    }
+
+    /// The same answer for a caller that has just derived the strip and would rather not pay for
+    /// it twice.
+    ///
+    /// `entries(in:)` maps the sessions, reads the tool tab list, works out what the tabs have
+    /// absorbed and lays the user's own order over the result, and the tab strip needs the list
+    /// itself as well as the selection. Asking through the parameterless overload above made every
+    /// pass derive it once for the `ForEach` and again in here.
+    func selectedTab(in model: WorkspaceModel, entries: [PaneContent]) -> PaneContent? {
         if let chosen = selected[model.workspace.id], entries.contains(chosen) { return chosen }
 
         // The active conversation, which is what the toolbar, the inspector and the pull request

--- a/Sources/BloomCore/PaneMeasure.swift
+++ b/Sources/BloomCore/PaneMeasure.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// A measured pane dimension, rounded to a step before anything holds on to it.
+///
+/// **This is the rule `TranscriptGeometry` wrote down, applied to the rest of the centre column.**
+/// A container's height arrives from `onGeometryChange` on every pixel of a window or divider
+/// drag, which is once a frame. Kept raw in `@State` it re-runs the body that holds it, and in the
+/// centre column that body is the whole chat pane: the transcript's list, every row it has
+/// realised, and the composer under it. Rounded to `step` it changes about once every eight
+/// points instead, and a drag stops rebuilding a pane to move a clamp by one point.
+///
+/// It is only ever worth doing where the number is used for something coarse. Both callers here
+/// are exactly that: `ChatPaneView.conversationHeight` and `ComposerView.chromeHeight` meet in
+/// `ComposerView.maxEditorHeight`, which decides how far the composer may be dragged before the
+/// transcript is squeezed, and a point either way there is invisible.
+public enum PaneMeasure {
+    /// The quantum. Eight points, the same as `TranscriptGeometry.step`, which is under a line of
+    /// the face the composer is set in and so cannot move the clamp by anything a reader sees.
+    public static let step: CGFloat = 8
+
+    /// Rounded DOWN, so a value worked out from this can never come out larger than the room
+    /// actually measured. Never below one step while there is a pane at all, because nought is
+    /// reserved for "not laid out yet, no cap" and a pane dragged to a sliver is not that. See
+    /// `TranscriptGeometry.height`, which is the same rule for the same reason.
+    public static func room(_ height: CGFloat) -> CGFloat {
+        guard height > 0 else { return 0 }
+        return max(step, (height / step).rounded(.down) * step)
+    }
+
+    /// Rounded UP, for a measurement that is SUBTRACTED from the room. Erring upwards on the
+    /// chrome and downwards on the room both leave the editor a little less space than it could
+    /// have had, which is the safe direction: the transcript keeps its floor either way.
+    ///
+    /// Negative is nought. The chrome is a difference between two measurements taken in the same
+    /// pass, and a pass that has laid out one of them and not the other can report the editor as
+    /// taller than the composer holding it.
+    public static func chrome(_ height: CGFloat) -> CGFloat {
+        guard height > 0 else { return 0 }
+        return (height / step).rounded(.up) * step
+    }
+}

--- a/Sources/BloomCore/PatchCache.swift
+++ b/Sources/BloomCore/PatchCache.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// The patches a workspace has already asked git for, and the rule for when one may be reused.
+///
+/// **Returning to the review tab used to spawn a `git diff` every time.** The pane is destroyed
+/// when the centre column switches tab and built again on the way back, so flicking between a
+/// conversation and the changes ran the same `git diff -M <base> -- <path>` over and over, on a
+/// worktree nothing had touched in between. `WorkspaceModel.pullRequestArrivalMaxAge` is the same
+/// bug already fixed once, for `gh auth status` and `gh pr view`, and its comment carries the
+/// measurement: 640ms to 1.1s per arrival, all of it repeated by flicking between two workspaces.
+///
+/// # What makes an answer reusable
+///
+/// Everything the command is built from is in `Key`, so an entry can only ever be handed back for
+/// a question byte for byte identical to the one it answered: the worktree, the base branch, the
+/// path, what happened to that path (an untracked file is diffed against `/dev/null` and a tracked
+/// one against a merge base, which are two different commands), and the scope the tab is set to.
+///
+/// `generation` is `WorkspaceModel.changesGeneration`, which counts refreshes that LANDED rather
+/// than refreshes that moved the list. That is deliberately the strictest thing available: an
+/// agent rewording a line one for one leaves a file's counts, and with them the whole
+/// `ChangedFile`, exactly where they were, so the counts cannot be trusted to say a patch is
+/// still current. The consequence is worth stating plainly: the changed file poll runs every six
+/// seconds, so an entry is good for at most that long. It is not a cache that saves a reader who
+/// comes back a minute later, and it is not meant to be. It is the one that saves the flick.
+public struct PatchCache: Sendable {
+    /// What a held patch is the answer to. Every field is part of the git command that produced
+    /// it, plus the generation that says the worktree has not been looked at again since.
+    public struct Key: Hashable, Sendable {
+        public var worktree: String
+        public var base: String
+        public var file: String
+        public var change: ChangedFile.Change
+        public var scope: DiffScope
+        public var generation: Int
+
+        public init(
+            worktree: String,
+            base: String,
+            file: ChangedFile,
+            scope: DiffScope,
+            generation: Int
+        ) {
+            self.worktree = worktree
+            self.base = base
+            self.file = file.path
+            self.change = file.change
+            self.scope = scope
+            self.generation = generation
+        }
+    }
+
+    /// How many patches are held at once.
+    ///
+    /// A dozen, which is more files than anybody clicks through between two refreshes and few
+    /// enough that a repository whose diffs are megabytes cannot quietly become the largest thing
+    /// in the process. The generation rule below is what does the real work; this is the backstop
+    /// for a reader moving fast through a large review inside one generation.
+    public static let capacity = 12
+
+    private var patches: [Key: String] = [:]
+    /// Keys oldest first, so the entry evicted for capacity is the one least recently stored.
+    private var order: [Key] = []
+
+    public init() {}
+
+    public var count: Int { patches.count }
+
+    public func patch(for key: Key) -> String? {
+        patches[key]
+    }
+
+    /// Files an answer, and throws away everything the answer supersedes.
+    ///
+    /// A new generation means git has looked at the worktree again, so every patch from an older
+    /// one is a claim about a worktree nobody has checked. They go in one sweep rather than
+    /// waiting to be evicted by capacity, because a stale patch is not merely useless: held in a
+    /// map keyed on a generation nothing will ask for again, it is a leak.
+    public mutating func store(_ patch: String, for key: Key) {
+        if patches[key] == nil || order.last != key {
+            order.removeAll { $0 == key }
+            order.append(key)
+        }
+        patches[key] = patch
+
+        let superseded = order.filter { $0.generation != key.generation }
+        for stale in superseded { patches[stale] = nil }
+        order.removeAll { $0.generation != key.generation }
+
+        while order.count > Self.capacity {
+            let oldest = order.removeFirst()
+            patches[oldest] = nil
+        }
+    }
+}

--- a/Tests/BloomCoreTests/PaneMeasureTests.swift
+++ b/Tests/BloomCoreTests/PaneMeasureTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// The point of rounding a pane measurement is that a drag stops writing state once a frame, so
+/// what is asserted is the step and the direction each side errs in, never a particular height.
+@Suite("Rounding a measured pane")
+struct PaneMeasureTests {
+    @Test("a pane not laid out yet stays nought, which reads as no cap")
+    func unmeasuredIsNought() {
+        #expect(PaneMeasure.room(0) == 0)
+        #expect(PaneMeasure.room(-40) == 0)
+        #expect(PaneMeasure.chrome(0) == 0)
+        #expect(PaneMeasure.chrome(-40) == 0)
+    }
+
+    /// Above one step, which is the only place the rounding has a choice to make. Below it the
+    /// floor below wins, deliberately.
+    @Test("room is rounded down and never overstates the space measured")
+    func roomRoundsDown() {
+        for step in Int(PaneMeasure.step)...400 {
+            let height = CGFloat(step)
+            #expect(PaneMeasure.room(height) <= height)
+        }
+        #expect(PaneMeasure.room(800) == 800)
+        #expect(PaneMeasure.room(807) == 800)
+    }
+
+    @Test("a pane dragged to a sliver keeps one step, because nought means unmeasured")
+    func slimPaneKeepsOneStep() {
+        #expect(PaneMeasure.room(1) == PaneMeasure.step)
+        #expect(PaneMeasure.room(PaneMeasure.step - 0.5) == PaneMeasure.step)
+    }
+
+    @Test("chrome is rounded up, because it is taken off the room")
+    func chromeRoundsUp() {
+        for step in 1...400 {
+            let height = CGFloat(step)
+            #expect(PaneMeasure.chrome(height) >= height)
+        }
+        #expect(PaneMeasure.chrome(80) == 80)
+        #expect(PaneMeasure.chrome(73) == 80)
+    }
+
+    /// The whole reason either function exists: a drag that crosses a pixel must not change the
+    /// answer, and one that crosses a step must.
+    @Test("a drag inside one step changes nothing")
+    func aDragInsideOneStepChangesNothing() {
+        let start = PaneMeasure.room(600)
+        for pixel in 0..<Int(PaneMeasure.step) {
+            #expect(PaneMeasure.room(600 + CGFloat(pixel)) == start)
+        }
+        #expect(PaneMeasure.room(600 + PaneMeasure.step) != start)
+    }
+}

--- a/Tests/BloomCoreTests/PatchCacheTests.swift
+++ b/Tests/BloomCoreTests/PatchCacheTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// A patch may only be handed back for a question identical to the one it answered, so every
+/// field of the key is asserted by changing it and expecting a miss. A cache that answers a
+/// question it was not asked is worse than no cache: it draws one file's diff under another
+/// file's name.
+@Suite("Reusing a patch git has already produced")
+struct PatchCacheTests {
+    private let worktree = "/tmp/work"
+    private let base = "main"
+
+    private func file(
+        _ path: String = "Sources/Bloom.swift",
+        change: ChangedFile.Change = .modified
+    ) -> ChangedFile {
+        ChangedFile(path: path, change: change, additions: 1, deletions: 1)
+    }
+
+    private func key(
+        file changed: ChangedFile? = nil,
+        worktree: String? = nil,
+        base: String? = nil,
+        scope: DiffScope = .all,
+        generation: Int = 1
+    ) -> PatchCache.Key {
+        PatchCache.Key(
+            worktree: worktree ?? self.worktree,
+            base: base ?? self.base,
+            file: changed ?? file(),
+            scope: scope,
+            generation: generation
+        )
+    }
+
+    @Test("the same question gets the answer back")
+    func sameQuestionHits() {
+        var cache = PatchCache()
+        cache.store("@@ -1 +1 @@", for: key())
+        #expect(cache.patch(for: key()) == "@@ -1 +1 @@")
+    }
+
+    @Test("nothing is answered before it is asked")
+    func emptyMisses() {
+        let cache = PatchCache()
+        #expect(cache.patch(for: key()) == nil)
+    }
+
+    @Test("every part of the question is part of the key")
+    func everyFieldSeparatesTheAnswer() {
+        var cache = PatchCache()
+        cache.store("held", for: key())
+
+        #expect(cache.patch(for: key(worktree: "/tmp/other")) == nil)
+        #expect(cache.patch(for: key(base: "develop")) == nil)
+        #expect(cache.patch(for: key(file: file("Sources/Other.swift"))) == nil)
+        #expect(cache.patch(for: key(file: file(change: .untracked))) == nil)
+        #expect(cache.patch(for: key(scope: .uncommitted)) == nil)
+        #expect(cache.patch(for: key(generation: 2)) == nil)
+    }
+
+    /// Two scopes that name two different commits are two different questions, which is the one
+    /// case an enum with an associated value could get wrong.
+    @Test("two commits are two scopes")
+    func sinceCommitsSeparate() {
+        var cache = PatchCache()
+        let first = BranchCommit(sha: "a", subject: "one", author: "x", date: .distantPast)
+        let second = BranchCommit(sha: "b", subject: "two", author: "x", date: .distantPast)
+        cache.store("held", for: key(scope: .since(first)))
+
+        #expect(cache.patch(for: key(scope: .since(first))) == "held")
+        #expect(cache.patch(for: key(scope: .since(second))) == nil)
+    }
+
+    /// A landed refresh means git has looked at the worktree again, so everything measured before
+    /// it is a claim about a worktree nobody has checked. It goes rather than sitting in the map
+    /// under a generation nothing will ask for again.
+    @Test("a new generation sweeps the old one out")
+    func newGenerationSweeps() {
+        var cache = PatchCache()
+        cache.store("old", for: key(file: file("a.swift"), generation: 1))
+        cache.store("old", for: key(file: file("b.swift"), generation: 1))
+        #expect(cache.count == 2)
+
+        cache.store("new", for: key(file: file("a.swift"), generation: 2))
+        #expect(cache.count == 1)
+        #expect(cache.patch(for: key(file: file("a.swift"), generation: 1)) == nil)
+        #expect(cache.patch(for: key(file: file("b.swift"), generation: 1)) == nil)
+        #expect(cache.patch(for: key(file: file("a.swift"), generation: 2)) == "new")
+    }
+
+    @Test("a reader moving through a large review inside one generation is bounded")
+    func capacityBounds() {
+        var cache = PatchCache()
+        for index in 0..<(PatchCache.capacity + 5) {
+            cache.store("patch \(index)", for: key(file: file("file\(index).swift")))
+        }
+        #expect(cache.count == PatchCache.capacity)
+        #expect(cache.patch(for: key(file: file("file0.swift"))) == nil)
+        #expect(cache.patch(for: key(file: file("file16.swift"))) == "patch 16")
+    }
+
+    /// Storing the same key again must not grow the eviction order, or a file looked at twelve
+    /// times would push out eleven other files that are still current.
+    @Test("looking at one file twice is one entry")
+    func repeatedStoreIsOneEntry() {
+        var cache = PatchCache()
+        for _ in 0..<20 { cache.store("held", for: key()) }
+        #expect(cache.count == 1)
+        #expect(cache.patch(for: key()) == "held")
+    }
+}


### PR DESCRIPTION
Switching centre tabs is slow, and worse when the tab has content. This is the work behind that which changes nothing anyone can see.

Five geometry probes wrote raw pixel values into state a resize moves once a frame. Two fed bodies that never read the number (`CenterPaneView.size`, `SessionTabsView.centres`) and go into a plain box a write cannot invalidate; the two that are read (`ChatPaneView.conversationHeight`, `ComposerView.chromeHeight`) are rounded to eight points, which is `TranscriptGeometry`'s own rule applied to the rest of the column, now `PaneMeasure` in the core with tests.

The tab strip derived its whole entry list about six times per tab per pass. It is derived once at the top of the body now and threaded down, which is `SidebarRepoGroup`'s fix.

The composer walked the transcript on every pass to read the context window, so every streamed row rebuilt the prompt subtree, and a session that had never finished a turn walked the whole array to return nil. `TranscriptModel` keeps that reading and folds each new row in. Around it: the draft is parsed once per pass rather than about fourteen times, `ComposerTextEditor.lineHeight` stops allocating an `NSLayoutManager` on every read, the footer's four picker lists are built once instead of three times inside `ViewThatFits`, the slash command and output style catalogues are shared per checkout so a tab switch does not rescan six directories, `hasBody` stops copying the draft, and attachments are observed per session rather than as one map.

Returning to the review tab spawned a `git diff` every time. `WorkspaceModel` holds a `PatchCache` keyed on the worktree, the base, the file, the scope and `changesGeneration`, tested in the core. The changed file poll bumps that generation every six seconds, so an entry is good for at most that long: it saves the flick between two tabs and never hands back a patch for a worktree git has looked at again.

Left out, both owned by other branches: the view half of the diff finding (`DiffView` asking again on every appearance) and the transcript list's view state.

The two roundings each err on the side of leaving the transcript its floor, so the composer can be dragged at most about sixteen points less far than before, which is under a line. Nothing else about behaviour is meant to move.