### PR TITLE
Split the start-from picker into two tabs

### DIFF
--- a/Sources/Bloom/Views/Sidebar/WorkspaceSourcePicker.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspaceSourcePicker.swift
@@ -4,12 +4,19 @@ import BloomCore
 /// Where the work comes from: an open pull request, a branch somebody has already written on, or a
 /// fresh branch cut off a base.
 ///
-/// It replaces a `Menu` that listed "New branch from <name>" for every branch in the project and
+/// It replaced a `Menu` that listed "New branch from <name>" for every branch in the project and
 /// filed "Open an existing branch" under all of them, with no way to search. A colleague's branch
 /// was picked out of the top of that list, which cut a new branch off their head, and the
-/// workspace came up empty with its Changes tab saying nothing differed. So the two verbs are
-/// drawn as two sections, one above the other, with the same branch in both: the choice is made
-/// with both answers in view rather than a screenful apart.
+/// workspace came up empty with its Changes tab saying nothing differed.
+///
+/// The first fix drew the two verbs as two sections of one scrolling list, so the choice could be
+/// made with both answers in view. That was right about the choice and wrong about the search. The
+/// owner went looking for a branch to carry on, typed its name, and did not recognise the row he
+/// got: half the offering was below the fold, the headings scrolled away, and the row that matched
+/// was named after a pull request title rather than after the branch he had typed. So the sections
+/// are tabs now, each carrying a sentence that says where a commit ends up, which is the only real
+/// difference between them and the thing neither heading ever said. The other half of that fix is
+/// `WorkspaceSource.name`, which names a pull request after the branch it lands on.
 ///
 /// A `.popover` rather than a `Menu`, and not by preference. An `NSMenu` cannot contain a text
 /// field, so a menu with a search box in it is not a thing macOS has; the panel is the app's own
@@ -28,6 +35,9 @@ struct WorkspaceSourcePicker: View {
 
     @State private var isPresented = false
     @State private var query = ""
+    /// Which verb is on screen. Opened on the tab the current choice belongs to, so a panel
+    /// reopened after picking a pull request does not start by hiding it.
+    @State private var tab: WorkspaceSourceTab = .newBranch
     /// The highlighted row, held as the row itself and never as an index into the list. A ranked
     /// list reorders under every keystroke, so an index highlights whatever has since moved into
     /// that slot and Return opens something other than what is drawn. `FileMentionMenu` carries
@@ -85,25 +95,26 @@ struct WorkspaceSourcePicker: View {
 
     private var panel: some View {
         // Ranked once for the whole pass, and everything below draws from that one value. The
-        // panel asks three questions of it (is there anything, what goes in each section) and a
-        // ranking run per question is the same list computed three times over a repository's worth
-        // of branches, on every keystroke.
+        // panel asks several questions of it (is this tab empty, what goes in the list) and a
+        // ranking run per question is the same list computed over a repository's worth of branches
+        // several times, on every keystroke.
         let matches = self.matches
         return VStack(alignment: .leading, spacing: 0) {
+            tabs
+            explanation
+            Hairline()
             searchRow
             Hairline()
 
-            if matches.isEmpty {
+            if matches.isEmpty(in: tab) {
                 MenuEmptyRow(
-                    text: query.isEmpty
-                        ? "No branches or pull requests yet"
-                        : "Nothing matches \(query)"
+                    text: query.isEmpty ? emptyTabText : "Nothing matches \(query)"
                 )
             } else {
                 list(matches)
             }
 
-            if let unavailable {
+            if let unavailable, tab == .existingBranch {
                 Hairline()
                 Text(unavailable)
                     .font(Typo.caption)
@@ -114,12 +125,48 @@ struct WorkspaceSourcePicker: View {
             }
         }
         .frame(width: Self.width)
+        .background { tabShortcuts }
         // A fresh query every time it opens. The panel is a way of finding one thing, not a filter
         // somebody set and left, and reopening it onto yesterday's word would hide the list that
         // has since loaded behind it.
         .onAppear {
             query = ""
-            selected = offering.search(query: "").ordered.first
+            tab = checkout == nil ? .newBranch : .existingBranch
+            selected = offering.search(query: "").rows(in: tab).first
+        }
+    }
+
+    private var tabs: some View {
+        Picker("Start from", selection: $tab) {
+            ForEach(WorkspaceSourceTab.allCases) { option in
+                Text(option.title).tag(option)
+            }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .padding(.horizontal, Metrics.spacingSmall)
+        .padding(.top, Metrics.spacingSmall)
+        .padding(.bottom, Metrics.spacingTight)
+        .onChange(of: tab) { _, _ in
+            // The highlight cannot stay in a tab nobody can see, so it settles into the new one.
+            selected = matches.settled(after: selected, in: tab)
+        }
+    }
+
+    private var explanation: some View {
+        Text(tab.explanation)
+            .font(Typo.caption)
+            .foregroundStyle(Palette.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.horizontal, Metrics.gutter)
+            .padding(.bottom, Metrics.spacingWide)
+    }
+
+    /// What an empty tab says, which differs because the two are empty for different reasons.
+    private var emptyTabText: String {
+        switch tab {
+        case .newBranch: "No branches to start from yet"
+        case .existingBranch: "No branches or pull requests to carry on yet"
         }
     }
 
@@ -131,7 +178,7 @@ struct WorkspaceSourcePicker: View {
 
             MenuSearchField(
                 text: $query,
-                placeholder: "Search branches and pull requests, or paste a pull request",
+                placeholder: tab.searchPlaceholder,
                 onKey: handle(key:)
             )
             .frame(height: Metrics.rowHeight)
@@ -141,7 +188,7 @@ struct WorkspaceSourcePicker: View {
         .onChange(of: query) { _, _ in
             // The highlight follows the list rather than staying where it was: a highlight left
             // pointing at a row the new query filtered out is a Return that does nothing.
-            selected = matches.settled(after: selected)
+            selected = matches.settled(after: selected, in: tab)
         }
     }
 
@@ -149,11 +196,16 @@ struct WorkspaceSourcePicker: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    // The heading says what happens to the work that is already there, because
-                    // "Open" alone reads as "open a copy of". Carrying on somebody's branch is
-                    // what the sheet could not say before.
-                    section("Open, and carry on", rows: matches.open)
-                    section("New branch from", rows: matches.new)
+                    ForEach(matches.rows(in: tab)) { row in
+                        WorkspaceSourceRow(
+                            source: row,
+                            isSelected: row == selected,
+                            onPick: { pick(row) },
+                            onHover: { selected = row }
+                        )
+                        // Identity is the thing the row names, never its position. See `selected`.
+                        .id(row.id)
+                    }
                 }
                 .padding(Metrics.spacingSmall)
             }
@@ -165,41 +217,40 @@ struct WorkspaceSourcePicker: View {
         }
     }
 
-    @ViewBuilder
-    private func section(_ title: String, rows: [WorkspaceSource]) -> some View {
-        if !rows.isEmpty {
-            Text(title)
-                .font(Typo.caption)
-                .foregroundStyle(Palette.textTertiary)
-                .padding(.horizontal, Metrics.spacing)
-                .padding(.top, Metrics.spacingWide)
-                .padding(.bottom, Metrics.spacingTight)
-                .accessibilityAddTraits(.isHeader)
-
-            ForEach(rows) { row in
-                WorkspaceSourceRow(
-                    source: row,
-                    isSelected: row == selected,
-                    onPick: { pick(row) },
-                    onHover: { selected = row }
-                )
-                // Identity is the thing the row names, never its position. See `selected`.
-                .id(row.id)
-            }
-        }
-    }
-
     // MARK: - Keys
+
+    /// Switching tab from the keyboard, on the keys macOS already uses for it.
+    ///
+    /// **Not the left and right arrows**, which was the first idea and is wrong: this panel has a
+    /// search field, and in a text field those two move the insertion point. Claiming them would
+    /// break correcting a typo in the very query the tabs exist to serve. Command+Shift+[ and
+    /// Command+Shift+] are what Safari and Terminal use to move between tabs, and being command
+    /// equivalents they reach the panel while the field holds the keyboard, which the arrows can
+    /// only do by being taken away from the caret first.
+    ///
+    /// Drawn in a `.background` and never seen. A button is how SwiftUI registers a key equivalent
+    /// for a window, and this one has nothing to show: the hint at the foot of the panel is what
+    /// tells anybody the keys exist.
+    private var tabShortcuts: some View {
+        ZStack {
+            Button("Previous tab") { tab = tab.stepped(by: -1) }
+                .keyboardShortcut("[", modifiers: [.command, .shift])
+            Button("Next tab") { tab = tab.stepped(by: 1) }
+                .keyboardShortcut("]", modifiers: [.command, .shift])
+        }
+        .opacity(0)
+        .accessibilityHidden(true)
+    }
 
     /// The panel's whole keyboard. Where the highlight lands is `WorkspaceSourceMatches`, in the
     /// core, because it is a decision and a decision taken in a view is one nothing can test.
     private func handle(key: ComposerKey) -> Bool {
         switch key {
         case .up:
-            selected = matches.stepped(from: selected, by: -1)
+            selected = matches.stepped(from: selected, by: -1, in: tab)
             return true
         case .down:
-            selected = matches.stepped(from: selected, by: 1)
+            selected = matches.stepped(from: selected, by: 1, in: tab)
             return true
         case .returnKey, .commandReturn:
             guard let selected else { return false }

--- a/Sources/Bloom/Views/Sidebar/WorkspaceSourceRow.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspaceSourceRow.swift
@@ -25,11 +25,28 @@ struct WorkspaceSourceRow: View {
                     .foregroundStyle(isEmphasized ? Palette.selectedEmphasizedText : Palette.textTertiary)
                     .frame(width: Metrics.glyph)
 
-                Text(source.name)
-                    .font(Typo.body)
-                    .foregroundStyle(nameColour)
-                    .lineLimit(1)
-                    .truncationMode(truncation)
+                VStack(alignment: .leading, spacing: Metrics.spacingTight) {
+                    Text(source.name)
+                        .font(Typo.body)
+                        .foregroundStyle(nameColour)
+                        .lineLimit(1)
+                        .truncationMode(truncation)
+
+                    // Only a pull request has one, so the list is not uniformly two lines high.
+                    // A branch with nothing to add would otherwise carry an empty line for the
+                    // sake of a shape.
+                    if let detail = source.detail {
+                        Text(detail)
+                            .font(Typo.caption)
+                            .foregroundStyle(
+                                isEmphasized
+                                    ? Palette.selectedEmphasizedText.opacity(0.75)
+                                    : Palette.textTertiary
+                            )
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                }
 
                 Spacer(minLength: Metrics.spacingSmall)
 
@@ -45,14 +62,17 @@ struct WorkspaceSourceRow: View {
                 }
             }
             .padding(.horizontal, Metrics.spacing)
-            .frame(height: Metrics.rowHeight)
+            .padding(.vertical, Metrics.spacingTight)
+            // A minimum rather than a fixed height, because a pull request row carries a second
+            // line and a branch row does not. Fixed, the second line was clipped.
+            .frame(minHeight: Metrics.rowHeight)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        // The verb is spoken even where the section heading carries it on screen, because a reader
-        // arrowing down the list hears one row at a time and the heading is above all of them.
+        // The verb is spoken even though the tab carries it on screen, because a reader arrowing
+        // down the list hears one row at a time and the tab strip is above all of them.
         .accessibilityLabel("\(source.verb) \(source.name)")
-        .accessibilityValue(source.note ?? "")
+        .accessibilityValue([source.detail, source.note].compactMap { $0 }.joined(separator: ", "))
         // Focused, for the reason spelled out on `SlashCommandRow`.
         .rowBackground(isSelected: isSelected, isHovered: isHovered, isFocused: true)
         .onHover { hovering in
@@ -63,14 +83,16 @@ struct WorkspaceSourceRow: View {
 
     /// Which end of a long name is dropped, and the two answers are opposite.
     ///
-    /// A branch loses its front: `feature/` and a colleague's login are the part everybody shares,
-    /// and the end is what tells two of somebody's `patch-1`s apart. A pull request loses its
-    /// tail, because it opens with the number it is referred to by out loud.
+    /// A ref loses its front: `feature/` and a colleague's login are the part everybody shares,
+    /// and the end is what tells two of somebody's `patch-1`s apart. A row drawn under a pull
+    /// request number loses its tail instead, because it opens with the number it is referred to
+    /// by out loud.
+    ///
+    /// Asked of the name rather than of the case, because which of the two a pull request row is
+    /// now depends on what it knows: it is named after its head branch when gh answered with one,
+    /// and falls back to its number and title when gh did not. See `WorkspaceSource.name`.
     private var truncation: Text.TruncationMode {
-        switch source {
-        case .pullRequest: .tail
-        case .newBranch, .existingBranch: .head
-        }
+        source.name.hasPrefix("#") ? .tail : .head
     }
 
     private var glyph: String {

--- a/Sources/BloomCore/Workspace/WorkspaceCheckout.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceCheckout.swift
@@ -26,6 +26,23 @@ public struct PullRequestListing: Sendable, Hashable, Identifiable, Codable {
 
     public var isOpen: Bool { state.uppercased() == "OPEN" }
 
+    /// The branch this pull request lands on, named the way the picker should draw it.
+    ///
+    /// A fork's head is qualified with its owner, which is git's own convention for the ref and is
+    /// not decoration: `heads(of:)` deliberately leaves a cross repository head out of the branches
+    /// it hides, because a local branch of the same name is somebody else's unrelated work wearing
+    /// the same word. Drawing both as a bare `patch-1` would put that collision on screen.
+    ///
+    /// Empty when an older gh did not answer `headRefName`, which is why every caller has to have
+    /// something to fall back on rather than drawing a blank row.
+    public var qualifiedHead: String {
+        guard !headRefName.isEmpty else { return "" }
+        guard isCrossRepository, let owner = headRepositoryOwner, !owner.isEmpty else {
+            return headRefName
+        }
+        return "\(owner):\(headRefName)"
+    }
+
     public init(
         number: Int,
         title: String,

--- a/Sources/BloomCore/Workspace/WorkspaceSource.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceSource.swift
@@ -58,13 +58,45 @@ public enum WorkspaceSource: Sendable, Hashable, Identifiable {
     }
 
     /// The thing the row names, as it is written everywhere else in the app.
+    ///
+    /// A listed pull request is named after the **branch it lands on**, not after its number and
+    /// title, and that is the fix for the bug this whole picker keeps being rewritten around.
+    /// `searchText` has always matched a pull request by its head, with a comment saying why ("the
+    /// figma one" is how a head is recalled long after the title has gone), so searching a branch
+    /// name already found the row. It found a row reading `#362 Lay the app-side styling
+    /// foundation`, on which the searched word appeared nowhere, and the owner scrolled past his
+    /// own result and concluded the branch was gone. A match nobody can see is not a match.
+    ///
+    /// The number and the title are not lost: they are `detail`, on the line underneath. The
+    /// branch is what was searched for and what is being chosen, so the branch is what the row is
+    /// called. The fallback matters, because an older gh does not answer `headRefName` at all.
     public var name: String {
         switch self {
         case .newBranch(let ref): ref
         case .existingBranch(let branch): branch.name
-        case .pullRequest(.listed(let request)): "#\(request.number) \(request.title)"
+        case .pullRequest(.listed(let request)):
+            request.qualifiedHead.isEmpty ? "#\(request.number) \(request.title)" : request.qualifiedHead
         case .pullRequest(.typed(let reference, _)): "#\(reference.number)"
         }
+    }
+
+    /// The tab this row belongs under, which is the verb it carries and nothing else.
+    public var tab: WorkspaceSourceTab {
+        switch self {
+        case .newBranch: .newBranch
+        case .existingBranch, .pullRequest: .existingBranch
+        }
+    }
+
+    /// The second line of the row, or nothing.
+    ///
+    /// Only a listed pull request has one, and it is what `name` used to be. A branch with no pull
+    /// request needs no second line, and drawing an empty one would make the list ragged for the
+    /// sake of a shape.
+    public var detail: String? {
+        guard case .pullRequest(.listed(let request)) = self else { return nil }
+        guard !request.qualifiedHead.isEmpty else { return nil }
+        return "#\(request.number) \(request.title)"
     }
 
     /// What is worth saying after the name, or nothing.
@@ -231,6 +263,66 @@ public struct WorkspaceSourceOffering: Sendable, Hashable {
     }
 }
 
+/// Which of the two things the picker can do is on screen.
+///
+/// The two verbs used to be two sections of one scrolling list, one above the other, so that the
+/// choice could be made with both answers in view. That was right about the choice and wrong about
+/// the search: half the offering was below the fold, the headings scrolled away, and "New branch
+/// from" and "Open, and carry on" are not words anybody reads before they start typing. They are
+/// tabs now, and the tab carries a sentence saying where a commit ends up, which is the only real
+/// difference between them and the thing neither heading ever said.
+///
+/// What tabs cost, written down because it is not fixed and should not be forgotten: they make the
+/// verb be chosen before the search, and people arrive knowing a branch name rather than the
+/// vocabulary. `WorkspaceSource.name` naming a pull request after its head is what keeps that from
+/// being the trap it was.
+public enum WorkspaceSourceTab: String, Sendable, Hashable, CaseIterable, Identifiable {
+    /// Cut a fresh branch off whatever is picked. The common case, so it leads.
+    case newBranch
+    /// Carry on a branch or a pull request that already exists.
+    case existingBranch
+
+    public var id: String { rawValue }
+
+    /// The tab strip's own words. Both start with a verb so neither reads as a category.
+    public var title: String {
+        switch self {
+        case .newBranch: "Create new branch"
+        case .existingBranch: "Continue on existing branch"
+        }
+    }
+
+    /// The line under the strip.
+    ///
+    /// Both halves open on the same three words so the eye lands on the fourth and reads only the
+    /// difference. Both say where a commit ends up and what merging does with it, because that is
+    /// the whole distinction: on a new branch the merge is yours to do later, and on an existing
+    /// one the merge already belongs to that branch and your commits ride it.
+    public var explanation: String {
+        switch self {
+        case .newBranch:
+            "Commits land on a new branch. Merging it brings them into the branch you pick here."
+        case .existingBranch:
+            "Commits land on the branch you pick here, and merge when it does."
+        }
+    }
+
+    /// What the search field says. Only one tab can be given a pull request number to look up.
+    public var searchPlaceholder: String {
+        switch self {
+        case .newBranch: "Search branches to start from"
+        case .existingBranch: "Search branches and pull requests, or paste a pull request"
+        }
+    }
+
+    /// The next tab along, wrapping, for the keyboard.
+    public func stepped(by step: Int) -> WorkspaceSourceTab {
+        let all = Self.allCases
+        guard let index = all.firstIndex(of: self) else { return self }
+        return all[(index + step + all.count) % all.count]
+    }
+}
+
 /// What the panel draws, in the order the arrow keys walk it.
 public struct WorkspaceSourceMatches: Sendable, Hashable {
     /// What was searched for, so the empty state can say it rather than shrugging. See
@@ -245,13 +337,24 @@ public struct WorkspaceSourceMatches: Sendable, Hashable {
         self.new = new
     }
 
+    /// Whether there is nothing at all, in either tab. The panel uses the per tab answer; this one
+    /// is for asking whether the offering is empty rather than whether a tab is.
     public var isEmpty: Bool { open.isEmpty && new.isEmpty }
 
-    /// Both sections as one list, top to bottom.
+    /// What one tab draws, and the only rows its keyboard may reach.
     ///
-    /// The keyboard walks this and the panel draws it in the same order, from the same value, so
-    /// Return cannot pick something other than the highlighted row.
-    public var ordered: [WorkspaceSource] { open + new }
+    /// The keyboard walks this and the panel draws it, from the same value, so Return cannot pick
+    /// something other than the highlighted row. It is scoped to the tab rather than spanning
+    /// both, because a highlight that can step into a tab nobody can see is a Return that opens
+    /// something off screen.
+    public func rows(in tab: WorkspaceSourceTab) -> [WorkspaceSource] {
+        switch tab {
+        case .newBranch: new
+        case .existingBranch: open
+        }
+    }
+
+    public func isEmpty(in tab: WorkspaceSourceTab) -> Bool { rows(in: tab).isEmpty }
 
     /// Where the highlight lands after a step, given what is highlighted now.
     ///
@@ -259,8 +362,10 @@ public struct WorkspaceSourceMatches: Sendable, Hashable {
     /// decision taken in a view is a decision nothing can test. It wraps at both ends, which is
     /// what every menu on the Mac does, and it answers with the first row when nothing is
     /// highlighted yet, so the first press of Down after typing does not swallow itself.
-    public func stepped(from current: WorkspaceSource?, by step: Int) -> WorkspaceSource? {
-        let rows = ordered
+    public func stepped(
+        from current: WorkspaceSource?, by step: Int, in tab: WorkspaceSourceTab
+    ) -> WorkspaceSource? {
+        let rows = rows(in: tab)
         guard !rows.isEmpty else { return nil }
         guard let current, let index = rows.firstIndex(of: current) else {
             return step < 0 ? rows.last : rows.first
@@ -271,9 +376,13 @@ public struct WorkspaceSourceMatches: Sendable, Hashable {
 
     /// What stays highlighted when the list changes under the field: the same row if it survived
     /// the new query, otherwise the best one there is now. A highlight left pointing at a row that
-    /// has been filtered out is a Return that does nothing.
-    public func settled(after current: WorkspaceSource?) -> WorkspaceSource? {
-        guard let current, ordered.contains(current) else { return ordered.first }
+    /// has been filtered out is a Return that does nothing, and one left pointing into the other
+    /// tab is worse, so switching tab settles through here too.
+    public func settled(
+        after current: WorkspaceSource?, in tab: WorkspaceSourceTab
+    ) -> WorkspaceSource? {
+        let rows = rows(in: tab)
+        guard let current, rows.contains(current) else { return rows.first }
         return current
     }
 }

--- a/Tests/BloomCoreTests/WorkspaceSourceTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceSourceTests.swift
@@ -75,10 +75,13 @@ struct WorkspaceSourceTests {
             listing(number: 41, title: "Serialise the drains", author: "freekmurze", head: "drains"),
             listing(number: 42, title: "Rename the sheet", author: "someone", head: "rename"),
         ])
-        #expect(offered.search(query: "drains").open.first?.name.hasPrefix("#41") == true)
-        #expect(offered.search(query: "freekmurze").open.first?.name.hasPrefix("#41") == true)
-        #expect(offered.search(query: "rename").open.first?.name.hasPrefix("#42") == true)
-        #expect(offered.search(query: "serialise").open.first?.name.hasPrefix("#41") == true)
+        // The row is named after the head branch, so all four of these find the same row and it
+        // is called "drains" whichever of the four things the reader happened to remember.
+        #expect(offered.search(query: "drains").open.first?.name == "drains")
+        #expect(offered.search(query: "freekmurze").open.first?.name == "drains")
+        #expect(offered.search(query: "rename").open.first?.name == "rename")
+        #expect(offered.search(query: "serialise").open.first?.name == "drains")
+        #expect(offered.search(query: "serialise").open.first?.detail == "#41 Serialise the drains")
     }
 
     @Test("A branch nothing matches is gone, and so is the whole result when nothing matches")
@@ -99,7 +102,7 @@ struct WorkspaceSourceTests {
             baseBranches: ["main", "wip"]
         ).search(query: "  ")
         #expect(matches.open.count == 2)
-        #expect(matches.open.first?.name.hasPrefix("#7") == true)
+        #expect(matches.open.first?.name == "fix-parser")
         #expect(matches.new.map(\.name) == ["main", "wip"])
     }
 
@@ -188,19 +191,80 @@ struct WorkspaceSourceTests {
 
     // MARK: - The keyboard
 
-    @Test("Down and up walk both sections as one list, and wrap")
-    func stepsThroughBothSections() {
+    @Test("Down and up walk the visible tab, and wrap inside it")
+    func stepsThroughTheVisibleTab() {
+        let matches = offering(
+            branches: [ExistingBranch(name: "wip", isLocal: true), ExistingBranch(name: "old", isLocal: true)],
+            baseBranches: ["main"]
+        ).search(query: "")
+        let rows = matches.rows(in: .existingBranch)
+        let first = rows.first
+        let last = rows.last
+        #expect(first != last)
+        #expect(matches.stepped(from: nil, by: 1, in: .existingBranch) == first)
+        #expect(matches.stepped(from: nil, by: -1, in: .existingBranch) == last)
+        #expect(matches.stepped(from: first, by: 1, in: .existingBranch) == last)
+        #expect(matches.stepped(from: last, by: 1, in: .existingBranch) == first)
+        #expect(WorkspaceSourceMatches().stepped(from: nil, by: 1, in: .newBranch) == nil)
+    }
+
+    @Test("The keyboard cannot step out of the tab that is on screen")
+    func doesNotStepIntoTheHiddenTab() {
         let matches = offering(
             branches: [ExistingBranch(name: "wip", isLocal: true)],
             baseBranches: ["main"]
         ).search(query: "")
-        let first = matches.ordered.first
-        let last = matches.ordered.last
-        #expect(matches.stepped(from: nil, by: 1) == first)
-        #expect(matches.stepped(from: nil, by: -1) == last)
-        #expect(matches.stepped(from: first, by: 1) == last)
-        #expect(matches.stepped(from: last, by: 1) == first)
-        #expect(WorkspaceSourceMatches().stepped(from: nil, by: 1) == nil)
+        // One row in each tab. Stepping in either direction stays put rather than crossing over,
+        // because a highlight in a tab nobody can see is a Return that opens something off screen.
+        let newRows = matches.rows(in: .newBranch)
+        #expect(newRows.count == 1)
+        #expect(matches.stepped(from: newRows.first, by: 1, in: .newBranch) == newRows.first)
+        #expect(matches.stepped(from: newRows.first, by: -1, in: .newBranch) == newRows.first)
+        #expect(matches.rows(in: .existingBranch).contains(newRows[0]) == false)
+    }
+
+    @Test("A pull request whose head gh did not answer keeps its number and title")
+    func fallsBackWhenThereIsNoHead() {
+        let row = WorkspaceSource.pullRequest(.listed(
+            listing(number: 88, title: "Teach it to wait", head: "")
+        ))
+        // An older gh does not answer headRefName. Naming the row after an empty string would draw
+        // a blank line where the branch should be, so the old name is what it falls back to, and
+        // there is no second line to repeat it on.
+        #expect(row.name == "#88 Teach it to wait")
+        #expect(row.detail == nil)
+    }
+
+    @Test("A fork's head is qualified by its owner, because a bare name is somebody else's branch")
+    func qualifiesAForkHead() {
+        let fork = PullRequestListing(
+            number: 91,
+            title: "Add the thing",
+            author: "stranger",
+            headRefName: "patch-1",
+            baseRefName: "main",
+            isCrossRepository: true,
+            headRepositoryOwner: "stranger"
+        )
+        #expect(WorkspaceSource.pullRequest(.listed(fork)).name == "stranger:patch-1")
+        // And the branch of the same name in this repository is left alone, which is the reason
+        // the qualification has to be on screen rather than only in the checkout.
+        #expect(WorkspaceCheckoutPlan.heads(of: [fork]).contains("patch-1") == false)
+    }
+
+    @Test("Each row knows which tab it belongs under")
+    func sortsRowsIntoTabs() {
+        #expect(WorkspaceSource.newBranch(from: "main").tab == .newBranch)
+        #expect(WorkspaceSource.existingBranch(ExistingBranch(name: "wip", isLocal: true)).tab
+            == .existingBranch)
+        #expect(WorkspaceSource.pullRequest(.listed(listing())).tab == .existingBranch)
+    }
+
+    @Test("Stepping a tab wraps, so one key reaches the other tab from either")
+    func stepsBetweenTabs() {
+        #expect(WorkspaceSourceTab.newBranch.stepped(by: 1) == .existingBranch)
+        #expect(WorkspaceSourceTab.newBranch.stepped(by: -1) == .existingBranch)
+        #expect(WorkspaceSourceTab.existingBranch.stepped(by: 1) == .newBranch)
     }
 
     @Test("A highlight that the next keystroke filters away moves to the best row there is")
@@ -210,9 +274,12 @@ struct WorkspaceSourceTests {
             baseBranches: ["main", "wip"]
         )
         let held = WorkspaceSource.existingBranch(ExistingBranch(name: "wip", isLocal: true))
-        #expect(offered.search(query: "wip").settled(after: held) == held)
-        #expect(offered.search(query: "main").settled(after: held)?.name == "main")
-        #expect(WorkspaceSourceMatches().settled(after: held) == nil)
+        #expect(offered.search(query: "wip").settled(after: held, in: .existingBranch) == held)
+        #expect(offered.search(query: "main").settled(after: held, in: .newBranch)?.name == "main")
+        #expect(WorkspaceSourceMatches().settled(after: held, in: .existingBranch) == nil)
+        // Switching tab settles through the same door: the held row is in the other tab, so the
+        // highlight lands on the first row of the one now on screen rather than staying off it.
+        #expect(offered.search(query: "").settled(after: held, in: .newBranch)?.name == "main")
     }
 
     // MARK: - What the button says


### PR DESCRIPTION
The two verbs were two sections of one scrolling list. Half the offering sat below the fold and the headings scrolled away, so the choice had to be made before the search and the search only ever showed one half of what it found.

They are tabs now, new work leading, each carrying a line that says where a commit ends up and what merging does with it. That sentence is the real difference between them and it is the thing neither heading ever said.

The other half is the row. A listed pull request is named after the branch it lands on rather than after its number and title. Search has always matched a pull request by its head, so searching a branch name already found the row; it found a row on which the searched word appeared nowhere, which is how a branch came to look as though it had gone. The number and title are the second line now. A fork's head is qualified by its owner, and a pull request whose head gh did not answer keeps its old name.

Command+Shift+[ and Command+Shift+] move between tabs, which is what Safari and Terminal use. Not the arrows: the panel has a search field, and there they move the caret.