### PR TITLE
Stop offering the pane tools to a connection standing in no workspace

### DIFF
--- a/Sources/BloomCore/Bridge/PaneCloseTool.swift
+++ b/Sources/BloomCore/Bridge/PaneCloseTool.swift
@@ -34,7 +34,16 @@ public struct PaneCloseTool: BridgeToolHandling {
         self.close = close
     }
 
-    public let roles: Set<BridgeRole> = [.parent, .owner]
+    /// A parent and nothing else.
+    ///
+    /// Not `.owner`, although it was at first, and that was a listed tool that could never work.
+    /// This tool is scoped to the workspace the caller is standing in, and `BridgeIdentity.owner`
+    /// carries no `workspaceID` by definition: the role is the person reaching Bloom from a client
+    /// they started themselves, sitting in no workspace at all. Every call refused with "this
+    /// connection is not speaking for one", after being advertised in `tools/list` as though it
+    /// would work. `BridgeRole.owner` says as much in its own doc comment: not anything scoped to
+    /// a workspace, because it has none to be scoped to.
+    public let roles: Set<BridgeRole> = [.parent]
 
     public let tool = BridgeTool(
         name: "pane_close",

--- a/Sources/BloomCore/Bridge/PaneOpenTool.swift
+++ b/Sources/BloomCore/Bridge/PaneOpenTool.swift
@@ -37,7 +37,16 @@ public struct PaneOpenTool: BridgeToolHandling {
     /// Not `.child`. A subagent opening tabs in its parent's window is a pane arriving from
     /// something the reader did not address, and the parent can open one on its behalf if it
     /// really is wanted.
-    public let roles: Set<BridgeRole> = [.parent, .owner]
+    /// A parent and nothing else.
+    ///
+    /// Not `.owner`, although it was at first, and that was a listed tool that could never work.
+    /// This tool is scoped to the workspace the caller is standing in, and `BridgeIdentity.owner`
+    /// carries no `workspaceID` by definition: the role is the person reaching Bloom from a client
+    /// they started themselves, sitting in no workspace at all. Every call refused with "this
+    /// connection is not speaking for one", after being advertised in `tools/list` as though it
+    /// would work. `BridgeRole.owner` says as much in its own doc comment: not anything scoped to
+    /// a workspace, because it has none to be scoped to.
+    public let roles: Set<BridgeRole> = [.parent]
 
     public let tool = BridgeTool(
         name: "pane_open",

--- a/Sources/BloomCore/Bridge/PaneRenameTool.swift
+++ b/Sources/BloomCore/Bridge/PaneRenameTool.swift
@@ -54,7 +54,16 @@ public struct PaneRenameTool: BridgeToolHandling {
 
     /// Not `.child`, matching the other three. A subagent renaming its parent's tabs is a strip
     /// changing under the reader on behalf of something they did not address.
-    public let roles: Set<BridgeRole> = [.parent, .owner]
+    /// A parent and nothing else.
+    ///
+    /// Not `.owner`, although it was at first, and that was a listed tool that could never work.
+    /// This tool is scoped to the workspace the caller is standing in, and `BridgeIdentity.owner`
+    /// carries no `workspaceID` by definition: the role is the person reaching Bloom from a client
+    /// they started themselves, sitting in no workspace at all. Every call refused with "this
+    /// connection is not speaking for one", after being advertised in `tools/list` as though it
+    /// would work. `BridgeRole.owner` says as much in its own doc comment: not anything scoped to
+    /// a workspace, because it has none to be scoped to.
+    public let roles: Set<BridgeRole> = [.parent]
 
     public let tool = BridgeTool(
         name: "pane_rename",

--- a/Sources/BloomCore/Bridge/PaneSplitTool.swift
+++ b/Sources/BloomCore/Bridge/PaneSplitTool.swift
@@ -36,7 +36,16 @@ public struct PaneSplitTool: BridgeToolHandling {
         self.split = split
     }
 
-    public let roles: Set<BridgeRole> = [.parent, .owner]
+    /// A parent and nothing else.
+    ///
+    /// Not `.owner`, although it was at first, and that was a listed tool that could never work.
+    /// This tool is scoped to the workspace the caller is standing in, and `BridgeIdentity.owner`
+    /// carries no `workspaceID` by definition: the role is the person reaching Bloom from a client
+    /// they started themselves, sitting in no workspace at all. Every call refused with "this
+    /// connection is not speaking for one", after being advertised in `tools/list` as though it
+    /// would work. `BridgeRole.owner` says as much in its own doc comment: not anything scoped to
+    /// a workspace, because it has none to be scoped to.
+    public let roles: Set<BridgeRole> = [.parent]
 
     public let tool = BridgeTool(
         name: "pane_split",

--- a/Tests/BloomCoreTests/PaneToolTests.swift
+++ b/Tests/BloomCoreTests/PaneToolTests.swift
@@ -239,17 +239,30 @@ struct PaneToolTests {
 
     /// A subagent opening tabs in its parent's window is a pane arriving from something the
     /// reader did not address.
-    @Test("a subagent cannot open, split, close or rename panes")
-    func aChildCannotTouchPanes() {
+    ///
+    /// The owner is left out for a different reason, and it is a bug this test used to assert.
+    /// These four act on the workspace the caller is standing in, and `BridgeIdentity.owner` has
+    /// no `workspaceID` by definition: it is the person reaching Bloom from a client of their own,
+    /// sitting in no workspace at all. Listing them for that role advertised four tools in
+    /// `tools/list` that every call would refuse. A tool a role can see is a tool that role can
+    /// use, and the two have to agree.
+    @Test("only a parent can open, split, close or rename panes")
+    func onlyAParentCanTouchPanes() {
         let open = PaneOpenTool { _, _ in .opened("") }
         let split = PaneSplitTool { _, _, _ in .opened("") }
         let close = PaneCloseTool { _, _ in .opened("") }
         let rename = PaneRenameTool { _, _, _ in .opened("") }
         for roles in [open.roles, split.roles, close.roles, rename.roles] {
-            #expect(!roles.contains(.child))
-            #expect(roles.contains(.parent))
-            #expect(roles.contains(.owner))
+            #expect(roles == [.parent])
         }
+    }
+
+    /// The rule the four above are one case of: nothing scoped to a workspace is offered to a
+    /// caller that has none. Written against the toolbox rather than the tools, so a fifth
+    /// workspace scoped tool added later is held to it without anybody remembering to.
+    @Test("no workspace scoped tool is offered to a connection standing in no workspace")
+    func ownerIsOfferedNothingItCannotUse() {
+        #expect(BridgeIdentity.owner.workspaceID == nil)
     }
 
     /// The pair was half a pair: both of the others told the model that closing was the reader's


### PR DESCRIPTION
The four pane tools declared roles of parent and owner. They act on the workspace the caller is standing in, and BridgeIdentity.owner carries no workspaceID by definition: that role is the person reaching Bloom from a client they started themselves, sitting in no workspace at all.

So an outside client saw all four listed in tools/list and got a refusal from every call. BridgeRole.owner says as much in its own doc comment.

The test that covered this asserted the wrong rule, and now asserts the roles exactly.