### PR TITLE
Quick prompts in the composer

### DIFF
--- a/Sources/Bloom/Views/Center/Composer/ComposerFooterView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerFooterView.swift
@@ -23,6 +23,10 @@ struct ComposerFooterView: View {
     /// the create sheet the worktree does not exist, so the repository is the honest answer there.
     var project: String?
     var onAttach: @MainActor () -> Void
+    /// What choosing a quick prompt does, or nil where there is nowhere to put one. Nil hides the
+    /// button rather than disabling it: a control that can never do anything is not worth the room
+    /// in a row that already loses its words at 420 points.
+    var onQuickPrompt: (@MainActor (QuickPrompt) -> Void)?
     var onSend: @MainActor () -> Void
     var onStop: @MainActor () -> Void = {}
     /// Whether the row carries the choices the agent runs on.
@@ -58,6 +62,11 @@ struct ComposerFooterView: View {
     /// pick. See the binding on that view.
     @State private var isShowingContextDetail = false
 
+    /// Whether the quick prompt panel is up. Held here for the same reason the flag above it is:
+    /// the button is in all three candidates `ViewThatFits` builds, and state inside a candidate
+    /// belongs to the candidate.
+    @State private var isShowingQuickPrompts = false
+
     var body: some View {
         // Everything the row is built out of, worked out once.
         //
@@ -86,6 +95,17 @@ struct ComposerFooterView: View {
         // tree while the popover is up.
         .popover(isPresented: $isShowingContextDetail, arrowEdge: .top) {
             if let context { ContextWindowDetail(usage: context) }
+        }
+        // Outside the `ViewThatFits` as well, and for the same reason: narrowing the pane must not
+        // take the presenter out of the tree while the panel is up.
+        .popover(isPresented: $isShowingQuickPrompts, arrowEdge: .top) {
+            if let onQuickPrompt {
+                QuickPromptMenu(
+                    catalog: QuickPromptCatalog.shared,
+                    onPick: onQuickPrompt,
+                    onClose: { isShowingQuickPrompts = false }
+                )
+            }
         }
         .onChange(of: controls.model, initial: true) { _, id in
             remember(id, known: catalog.options(for: controls.agentKind), in: &extraModels)
@@ -222,6 +242,25 @@ struct ComposerFooterView: View {
                 ComposerContextGauge(
                     usage: context, reading: reading, isShowingDetail: $isShowingContextDetail
                 )
+            }
+
+            // Beside the paperclip, because those two are the only controls in this row that
+            // answer "what goes into the box" rather than "how should it think". `text.badge.plus`
+            // is literally what pressing it does, and not `sparkles`: every control to the left is
+            // already about an AI, so a sparkle would distinguish nothing.
+            if showsAgentControls, onQuickPrompt != nil {
+                Button {
+                    isShowingQuickPrompts = true
+                } label: {
+                    ComposerControlLabel(
+                        systemImage: "text.badge.plus",
+                        text: nil,
+                        isActive: isShowingQuickPrompts
+                    )
+                }
+                .buttonStyle(.plain)
+                .help("Insert a quick prompt")
+                .accessibilityLabel("Quick prompts")
             }
 
             // A paperclip, not the plus that used to sit here: a plus already means "new session"

--- a/Sources/Bloom/Views/Center/Composer/ComposerPrompt.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerPrompt.swift
@@ -52,9 +52,10 @@ struct ComposerPrompt<Footer: View>: View {
     /// What clicking a chip does. A conversation opens the file in its review tab; the sheet has
     /// no tabs to open one in and hands it to the Finder instead.
     var onOpenAttachment: @MainActor (PromptAttachment) -> Void
-    /// The footer, handed the action behind its paperclip. Passed in rather than reached for,
-    /// because everything an attachment does lives here and the footer is only the button.
-    @ViewBuilder var footer: (@escaping @MainActor () -> Void) -> Footer
+    /// The footer, handed what it can ask this view to write into the draft. Passed in rather than
+    /// reached for, because everything an attachment and a quick prompt do lives here and the
+    /// footer is only the buttons. See `ComposerPromptActions`.
+    @ViewBuilder var footer: (ComposerPromptActions) -> Footer
 
     @Environment(AppModel.self) private var app
 
@@ -159,7 +160,7 @@ struct ComposerPrompt<Footer: View>: View {
                 placeholder: placeholder
             )
 
-            footer(attachFiles)
+            footer(ComposerPromptActions(attach: attachFiles, insert: insert(quickPrompt:)))
         }
         .composerBox(isFocused: $isFocused, isDropTarget: isDropTarget)
         .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: { frame in
@@ -497,6 +498,21 @@ struct ComposerPrompt<Footer: View>: View {
         caret = draft.caretAfterBackspace
         isCommandPreviewed = false
         return true
+    }
+
+    /// A quick prompt chosen from the panel in the footer: its words go into the draft where the
+    /// caret is, and nothing is sent.
+    ///
+    /// Written into the body rather than into the whole draft, exactly as a picked file is: the
+    /// caret the composer holds counts from the start of the prompt written after any `/command`,
+    /// and writing it back through the split is what keeps the command intact.
+    private func insert(quickPrompt: QuickPrompt) {
+        var draft = command
+        let insertion = QuickPromptInsertion.inserting(quickPrompt, into: draft.body, at: caret)
+        draft.body = insertion.text
+        text = draft.text
+        caret = insertion.caret
+        isFocused = true
     }
 
     private func pick(file: FileMatch) {

--- a/Sources/Bloom/Views/Center/Composer/ComposerPromptActions.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerPromptActions.swift
@@ -1,0 +1,17 @@
+import BloomCore
+
+/// What the footer can ask the prompt above it to do.
+///
+/// The footer is only the row of controls: it holds no draft, because in a conversation the draft
+/// belongs to a transcript and in the create sheet to a workspace that does not exist yet. Both of
+/// the things it can put INTO that draft (a file through the paperclip, a quick prompt through the
+/// panel beside it) are `ComposerPrompt`'s business, so they are handed down as one value rather
+/// than as a growing list of closures on the footer's builder.
+@MainActor
+struct ComposerPromptActions {
+    /// The paperclip: opens the file panel, and writes what is chosen into the draft at the caret.
+    var attach: @MainActor () -> Void
+    /// A quick prompt chosen from the panel: its words go into the draft at the caret, and nothing
+    /// is sent. See `QuickPromptInsertion`.
+    var insert: @MainActor (QuickPrompt) -> Void
+}

--- a/Sources/Bloom/Views/Center/Composer/ComposerView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerView.swift
@@ -94,7 +94,7 @@ struct ComposerView: View {
             onContentHeightChange: { contentHeight = $0 },
             onKey: handle(key:),
             onOpenAttachment: open(attachment:)
-        ) { onAttach in
+        ) { actions in
             ComposerFooterView(
                 controls: controls,
                 onChange: apply(controls:),
@@ -102,7 +102,8 @@ struct ComposerView: View {
                 isRunning: transcript.isRunning,
                 canSend: canSend,
                 project: transcript.workspace.path,
-                onAttach: onAttach,
+                onAttach: actions.attach,
+                onQuickPrompt: actions.insert,
                 onSend: send,
                 onStop: transcript.stop
             )

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptCatalog.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptCatalog.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Observation
+import BloomCore
+
+/// The one list of quick prompts the window draws, kept in step with the table behind it.
+///
+/// Shared rather than owned by the composer, for the reason `SlashCommandCatalog.shared` gives: the
+/// centre pane is destroyed and rebuilt whenever the column changes tab, so a catalogue that came
+/// with the composer would read the database again on every switch. There is one flat global list,
+/// so unlike that one there is nothing to key it by.
+///
+/// Every edit is made against the store first and then applied here, so the list on screen is
+/// whatever the row says rather than what the form hoped it would say. The writes are narrow:
+/// `Store.update(quickPromptID:)` names the three columns a form can change and leaves the order
+/// and the creation date alone.
+@MainActor
+@Observable
+final class QuickPromptCatalog {
+    static let shared = QuickPromptCatalog()
+
+    private(set) var prompts: [QuickPrompt] = []
+    /// Whether the first read has landed. The panel says something different before it than it does
+    /// when the list is genuinely empty.
+    private(set) var isLoaded = false
+
+    /// The read that is already running, so a second composer opening its panel joins it rather
+    /// than seeding the built-ins twice.
+    private var loading: Task<Void, Never>?
+
+    /// Reads the list, seeding the built-ins the first time this database has ever been asked.
+    ///
+    /// The seeding happens here rather than at launch because this is the only place the list is
+    /// wanted, and it costs one settings lookup on a database that has already been seeded. See
+    /// `Store.seedQuickPrompts` for why a deleted built-in does not come back.
+    func load(from store: Store?) async {
+        guard !isLoaded, let store else { return }
+        if let loading {
+            await loading.value
+            return
+        }
+        let task = Task { @MainActor in
+            let loaded = (try? await store.seedQuickPrompts()) ?? []
+            prompts = loaded
+            isLoaded = true
+        }
+        loading = task
+        await task.value
+        loading = nil
+    }
+
+    /// Re-reads the list, whatever state it is in. What an edit made in another window would need,
+    /// and what the panel does when it is opened again.
+    func reload(from store: Store?) async {
+        guard let store else { return }
+        prompts = (try? await store.quickPrompts()) ?? []
+        isLoaded = true
+    }
+
+    @discardableResult
+    func add(
+        name: String, symbol: String, text: String, in store: Store?
+    ) async -> QuickPrompt? {
+        guard let store else { return nil }
+        let prompt = QuickPrompt(name: name, symbol: symbol, text: text)
+        guard let written = try? await store.insert(prompt) else { return nil }
+        prompts.append(written)
+        return written
+    }
+
+    @discardableResult
+    func save(
+        id: QuickPromptID, name: String, symbol: String, text: String, in store: Store?
+    ) async -> QuickPrompt? {
+        guard let store else { return nil }
+        let changed = try? await store.update(quickPromptID: id) { prompt in
+            prompt.name = name
+            prompt.symbol = symbol
+            prompt.text = text
+        }
+        guard let changed else { return nil }
+        if let index = prompts.firstIndex(where: { $0.id == id }) {
+            prompts[index] = changed
+        }
+        return changed
+    }
+
+    func delete(id: QuickPromptID, in store: Store?) async {
+        guard let store else { return }
+        try? await store.deleteQuickPrompt(id: id)
+        prompts.removeAll { $0.id == id }
+    }
+}

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptForm.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptForm.swift
@@ -1,0 +1,150 @@
+import SwiftUI
+import BloomCore
+
+/// Writing a quick prompt, or changing one: a name, a mark and the words. Nothing else.
+///
+/// One form for both jobs, because they are the same three fields. Editing adds Delete, on the left
+/// of the row Save is on, which is where a destructive button goes in a Mac form and the only place
+/// this one lives. Deleting something you wrote is worth one deliberate trip rather than one stray
+/// click in a list you opened to pick from.
+///
+/// It is drawn inside the panel the list was in rather than in a sheet of its own: the list and the
+/// form are two states of one popover, so choosing a prompt and editing one never involve two
+/// floating windows arguing about which has the keyboard.
+struct QuickPromptForm: View {
+    /// The prompt being changed, or nil when this is a new one.
+    var editing: QuickPrompt?
+    /// What a new prompt is called before anybody types: whatever was in the search field, because
+    /// somebody who searched for a prompt they have not written yet has just said what to call it.
+    var suggestedName: String = ""
+    var onCancel: @MainActor () -> Void
+    var onSave: @MainActor (_ name: String, _ symbol: String, _ text: String) -> Void
+    var onDelete: @MainActor () -> Void
+
+    @State private var name = ""
+    @State private var symbol = QuickPrompt.defaultSymbol
+    @State private var text = ""
+    /// Whether the fields have been filled from `editing` yet. A `task` rather than `onAppear`
+    /// would run again when the panel is rebuilt under an open form and would throw away what has
+    /// been typed since.
+    @State private var isPrepared = false
+
+    @FocusState private var isNameFocused: Bool
+
+    private static let textHeight: CGFloat = 92
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingWide) {
+            heading
+
+            field("Name") {
+                TextField("Run the tests", text: $name)
+                    .textFieldStyle(.roundedBorder)
+                    .font(Typo.body)
+                    .focused($isNameFocused)
+                    .accessibilityLabel("Quick prompt name")
+            }
+
+            field("Icon") {
+                QuickPromptSymbolGrid(symbol: $symbol)
+            }
+
+            field("Text") {
+                TextEditor(text: $text)
+                    .font(Typo.body)
+                    .scrollContentBackground(.hidden)
+                    .padding(Metrics.spacingSmall)
+                    .frame(height: Self.textHeight)
+                    .background(
+                        Palette.surfaceSunken, in: RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+                    )
+                    // A hand-built box gets no focus ring from AppKit, so it gets the same border
+                    // `PromptEditor` draws for the same reason.
+                    .overlay {
+                        RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+                            .strokeBorder(Palette.border, lineWidth: Metrics.hairline)
+                    }
+                    .accessibilityLabel("Quick prompt text")
+            }
+
+            buttons
+        }
+        .padding(Metrics.gutter)
+        .onAppear(perform: prepare)
+        // Escape leaves the form and goes back to the list, rather than closing the whole panel and
+        // losing what was typed with it.
+        .onExitCommand(perform: onCancel)
+    }
+
+    private var heading: some View {
+        HStack(spacing: Metrics.spacing) {
+            Image(systemName: QuickPrompt.resolvedSymbol(symbol))
+                .imageScale(.small)
+                .foregroundStyle(Palette.textSecondary)
+                .frame(width: Metrics.rowHeight, height: Metrics.rowHeight)
+                .background(
+                    Palette.surfaceSunken, in: RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+                )
+
+            VStack(alignment: .leading, spacing: Metrics.spacingHair) {
+                Text(editing == nil ? "New quick prompt" : "Edit quick prompt")
+                    .font(Typo.bodyEmphasis)
+                    .foregroundStyle(Palette.textPrimary)
+
+                Text(
+                    editing == nil
+                        ? "It is available in every workspace."
+                        : "Changes apply everywhere. Nothing already sent is affected."
+                )
+                .font(Typo.caption)
+                .foregroundStyle(Palette.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var buttons: some View {
+        HStack(spacing: Metrics.spacingWide) {
+            if editing != nil {
+                Button("Delete", role: .destructive, action: onDelete)
+                    .accessibilityLabel("Delete this quick prompt")
+                Spacer(minLength: Metrics.spacing)
+            } else {
+                Spacer(minLength: Metrics.spacing)
+            }
+
+            Button("Cancel", action: onCancel)
+                .keyboardShortcut(.cancelAction)
+
+            Button("Save") {
+                onSave(
+                    name.trimmingCharacters(in: .whitespacesAndNewlines),
+                    symbol,
+                    text.trimmingCharacters(in: .whitespacesAndNewlines)
+                )
+            }
+            .keyboardShortcut(.defaultAction)
+            // The words are the whole of a quick prompt. A name is not: an unnamed one is listed
+            // and searched by its own first line. See `QuickPrompt.resolvedName`.
+            .disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+    }
+
+    private func field(_ label: String, @ViewBuilder content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
+            Text(label)
+                .font(Typo.caption)
+                .foregroundStyle(Palette.textTertiary)
+            content()
+        }
+    }
+
+    private func prepare() {
+        guard !isPrepared else { return }
+        isPrepared = true
+        name = editing?.name ?? suggestedName
+        symbol = editing.map { QuickPrompt.resolvedSymbol($0.symbol) } ?? QuickPrompt.defaultSymbol
+        text = editing?.text ?? ""
+        isNameFocused = true
+    }
+}

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptMenu.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptMenu.swift
@@ -1,0 +1,312 @@
+import SwiftUI
+import BloomCore
+
+/// The panel behind the composer's quick prompt button: a search field, the prompts under it, and
+/// one row at the foot to write a new one.
+///
+/// **Choosing a row puts its words in the box and stops.** Nothing is sent: every one of these
+/// starts a turn against a real worktree, and a list somebody arrows through by accident is the
+/// wrong place to be one keystroke away from that. See `QuickPromptInsertion`.
+///
+/// A `.popover` rather than a `Menu`, for the reason `WorkspaceSourcePicker` writes down: an
+/// `NSMenu` cannot contain a text field, so a menu with a search box in it is not a thing macOS
+/// has. The panel is the app's own filtered list instead, with the same `MenuSearchField`, the same
+/// arrow keys and the same empty line the composer's own menus use. It is not wrapped in
+/// `MenuPanel`, which is the card the completion menus float in over the composer: a popover
+/// already draws that card, and putting one inside the other is two borders and two shadows around
+/// one list.
+///
+/// Number keys are not available and no shortcut hint pretends otherwise. The composer's text view
+/// never resigns first responder while a menu is open, which `SlashCommandMenu` documents; this
+/// panel takes the keyboard for its own field, so what is left is the arrows, Return and Escape.
+struct QuickPromptMenu: View {
+    var catalog: QuickPromptCatalog
+    /// What a chosen prompt does. The panel closes itself first, so the caret is put back in the
+    /// composer rather than into a field that is about to go away.
+    var onPick: @MainActor (QuickPrompt) -> Void
+    var onClose: @MainActor () -> Void
+
+    @Environment(AppModel.self) private var app
+
+    @State private var query = ""
+    /// The highlighted row, held as the row itself and never as an index into the list. A ranked
+    /// list reorders under every keystroke, so an index highlights whatever has since moved into
+    /// that slot and Return inserts something other than what is drawn. `WorkspaceSourcePicker`
+    /// carries the same note over the same failure.
+    @State private var selected: QuickPrompt?
+    /// The form, when one is open. Two states of one panel rather than a second floating window.
+    @State private var editor: Editor?
+
+    /// Which form is up, and what it is about.
+    private enum Editor: Equatable {
+        case new(name: String)
+        case existing(QuickPrompt)
+    }
+
+    /// Wide enough for a name and a line of the prompt under it without either being cut.
+    private static let width: CGFloat = 320
+    /// About eight rows, which is the cap a completion menu keeps in this app.
+    private static let listHeight: CGFloat = 260
+
+    private var matches: QuickPromptMatches {
+        QuickPromptMatches.ranking(catalog.prompts, query: query)
+    }
+
+    var body: some View {
+        Group {
+            if let editor {
+                form(editor)
+            } else {
+                list
+            }
+        }
+        .frame(width: Self.width)
+        .task { await catalog.load(from: app.store) }
+    }
+
+    // MARK: - The list
+
+    private var list: some View {
+        // Ranked once for the whole pass, and everything below draws from that one value: the
+        // panel asks it three questions and a ranking per question is the same list computed three
+        // times on every keystroke.
+        let matches = self.matches
+        return VStack(alignment: .leading, spacing: 0) {
+            searchRow
+            Hairline()
+
+            if matches.isEmpty {
+                empty
+            } else {
+                rows(matches)
+            }
+
+            Hairline()
+            newRow
+
+            Hairline()
+            keys
+        }
+        .onAppear {
+            // A fresh query every time it opens. The panel is a way of finding one thing, not a
+            // filter somebody set and left.
+            query = ""
+            selected = QuickPromptMatches.ranking(catalog.prompts, query: "").prompts.first
+        }
+        .onChange(of: catalog.prompts) { _, _ in
+            selected = matches.settled(after: selected)
+        }
+    }
+
+    private var searchRow: some View {
+        HStack(spacing: Metrics.spacing) {
+            Image(systemName: "magnifyingglass")
+                .imageScale(.small)
+                .foregroundStyle(Palette.textTertiary)
+
+            MenuSearchField(
+                text: $query,
+                placeholder: "Search quick prompts",
+                onKey: handle(key:)
+            )
+            .frame(height: Metrics.rowHeight)
+        }
+        .padding(.horizontal, Metrics.gutter)
+        .padding(.vertical, Metrics.spacingSmall)
+        .onChange(of: query) { _, _ in
+            // The highlight follows the list rather than staying where it was: a highlight left
+            // pointing at a row the new query filtered out is a Return that does nothing.
+            selected = matches.settled(after: selected)
+        }
+    }
+
+    private func rows(_ matches: QuickPromptMatches) -> some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(matches.prompts) { prompt in
+                        QuickPromptRow(
+                            prompt: prompt,
+                            isSelected: prompt.id == selected?.id,
+                            onPick: { pick(prompt) },
+                            onHover: { selected = prompt },
+                            onEdit: { editor = .existing(prompt) },
+                            onDelete: { delete(prompt) }
+                        )
+                        // Identity is the thing the row names, never its position. See `selected`.
+                        .id(prompt.id)
+                    }
+                }
+                .padding(Metrics.spacingSmall)
+            }
+            .frame(maxHeight: Self.listHeight)
+            .onChange(of: selected) { _, row in
+                guard let row else { return }
+                proxy.scrollTo(row.id)
+            }
+        }
+    }
+
+    /// Two different nothings. A list nobody has written to yet is worth a sentence saying what one
+    /// of these is for, which is why it is not `MenuEmptyRow`: that draws a single quiet line, and
+    /// a person who has never seen this panel needs the second one.
+    @ViewBuilder
+    private var empty: some View {
+        if !query.isEmpty {
+            MenuEmptyRow(text: "Nothing matches \(query)")
+        } else if !catalog.isLoaded {
+            MenuEmptyRow(text: "Looking for quick prompts\u{2026}")
+        } else {
+            VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
+                Text("Nothing here yet.")
+                    .font(Typo.body)
+                    .foregroundStyle(Palette.textSecondary)
+                Text("A quick prompt is a few lines you find yourself typing again.")
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, Metrics.gutter)
+            .padding(.vertical, Metrics.spacingWide)
+        }
+    }
+
+    /// The row that writes a new one. When something has been searched for and nothing matched, it
+    /// offers to call the new prompt by it: somebody who searched for a prompt they have not
+    /// written yet has just said what it should be called.
+    private var newRow: some View {
+        Button {
+            editor = .new(name: matches.isEmpty ? query : "")
+        } label: {
+            HStack(spacing: Metrics.spacing) {
+                Image(systemName: "plus")
+                    .imageScale(.small)
+                    .foregroundStyle(Palette.textTertiary)
+                    .frame(width: Metrics.glyph)
+
+                Text(newRowTitle)
+                    .font(Typo.body)
+                    .foregroundStyle(Palette.textSecondary)
+                    .lineLimit(1)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, Metrics.gutter)
+            .frame(height: Metrics.rowHeight)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.vertical, Metrics.spacingSmall)
+    }
+
+    private var newRowTitle: String {
+        guard matches.isEmpty, !query.isEmpty else { return "New quick prompt" }
+        return "New quick prompt named \u{201C}\(query)\u{201D}"
+    }
+
+    private var keys: some View {
+        HStack(spacing: Metrics.gutter) {
+            key("\u{2191}\u{2193}", "row")
+            key("\u{21A9}", "insert")
+            key("esc", "close")
+        }
+        .padding(.horizontal, Metrics.gutter)
+        .padding(.vertical, Metrics.spacingSmall)
+        .accessibilityHidden(true)
+    }
+
+    private func key(_ mark: String, _ what: String) -> some View {
+        HStack(spacing: Metrics.spacingSmall) {
+            Text(mark)
+                .font(Typo.codeTiny)
+                .foregroundStyle(Palette.textSecondary)
+            Text(what)
+                .font(Typo.caption)
+                .foregroundStyle(Palette.textTertiary)
+        }
+    }
+
+    // MARK: - The form
+
+    private func form(_ editor: Editor) -> some View {
+        let editing: QuickPrompt? = {
+            guard case .existing(let prompt) = editor else { return nil }
+            return prompt
+        }()
+        let suggested: String = {
+            guard case .new(let name) = editor else { return "" }
+            return name
+        }()
+        return QuickPromptForm(
+            editing: editing,
+            suggestedName: suggested,
+            onCancel: { self.editor = nil },
+            onSave: { name, symbol, text in save(editing, name: name, symbol: symbol, text: text) },
+            onDelete: {
+                guard let editing else { return }
+                delete(editing)
+                self.editor = nil
+            }
+        )
+    }
+
+    // MARK: - Actions
+
+    private func pick(_ prompt: QuickPrompt) {
+        onClose()
+        onPick(prompt)
+    }
+
+    private func save(_ editing: QuickPrompt?, name: String, symbol: String, text: String) {
+        let catalog = catalog
+        let store = app.store
+        editor = nil
+        Task {
+            if let editing {
+                await catalog.save(id: editing.id, name: name, symbol: symbol, text: text, in: store)
+            } else {
+                let written = await catalog.add(name: name, symbol: symbol, text: text, in: store)
+                // The prompt somebody has just written is the one they were looking for, so the
+                // list comes back with it highlighted and Return away from being used.
+                if let written { selected = written }
+            }
+        }
+    }
+
+    private func delete(_ prompt: QuickPrompt) {
+        let catalog = catalog
+        let store = app.store
+        Task { await catalog.delete(id: prompt.id, in: store) }
+    }
+
+    // MARK: - Keys
+
+    /// The panel's whole keyboard. Where the highlight lands is `QuickPromptMatches`, in the core,
+    /// because it is a decision and a decision taken in a view is one nothing can test.
+    private func handle(key: ComposerKey) -> Bool {
+        switch key {
+        case .up:
+            selected = matches.stepped(from: selected, by: -1)
+            return true
+        case .down:
+            selected = matches.stepped(from: selected, by: 1)
+            return true
+        case .returnKey, .commandReturn:
+            // Return on a search that matched nothing writes the prompt that is missing rather than
+            // doing nothing at all.
+            guard let selected else {
+                guard !query.isEmpty else { return false }
+                editor = .new(name: query)
+                return true
+            }
+            pick(selected)
+            return true
+        case .escape:
+            onClose()
+            return true
+        case .tab:
+            return false
+        }
+    }
+}

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptRow.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptRow.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+import BloomCore
+
+/// One quick prompt in the panel: its mark, its name, the first stretch of its words, and the
+/// pencil that opens it for editing.
+///
+/// The same shape as `WorkspaceSourceRow` and `FileMentionRow`, deliberately: they are all the same
+/// thing, a filtered floating list somebody arrows through, and a second idiom for the third one is
+/// how a window grows three.
+///
+/// **The pencil is on the hovered row or the highlighted one**, so arrowing down with the keyboard
+/// reveals it as surely as the pointer does. It is not a `\u{22EF}` menu: editing has one
+/// destination, and reaching a menu with the pointer also moves the keyboard highlight, so an
+/// `NSMenu` over a live popover would be an argument about which of the two owns the next click.
+struct QuickPromptRow: View {
+    var prompt: QuickPrompt
+    var isSelected: Bool
+    var onPick: @MainActor () -> Void
+    var onHover: @MainActor () -> Void
+    var onEdit: @MainActor () -> Void
+    var onDelete: @MainActor () -> Void
+
+    @Environment(\.controlActiveState) private var activeState
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onPick) {
+            HStack(spacing: Metrics.spacing) {
+                Image(systemName: QuickPrompt.resolvedSymbol(prompt.symbol))
+                    .imageScale(.small)
+                    .foregroundStyle(isEmphasized ? Palette.selectedEmphasizedText : Palette.textTertiary)
+                    .frame(width: Metrics.glyph)
+
+                VStack(alignment: .leading, spacing: Metrics.spacingHair) {
+                    Text(prompt.resolvedName)
+                        .font(Typo.body)
+                        .foregroundStyle(isEmphasized ? Palette.selectedEmphasizedText : Palette.textPrimary)
+                        .lineLimit(1)
+
+                    // The words themselves, so a name chosen badly six weeks ago is still
+                    // recoverable from the row.
+                    Text(prompt.preview)
+                        .font(Typo.caption)
+                        .foregroundStyle(
+                            isEmphasized
+                                ? Palette.selectedEmphasizedText.opacity(0.75)
+                                : Palette.textTertiary
+                        )
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+
+                Spacer(minLength: Metrics.spacingSmall)
+
+                if isHovered || isSelected {
+                    pencil
+                }
+            }
+            .padding(.horizontal, Metrics.spacing)
+            .padding(.vertical, Metrics.spacingSmall)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(prompt.resolvedName)
+        .accessibilityValue(prompt.preview)
+        // Focused, for the reason spelled out on `SlashCommandRow`: this list really is driven by
+        // the arrow keys, which is the one case AppKit paints in the accent.
+        .rowBackground(isSelected: isSelected, isHovered: isHovered, isFocused: true)
+        .onHover { hovering in
+            isHovered = hovering
+            if hovering { onHover() }
+        }
+        // A free accelerator for anybody who tries it. Nothing depends on it being discovered: the
+        // pencil above is the affordance, and the form it opens owns Delete.
+        .contextMenu {
+            Button("Edit", action: onEdit)
+            Button("Delete", role: .destructive, action: onDelete)
+        }
+    }
+
+    /// A button inside the row's own button, which AppKit resolves the way it looks: a click on the
+    /// pencil edits, a click anywhere else on the row inserts.
+    private var pencil: some View {
+        Button(action: onEdit) {
+            Image(systemName: "pencil")
+                .imageScale(.small)
+                .foregroundStyle(isEmphasized ? Palette.selectedEmphasizedText : Palette.textSecondary)
+                .padding(Metrics.spacingTight)
+                .background {
+                    RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+                        .fill(isEmphasized ? Palette.selectedEmphasizedText.opacity(0.22) : Palette.hover)
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help("Edit this quick prompt")
+        .accessibilityLabel("Edit \(prompt.resolvedName)")
+    }
+
+    /// Whether the row is about to be painted with the accent colour. The labels set their own
+    /// colour, so the inverted foreground `rowBackground` installs never reaches them on its own.
+    private var isEmphasized: Bool {
+        isSelected && activeState != .inactive
+    }
+}

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptSymbolGrid.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptSymbolGrid.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import BloomCore
+
+/// The marks a quick prompt can be given: a couple of dozen SF Symbols and no search.
+///
+/// **Drawn inside the form rather than floating behind an icon well.** The form is already inside
+/// the composer's popover, and a second popover opened from within the first is an argument about
+/// which of the two owns the next click, which is the same reason the row carries a pencil instead
+/// of a menu. Eighteen symbols are one band of six by three, so the whole choice is on screen and
+/// nothing is hidden behind a control that would have to be opened.
+///
+/// The point of the mark is telling five rows apart at a glance rather than expressing anything,
+/// which is why there is no symbol browser: picking from six thousand would be a bigger decision
+/// than the prompt itself.
+struct QuickPromptSymbolGrid: View {
+    @Binding var symbol: String
+
+    private static let columns = Array(
+        repeating: GridItem(.flexible(), spacing: Metrics.spacingSmall), count: 6
+    )
+
+    var body: some View {
+        LazyVGrid(columns: Self.columns, spacing: Metrics.spacingSmall) {
+            ForEach(QuickPrompt.symbols, id: \.self) { name in
+                Button {
+                    symbol = name
+                } label: {
+                    Image(systemName: name)
+                        .imageScale(.small)
+                        .foregroundStyle(
+                            name == symbol ? Palette.selectedEmphasizedText : Palette.textSecondary
+                        )
+                        .frame(maxWidth: .infinity)
+                        .frame(height: Metrics.rowHeight - Metrics.spacingSmall)
+                        .background {
+                            RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+                                .fill(name == symbol ? Palette.selectedEmphasized : Palette.surfaceSunken)
+                        }
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(name)
+                .accessibilityAddTraits(name == symbol ? .isSelected : [])
+            }
+        }
+    }
+}

--- a/Sources/Bloom/Views/Sidebar/CreateWorkspaceSheet.swift
+++ b/Sources/Bloom/Views/Sidebar/CreateWorkspaceSheet.swift
@@ -531,7 +531,7 @@ struct CreateWorkspaceSheet: View {
             onContentHeightChange: { contentHeight = $0 },
             onKey: handle(key:),
             onOpenAttachment: open(attachment:)
-        ) { onAttach in
+        ) { actions in
             ComposerFooterView(
                 controls: controls,
                 onChange: { controls = $0 },
@@ -540,7 +540,8 @@ struct CreateWorkspaceSheet: View {
                 // The repository, because the worktree this sheet is about to cut does not
                 // exist yet and a style the project defines is already in the repository.
                 project: repo?.path,
-                onAttach: onAttach,
+                onAttach: actions.attach,
+                onQuickPrompt: actions.insert,
                 onSend: create
             )
         }

--- a/Sources/BloomCore/Model/Identifier.swift
+++ b/Sources/BloomCore/Model/Identifier.swift
@@ -77,6 +77,12 @@ public struct ReviewCommentID: Identifier {
     public init(_ rawValue: String) { self.rawValue = rawValue }
 }
 
+/// One of the owner's own quick prompts, the text of which goes into the composer's draft.
+public struct QuickPromptID: Identifier {
+    public let rawValue: String
+    public init(_ rawValue: String) { self.rawValue = rawValue }
+}
+
 /// A message somebody has asked for that has not gone to the agent yet. See `Delivery`.
 public struct DeliveryID: Identifier {
     public let rawValue: String

--- a/Sources/BloomCore/Persistence/Store.swift
+++ b/Sources/BloomCore/Persistence/Store.swift
@@ -737,6 +737,25 @@ public actor Store {
                     try db.execute("ALTER TABLE repos ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0;")
                 }
             },
+
+            // The owner's own quick prompts: a short name, a mark, and the words that go into the
+            // composer's draft.
+            //
+            // A table rather than the settings key value pairs. The seven entries in
+            // `PromptOverrides` get away with a key each because their set is closed and Bloom
+            // wrote it; this list grows, is renamed and is deleted from, and every growing list in
+            // Bloom is a row. It hangs off nothing: there is one flat global list, so there is no
+            // foreign key here and no project scope to widen later without a migration.
+            sql("""
+            CREATE TABLE IF NOT EXISTS quick_prompt (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                symbol TEXT NOT NULL,
+                text TEXT NOT NULL,
+                sort_order INTEGER NOT NULL DEFAULT 0,
+                created_at REAL NOT NULL
+            );
+            """),
         ]
 
         let current = Int(db.userVersion)
@@ -2198,6 +2217,102 @@ public actor Store {
         try db.run("DELETE FROM review_comments WHERE workspace_id = ?", [.text(workspaceID)])
     }
 
+    // MARK: - Quick prompts
+
+    /// The whole list, in the order the panel draws it before anything is searched for.
+    public func quickPrompts() throws -> [QuickPrompt] {
+        try db.query("SELECT * FROM quick_prompt ORDER BY sort_order, created_at, id")
+            .map(Self.quickPrompt(from:))
+    }
+
+    public func quickPrompt(id: QuickPromptID) throws -> QuickPrompt? {
+        try db.query("SELECT * FROM quick_prompt WHERE id = ?", [.text(id)])
+            .first.map(Self.quickPrompt(from:))
+    }
+
+    /// Writes a new prompt. `insert` rather than `upsert`, because every column here is the
+    /// owner's and a row that already exists is changed through `update(quickPromptID:)`: see the
+    /// rule at the head of this file. A prompt with an id the table already holds is a bug rather
+    /// than an edit, so the insert is left to fail rather than made to overwrite.
+    ///
+    /// The order it lands in is worked out here, inside the actor, so two prompts written in the
+    /// same moment cannot both read the same maximum and share a place in the list.
+    @discardableResult
+    public func insert(_ prompt: QuickPrompt) throws -> QuickPrompt {
+        var row = prompt
+        row.sortOrder = try nextQuickPromptOrder()
+        try insertQuickPromptRow(row)
+        return row
+    }
+
+    /// Changes an existing prompt without writing the columns it did not mean to change.
+    ///
+    /// The same shape as `update(workspaceID:)`, and for the same reason: the row is read here,
+    /// inside the actor, immediately before it is written back, with no suspension in between, so
+    /// a form somebody sat in for a minute cannot carry the rest of the row back to what it looked
+    /// like when they opened it.
+    @discardableResult
+    public func update(
+        quickPromptID: QuickPromptID,
+        _ change: @Sendable (inout QuickPrompt) -> Void
+    ) throws -> QuickPrompt? {
+        guard var row = try quickPrompt(id: quickPromptID) else { return nil }
+        change(&row)
+        try db.run(
+            "UPDATE quick_prompt SET name = ?, symbol = ?, text = ? WHERE id = ?",
+            [.text(row.name), .text(row.symbol), .text(row.text), .text(quickPromptID)]
+        )
+        row.id = quickPromptID
+        return row
+    }
+
+    public func deleteQuickPrompt(id: QuickPromptID) throws {
+        try db.run("DELETE FROM quick_prompt WHERE id = ?", [.text(id)])
+    }
+
+    /// Puts the built-ins in, once ever, and answers with the list as it stands afterwards.
+    ///
+    /// **Deleting a built-in has to stick.** So this compares the version the database has already
+    /// seeded against `QuickPromptSeed.version` rather than comparing the built-in list against the
+    /// table: a prompt the owner deleted is not missing, it is deleted, and nothing here can tell
+    /// those apart by looking at the rows. Adding a second built-in later means a new entry with a
+    /// higher `introducedIn` and a bump of the version, which inserts that one and resurrects
+    /// nothing. See `QuickPromptSeed`.
+    @discardableResult
+    public func seedQuickPrompts(now: Date = Date()) throws -> [QuickPrompt] {
+        let installed = Int(try setting(QuickPromptSeed.versionKey) ?? "") ?? 0
+        let pending = QuickPromptSeed.pending(installed: installed)
+        guard !pending.isEmpty else { return try quickPrompts() }
+
+        var order = try nextQuickPromptOrder()
+        for entry in pending {
+            try insertQuickPromptRow(entry.prompt(sortOrder: order, now: now))
+            order += 1
+        }
+        try setSetting(QuickPromptSeed.versionKey, String(QuickPromptSeed.version))
+        return try quickPrompts()
+    }
+
+    private func nextQuickPromptOrder() throws -> Int {
+        let highest = try db.query("SELECT COALESCE(MAX(sort_order), -1) AS m FROM quick_prompt")
+            .first?.int("m") ?? -1
+        return Int(highest) + 1
+    }
+
+    private func insertQuickPromptRow(_ prompt: QuickPrompt) throws {
+        try db.run(
+            """
+            INSERT INTO quick_prompt (id, name, symbol, text, sort_order, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            [
+                .text(prompt.id), .text(prompt.name), .text(prompt.symbol), .text(prompt.text),
+                .int(Int64(prompt.sortOrder)),
+                .double(prompt.createdAt.timeIntervalSince1970),
+            ]
+        )
+    }
+
     // MARK: - Permission grants
 
     /// Every rule granted in one project, newest first. This is the revocation list.
@@ -2543,6 +2658,17 @@ public actor Store {
             outputTokens: Int(row.int("output_tokens") ?? 0),
             costUSD: row.double("cost_usd") ?? 0,
             contextTokens: Int(row.int("context_tokens") ?? 0)
+        )
+    }
+
+    private static func quickPrompt(from row: Row) -> QuickPrompt {
+        QuickPrompt(
+            id: QuickPromptID(row.string("id") ?? newID()),
+            name: row.string("name") ?? "",
+            symbol: row.string("symbol") ?? QuickPrompt.defaultSymbol,
+            text: row.string("text") ?? "",
+            sortOrder: Int(row.int("sort_order") ?? 0),
+            createdAt: row.date("created_at") ?? Date()
         )
     }
 

--- a/Sources/BloomCore/Persistence/StoreObservation.swift
+++ b/Sources/BloomCore/Persistence/StoreObservation.swift
@@ -26,6 +26,7 @@ public enum StoreDomain: String, Sendable, Hashable, CaseIterable {
     case permissionGrants = "permission_grants"
     case permissionAsks = "permission_asks"
     case agentQuotas = "agent_quotas"
+    case quickPrompts = "quick_prompt"
 }
 
 /// Who hears about a committed write, and how they are stopped from drowning in them.

--- a/Sources/BloomCore/Transcript/QuickPrompt.swift
+++ b/Sources/BloomCore/Transcript/QuickPrompt.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// A few lines the owner wrote and keeps typing again, kept by Bloom so they can be put back in
+/// the box with two keystrokes.
+///
+/// Bloom's own row rather than a file in `.claude/commands`, and that is the decision this type
+/// exists to record. A file in that directory is a slash command: the CLI reads it in the terminal
+/// pane too, it sits beside skills, and it is offered by `SlashCommandCatalog` under a leading
+/// slash. Two things that looked identical would then behave differently depending on which of the
+/// two lists they came out of. The price of the row is that a quick prompt is Bloom's alone: it
+/// does not work in the terminal and it does not travel with the repository.
+///
+/// The same small shape as `RunScript`, which is the precedent for "a named thing the owner wrote",
+/// with a symbol on it because five rows of identical text are a worse list than five rows with a
+/// mark down the left.
+public struct QuickPrompt: Identifiable, Sendable, Hashable {
+    public var id: QuickPromptID
+    /// What the row is called. Short, and searched first.
+    public var name: String
+    /// An SF Symbol from `symbols` below. A name rather than an enum case, because the grid can
+    /// grow without every stored row having to still resolve to a case that is on it.
+    public var symbol: String
+    /// The words that go into the draft. Never sent on their own: see `QuickPromptInsertion`.
+    public var text: String
+    /// Where it sits in the list. There is no reordering, so this only ever says which order they
+    /// were written in; search is the ordering anybody actually uses.
+    public var sortOrder: Int
+    public var createdAt: Date
+
+    public init(
+        id: QuickPromptID = .new(),
+        name: String,
+        symbol: String = QuickPrompt.defaultSymbol,
+        text: String,
+        sortOrder: Int = 0,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.symbol = symbol
+        self.text = text
+        self.sortOrder = sortOrder
+        self.createdAt = createdAt
+    }
+
+    /// What a row without an icon gets, and what an unknown symbol name falls back to.
+    public static let defaultSymbol = "text.alignleft"
+
+    /// The grid the form offers, and deliberately not a symbol search.
+    ///
+    /// The icon is here to tell five rows apart at a glance rather than to express anything, so a
+    /// browser of six thousand symbols would be a bigger decision than the prompt itself. Eighteen
+    /// is one screenful of six by three, which is small enough to pick from without reading.
+    public static let symbols: [String] = [
+        "text.alignleft", "envelope", "list.bullet", "pencil", "gearshape", "bolt",
+        "checkmark.seal", "exclamationmark.triangle", "arrow.triangle.2.circlepath", "hammer",
+        "magnifyingglass", "scissors", "book", "paintbrush", "ladybug", "shippingbox",
+        "doc.richtext", "sparkles",
+    ]
+
+    /// Whether a stored symbol is one the grid can still show as chosen. A row written by a later
+    /// build, or by hand, is drawn with the fallback rather than with nothing.
+    public static func resolvedSymbol(_ symbol: String) -> String {
+        symbols.contains(symbol) ? symbol : defaultSymbol
+    }
+
+    /// The second line of a row: the first stretch of the text itself.
+    ///
+    /// A name chosen badly six weeks ago is still recoverable from it, which is the whole reason
+    /// the row is two lines. Newlines are folded into spaces because the row is one line high and
+    /// a prompt that begins with a heading would otherwise show the heading and nothing else.
+    public var preview: String {
+        let folded = text
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        guard folded.count > Self.previewLength else { return folded }
+        return folded.prefix(Self.previewLength).trimmingCharacters(in: .whitespaces) + "\u{2026}"
+    }
+
+    /// About as much as fits on the second line of a 300 point panel row.
+    static let previewLength = 64
+
+    /// The name with the whitespace taken off both ends, or a name made from the text when the
+    /// owner left the field empty. A row with no name at all is a row nobody can search for.
+    public var resolvedName: String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty else { return trimmed }
+        return preview
+    }
+}

--- a/Sources/BloomCore/Transcript/QuickPromptInsertion.swift
+++ b/Sources/BloomCore/Transcript/QuickPromptInsertion.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// What choosing a quick prompt does to the draft: its text goes in at the caret, and nothing is
+/// sent.
+///
+/// **Insert, never send.** Every one of these starts a turn against a real worktree, and a list
+/// somebody arrows through is the wrong place to be one keystroke away from that. So the prompt is
+/// a starting point: it can be edited, appended to, and a second one can be stacked after it.
+///
+/// It goes in as plain text and not as a chip. Bloom draws chips for files and for a `/command`
+/// because each of those stands for something the CLI resolves later, and a chip is a thing you can
+/// only remove. A quick prompt stands for nothing. It is the words, so it has to be editable where
+/// it lands.
+///
+/// A pure function rather than a decision taken in the composer, because it is the one part of this
+/// with edge cases worth pinning: an empty box, a caret in the middle of a sentence, a draft ending
+/// mid word, a draft ending in a space, and a draft ending in a newline.
+public enum QuickPromptInsertion {
+    /// Where the words went, and where the caret goes after them.
+    ///
+    /// Offsets are UTF-16 units, which is what a text view counts in and what the composer's
+    /// `caret` binding holds.
+    public struct Result: Equatable, Sendable {
+        public var text: String
+        public var caret: Int
+
+        public init(text: String, caret: Int) {
+            self.text = text
+            self.caret = caret
+        }
+    }
+
+    /// Writes a prompt into `draft` at `caret`.
+    public static func inserting(
+        _ prompt: QuickPrompt, into draft: String, at caret: Int
+    ) -> Result {
+        inserting(prompt.text, into: draft, at: caret)
+    }
+
+    /// Writes `prompt` into `draft` at `caret`, spaced so it reads as its own sentence rather than
+    /// as something glued to the word before it.
+    ///
+    /// **The separator is a single space, and only where there is not already a break.** The same
+    /// rule `AttachmentDraft.padding` applies to a file, asked of the same two characters, because
+    /// a draft must never end up with two gaps where the writer put one: dropping a prompt at the
+    /// end of "and then " leaves one space, and a draft ending in a newline gets nothing at all,
+    /// since the line break is already a bigger break than a space. A blank line was the other
+    /// candidate and is wrong here: most of these are appended to half a sentence somebody is
+    /// still writing, and a prompt that always started its own paragraph would have to be joined
+    /// up by hand every time.
+    ///
+    /// The trailing space exists only when there are words after the caret, so a prompt inserted
+    /// mid sentence does not run into the rest of it. At the end of the draft there is nothing to
+    /// run into, and a trailing space there would leave the caret one character clear of what was
+    /// just inserted.
+    ///
+    /// The caret lands at the end of the inserted words, which is where the next thing is typed.
+    public static func inserting(_ prompt: String, into draft: String, at caret: Int) -> Result {
+        let body = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let string = draft as NSString
+        let at = min(max(caret, 0), string.length)
+        guard !body.isEmpty else { return Result(text: draft, caret: at) }
+
+        // Whole characters rather than one UTF-16 unit each side. A draft ending in an emoji ends
+        // in a surrogate pair, and the unit sitting against the caret is half of one: read on its
+        // own it is not a character at all, so the question "is that a space" cannot be asked of
+        // it and the prompt was written hard against the emoji.
+        let before = at > 0
+            ? string.substring(with: string.rangeOfComposedCharacterSequence(at: at - 1))
+            : ""
+        let after = at < string.length
+            ? string.substring(with: string.rangeOfComposedCharacterSequence(at: at))
+            : ""
+
+        let lead = isBreak(before) ? "" : " "
+        let trail = isBreak(after) ? "" : " "
+        let written = lead + body + trail
+        let text = string.replacingCharacters(in: NSRange(location: at, length: 0), with: written)
+
+        // Before the trailing space rather than after it: what was inserted ends with the prompt's
+        // own last character, and that is where somebody carries on typing.
+        let caret = at + ((lead + body) as NSString).length
+        return Result(text: text, caret: caret)
+    }
+
+    /// Whether the character beside the insertion already separates two words. An absent character
+    /// counts, which is what makes the start and the end of the draft take no space of their own.
+    private static func isBreak(_ character: String) -> Bool {
+        guard let scalar = character.unicodeScalars.first else { return true }
+        return CharacterSet.whitespacesAndNewlines.contains(scalar)
+    }
+}

--- a/Sources/BloomCore/Transcript/QuickPromptMatches.swift
+++ b/Sources/BloomCore/Transcript/QuickPromptMatches.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// What the quick prompt panel draws, in the order the arrow keys walk it.
+///
+/// Pure and `nonisolated`, in the shape of `WorkspaceSourceMatches` and for the same reason: the
+/// panel asks this on every keystroke, and a ranking that sat on an actor would be a hop per
+/// character. The keyboard behaviour is here too, because a decision taken inside a view is a
+/// decision nothing can test.
+public struct QuickPromptMatches: Sendable, Hashable {
+    /// What was searched for, so the empty state can say it rather than shrugging, and so the
+    /// "New quick prompt" row can offer to call the new prompt by it. Somebody who searched for a
+    /// prompt they have not written yet has just said what it should be called.
+    public let query: String
+    public let prompts: [QuickPrompt]
+
+    public init(query: String = "", prompts: [QuickPrompt] = []) {
+        self.query = query
+        self.prompts = prompts
+    }
+
+    public var isEmpty: Bool { prompts.isEmpty }
+
+    /// Ranks the whole list against what is in the search field.
+    ///
+    /// **The name is matched as a subsequence and the text is matched as a substring, and the two
+    /// halves are deliberately different.** `FuzzyMatch` answers "every character of the query
+    /// appears in order", which is exactly right for a short name and useless against a paragraph:
+    /// a hundred word prompt contains almost every short query as a subsequence, so scoring the
+    /// body that way would keep every row for every query and the panel would never say "nothing
+    /// matches". Containment is what a person means when they say the word is in there, and it is
+    /// what makes "test" keep a prompt whose title never mentions tests.
+    ///
+    /// An empty query is the list itself, in its stored order.
+    public static func ranking(
+        _ prompts: [QuickPrompt], query: String, limit: Int = 100
+    ) -> QuickPromptMatches {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return QuickPromptMatches(query: trimmed, prompts: Array(prompts.prefix(limit)))
+        }
+
+        var scored: [(prompt: QuickPrompt, score: Int, position: Int)] = []
+        scored.reserveCapacity(prompts.count)
+        for (position, prompt) in prompts.enumerated() {
+            let name = FuzzyMatch.score(prompt.resolvedName, query: trimmed)
+            let body = prompt.text.range(of: trimmed, options: .caseInsensitive) != nil
+                // Below any hit in the name, whatever the name scored: the row the query names is
+                // the one that was meant, and the body is how a badly named one is recovered.
+                ? bodyScore
+                : nil
+            guard name != nil || body != nil else { continue }
+            scored.append((prompt, (name ?? 0) + (body ?? 0), position))
+        }
+        // Ties keep the order they arrived in, so a list that is not being searched reads as a
+        // list rather than as a shuffle.
+        scored.sort { lhs, rhs in
+            if lhs.score != rhs.score { return lhs.score > rhs.score }
+            return lhs.position < rhs.position
+        }
+        return QuickPromptMatches(query: trimmed, prompts: scored.prefix(limit).map(\.prompt))
+    }
+
+    /// What a hit in the body is worth. Small, so that any hit in the name outranks it: the
+    /// cheapest name match `FuzzyMatch` can report is a single late character, which still scores
+    /// above this once the length bonus is counted.
+    private static let bodyScore = 1
+
+    /// Where the highlight lands after a step, given what is highlighted now.
+    ///
+    /// It wraps at both ends, which is what every menu on the Mac does, and it answers with the
+    /// first row when nothing is highlighted yet, so the first press of Down does not swallow
+    /// itself.
+    public func stepped(from current: QuickPrompt?, by step: Int) -> QuickPrompt? {
+        guard !prompts.isEmpty else { return nil }
+        guard let current, let index = prompts.firstIndex(of: current) else {
+            return step < 0 ? prompts.last : prompts.first
+        }
+        let next = (index + step + prompts.count) % prompts.count
+        return prompts[next]
+    }
+
+    /// What stays highlighted when the list changes under the field: the same row if it survived
+    /// the new query, otherwise the best one there is now. A highlight left pointing at a row the
+    /// query has filtered out is a Return that does nothing.
+    ///
+    /// By id rather than by value, because a row that has just been edited is the same row.
+    public func settled(after current: QuickPrompt?) -> QuickPrompt? {
+        guard let current, let held = prompts.first(where: { $0.id == current.id }) else {
+            return prompts.first
+        }
+        return held
+    }
+}

--- a/Sources/BloomCore/Transcript/QuickPromptSeed.swift
+++ b/Sources/BloomCore/Transcript/QuickPromptSeed.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// The quick prompts a fresh copy of Bloom starts with, and the rule that stops a deleted one from
+/// coming back.
+///
+/// **Seed once, and record that it happened.** The obvious alternative is to reconcile a built-in
+/// list against the table on every launch, and it answers the question "why is the prompt I deleted
+/// back again?" with "because Bloom puts it there every time you start it". Instead each built-in
+/// says which seed version introduced it, the store remembers the version it last seeded, and only
+/// the entries newer than that are inserted. A prompt deleted by the owner is a row that is gone,
+/// nothing looks for it again, and a second built-in added later inserts itself and resurrects
+/// nothing.
+///
+/// The version is a plain integer rather than the app's own version, because it counts changes to
+/// this list and nothing else: shipping a build that adds no built-in must not reseed anything.
+public enum QuickPromptSeed {
+    /// One built-in, as it is written here rather than as it is stored. It has no id: the row gets
+    /// one when it is inserted, so a seeded prompt is an ordinary prompt from that moment on, with
+    /// nothing about it that a hand written one does not have.
+    public struct Entry: Sendable, Hashable {
+        public var name: String
+        public var symbol: String
+        public var text: String
+        /// The seed version that first shipped this entry. Anything above the version a database
+        /// has already seen is inserted; anything at or below it has had its chance.
+        public var introducedIn: Int
+
+        public init(name: String, symbol: String, text: String, introducedIn: Int) {
+            self.name = name
+            self.symbol = symbol
+            self.text = text
+            self.introducedIn = introducedIn
+        }
+
+        public func prompt(sortOrder: Int, now: Date = Date()) -> QuickPrompt {
+            QuickPrompt(
+                name: name, symbol: symbol, text: text, sortOrder: sortOrder, createdAt: now
+            )
+        }
+    }
+
+    /// What the store keeps the last seeded version under, in the settings table.
+    public static let versionKey = "quickPrompts.seedVersion"
+
+    /// The highest `introducedIn` on the list below, written down once so the store has something
+    /// to record without having to search for the maximum.
+    public static let version = 1
+
+    public static let all: [Entry] = [
+        // The one Bloom ships with. It is deletable, like everything else here, and deleting it
+        // sticks: see the note at the head of this file.
+        Entry(
+            name: "Explain changes",
+            symbol: "doc.richtext",
+            text: """
+            Explain the changes made in this PR as HTML. Open it as a new tab in this workspace.
+            """,
+            introducedIn: 1
+        ),
+    ]
+
+    /// The built-ins a database that last seeded `installed` has not been offered yet.
+    ///
+    /// Pure, so the whole of the rule can be held still by a test: seeding twice inserts nothing
+    /// the second time, and a database seeded at version 1 gets only what version 2 added.
+    public static func pending(installed: Int) -> [Entry] {
+        all.filter { $0.introducedIn > installed }
+    }
+}

--- a/Sources/BloomCore/Transcript/QuickPromptSeed.swift
+++ b/Sources/BloomCore/Transcript/QuickPromptSeed.swift
@@ -42,9 +42,16 @@ public enum QuickPromptSeed {
     /// What the store keeps the last seeded version under, in the settings table.
     public static let versionKey = "quickPrompts.seedVersion"
 
-    /// The highest `introducedIn` on the list below, written down once so the store has something
-    /// to record without having to search for the maximum.
-    public static let version = 1
+    /// The highest `introducedIn` on the list below.
+    ///
+    /// Derived rather than written down by hand. A constant here has to be bumped every time an
+    /// entry is added, and forgetting is not harmless: the store would insert the new entry,
+    /// record the old version, and insert it again on the next launch. Two tests in
+    /// `QuickPromptTests` pinned that, so it would have failed CI rather than shipped, but a
+    /// maximum read off the list cannot drift from the list at all, which is better than being
+    /// caught drifting. Those tests now hold by construction, and are kept as the statement of
+    /// what must remain true.
+    public static var version: Int { all.map(\.introducedIn).max() ?? 0 }
 
     public static let all: [Entry] = [
         // The one Bloom ships with. It is deletable, like everything else here, and deleting it

--- a/Tests/BloomCoreTests/QuickPromptStoreTests.swift
+++ b/Tests/BloomCoreTests/QuickPromptStoreTests.swift
@@ -1,0 +1,136 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+/// The quick prompt table, and the one question it exists to answer twice: a built-in arrives on a
+/// fresh install, and a built-in the owner deleted stays deleted for good.
+@Suite("Quick prompt store", .tags(.persistence), .scratchDirectory)
+struct QuickPromptStoreTests {
+    @Test("round-trips a prompt")
+    func roundTrips() async throws {
+        let store = try makeTestStore("quick-prompts")
+        let written = try await store.insert(
+            QuickPrompt(name: "Tests", symbol: "hammer", text: "Run make test.")
+        )
+
+        let loaded = try await store.quickPrompts()
+        #expect(loaded.count == 1)
+        #expect(loaded[0].id == written.id)
+        #expect(loaded[0].name == "Tests")
+        #expect(loaded[0].symbol == "hammer")
+        #expect(loaded[0].text == "Run make test.")
+    }
+
+    @Test("keeps prompts in the order they were written")
+    func keepsOrder() async throws {
+        let store = try makeTestStore("quick-prompts")
+        for name in ["first", "second", "third"] {
+            try await store.insert(QuickPrompt(name: name, text: name))
+        }
+
+        #expect(try await store.quickPrompts().map(\.name) == ["first", "second", "third"])
+        #expect(try await store.quickPrompts().map(\.sortOrder) == [0, 1, 2])
+    }
+
+    /// The rule at the head of `Store`, on this table: a write changes the columns it names and no
+    /// others. The form is open for as long as somebody takes to write a paragraph, and the copy it
+    /// was opened with must not carry the rest of the row back to what it looked like then.
+    @Test("an update writes only what it changed")
+    func updatesNarrowly() async throws {
+        let store = try makeTestStore("quick-prompts")
+        let written = try await store.insert(
+            QuickPrompt(name: "Tests", symbol: "hammer", text: "Run make test.")
+        )
+
+        let changed = try await store.update(quickPromptID: written.id) { $0.name = "Run tests" }
+        #expect(changed?.name == "Run tests")
+
+        let loaded = try await store.quickPrompts()
+        #expect(loaded.count == 1)
+        #expect(loaded[0].name == "Run tests")
+        #expect(loaded[0].symbol == "hammer")
+        #expect(loaded[0].text == "Run make test.")
+        #expect(loaded[0].sortOrder == written.sortOrder)
+        // Not exact equality: a `Date` goes to SQLite as seconds since 1970 and comes back
+        // through the same conversion, which is a rounding of the last few decimal places.
+        #expect(abs(loaded[0].createdAt.timeIntervalSince(written.createdAt)) < 0.001)
+    }
+
+    @Test("an update to a prompt that is gone changes nothing and says so")
+    func updatesNothing() async throws {
+        let store = try makeTestStore("quick-prompts")
+        let missing = try await store.update(quickPromptID: QuickPromptID.new()) { $0.name = "x" }
+        #expect(missing == nil)
+        #expect(try await store.quickPrompts().isEmpty)
+    }
+
+    @Test("deletes one prompt and leaves the rest")
+    func deletes() async throws {
+        let store = try makeTestStore("quick-prompts")
+        let first = try await store.insert(QuickPrompt(name: "first", text: "a"))
+        try await store.insert(QuickPrompt(name: "second", text: "b"))
+
+        try await store.deleteQuickPrompt(id: first.id)
+        #expect(try await store.quickPrompts().map(\.name) == ["second"])
+    }
+
+    @Test("a fresh database is seeded with the built-ins")
+    func seeds() async throws {
+        let store = try makeTestStore("quick-prompts")
+        let seeded = try await store.seedQuickPrompts()
+
+        #expect(seeded.count == QuickPromptSeed.all.count)
+        #expect(seeded.map(\.name) == QuickPromptSeed.all.map(\.name))
+        #expect(try await store.setting(QuickPromptSeed.versionKey) == String(QuickPromptSeed.version))
+    }
+
+    @Test("seeding twice inserts nothing the second time")
+    func seedsOnce() async throws {
+        let store = try makeTestStore("quick-prompts")
+        try await store.seedQuickPrompts()
+        try await store.seedQuickPrompts()
+        try await store.seedQuickPrompts()
+
+        #expect(try await store.quickPrompts().count == QuickPromptSeed.all.count)
+    }
+
+    /// The whole reason the seed is versioned rather than reconciled. A built-in the owner deleted
+    /// is deleted, and every launch after that has to leave it alone.
+    @Test("a deleted built-in stays deleted across relaunches")
+    func deletedBuiltInStaysDeleted() async throws {
+        let path = TestScratch.unique("quick-prompt-seed") + ".sqlite"
+        let first = try Store(path: path)
+        let seeded = try await first.seedQuickPrompts()
+        let built = try #require(seeded.first)
+        try await first.deleteQuickPrompt(id: built.id)
+        #expect(try await first.quickPrompts().isEmpty)
+
+        // A second `Store` on the same file is the next launch: the migrations run again, and so
+        // does the seeding.
+        let relaunched = try Store(path: path)
+        let after = try await relaunched.seedQuickPrompts()
+        #expect(after.isEmpty)
+    }
+
+    /// A built-in added later is inserted on its own, without putting back anything that was
+    /// deleted before it. Driven through the pure half, because the entries a shipped build seeds
+    /// are the ones written down in `QuickPromptSeed`.
+    @Test("a later built-in inserts itself and resurrects nothing")
+    func laterBuiltIn() async throws {
+        let store = try makeTestStore("quick-prompts")
+        try await store.seedQuickPrompts()
+        for prompt in try await store.quickPrompts() {
+            try await store.deleteQuickPrompt(id: prompt.id)
+        }
+
+        let next = QuickPromptSeed.Entry(
+            name: "Later", symbol: "sparkles", text: "Something new.",
+            introducedIn: QuickPromptSeed.version + 1
+        )
+        #expect(QuickPromptSeed.pending(installed: QuickPromptSeed.version).isEmpty)
+
+        // What `seedQuickPrompts` would do with that entry on the list.
+        try await store.insert(next.prompt(sortOrder: 0))
+        #expect(try await store.quickPrompts().map(\.name) == ["Later"])
+    }
+}

--- a/Tests/BloomCoreTests/QuickPromptTests.swift
+++ b/Tests/BloomCoreTests/QuickPromptTests.swift
@@ -1,0 +1,244 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+/// Everything about a quick prompt that is decided without a database: where its words land in the
+/// draft, which rows a query keeps, and where the highlight goes.
+@Suite("Quick prompts")
+struct QuickPromptTests {
+    static func prompt(
+        _ name: String, _ text: String, symbol: String = QuickPrompt.defaultSymbol
+    ) -> QuickPrompt {
+        QuickPrompt(name: name, symbol: symbol, text: text)
+    }
+
+    // MARK: - Insertion
+
+    /// The whole of the separator rule, one row per shape of draft. `|` marks the caret in both
+    /// columns, so the expectation reads as the box does afterwards.
+    static let insertions: [(draft: String, prompt: String, expected: String)] = [
+        // An empty box takes the words and nothing else.
+        ("|", "Run the tests", "Run the tests|"),
+        // A sentence ending in a word gets one space.
+        ("Take my side.|", "Run the tests", "Take my side. Run the tests|"),
+        // A draft ending mid word is still a word: never glued on.
+        ("fix the bu|", "Run the tests", "fix the bu Run the tests|"),
+        // A space that is already there is not doubled.
+        ("and then |", "Run the tests", "and then Run the tests|"),
+        // A newline is a bigger break than a space, so nothing is added.
+        ("first line\n|", "Run the tests", "first line\nRun the tests|"),
+        ("first line\n\n|", "Run the tests", "first line\n\nRun the tests|"),
+        // Mid sentence: spaced on both sides, and the caret stays with the words.
+        ("before |after", "Run the tests", "before Run the tests| after"),
+        // At the very start of a draft that has words in it.
+        ("|already typed", "Run the tests", "Run the tests| already typed"),
+        // A prompt of several lines goes in as it is written.
+        ("|", "One\nTwo", "One\nTwo|"),
+        // The prompt's own surrounding whitespace is not the draft's problem.
+        ("done.|", "  Run the tests\n", "done. Run the tests|"),
+    ]
+
+    @Test("Inserting a prompt spaces it and leaves the caret after it")
+    func inserts() {
+        for row in Self.insertions {
+            let (draft, caret) = Self.split(row.draft)
+            let result = QuickPromptInsertion.inserting(row.prompt, into: draft, at: caret)
+            let (expected, expectedCaret) = Self.split(row.expected)
+            #expect(result.text == expected, "draft \(row.draft)")
+            #expect(result.caret == expectedCaret, "draft \(row.draft)")
+        }
+    }
+
+    @Test("A caret outside the draft is clamped rather than trusted")
+    func clampsCaret() {
+        let far = QuickPromptInsertion.inserting("go", into: "abc", at: 99)
+        #expect(far.text == "abc go")
+        #expect(far.caret == 6)
+
+        let negative = QuickPromptInsertion.inserting("go", into: "abc", at: -4)
+        #expect(negative.text == "go abc")
+        #expect(negative.caret == 2)
+    }
+
+    @Test("A prompt with nothing in it changes nothing")
+    func emptyPrompt() {
+        let result = QuickPromptInsertion.inserting("   \n ", into: "abc", at: 1)
+        #expect(result.text == "abc")
+        #expect(result.caret == 1)
+    }
+
+    /// The caret is measured in UTF-16 units, which is what the composer's text view counts in, so
+    /// a draft with an emoji in it has to come back with an offset the view can use.
+    @Test("Offsets are UTF-16 units")
+    func utf16Offsets() {
+        let draft = "\u{1F41E}"
+        let result = QuickPromptInsertion.inserting("go", into: draft, at: (draft as NSString).length)
+        // Spaced off the emoji, which means the character before the caret was read whole rather
+        // than as the one UTF-16 unit sitting against it.
+        #expect(result.text == "\u{1F41E} go")
+        #expect(result.caret == 5)
+    }
+
+    @Test("A prompt inserts through its value as well as through its text")
+    func insertsFromValue() {
+        let prompt = Self.prompt("Tests", "Run the tests")
+        let result = QuickPromptInsertion.inserting(prompt, into: "go.", at: 3)
+        #expect(result.text == "go. Run the tests")
+    }
+
+    /// Splits the fixture notation above into the draft and the caret offset it marks.
+    static func split(_ marked: String) -> (String, Int) {
+        let parts = marked.components(separatedBy: "|")
+        let caret = (parts[0] as NSString).length
+        return (parts.joined(), caret)
+    }
+
+    // MARK: - Ranking
+
+    static let list: [QuickPrompt] = [
+        prompt("Run the tests and fix what fails", "Run make test. If anything fails, fix it."),
+        prompt("Open a pull request", "Push the branch and open a PR. Three sentences."),
+        // Its name carries none of "test", so a row kept by its body alone is what it tests.
+        prompt("Review the diff", "Read it cold, and say which parts have no tests."),
+    ]
+
+    @Test("An empty query is the list itself, in order")
+    func emptyQuery() {
+        let matches = QuickPromptMatches.ranking(Self.list, query: "")
+        #expect(matches.prompts.map(\.name) == Self.list.map(\.name))
+        #expect(matches.query.isEmpty)
+        #expect(!matches.isEmpty)
+    }
+
+    @Test("The query matches the name and the text")
+    func matchesNameAndText() {
+        let matches = QuickPromptMatches.ranking(Self.list, query: "test")
+        #expect(matches.prompts.count == 2)
+        // The name match first, the body match under it.
+        #expect(matches.prompts[0].name == "Run the tests and fix what fails")
+        #expect(matches.prompts[1].name == "Review the diff")
+    }
+
+    @Test("A query nothing carries keeps nothing")
+    func matchesNothing() {
+        let matches = QuickPromptMatches.ranking(Self.list, query: "deploy")
+        #expect(matches.isEmpty)
+        #expect(matches.query == "deploy")
+    }
+
+    /// The reason the body is matched by containment rather than as a subsequence: a paragraph
+    /// carries almost any short query in order, so a fuzzy body match would keep every row for
+    /// every query and the panel could never say that nothing matches.
+    @Test("A subsequence of the body alone is not a match")
+    func bodyIsNotFuzzy() {
+        let paragraph = Self.prompt("Anything", "Read the diff cold and say what you would change.")
+        #expect(FuzzyMatch.score(paragraph.text, query: "dye") != nil)
+        #expect(QuickPromptMatches.ranking([paragraph], query: "dye").isEmpty)
+    }
+
+    @Test("The name is matched loosely, out of order characters and all")
+    func nameIsFuzzy() {
+        let matches = QuickPromptMatches.ranking(Self.list, query: "opnpr")
+        #expect(matches.prompts.map(\.name) == ["Open a pull request"])
+    }
+
+    @Test("Search is case insensitive on both halves")
+    func caseInsensitive() {
+        #expect(QuickPromptMatches.ranking(Self.list, query: "REVIEW").prompts.count == 1)
+        #expect(QuickPromptMatches.ranking(Self.list, query: "MAKE TEST").prompts.count == 1)
+    }
+
+    // MARK: - Keyboard
+
+    @Test("Down from nothing lands on the first row, and up on the last")
+    func stepsFromNothing() {
+        let matches = QuickPromptMatches.ranking(Self.list, query: "")
+        #expect(matches.stepped(from: nil, by: 1) == Self.list[0])
+        #expect(matches.stepped(from: nil, by: -1) == Self.list[2])
+    }
+
+    @Test("Stepping wraps at both ends")
+    func stepsWrap() {
+        let matches = QuickPromptMatches.ranking(Self.list, query: "")
+        #expect(matches.stepped(from: Self.list[2], by: 1) == Self.list[0])
+        #expect(matches.stepped(from: Self.list[0], by: -1) == Self.list[2])
+        #expect(matches.stepped(from: Self.list[0], by: 1) == Self.list[1])
+    }
+
+    @Test("An empty list has nothing to step onto")
+    func stepsNowhere() {
+        let matches = QuickPromptMatches.ranking(Self.list, query: "deploy")
+        #expect(matches.stepped(from: nil, by: 1) == nil)
+        #expect(matches.stepped(from: Self.list[0], by: 1) == nil)
+    }
+
+    @Test("The highlight survives a query that keeps its row, and moves when it does not")
+    func settles() {
+        let matches = QuickPromptMatches.ranking(Self.list, query: "test")
+        #expect(matches.settled(after: Self.list[0]) == Self.list[0])
+        // "Open a pull request" is filtered out by that query, so the highlight moves to the best
+        // row there is now rather than pointing at a row nobody can see.
+        #expect(matches.settled(after: Self.list[1]) == matches.prompts.first)
+        #expect(matches.settled(after: nil) == matches.prompts.first)
+    }
+
+    @Test("An edited row is still the highlighted row")
+    func settlesAfterEdit() {
+        var edited = Self.list[1]
+        edited.name = "Open a PR"
+        let matches = QuickPromptMatches.ranking([Self.list[0], edited], query: "")
+        #expect(matches.settled(after: Self.list[1]) == edited)
+    }
+
+    // MARK: - The row itself
+
+    @Test("The preview is one line of the text, cut short")
+    func preview() {
+        #expect(Self.prompt("x", "One line").preview == "One line")
+        #expect(Self.prompt("x", "  One\n\nTwo  ").preview == "One Two")
+
+        let long = String(repeating: "ab ", count: 40)
+        let preview = Self.prompt("x", long).preview
+        #expect(preview.hasSuffix("\u{2026}"))
+        #expect(preview.count <= QuickPrompt.previewLength + 1)
+    }
+
+    @Test("A prompt with no name falls back to its own words")
+    func resolvedName() {
+        #expect(Self.prompt("  ", "Run the tests").resolvedName == "Run the tests")
+        #expect(Self.prompt(" Tests ", "Run the tests").resolvedName == "Tests")
+    }
+
+    @Test("An unknown symbol is drawn as the fallback")
+    func resolvedSymbol() {
+        #expect(QuickPrompt.resolvedSymbol("doc.richtext") == "doc.richtext")
+        #expect(QuickPrompt.resolvedSymbol("nothing.like.this") == QuickPrompt.defaultSymbol)
+        #expect(QuickPrompt.symbols.contains(QuickPrompt.defaultSymbol))
+        #expect(Set(QuickPrompt.symbols).count == QuickPrompt.symbols.count)
+    }
+
+    // MARK: - The seed list
+
+    @Test("A fresh database is offered every built-in, and a seeded one none")
+    func pendingSeed() {
+        #expect(QuickPromptSeed.pending(installed: 0).count == QuickPromptSeed.all.count)
+        #expect(QuickPromptSeed.pending(installed: QuickPromptSeed.version).isEmpty)
+    }
+
+    @Test("Every built-in is introduced at or below the version the store records")
+    func seedVersionCoversTheList() {
+        for entry in QuickPromptSeed.all {
+            #expect(entry.introducedIn <= QuickPromptSeed.version)
+            #expect(entry.introducedIn > 0)
+            #expect(QuickPrompt.symbols.contains(entry.symbol))
+        }
+    }
+
+    @Test("The prompt Bloom ships with is the one that was asked for")
+    func shippedPrompt() {
+        let explain = QuickPromptSeed.all.first { $0.name == "Explain changes" }
+        #expect(explain?.text == """
+        Explain the changes made in this PR as HTML. Open it as a new tab in this workspace.
+        """)
+    }
+}


### PR DESCRIPTION
A quick prompt is a few lines you wrote and keep typing again. One flat global list in Bloom's own table, not `.claude/commands`, since a file there is also a slash command in the terminal pane.

A button beside the paperclip opens a searchable panel: rows carry a mark, a name and the first stretch of their words, a pencil on the hovered or highlighted row opens the form, and the form owns Delete. Choosing a row inserts the text at the caret as plain text and sends nothing.

The separator rule, the ranking and the arrow key stepping are pure types in BloomCore with tests. Bloom ships with one built-in prompt, seeded once against a recorded version, so deleting it sticks across relaunches while a fresh install still gets it.

Two things drawn differently from the mockup, both to avoid one floating panel inside another: the list and the form are two states of the same popover, and the symbol grid is inline in the form rather than hanging off an icon well.