### PR TITLE
Stop a chat pane opening the session again every time it comes back

### DIFF
--- a/Sources/Bloom/BloomApp.swift
+++ b/Sources/Bloom/BloomApp.swift
@@ -39,6 +39,10 @@ struct BloomApp: App {
         // to seeing it. See `SwitchProbe`.
         if SwitchProbe.isRequested { SwitchProbe.schedule() }
 
+        // And its sibling one level in: `Bloom --tab-probe <out.json>` times the path from picking
+        // a tab in the centre column to seeing it. See `TabProbe`.
+        if TabProbe.isRequested { TabProbe.schedule() }
+
         // And two last ones. `Bloom --menu-probe <out.png>` opens one of the centre pane's split
         // submenus and photographs it, which nothing else can; `Bloom --menu-action <title>`
         // performs a real item of a real menu and reports the windows either side of it, which is

--- a/Sources/Bloom/Design/SwitchProbe.swift
+++ b/Sources/Bloom/Design/SwitchProbe.swift
@@ -1,6 +1,5 @@
 import AppKit
 import SwiftUI
-import QuartzCore
 import Synchronization
 import BloomCore
 
@@ -362,58 +361,5 @@ enum SwitchProbe {
     private static func fail(_ message: String) -> Never {
         FileHandle.standardError.write(Data("switch probe: \(message)\n".utf8))
         exit(1)
-    }
-}
-
-/// Drives `SwitchTrace.tick` once per vsync, and records how long each frame took.
-///
-/// The frame intervals matter as much as the marks. A switch whose data is ready in 40ms and whose
-/// next frame takes 700ms is not a slow database, it is a slow layout, and only the interval says
-/// which of the two is being looked at.
-@MainActor
-private final class Ticker {
-    private var link: CADisplayLink?
-    private let view: NSView
-    private var last: CFTimeInterval = 0
-    private(set) var intervalsMs: [Double] = []
-
-    init(view: NSView) { self.view = view }
-
-    func start() {
-        let link = view.displayLink(target: self, selector: #selector(tick))
-        link.add(to: .main, forMode: .common)
-        self.link = link
-    }
-
-    func stop() {
-        link?.invalidate()
-        link = nil
-    }
-
-    /// Where each frame fell relative to the switch, and how long it took. The offsets are what
-    /// turn a list of intervals into a picture of when the window was frozen.
-    private(set) var blocksMs: [[Double]] = []
-    private var origin: CFTimeInterval = 0
-
-    /// Clears the frame record so each switch reports only its own frames.
-    func beginRun() {
-        intervalsMs.removeAll()
-        blocksMs.removeAll()
-        last = 0
-        origin = CACurrentMediaTime()
-    }
-
-    @objc private func tick() {
-        SwitchTrace.tick()
-        let now = CACurrentMediaTime()
-        defer { last = now }
-        guard last != 0 else { return }
-        let interval = (now - last) * 1000
-        intervalsMs.append(interval)
-        // Only the frames that were late. A list of six hundred 8ms ticks says nothing, and the
-        // ones over two frame times are exactly the moments the window stood still.
-        if interval > 20 {
-            blocksMs.append([(last - origin) * 1000, interval])
-        }
     }
 }

--- a/Sources/Bloom/Design/TabProbe.swift
+++ b/Sources/Bloom/Design/TabProbe.swift
@@ -1,0 +1,274 @@
+import AppKit
+import SwiftUI
+import QuartzCore
+import BloomCore
+
+/// Times what happens between picking a tab in the centre column and seeing it.
+///
+/// The third of the family, after `FrameProbe` (a drag) and `SwitchProbe` (a workspace). It exists
+/// because the owner's complaint moved: switching workspace was measured and fixed, and switching
+/// TAB was then reported as slow "certainly when there's already some content". That is a claim
+/// about one column rebuilding itself, and only a timeline can say which part of the rebuild the
+/// wait is in.
+///
+/// **One driver, and it is the only one this probe will ever have.** `WorkspaceTabsStore.select`
+/// is called directly, which is everything a click on the strip does once the hit test is over.
+/// The owner is sitting at this Mac while a run happens, so a probe that posted mouse events would
+/// need the window in front and would take his keyboard: `SwitchProbe`'s `click` driver is the
+/// faithful one for the sidebar and it is deliberately not copied here. A run needs no pointer, no
+/// focus and no window in front.
+///
+///     Bloom --tab-probe /tmp/tab.json --tab-workspace <id> --tab-order chat,review,chat
+///           [--tab-cycles 3] [--tab-settle 2500] [--window-size 1440x900]
+///
+/// Each entry of `--tab-order` names a tab rather than carrying its id, because a tool tab's id is
+/// a uuid minted at runtime and a run has to be repeatable from a shell:
+///
+/// - `chat` is the workspace's first conversation, `chat:<sessionID>` a named one.
+/// - `review`, `terminal`, `browser` and `notes` are that kind of tool tab, opened if the
+///   workspace has not got one, so an order can name a tab the workspace has never had.
+@MainActor
+enum TabProbe {
+    static var isRequested: Bool {
+        CommandLine.arguments.contains("--tab-probe")
+    }
+
+    // MARK: - Arguments
+
+    private static func value(for flag: String) -> String? {
+        let arguments = CommandLine.arguments
+        guard let index = arguments.firstIndex(of: flag), index + 1 < arguments.count else {
+            return nil
+        }
+        return arguments[index + 1]
+    }
+
+    private static var outputPath: String {
+        value(for: "--tab-probe") ?? (NSTemporaryDirectory() + "bloom-tab-probe.json")
+    }
+
+    private static var workspaceID: WorkspaceID? {
+        value(for: "--tab-workspace").map(WorkspaceID.init)
+    }
+
+    private static var order: [String] {
+        (value(for: "--tab-order") ?? "chat").split(separator: ",").map(String.init)
+    }
+
+    private static var cycles: Int { Int(value(for: "--tab-cycles") ?? "") ?? 3 }
+
+    /// How long a tab switch is given to finish before the next one starts. Shorter than
+    /// `SwitchProbe`'s, because nothing here reaches `gh` or the network: what a tab switch starts
+    /// is a transcript read at worst, and the deferred history a hundred milliseconds behind it.
+    private static var settle: Int { Int(value(for: "--tab-settle") ?? "") ?? 2500 }
+
+    private static var windowSize: CGSize? {
+        guard let raw = value(for: "--window-size") else { return nil }
+        let parts = raw.split(separator: "x")
+        guard parts.count == 2, let width = Double(parts[0]), let height = Double(parts[1])
+        else { return nil }
+        return CGSize(width: width, height: height)
+    }
+
+    // MARK: - Entry
+
+    static func schedule() {
+        Task { @MainActor in await run() }
+    }
+
+    private static func run() async {
+        // Deliberately never brought to the front, for the reason `FrameProbe` gives: a run
+        // happens while the owner is using his own copy of the app.
+        if let driver = value(for: "--tab-driver"), driver != "programmatic" {
+            fail("the only driver is `programmatic`. See the head of TabProbe.swift")
+        }
+
+        try? await Task.sleep(for: .seconds(3))
+
+        var window: NSWindow?
+        for _ in 0..<60 {
+            window = NSApp.windows.first {
+                $0.isVisible && $0.contentView != nil && $0.parent == nil
+                    && $0.styleMask.contains(.titled)
+            }
+            if window != nil { break }
+            try? await Task.sleep(for: .milliseconds(250))
+        }
+        guard let window, let contentView = window.contentView else {
+            fail("no window to probe")
+        }
+
+        if let size = windowSize {
+            window.setContentSize(size)
+            window.layoutIfNeeded()
+            try? await Task.sleep(for: .seconds(1))
+        }
+
+        guard let app = model() else { fail("no app model") }
+        guard let workspaceID else { fail("--tab-workspace named no workspace") }
+        app.selection = .workspace(workspaceID)
+
+        // The workspace's own arrival, which this probe is not measuring: its sessions, its
+        // transcript, `git status` and the first diff all land in here rather than inside a
+        // measurement.
+        try? await Task.sleep(for: .seconds(8))
+
+        guard let workspace = app.existingModel(for: workspaceID) else {
+            fail("workspace \(workspaceID.rawValue) is not open")
+        }
+
+        let tabs = order.map { token -> (token: String, tab: PaneContent) in
+            guard let tab = resolve(token, in: workspace) else {
+                fail("--tab-order named `\(token)`, which is not a tab this workspace can have")
+            }
+            return (token, tab)
+        }
+        // Opening a tool tab a moment ago changed the strip, and the first measurement must not be
+        // paying for that.
+        try? await Task.sleep(for: .seconds(2))
+
+        let ticker = Ticker(view: contentView)
+        ticker.start()
+        SwitchTrace.isEnabled = true
+
+        var runs: [[String: Any]] = []
+
+        // The first pass over the order is kept and labelled rather than thrown away, for the
+        // reason `SwitchProbe` keeps its own: a first visit to a tab and a return to it are two
+        // different switches, and the complaint being measured is about the second one.
+        for entry in tabs {
+            runs.append(
+                await select(entry.tab, token: entry.token, of: workspace, ticker: ticker)
+                    .merging(["pass": "cold"]) { current, _ in current }
+            )
+            try? await Task.sleep(for: .milliseconds(600))
+        }
+
+        for cycle in 0..<cycles {
+            for entry in tabs {
+                runs.append(
+                    await select(entry.tab, token: entry.token, of: workspace, ticker: ticker)
+                        .merging(["cycle": cycle, "pass": "warm"]) { current, _ in current }
+                )
+                try? await Task.sleep(for: .milliseconds(600))
+            }
+        }
+
+        SwitchTrace.isEnabled = false
+        ticker.stop()
+
+        write([
+            "driver": "programmatic",
+            "configuration": buildConfiguration,
+            "workspace": workspaceID.rawValue,
+            "workspaceName": workspace.workspace.name,
+            "order": order,
+            "cycles": cycles,
+            "settleMs": settle,
+            "windowSize": ["w": window.frame.width, "h": window.frame.height],
+            "loadAverage": systemLoadAverage(),
+            "sessionRows": workspace.activeTranscript?.rows.count ?? 0,
+            "runs": runs,
+        ])
+        exit(0)
+    }
+
+    /// One tab switch, from the selection to everything the timeline caught.
+    private static func select(
+        _ tab: PaneContent, token: String, of workspace: WorkspaceModel, ticker: Ticker
+    ) async -> [String: Any] {
+        ticker.beginRun()
+        PaneLayoutTiming.reset()
+        PaneLayoutTiming.isEnabled = true
+        // The same timeline `SwitchProbe` reads, begun by hand: the app itself only begins one
+        // when the SIDEBAR selection changes, and nothing about a tab switch moves that.
+        SwitchTrace.begin(workspaceID: workspace.workspace.id)
+        FileHandle.standardError.write(
+            Data("TAB \(token) \(Date().timeIntervalSince1970)\n".utf8)
+        )
+
+        WorkspaceTabsStore.shared.select(tab, in: workspace)
+
+        try? await Task.sleep(for: .milliseconds(settle))
+        PaneLayoutTiming.isEnabled = false
+
+        return [
+            "token": token,
+            "tab": tab.id,
+            "marks": SwitchTrace.timeline(),
+            "frameCount": ticker.intervalsMs.count,
+            "blocks": ticker.blocksMs,
+            "paneLayout": PaneLayoutTiming.summary(),
+            "panePasses": PaneLayoutTiming.timeline(),
+            "worstFrameMs": ticker.intervalsMs.max() ?? 0,
+        ]
+    }
+
+    // MARK: - Naming a tab
+
+    /// What one entry of `--tab-order` names, opening a tool tab if the workspace has not got one.
+    private static func resolve(_ token: String, in workspace: WorkspaceModel) -> PaneContent? {
+        let id = workspace.workspace.id
+        if token == "chat" {
+            return WorkspaceTabsStore.shared.entries(in: workspace).first { $0.isChat }
+        }
+        if token.hasPrefix("chat:") {
+            return .chat(SessionID(String(token.dropFirst("chat:".count))))
+        }
+        guard let kind = CenterTabKind(rawValue: token) else { return nil }
+        let store = CenterTabStore.shared
+        if let existing = store.tabs(for: id).first(where: { $0.kind == kind }) {
+            return .tool(existing.id)
+        }
+        return .tool(store.add(kind: kind, workspaceID: id).id)
+    }
+
+    // MARK: - Reaching the model
+
+    /// The app's state, handed over by the delegate on launch. Weak, for the reason `SwitchProbe`
+    /// gives: a probe has no business keeping the app alive.
+    private weak static var app: AppModel?
+
+    static func attach(_ model: AppModel) {
+        guard isRequested else { return }
+        app = model
+    }
+
+    private static func model() -> AppModel? { app }
+
+    // MARK: - Reporting
+
+    private static var buildConfiguration: String {
+        #if DEBUG
+        "debug"
+        #else
+        "release"
+        #endif
+    }
+
+    private static func systemLoadAverage() -> Double {
+        var loads = [Double](repeating: 0, count: 3)
+        guard getloadavg(&loads, 3) > 0 else { return 0 }
+        return loads[0]
+    }
+
+    private static func write(_ report: [String: Any]) {
+        // Asked before the encode, for the reason written down in `SwitchProbe.write`: a typed id
+        // in a `[String: Any]` arrives as `__SwiftValue` and `JSONSerialization` raises rather
+        // than throwing, which is not something `try?` catches, so it killed a run on its last
+        // line.
+        guard JSONSerialization.isValidJSONObject(report) else {
+            fail("the report holds a value JSON cannot carry, probably an id that needed .rawValue")
+        }
+        let data = (try? JSONSerialization.data(withJSONObject: report, options: [.prettyPrinted]))
+            ?? Data()
+        try? data.write(to: URL(fileURLWithPath: outputPath))
+        FileHandle.standardError.write(Data("tab probe wrote \(outputPath)\n".utf8))
+    }
+
+    /// `Never`, so the callers above can end the run with it from inside a `guard`.
+    private static func fail(_ message: String) -> Never {
+        FileHandle.standardError.write(Data("tab probe: \(message)\n".utf8))
+        exit(1)
+    }
+}

--- a/Sources/Bloom/Design/Ticker.swift
+++ b/Sources/Bloom/Design/Ticker.swift
@@ -37,11 +37,20 @@ final class Ticker {
     private var origin: CFTimeInterval = 0
 
     /// Clears the frame record so each switch reports only its own frames.
+    ///
+    /// **`last` is set to now rather than to nought, and that is a bug fix rather than a tidy-up.**
+    /// Nought means "no previous tick", so the first tick after a run began recorded no interval,
+    /// and the gap it was the end of was the one gap that mattered: the stall between asking for
+    /// the switch and the first frame that could show it. A tab switch measured this way reported
+    /// a worst frame of 20ms over a return whose display link had not run for 290ms, because the
+    /// 290ms was the interval that was thrown away. Timed from here, the first tick of a run is
+    /// measured against the instant the run was asked for, which is what everything else in the
+    /// report is measured against too.
     func beginRun() {
         intervalsMs.removeAll()
         blocksMs.removeAll()
-        last = 0
         origin = CACurrentMediaTime()
+        last = origin
     }
 
     @objc private func tick() {

--- a/Sources/Bloom/Design/Ticker.swift
+++ b/Sources/Bloom/Design/Ticker.swift
@@ -1,0 +1,60 @@
+import AppKit
+import QuartzCore
+
+/// Drives `SwitchTrace.tick` once per vsync, and records how long each frame took.
+///
+/// The frame intervals matter as much as the marks. A switch whose data is ready in 40ms and whose
+/// next frame takes 700ms is not a slow database, it is a slow layout, and only the interval says
+/// which of the two is being looked at.
+///
+/// Its own file because it has two probes reading it. It was `private` inside `SwitchProbe.swift`,
+/// and `TabProbe` needs exactly the same clock: a second copy of a display link that measures the
+/// main thread is two things to keep in step, and the whole point of a measurement is that two
+/// runs of it are comparable.
+@MainActor
+final class Ticker {
+    private var link: CADisplayLink?
+    private let view: NSView
+    private var last: CFTimeInterval = 0
+    private(set) var intervalsMs: [Double] = []
+
+    init(view: NSView) { self.view = view }
+
+    func start() {
+        let link = view.displayLink(target: self, selector: #selector(tick))
+        link.add(to: .main, forMode: .common)
+        self.link = link
+    }
+
+    func stop() {
+        link?.invalidate()
+        link = nil
+    }
+
+    /// Where each frame fell relative to the switch, and how long it took. The offsets are what
+    /// turn a list of intervals into a picture of when the window was frozen.
+    private(set) var blocksMs: [[Double]] = []
+    private var origin: CFTimeInterval = 0
+
+    /// Clears the frame record so each switch reports only its own frames.
+    func beginRun() {
+        intervalsMs.removeAll()
+        blocksMs.removeAll()
+        last = 0
+        origin = CACurrentMediaTime()
+    }
+
+    @objc private func tick() {
+        SwitchTrace.tick()
+        let now = CACurrentMediaTime()
+        defer { last = now }
+        guard last != 0 else { return }
+        let interval = (now - last) * 1000
+        intervalsMs.append(interval)
+        // Only the frames that were late. A list of six hundred 8ms ticks says nothing, and the
+        // ones over two frame times are exactly the moments the window stood still.
+        if interval > 20 {
+            blocksMs.append([(last - origin) * 1000, interval])
+        }
+    }
+}

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -112,6 +112,17 @@ final class WorkspaceModel {
     /// not another subprocess. Not observed: nothing draws it, and a write on every file opened
     /// would invalidate every view watching this model. See `PatchCache`.
     @ObservationIgnored private var patches = PatchCache()
+    /// Where each chat pane had got to in each conversation, so that coming back to a tab is not
+    /// the session being opened all over again.
+    ///
+    /// Here rather than in the list view because the list view is the thing that dies: a tab
+    /// switch destroys the whole subtree under `CenterPaneView.content`, which is exactly why the
+    /// unfolded rows re-folded and the history was laid out twice. `TranscriptResume` is the rule
+    /// and carries the measurements.
+    ///
+    /// Not observed, for the reason `patches` is not: a scroll writes this and nothing draws it,
+    /// so an observed write would invalidate every view watching this model once per gesture.
+    @ObservationIgnored private var panePositions: [TranscriptPaneState.Key: TranscriptPaneState] = [:]
     /// Why the last refresh could not answer. Non-nil means `changedFiles` is the last list git was
     /// able to produce, not what the worktree looks like now.
     var changesError: String?
@@ -1180,6 +1191,20 @@ final class WorkspaceModel {
         }
         fileTreeTask = task
         await task.value
+    }
+
+    // MARK: - Where a chat pane had got to
+
+    /// What this pane last wrote down about this conversation, if it has been here before.
+    func panePosition(pane: String, session: SessionID) -> TranscriptPaneState? {
+        panePositions[TranscriptPaneState.Key(pane: pane, session: session)]
+    }
+
+    /// Written by the transcript when the reader stops scrolling, when a row is folded or
+    /// unfolded, and when the pane goes away. Everything about when it is worth reading back is
+    /// `TranscriptResume`'s.
+    func rememberPanePosition(_ state: TranscriptPaneState, pane: String, session: SessionID) {
+        panePositions[TranscriptPaneState.Key(pane: pane, session: session)] = state
     }
 
     /// One file's diff, from the cache where the worktree has not been looked at since the last

--- a/Sources/Bloom/Views/Center/CenterPaneView.swift
+++ b/Sources/Bloom/Views/Center/CenterPaneView.swift
@@ -92,7 +92,7 @@ struct CenterPaneView: View {
             // The lookup only, never `transcript(for:)`: building one writes observed state, and a
             // body may not do that. `prepare` below is where it is built.
             if let transcript = model.existingTranscript(for: sessionID) {
-                ChatPaneView(transcript: transcript, model: model)
+                ChatPaneView(transcript: transcript, model: model, pane: pane)
             } else if model.sessions.contains(where: { $0.id == sessionID }) {
                 LoadingView()
             } else {

--- a/Sources/Bloom/Views/Center/CenterPaneView.swift
+++ b/Sources/Bloom/Views/Center/CenterPaneView.swift
@@ -82,6 +82,11 @@ struct CenterPaneView: View {
 
     @ViewBuilder
     private var content: some View {
+        // The first thing a tab switch rebuilds, and therefore the start of everything `TabProbe`
+        // is timing. Off unless a probe run turned the trace on, and stamped once per timeline.
+        let _ = SwitchTrace.mark("pane.body", workspace: model.workspace.id)
+        let _ = SwitchTrace.markOnScreen("pane.body", workspace: model.workspace.id)
+
         switch showing {
         case .chat(let sessionID):
             // The lookup only, never `transcript(for:)`: building one writes observed state, and a

--- a/Sources/Bloom/Views/Center/ChatPaneView.swift
+++ b/Sources/Bloom/Views/Center/ChatPaneView.swift
@@ -11,6 +11,9 @@ import BloomCore
 struct ChatPaneView: View {
     var transcript: TranscriptModel
     @Bindable var model: WorkspaceModel
+    /// Which pane of the tab this is, and the only thing it is used for is remembering where the
+    /// reader had got to in the conversation. See `TranscriptPaneMemory`.
+    var pane: String
 
     /// Whether the user has scrolled away from the newest row, which is the only thing the jump
     /// pill is an answer to. Read here rather than passed on, because the pill is drawn here.
@@ -43,7 +46,8 @@ struct ChatPaneView: View {
         VStack(spacing: 0) {
             TranscriptView(
                 transcript: transcript,
-                isRunningSetup: model.isRunningSetup
+                isRunningSetup: model.isRunningSetup,
+                memory: TranscriptPaneMemory(model: model, pane: pane)
             ) { isTranscriptScrolledUp = $0 }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             // On the transcript, not on the composer, and that is the whole of the change.

--- a/Sources/Bloom/Views/Center/ComposerView.swift
+++ b/Sources/Bloom/Views/Center/ComposerView.swift
@@ -411,6 +411,14 @@ struct ComposerView: View {
     /// All of it is only interesting once, hence the `task(id:)`. The precedence rules live in
     /// `ComposerDefaults`.
     private func prepare() async {
+        // A `defer`, because this function has five ways out and every one of them is a composer
+        // that is ready: the common one by far is the early return below for a session whose
+        // defaults were applied on an earlier launch, which is exactly the path a return to a chat
+        // tab takes. A mark on the last line would never fire for it. See `TabProbe`.
+        defer {
+            SwitchTrace.mark("composer.prepared", workspace: transcript.workspace.id)
+            SwitchTrace.markOnScreen("composer.prepared", workspace: transcript.workspace.id)
+        }
         isFocused = true
         caret = (transcript.draft as NSString).length
 

--- a/Sources/Bloom/Views/Chrome/BloomAppDelegate.swift
+++ b/Sources/Bloom/Views/Chrome/BloomAppDelegate.swift
@@ -34,6 +34,9 @@ final class BloomAppDelegate: NSObject, NSApplicationDelegate, UNUserNotificatio
         // needs the state too, and this is the same one moment everything else is handed it. It
         // keeps a weak reference and only ever looks when `--switch-probe` asked it to.
         SwitchProbe.attach(model)
+        // The tab probe needs it for the same reason, and reaches one workspace's model through
+        // it: what it drives is `WorkspaceTabsStore.select`, which takes one.
+        TabProbe.attach(model)
         servicesProvider.attach(model)
         // And a Shortcut needs it for the same reason the Services menu does: an intent runs in
         // this process and has to execute the same code a click in the create sheet does, rather

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -56,6 +56,12 @@ struct DiffView: View {
     @State private var source: FileDiff?
     @State private var mode: FileViewMode
     @State private var isEditable = false
+    /// The file whose diff is on screen, which is not the same question as `file`.
+    ///
+    /// `file` is what this view has been asked for, and it changes before `load` runs. This is what
+    /// `load` last finished, and the difference between the two is exactly what decides whether a
+    /// reload may keep what the reader is looking at. See `load`.
+    @State private var presented: String?
     @State private var revertProblem: String?
     /// Editing buffers outlive this view, so flipping back to the diff, walking to the next file
     /// or switching workspace cannot discard what the user typed.
@@ -173,12 +179,35 @@ struct DiffView: View {
 
     private func load() async {
         priming?.cancel()
-        phase = .loading
-        rows = []
-        expandedRuns = []
-        revealedGaps = [:]
-        fileLines = nil
-        source = nil
+        // **A reload of the file already on screen keeps what is on screen.**
+        //
+        // This used to say `phase = .loading` unconditionally, and the reader paid for it twice.
+        // The changed file poll runs every six seconds and hands this view a fresh `ChangedFile`
+        // whenever a count moves, which re-runs the `task` keyed on it: the diff they were reading
+        // was replaced by "Reading the diff" and came back a moment later, mid sentence. And the
+        // whitespace and layout toggles go through the same door.
+        //
+        // Only the same file, and `presented` is what says so rather than `file`, because `file`
+        // IS the task's id and has already changed by the time this runs. Walking to another file
+        // still drops to the spinner, because the alternative is holding one file's diff under
+        // another file's name.
+        //
+        // It does not answer the case a rebuilt view has. A tab switch destroys this view, so the
+        // way back starts at `Phase.loading` from the state's own initialiser whatever this does,
+        // and what shortens that is `PatchCache` already having the patch: no `git diff`, only the
+        // parse. See `WorkspaceModel.patch(for:)`.
+        if presented != file.path {
+            phase = .loading
+            rows = []
+            expandedRuns = []
+            revealedGaps = [:]
+            fileLines = nil
+            source = nil
+            // Another file's answer to another file's question. It is set at the foot of this
+            // function rather than in the middle of it now, so without this the header bar would
+            // offer Edit on the strength of the file the reader has just walked away from.
+            isEditable = false
+        }
 
         let patch = await model.patch(for: file)
         let path = file.path
@@ -188,15 +217,7 @@ struct DiffView: View {
 
         guard !Task.isCancelled else { return }
 
-        // Whether Edit mode is even offered is a question about the bytes on disk, not about the
-        // patch, so it is asked once here and off the main thread.
-        let absolute = absolutePath
-        let binary = file.isBinary
-        isEditable = await Task.detached(priority: .utility) {
-            !binary && FileEditor.isEditable(absolute)
-        }.value
-
-        guard !Task.isCancelled else { return }
+        presented = file.path
 
         guard let parsed else {
             phase = .notice(
@@ -208,6 +229,20 @@ struct DiffView: View {
         }
         source = parsed
         await apply(parsed)
+
+        // Whether Edit mode is even offered is a question about the bytes on disk rather than
+        // about the patch, so it is asked off the main thread, and it is asked AFTER the diff is
+        // on screen rather than before. It used to sit between the parse and the presentation,
+        // where a `stat` and a read of the first bytes of the file stood between the reader and
+        // the thing they had clicked. Nothing above it needs the answer; only the header bar's
+        // Edit control does, and it appears with the bar rather than with the diff.
+        let absolute = absolutePath
+        let binary = file.isBinary
+        let editable = await Task.detached(priority: .utility) {
+            !binary && FileEditor.isEditable(absolute)
+        }.value
+        guard !Task.isCancelled else { return }
+        isEditable = editable
     }
 
     /// Turn the parsed patch into whatever the current settings say it should be.

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -11,10 +11,39 @@ struct TranscriptListView: View {
     /// Only to explain an empty transcript: a workspace whose setup script is still running has a
     /// session but cannot have said anything yet.
     var isRunningSetup: Bool = false
+    /// Where this pane's place in this conversation is kept while the pane does not exist. Nil for
+    /// a transcript nobody comes back to, which is the archive sheet's. See `TranscriptResume`.
+    let memory: TranscriptPaneMemory?
     let onScrolledUpChange: (@MainActor @Sendable (Bool) -> Void)?
 
-    /// Expansion is a property of this view, not of the session. Reopening a workspace should not
-    /// restore forty open tool results, and the model has no business knowing what is unfolded.
+    init(
+        transcript: TranscriptModel,
+        isRunningSetup: Bool = false,
+        memory: TranscriptPaneMemory? = nil,
+        onScrolledUpChange: (@MainActor @Sendable (Bool) -> Void)? = nil
+    ) {
+        self.transcript = transcript
+        self.isRunningSetup = isRunningSetup
+        self.memory = memory
+        self.onScrolledUpChange = onScrolledUpChange
+        // Seeded here rather than restored from a `task`, because both of these decide what the
+        // FIRST pass of this body draws and a task runs after it. `remembered` reads a dictionary
+        // that is `@ObservationIgnored`, so asking costs nothing and subscribes to nothing.
+        let remembered = memory?.remembered(session: transcript.session.id)
+        _expanded = State(initialValue: remembered?.expanded ?? [])
+        _drawnInFull = State(
+            initialValue: TranscriptResume.drawsInFull(remembered) ? transcript.session.id : nil
+        )
+    }
+
+    /// Which tool results are unfolded.
+    ///
+    /// It used to say that expansion is a property of this view and not of the session, and the
+    /// second half of that is still true: the model has no business knowing what is unfolded, and
+    /// reopening a workspace should not restore forty open tool results. The first half was the
+    /// bug. This view is destroyed and rebuilt by every tab switch, so an unfolded result silently
+    /// re-folded every time the reader looked at the changes and came back. It is seeded from, and
+    /// written to, the pane's own memory, which lasts as long as the launch and no longer.
     @State private var expanded: Set<Int> = []
     @State private var geometry = TranscriptGeometry()
     @State private var didPosition = false
@@ -95,9 +124,25 @@ struct TranscriptListView: View {
         case liveEnd
         /// A row, and where in the pane it was put.
         case row(Int, UnitPoint)
+        /// A number of points down the content, which only a pane coming back to a session it has
+        /// already drawn ever has. See `TranscriptResume`.
+        case offset(Double)
     }
 
     @State private var opening: Opening?
+
+    /// Where the scroll view is now, so that leaving the pane can write it down.
+    ///
+    /// In a box rather than in `@State` for the reason `GeometryBox` sets out: this is written on
+    /// every frame of every scroll, and as `@State` every one of those frames would re-run this
+    /// body and with it every realised row, to store a number the body never reads. It is
+    /// deliberately not folded into `TranscriptGeometry` either: every value in there is quantised
+    /// so that a drag stops writing state, and a raw offset would undo that for all of them.
+    @State private var contentOffset = GeometryBox(0.0)
+
+    /// The text scale the rows are being drawn at, read for one thing: an offset written down at
+    /// one size is a point into a document laid out at another. See `TranscriptPaneState.Measure`.
+    @Environment(\.fontScale) private var fontScale
 
     /// The session whose history has been put back, if any. See `visibleRows`.
     ///
@@ -425,6 +470,23 @@ struct TranscriptListView: View {
                 // scroll, and each of them is a correction the transition form could not make.
                 onScrolledUpChange?(!new.isNearBottom)
             }
+            // A second subscription, on the raw offset, and deliberately not folded into the one
+            // above. Everything in `TranscriptGeometry` is quantised precisely so that a drag
+            // stops writing state; a raw offset in that value would undo the quantisation for all
+            // of it. This one writes a box, which SwiftUI cannot see, so a scroll costs one
+            // closure call per frame and no pass over this list. See `contentOffset`.
+            .onScrollGeometryChange(for: Double.self) { $0.contentOffset.y } action: { _, new in
+                contentOffset.value = new
+            }
+            // Where the reader ends up, written down for the pane that is built next. On the end
+            // of a gesture rather than during one: see `remember`.
+            .onScrollPhaseChange { _, phase in
+                if phase == .idle { remember() }
+            }
+            // And on the way out, which is the case the whole of `TranscriptResume` is about: a
+            // tab switch destroys this view, and a reader who arrived, read what was on screen and
+            // moved on has scrolled nothing for the closure above to fire on.
+            .onDisappear { remember() }
             // No `settlesArrivals` here, unlike the two lists. That modifier bounds how long
             // `arriving` keeps saying yes, and the transcript no longer asks `arriving` anything:
             // it asks `isNew`, which stops being true the moment `trackArrivals` takes the new
@@ -454,13 +516,25 @@ struct TranscriptListView: View {
                 goToLiveEnd()
             }
             .onChange(of: transcript.session.id) { _, _ in
+                // Nothing is written down for the session being left here, and that is deliberate
+                // rather than an omission. Everything `remember` reads describes the pane as it
+                // was laid out a moment ago, and by the time this runs `transcript` is already the
+                // NEW model: the row count would be the wrong session's. What the old session has
+                // is whatever its last settled scroll wrote, which is a position in a document
+                // that has only grown since, and that is exactly what `TranscriptResume` is built
+                // to read back.
+                //
                 // Nothing owed to a conversation the pane has left.
                 scroller.stop()
                 follower.stop()
                 catchUp?.cancel()
                 didPosition = false
                 opening = nil
-                expanded.removeAll()
+                // The folds of the session being arrived at, which are its own and are usually
+                // none. It used to be `removeAll`, which was the same claim for a session this
+                // pane has never held and the wrong one for a session it is coming back to.
+                let remembered = memory?.remembered(session: transcript.session.id)
+                expanded = remembered?.expanded ?? []
                 // A session opens at its live end whatever the one being left was scrolled to,
                 // and the anchor is read before the new rows arrive.
                 geometry.isNearBottom = true
@@ -468,11 +542,13 @@ struct TranscriptListView: View {
                 // CHANGES, and a pane that arrives on the live end and stays there changes
                 // nothing. Without this the composer keeps whatever the last session told it.
                 onScrolledUpChange?(false)
-                // Arriving somewhere means arriving on its tail. Cleared here as well as set in
-                // `task`, because leaving a session before its history had landed and coming
-                // straight back would otherwise find its own id still recorded and put four
-                // thousand rows on the frame that is trying to arrive.
-                drawnInFull = nil
+                // Arriving somewhere means arriving on its tail, unless this pane has drawn the
+                // session before, in which case there is nothing to arrive at: see
+                // `TranscriptResume.drawsInFull`. Said here as well as in `task`, because leaving
+                // a session before its history had landed and coming straight back would
+                // otherwise find its own id still recorded and put four thousand rows on the
+                // frame that is trying to arrive.
+                drawnInFull = TranscriptResume.drawsInFull(remembered) ? transcript.session.id : nil
                 // And nothing in the session being arrived at counts as having arrived. Cleared
                 // here as well as set in `task` for the same reason `drawnInFull` is: leaving a
                 // session before it had settled and coming straight back must not find its own
@@ -501,6 +577,29 @@ struct TranscriptListView: View {
                 // the same number of rows never positioned and never marked the session read,
                 // and the unread badge stuck until the next row happened to land.
                 position(proxy)
+
+                // A pane coming back to a session it has drawn before has the whole of it on the
+                // frame it arrived on and is already where the reader left it, so none of the
+                // reveal below applies: there is no tail to grow into the history, nothing moves
+                // under the viewport, and the two-call dance that exists because something does
+                // has nothing to correct. Measured on a release build at 1440 by 900 against a
+                // 3,848 row session: the reveal cost a 163ms to 169ms main thread block on every
+                // return, on top of the 104ms to 125ms the tail before it cost, and this is the
+                // whole of what removing it removes.
+                //
+                // It is skipped rather than deleted. On a FIRST open the sequence is still right
+                // and `TranscriptTail` still carries the argument for it.
+                guard drawnInFull != transcript.session.id else {
+                    arrivalSession = transcript.session.id
+                    // The same mark pair the deferred path carries below, so that a run of
+                    // `TabProbe` before and after this change is comparing the same span: the
+                    // moment the whole session is on the list, and the first frame that can show
+                    // it. Here the first half is already true when this line is reached, which is
+                    // the entire change.
+                    SwitchTrace.mark("transcript.full", workspace: transcript.workspace.id)
+                    SwitchTrace.markOnScreen("transcript.full", workspace: transcript.workspace.id)
+                    return
+                }
 
                 // The rest of the session, once the frame carrying the tail has been drawn.
                 //
@@ -783,23 +882,75 @@ struct TranscriptListView: View {
         guard !transcript.rows.isEmpty, !didPosition else { return }
         didPosition = true
 
-        // A search result outranks both. Somebody who clicked a line of a transcript in the search
-        // screen asked for that line, and taking them to their unread mark or to the live end
-        // instead would be the app finding the answer and then hiding it again. Centred rather
-        // than at the top, because the sentence usually needs the turn around it to make sense.
+        // A pane coming back to a session it has already drawn is put back where the reader left
+        // it, and none of the three openings below applies: they are all answers to "where should
+        // somebody arriving at this conversation start reading", and this reader is not arriving.
+        // The rule, and what makes a written down position stale, is `TranscriptResume`'s.
         //
-        // Which of the three it was is written down as it is chosen, because the history landing
-        // behind this a moment later moves everything on screen and the view has to be put back
-        // where it was put. See the reveal in `task`.
-        if let target = app.takeTranscriptTarget(for: transcript.workspace.id) {
-            opening = .row(target.seq, .center)
-        } else if let unread = transcript.firstUnreadSeq, unread != transcript.rows.first?.seq {
-            opening = .row(unread, .top)
-        } else {
+        // Still marked read at the foot of this function, because a turn can have run while the
+        // pane was on another tab and those rows are rows the reader is now looking at.
+        switch TranscriptResume.placement(
+            for: memory?.remembered(session: transcript.session.id),
+            rowCount: transcript.rows.count,
+            measure: currentMeasure
+        ) {
+        case .liveEnd:
             opening = .liveEnd
+        case .offset(let y):
+            opening = .offset(y)
+        case .first:
+            // A search result outranks both of the others. Somebody who clicked a line of a
+            // transcript in the search screen asked for that line, and taking them to their unread
+            // mark or to the live end instead would be the app finding the answer and then hiding
+            // it again. Centred rather than at the top, because the sentence usually needs the
+            // turn around it to make sense.
+            //
+            // Which of the three it was is written down as it is chosen, because the history
+            // landing behind this a moment later moves everything on screen and the view has to be
+            // put back where it was put. See the reveal in `task`.
+            if let target = app.takeTranscriptTarget(for: transcript.workspace.id) {
+                opening = .row(target.seq, .center)
+            } else if let unread = transcript.firstUnreadSeq, unread != transcript.rows.first?.seq {
+                opening = .row(unread, .top)
+            } else {
+                opening = .liveEnd
+            }
         }
         open(opening, with: proxy)
         Task { await transcript.markAllRead() }
+    }
+
+    // MARK: Remembering where the reader was
+
+    /// What this pane is now, or nothing if it has not been laid out yet.
+    ///
+    /// `bubbleCap` rather than the container width, because that is the number this view actually
+    /// holds and it is a step function of the width: see `TranscriptGeometry`, which explains why
+    /// the raw width is deliberately not kept. `paneHeight` is nought until the first layout, and
+    /// that is what tells an unmeasured pane apart from a narrow one.
+    private var currentMeasure: TranscriptPaneState.Measure? {
+        guard geometry.paneHeight > 0 else { return nil }
+        return TranscriptPaneState.Measure(width: geometry.bubbleCap, fontScale: fontScale)
+    }
+
+    /// Writes down where the reader is, for the pane to find when it is built again.
+    ///
+    /// Called when a scroll settles, when a row is folded or unfolded, and when the pane goes
+    /// away, rather than on every frame of a scroll. The last of those is the one that cannot be
+    /// dropped: a reader who arrives, reads what is on screen and switches tab has scrolled
+    /// nothing and folded nothing, and is exactly the case this whole file is about.
+    private func remember() {
+        guard let memory else { return }
+        memory.remember(
+            TranscriptPaneState(
+                expanded: expanded,
+                offset: contentOffset.value,
+                isAtLiveEnd: geometry.isNearBottom,
+                rowCount: transcript.rows.count,
+                measure: currentMeasure
+            ),
+            session: transcript.session.id
+        )
     }
 
     /// Puts the view where the session was opened.
@@ -814,6 +965,13 @@ struct TranscriptListView: View {
             proxy.scrollTo(seq, anchor: anchor)
         case .liveEnd:
             scrollPosition.scrollTo(edge: .bottom)
+        case .offset(let y):
+            // A point rather than an edge or a row, and it needs neither of the two dances above.
+            // The content is already whole on the frame this runs on, so nothing grows underneath
+            // it and there is nothing for the reveal to put back; and the value it is being moved
+            // to is a value the state does not already hold, so one update is a change SwiftUI
+            // applies. See the reveal in `task` for why the LIVE END takes two.
+            scrollPosition.scrollTo(y: y)
         case nil:
             break
         }
@@ -861,5 +1019,9 @@ struct TranscriptListView: View {
         } else {
             expanded.insert(seq)
         }
+        // Written down straight away rather than left to the next settled scroll, because
+        // unfolding a tool result and switching tab to look at what it did is one gesture, and
+        // re-folding it behind the reader's back was the bug. See `TranscriptResume`.
+        remember()
     }
 }

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -216,6 +216,10 @@ struct TranscriptListView: View {
     private var maxBubbleWidth: CGFloat { geometry.bubbleCap }
 
     var body: some View {
+        // The first pass of this body after a tab switch, which is where the rebuilt list starts.
+        // Stamped once per timeline, so the passes that follow it cost nothing to ignore.
+        let _ = SwitchTrace.mark("transcript.body", workspace: transcript.workspace.id)
+        let _ = SwitchTrace.markOnScreen("transcript.body", workspace: transcript.workspace.id)
         // Read once for the pass rather than once per footer: resolving it walks the row list,
         // and every realised footer would otherwise pay for its own walk. See `TranscriptModel`.
         let stoppedTurnSeq = transcript.stoppedTurnSeq
@@ -512,6 +516,13 @@ struct TranscriptListView: View {
                 try? await Task.sleep(for: .milliseconds(100))
                 guard !Task.isCancelled else { return }
                 drawnInFull = transcript.session.id
+                // **The number the whole of this is about.** The work stamp is the instant the
+                // history was asked for; the vsync stamp is the first frame that could show it,
+                // and the display link cannot run while the main thread is laying rows out. The
+                // gap between the two IS the layout `TranscriptTail` exists to keep off the
+                // arrival frame, and on a return to a chat tab it is paid all over again.
+                SwitchTrace.mark("transcript.full", workspace: transcript.workspace.id)
+                SwitchTrace.markOnScreen("transcript.full", workspace: transcript.workspace.id)
                 // Not an arrival. See `TranscriptLiveEndFollower.forget`.
                 follower.forget()
                 // And the live end again, in two calls, in two passes.

--- a/Sources/Bloom/Views/Transcript/TranscriptPaneMemory.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptPaneMemory.swift
@@ -1,0 +1,28 @@
+import BloomCore
+
+/// The one pane's worth of `WorkspaceModel.panePositions` a transcript list is allowed to read and
+/// write.
+///
+/// A pass-through rather than a store of its own, and it exists so that the list does not have to
+/// be handed a whole `WorkspaceModel` to remember where it was. Two views between the pane and the
+/// list would then be carrying a model neither of them draws anything from, and a `@Bindable` one
+/// at that.
+///
+/// The pane id is half the key because a split tab can hold the same conversation twice, each half
+/// scrolled somewhere else, and `CenterPanesView.soloPane` means an unsplit tab's pane answers to
+/// the same name in every workspace and every tab. See `TranscriptPaneState.Key`.
+///
+/// Nil for a transcript nobody can scroll back to: the archive sheet draws one and is gone.
+@MainActor
+struct TranscriptPaneMemory {
+    let model: WorkspaceModel
+    let pane: String
+
+    func remembered(session: SessionID) -> TranscriptPaneState? {
+        model.panePosition(pane: pane, session: session)
+    }
+
+    func remember(_ state: TranscriptPaneState, session: SessionID) {
+        model.rememberPanePosition(state, pane: pane, session: session)
+    }
+}

--- a/Sources/Bloom/Views/Transcript/TranscriptView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import BloomCore
 
 /// The transcript: the surface where a user watches an agent work.
 ///
@@ -13,13 +14,20 @@ struct TranscriptView: View {
     /// uses it to decide whether a "jump to newest" pill is worth offering.
     private let onScrolledUpChange: (@MainActor @Sendable (Bool) -> Void)?
 
+    /// Where this pane's place in this conversation is kept while the pane does not exist, which
+    /// is every moment the centre column is showing another tab. Nil for a transcript nobody comes
+    /// back to. See `TranscriptPaneMemory`.
+    private let memory: TranscriptPaneMemory?
+
     init(
         transcript: TranscriptModel,
         isRunningSetup: Bool = false,
+        memory: TranscriptPaneMemory? = nil,
         onScrolledUpChange: (@MainActor @Sendable (Bool) -> Void)? = nil
     ) {
         self.transcript = transcript
         self.isRunningSetup = isRunningSetup
+        self.memory = memory
         self.onScrolledUpChange = onScrolledUpChange
     }
 
@@ -28,10 +36,12 @@ struct TranscriptView: View {
     init(
         transcript: TranscriptModel?,
         isRunningSetup: Bool = false,
+        memory: TranscriptPaneMemory? = nil,
         onScrolledUpChange: (@MainActor @Sendable (Bool) -> Void)? = nil
     ) {
         self.transcript = transcript
         self.isRunningSetup = isRunningSetup
+        self.memory = memory
         self.onScrolledUpChange = onScrolledUpChange
     }
 
@@ -41,6 +51,7 @@ struct TranscriptView: View {
                 TranscriptListView(
                     transcript: transcript,
                     isRunningSetup: isRunningSetup,
+                    memory: memory,
                     onScrolledUpChange: onScrolledUpChange
                 )
             } else {

--- a/Sources/BloomCore/TranscriptResume.swift
+++ b/Sources/BloomCore/TranscriptResume.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// What a chat pane remembers about a conversation while its view does not exist, and what it does
+/// with that on the way back.
+///
+/// **The centre column's panes are destroyed by a tab switch.** `CenterPaneView.content` is a
+/// switch on what the pane is showing, so moving from a conversation to the changes takes the whole
+/// subtree with it: the scroll view, every row it had realised, and every scrap of the list's own
+/// `@State`. Moving back builds all of it again from nothing.
+///
+/// Measured with `--tab-probe` on a release build at 1440 by 900, against a 3,848 row session,
+/// three warm returns to the chat tab. The list restarted in tail mode, drew `TranscriptTail`'s
+/// last eighty rows, and a hundred milliseconds later put the whole history back, so the main
+/// thread stopped twice: 125ms, 125ms and 104ms for the tail, and then 169ms, 163ms and 163ms for
+/// the history. The transcript was not settled until 334ms, 327ms and 333ms after the tab was
+/// picked. Drawing the whole session on the arrival frame instead is ONE stop of 209ms, 207ms and
+/// 207ms, and the transcript is settled when it ends. Less total work, because the tail is not
+/// laid out and then thrown away, and one settle rather than a paint followed by a jump.
+///
+/// What it is not is cheap. A return to the review tab in the same fixture costs 85ms to 102ms
+/// with six milliseconds of centre column layout in it, so most of what is left is the pane being
+/// rebuilt at all rather than anything about a transcript. Opening anywhere but the top of a
+/// `LazyVStack` realises every row above the target, so a list built from nothing is O(rows)
+/// however it is positioned, and the only thing that would make it O(1) is not destroying the
+/// view. That is a bigger change than this one and it has a cost of its own: a pane kept alive is
+/// a pane laid out on every frame of every window resize.
+///
+/// It also carries a correctness bug with it, and the same cause: a tool result the reader had
+/// unfolded silently re-folded on every tab round trip, because `expanded` was view state and the
+/// view was new.
+///
+/// # The folds and the place are two different claims
+///
+/// `placement` answers about the place, and the folds are handed back whatever it says, because
+/// the two have different lifetimes. A fold is about a row: it survives the pane being made
+/// narrower, the text being made bigger and the session growing. An offset is a number of points
+/// into a laid out document, and every one of those changes makes it a number into a different
+/// document.
+public struct TranscriptPaneState: Equatable, Sendable {
+    /// One pane's memory of one conversation. Both halves are needed: a split tab can hold the
+    /// same session in two panes, each scrolled somewhere else, and an unsplit tab's pane is
+    /// called the same thing in every workspace (see `CenterPanesView.soloPane`), so the session
+    /// is what tells two of those apart.
+    public struct Key: Hashable, Sendable {
+        public var pane: String
+        public var session: SessionID
+
+        public init(pane: String, session: SessionID) {
+            self.pane = pane
+            self.session = session
+        }
+    }
+
+    /// The width the rows were laid out at and the scale they were drawn at, which are the two
+    /// things that decide how tall a row is and so what a point of offset means.
+    ///
+    /// Optional at both ends, and that is the rule rather than a convenience: a pane that has not
+    /// been laid out yet has no width to offer, and a measurement nobody has taken cannot
+    /// contradict one that was. The alternative was to treat "not measured" as "different" and
+    /// throw away every restored position on the frame the geometry had not landed on yet, which
+    /// is most of them.
+    public struct Measure: Equatable, Sendable {
+        public var width: Double
+        public var fontScale: Double
+
+        public init(width: Double, fontScale: Double) {
+            self.width = width
+            self.fontScale = fontScale
+        }
+    }
+
+    /// The sequence numbers of the rows the reader had unfolded.
+    public var expanded: Set<Int>
+    /// Where the view was, in points from the top of the content.
+    public var offset: Double
+    /// Whether that offset was the live end.
+    ///
+    /// Kept as a flag rather than inferred from the offset, because a turn can run while the
+    /// reader is away: the content grows, and the number of points that meant "the end" when it
+    /// was written names somewhere in the middle by the time it is read.
+    public var isAtLiveEnd: Bool
+    /// How many rows the session held when this was written. See `TranscriptResume.placement`.
+    public var rowCount: Int
+    public var measure: Measure?
+
+    public init(
+        expanded: Set<Int>,
+        offset: Double,
+        isAtLiveEnd: Bool,
+        rowCount: Int,
+        measure: Measure?
+    ) {
+        self.expanded = expanded
+        self.offset = offset
+        self.isAtLiveEnd = isAtLiveEnd
+        self.rowCount = rowCount
+        self.measure = measure
+    }
+}
+
+/// Where a chat pane opens.
+public enum TranscriptPlacement: Equatable, Sendable {
+    /// Nowhere worth restoring, so the session is opened the way a session has always been opened:
+    /// on the first unread row, or on a row somebody searched for, or on the live end.
+    case first
+    /// The reader left at the live end, so that is where they are put back.
+    case liveEnd
+    /// The reader left this many points down, and the document is the same document.
+    case offset(Double)
+}
+
+/// The rule for what a pane may do with what it remembers.
+public enum TranscriptResume {
+    /// Whether the arrival frame may draw the whole session rather than `TranscriptTail`'s tail.
+    ///
+    /// **Asked before anything has been laid out**, because it decides what the FIRST pass of the
+    /// list's body draws, so it can read nothing that a measurement has to arrive for. The
+    /// existence of a memory for this pane and this session is the whole of it, and that is enough:
+    /// a pane that has drawn this session before is not arriving at it. The tail exists to keep a
+    /// 269ms layout off the frame that arrives at a session, and the price of it is the same layout
+    /// a hundred milliseconds later; paying that on every return is the trade going the wrong way.
+    public static func drawsInFull(_ remembered: TranscriptPaneState?) -> Bool {
+        remembered != nil
+    }
+
+    /// Where a pane opens a session, given what it wrote down when it last left one.
+    ///
+    /// Asked once the list has been laid out, so `measure` is what the pane is now and
+    /// `remembered.measure` is what it was. Either being nil means one of the two was never taken.
+    ///
+    /// Every `.first` below is a case where restoring would put the reader somewhere that is not
+    /// where they were, and the arrival that answers instead is not merely a fallback: it opens on
+    /// the first unread row, which is what a session nobody has read wants.
+    public static func placement(
+        for remembered: TranscriptPaneState?,
+        rowCount: Int,
+        measure: TranscriptPaneState.Measure?
+    ) -> TranscriptPlacement {
+        guard let remembered, rowCount > 0 else { return .first }
+        // A session with fewer rows than it had is not the session that offset was measured in.
+        // Rows are appended and never removed while a pane is away, so this is a transcript that
+        // was read again from the start rather than one that grew, and nothing written about the
+        // old one carries.
+        guard remembered.rowCount <= rowCount else { return .first }
+        // The end has moved if a turn ran while the reader was away, and it is still the end. A
+        // width change moves nobody who was there, because the end is a place rather than a
+        // measurement, so this is asked before the measure is looked at.
+        if remembered.isAtLiveEnd { return .liveEnd }
+        // A point into a document laid out at another width, or at another text size, is a point
+        // into a different document. Rather than land the reader at a plausible looking wrong
+        // place, this opens the way a fresh visit does.
+        if let measure, let was = remembered.measure, was != measure { return .first }
+        guard remembered.offset > 0 else { return .first }
+        return .offset(remembered.offset)
+    }
+}

--- a/Tests/BloomCoreTests/TranscriptResumeTests.swift
+++ b/Tests/BloomCoreTests/TranscriptResumeTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// What a chat pane does with what it wrote down when it last left a conversation.
+///
+/// The decision is here rather than in `TranscriptListView` for the reason the split exists: the
+/// view is destroyed by every tab switch, which is the very thing being fixed, and a rule taken
+/// inside one is a rule nothing can hold still.
+@Suite("Transcript resume")
+struct TranscriptResumeTests {
+    private func measure(width: Double = 900, fontScale: Double = 1) -> TranscriptPaneState.Measure {
+        TranscriptPaneState.Measure(width: width, fontScale: fontScale)
+    }
+
+    private func state(
+        expanded: Set<Int> = [],
+        offset: Double = 1_200,
+        isAtLiveEnd: Bool = false,
+        rowCount: Int = 400,
+        measure: TranscriptPaneState.Measure? = nil
+    ) -> TranscriptPaneState {
+        TranscriptPaneState(
+            expanded: expanded,
+            offset: offset,
+            isAtLiveEnd: isAtLiveEnd,
+            rowCount: rowCount,
+            measure: measure ?? self.measure()
+        )
+    }
+
+    // MARK: What the arrival frame draws
+
+    @Test("a pane that has never held this session draws the tail")
+    func nothingRememberedDrawsTheTail() {
+        #expect(TranscriptResume.drawsInFull(nil) == false)
+    }
+
+    @Test("a pane coming back to a session it has drawn draws the whole of it")
+    func aReturnDrawsInFull() {
+        #expect(TranscriptResume.drawsInFull(state()))
+    }
+
+    // MARK: Where it opens
+
+    @Test("a pane that has never held this session opens the way it always did")
+    func nothingRemembered() {
+        let placement = TranscriptResume.placement(
+            for: nil, rowCount: 400, measure: measure()
+        )
+        #expect(placement == .first)
+    }
+
+    @Test("a session with no rows opens the way it always did")
+    func emptySession() {
+        #expect(TranscriptResume.placement(for: state(), rowCount: 0, measure: measure()) == .first)
+    }
+
+    @Test("a reader who left at the end is put back at the end, not at the offset")
+    func liveEndOutranksTheOffset() {
+        let placement = TranscriptResume.placement(
+            for: state(offset: 9_000, isAtLiveEnd: true), rowCount: 400, measure: measure()
+        )
+        #expect(placement == .liveEnd)
+    }
+
+    /// The case the flag exists for: a turn ran while the pane was on another tab, so the content
+    /// grew and the number of points that meant the end names the middle now.
+    @Test("the end still means the end after the session has grown")
+    func liveEndAfterGrowth() {
+        let placement = TranscriptResume.placement(
+            for: state(offset: 9_000, isAtLiveEnd: true, rowCount: 400),
+            rowCount: 6_000, measure: measure()
+        )
+        #expect(placement == .liveEnd)
+    }
+
+    @Test("a reader who left part way up is put back there")
+    func offsetIsRestored() {
+        let placement = TranscriptResume.placement(
+            for: state(offset: 1_200), rowCount: 400, measure: measure()
+        )
+        #expect(placement == .offset(1_200))
+    }
+
+    @Test("a session that has grown under a scrolled reader keeps their offset")
+    func growthDoesNotMoveAReader() {
+        let placement = TranscriptResume.placement(
+            for: state(offset: 1_200, rowCount: 400), rowCount: 900, measure: measure()
+        )
+        #expect(placement == .offset(1_200))
+    }
+
+    /// Rows are appended and never removed while a pane is away, so fewer of them means the
+    /// session was read again from the start and nothing measured against the old one carries.
+    @Test("a session with fewer rows than it had is not the one that offset was measured in")
+    func shrunkSessionIsNotResumed() {
+        let placement = TranscriptResume.placement(
+            for: state(rowCount: 400), rowCount: 12, measure: measure()
+        )
+        #expect(placement == .first)
+    }
+
+    @Test("an offset measured at another width is a point into another document")
+    func widthChangeStalesTheOffset() {
+        let placement = TranscriptResume.placement(
+            for: state(measure: measure(width: 900)), rowCount: 400, measure: measure(width: 640)
+        )
+        #expect(placement == .first)
+    }
+
+    @Test("and so is one measured at another text size")
+    func fontScaleChangeStalesTheOffset() {
+        let placement = TranscriptResume.placement(
+            for: state(measure: measure(fontScale: 1)),
+            rowCount: 400, measure: measure(fontScale: 1.2)
+        )
+        #expect(placement == .first)
+    }
+
+    /// A width change moves nobody who was at the end, because the end is a place rather than a
+    /// measurement.
+    @Test("a width change does not throw away the live end")
+    func widthChangeKeepsTheLiveEnd() {
+        let placement = TranscriptResume.placement(
+            for: state(isAtLiveEnd: true, measure: measure(width: 900)),
+            rowCount: 400, measure: measure(width: 640)
+        )
+        #expect(placement == .liveEnd)
+    }
+
+    /// The frame the geometry has not landed on yet, which is most arrival frames. A measurement
+    /// nobody has taken must not be allowed to contradict one that was.
+    @Test("a pane that has not been measured yet keeps the offset it was given")
+    func unmeasuredPaneKeepsTheOffset() {
+        let placement = TranscriptResume.placement(
+            for: state(offset: 1_200, measure: measure(width: 900)), rowCount: 400, measure: nil
+        )
+        #expect(placement == .offset(1_200))
+    }
+
+    @Test("and so does one whose last visit was never measured")
+    func unmeasuredMemoryKeepsTheOffset() {
+        let unmeasured = TranscriptPaneState(
+            expanded: [], offset: 1_200, isAtLiveEnd: false, rowCount: 400, measure: nil
+        )
+        let placement = TranscriptResume.placement(
+            for: unmeasured, rowCount: 400, measure: measure(width: 640)
+        )
+        #expect(placement == .offset(1_200))
+    }
+
+    @Test("the top of the content is a first open rather than a restored nought")
+    func topIsNotRestored() {
+        let placement = TranscriptResume.placement(
+            for: state(offset: 0), rowCount: 400, measure: measure()
+        )
+        #expect(placement == .first)
+    }
+}


### PR DESCRIPTION
`--tab-probe` is the third of the family after `FrameProbe` and `SwitchProbe`: it drives `WorkspaceTabsStore.select` and reads `SwitchTrace`'s timeline back. One driver, programmatic, so a run needs no pointer, no focus and no window in front.

Measured on a release build at 1440 by 900 against a 3,848 row session, three warm returns to the chat tab. Before, the main thread stopped twice, for 104ms to 125ms drawing `TranscriptTail`'s tail and then for 163ms to 169ms putting the history back, and the transcript was not settled until 327ms to 334ms after the tab was picked. After, one stop of 207ms to 209ms, and it is settled when that ends.

The pane writes down where the reader was and what they had unfolded, on `WorkspaceModel`, and reads it back in `init` so it decides what the first pass of the body draws. `TranscriptResume` in the core is the rule and what makes a written position stale. The tail and its reveal are untouched on a first open. `9c12552`'s two-update `ScrollPosition` sequence stays with them.

That also fixes the re-folding bug: `expanded` was view state and the view was new, so an unfolded tool result silently re-folded on every tab round trip.

Two things found on the way. `Ticker.beginRun` zeroed `last`, so the first interval of every run was dropped, which is the stall the probe exists to find. And `DiffView.load` set `phase = .loading` on every reload, so the six second changed file poll replaced a diff somebody was reading with a spinner.

What this does not reach is one frame. A return to the review tab in the same fixture costs 85ms to 102ms with six milliseconds of centre column layout in it, so most of what is left is the pane being rebuilt at all. Opening anywhere but the top of a `LazyVStack` realises every row above the target, so a list built from nothing is O(rows) however it is positioned, and only not destroying the view makes it O(1).