### PR TITLE
Fix what the documents say about running Codex, and write the bridge down

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,10 @@ worktree on disk, which is why so much of what follows is about not destroying o
 Longer documents, pointed at rather than repeated here: `README.md` for what the app is,
 `RELEASING.md` for signing, notarising and the appcast, `docs/CODEX.md` for the Codex app-server
 protocol as measured, `docs/PROTOCOL.md` for Claude Code's stream-json,
-`docs/AGENTS-INTEGRATION.md` for how the four CLIs are detected, `docs/PLAN.md` for what is next,
-`docs/start-from.html` for what the create sheet's three sources each do, which is a page to open in a
-browser rather than to read here.
+`docs/AGENTS-INTEGRATION.md` for how the four CLIs are detected, `docs/BRIDGE.md` for the MCP
+bridge an agent calls back in through and which callers may call what, `docs/PLAN.md` for what was
+built and in what order, `docs/start-from.html` for the design note the create sheet's source picker
+was drawn from, which is a page to open in a browser rather than to read here.
 
 ## Three targets, and the line between them
 
@@ -44,6 +45,8 @@ Everything real is a script in `Tools/`; the `Makefile` is the index.
     make master     install ~/Applications/Bloom.app  (see the guard below)
     make dev        install ~/Applications/Bloom Dev.app
     make dev-db     copy the real database into the dev copy
+    make release    sign, notarise and staple a zip and a disk image into dist/
+    make dmg        wrap the newest built .app in the beach disk image
 
 Anything that takes an argument is run directly: `./Tools/test-core.sh DiffParser`,
 `./Tools/master.sh v0.3.0`, `./Tools/dev-build.sh --no-launch`.
@@ -51,7 +54,8 @@ Anything that takes an argument is run directly: `./Tools/test-core.sh DiffParse
 `./Tools/test-core.sh` mirrors the core sources into a throwaway package with no app target, so one
 broken view cannot stop the core suite. Its head documents the environment it reads: `BLOOM_TEST_ID`
 for a stable work and build directory, `BLOOM_TEST_RUNS` to run the suite repeatedly and shake out
-flakes, `BLOOM_LOCAL_AGENTS=1` and `BLOOM_LOCAL_SETTINGS=1` to assert against this machine,
+flakes, `BLOOM_LOCAL_AGENTS=1`, `BLOOM_LOCAL_SETTINGS=1` and `BLOOM_LOCAL_SKILLS=1` to assert
+against this machine, with `BLOOM_LOCAL_PROJECT` naming the checkout the last of those reads,
 `BLOOM_LIVE=1` to drive the real `claude` binary (**this costs money**), and
 `BLOOM_TEST_SWIFT_ARGS` for flags like `--sanitize=thread`.
 
@@ -103,15 +107,16 @@ is that bug written down: a write changes the columns it names and no others. Ad
 ## Views
 
 A type conforming to `View` does not run a subprocess. `Shell` and `Git` are reached from a store,
-a model or a helper type beside the view (`FileRevert`, `FileIndex`, `TerminalPersistence`,
-`WorkspaceModel`), never from a `body` or a button action. `make lint` holds this one too, by
-looking for `await Git.` and `await Shell.` under `Sources/Bloom/Views/`: the subprocess calls are
-all async and the pure helpers on the same types are not, so the test costs no exception list of
-its own. The three helper types above are named in the allow-list because they are what a view
-calls **instead** of reaching for a process itself. `CreateWorkspaceSheet` was the last exception,
-calling `Git.branches` from its own `.task`; that loading and both branch decisions it fed are
-`WorkspaceStartContext` in the core now, tested, so the sheet's entry came off and the allow-list
-in `Tools/house-rules.sh` is back to the three helper types it was meant to hold.
+a model or a helper type beside the view (`FileRevert`, `FileIndex`, `TerminalPersistence`, or
+`WorkspaceModel` over in `State/`), never from a `body` or a button action. `make lint` holds this
+one too, by looking for `await Git.` and `await Shell.` under `Sources/Bloom/Views/`: the subprocess
+calls are all async and the pure helpers on the same types are not, so the test costs no exception
+list of its own. The three of those that live under `Views/` are named in the allow-list because
+they are what a view calls **instead** of reaching for a process itself; `WorkspaceModel` is outside
+that path, so the rule never sees it and needs no entry. `CreateWorkspaceSheet` was the last
+exception, calling `Git.branches` from its own `.task`; that loading and both branch decisions it
+fed are `WorkspaceStartContext` in the core now, tested, so the sheet's entry came off and the
+allow-list in `Tools/house-rules.sh` is back to the three helper types it was meant to hold.
 
 ## Where a file goes
 
@@ -142,10 +147,16 @@ subjects so that "this is a view's decision, moved" stays visible.
 
 `Sources/Bloom` is grouped the same way, by **pane rather than by kind**. `Views/` holds one
 directory per region of the window (`Sidebar`, `Center`, `Inspector`, `Home`, `Transcript`,
-`Terminal`, `Chrome`), and the two that outgrew a single directory are split by what they are for
-rather than by what they are: `Center/Composer`, `Center/Panes`, `Center/Attachments`,
-`Center/Browser`; `Chrome/Window`, `Chrome/Settings`, `Chrome/MenuBar`, `Chrome/App`,
-`Chrome/Feedback`, `Chrome/Notices`.
+`Terminal`, `Chrome`, `Tabs`) and one per thing that gets a window or a sheet of its own
+(`Archive`, `Code`, `Markdown`, `Oceans`, `OpenIn`, `RepoSettings`), and the two that outgrew a
+single directory are split by what they are for rather than by what they are: `Center/Composer`,
+`Center/Panes`, `Center/Attachments`, `Center/Browser`; `Chrome/Window`, `Chrome/Settings`,
+`Chrome/MenuBar`, `Chrome/App`, `Chrome/Feedback`, `Chrome/Notices`.
+
+Four directories sit beside `Views/` and are not panes, because none of them is drawn in one
+place. `Design/` is the theme and the snapshot galleries, `State/` is `AppModel` with its
+extensions and the two models under it, `Intents/` is App Intents, Shortcuts and the Services menu,
+and `System/` is the app target's half of talking to this Mac.
 
 A directory with one file in it is not a subject. Leave it at the folder's root and give it one
 when a second arrives. `Tools/house-rules.sh` names about twenty of these paths in its allow-lists,
@@ -184,10 +195,11 @@ rather than a longer one.
 ## Comments
 
 Comments say **why**, never what, and the good ones name the bug that forced the design. Read the
-head of `Tools/build.sh`, `Store`, or `WindowProxyIcon` for the register: a paragraph that explains
-what was tried, what broke, and what the measurement was. A comment restating the line under it is
-noise; a comment saying "not `.hiddenTitleBar`, because that left the traffic lights floating"
-survives the next person who thinks they have a tidier idea.
+head of `Tools/build.sh`, `Store`, or `WindowChrome` for the register: a paragraph that explains
+what was tried, what broke, and what the measurement was, which in `WindowChrome` is the hex value
+the title bar came out at. A comment restating the line under it is noise; the note in `BloomApp`
+saying "not `.hiddenTitleBar`, because that left the traffic lights floating" survives the next
+person who thinks they have a tidier idea.
 
 ## Prose
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ frameworks.
 
 - macOS 26 or later
 - Xcode 26 or a Swift 6 toolchain
-- `claude` on your PATH (Claude Code)
+- `claude` (Claude Code) or `codex` on your PATH. Either can drive a chat, and a chat picks one,
+  so a single worktree can hold chats on both
 - `git`, and `gh` if you want the pull request features
 
 ## Building
@@ -84,9 +85,10 @@ meanings, so a script written for Conductor runs unchanged:
 
 Supported settings keys: `scripts.setup`, `scripts.archive`, `scripts.run` (a string, or a table
 of named scripts with a `command`), `scripts.run_mode`, `files_to_copy`, `git.branch_prefix`,
-`git.branch_prefix_type`, `git.delete_branch_on_archive`, `models.default`. A key ending in
-`_file` (`scripts.setup_file`, `scripts.archive_file`) names an executable file relative to the
-repository instead of an inline command.
+`git.branch_prefix_type`, `git.delete_branch_on_archive`, `models.default` and
+`models.claude.default_thinking_level`. A key ending in `_file` (`scripts.setup_file`,
+`scripts.archive_file`) names an executable file relative to the repository instead of an inline
+command.
 
 ### A database per worktree
 
@@ -152,25 +154,30 @@ Same shape as Conductor's, so existing scripts keep working.
 ## How it is put together
 
 ```
-Sources/BloomCore/     No SwiftUI. Everything testable lives here.
-  Shell.swift            Every subprocess goes through here
-  StreamingProcess.swift Long-lived process with a live stdout and an open stdin
-  SQLite.swift           Thin wrapper over the system sqlite3
-  Store.swift            One actor, all persistence
-  Git.swift              Worktrees, branches, diffs, branch naming
-  GitHub.swift           gh wrapper for pull requests and checks
-  TOML.swift             Enough TOML to read a settings file
-  Settings.swift         Layering those files into RepoSettings
-  WorkspaceManager.swift Creating, setting up and archiving a workspace
-  AgentEvent.swift       Decoding the claude stream-json protocol
-  AgentRunner.swift      Supervising one claude process per session
-  DiffParser.swift       Unified diffs into something renderable
-  SyntaxHighlighter.swift Per-line lexers, no dependency, no regex
+Sources/BloomCore/     No SwiftUI. Everything testable lives here, grouped by subject.
+  Agent/                 Running one: the runners, the events, the quotas, the turns
+  Agent/Codex/           The Codex app-server protocol, which is its own vocabulary
+  Bridge/                The unix socket and the MCP tools an agent calls back in with
+  Git/                   Worktrees, branches, diffs, branch naming, diff parsing
+  GitHub/                gh, pull requests, checks
+  Workspace/             Creating, starting, archiving, restoring, a project's settings
+  Transcript/            What a turn is made of: rows, tools, subagents, attachments
+  Persistence/           Store, SQLite, the settings file, the old app's leftovers
+  Model/                 The row types, the typed ids, the lifecycle rules over them
+  Presentation/          Decisions the window needs that hold no UI framework
+  Ocean/                 The chart
+  System/                This Mac: the shell, notifications, updates, other applications
+  Support/               Small things with no subject of their own
 
 Sources/Bloom/         SwiftUI.
-  Design/Theme.swift     Every colour, font and metric, defined once
+  Design/                Every colour, font and metric, defined once, and the galleries
   State/                 AppModel, WorkspaceModel, TranscriptModel
-  Views/                 Sidebar, Center, Transcript, Inspector, Terminal, Markdown, Chrome
+  Intents/               App Intents, Shortcuts and the Services menu
+  System/                The app target's half of talking to this Mac
+  Views/                 One directory per region of the window
+
+Sources/bloom-bridge/  The MCP stdio shim an agent CLI launches. Three lines; everything
+                       worth testing is BridgeShim, in the core, where the suite reaches it.
 ```
 
 ## The documents under `docs/`
@@ -184,7 +191,10 @@ answer to "has this already been worked out" rather than a tour of the code.
 - `docs/CODEX.md` is the same for Codex's JSON-RPC app-server, plus the decisions that shaped
   the Codex backend and the work still outstanding on it.
 - `docs/AGENTS-INTEGRATION.md` is what the four agent CLIs actually put on disk, read off a real
-  machine, and the rule that none of it may be rendered.
+  machine, the rule that none of it may be rendered, and what `claude mcp add` accepts when
+  registering Bloom in a client you started yourself.
+- `docs/BRIDGE.md` is the MCP bridge the other way round: what an agent can ask Bloom to do, which
+  callers may ask for what, and which of those questions Bloom answers for itself.
 - `docs/PLAN.md` is the build order this was written to, kept for the bug reports in it: what
   broke, why, and what now stops it.
 

--- a/Sources/Bloom/Views/Chrome/Settings/AgentsSettingsView.swift
+++ b/Sources/Bloom/Views/Chrome/Settings/AgentsSettingsView.swift
@@ -248,14 +248,16 @@ struct AgentsSettingsView: View {
     }
 
     /// Detecting a CLI and being able to drive a workspace with it are two different things, and
-    /// only Claude Code can do the second one today. Saying so here is cheaper than letting
-    /// someone find out when a workspace refuses to start.
+    /// only the ones with a runner behind them can do the second. Saying so here is cheaper than
+    /// letting someone find out when a workspace refuses to start. It reads the answer off
+    /// `AgentKind.canRunWorkspaces` rather than naming a backend, so a CLI that grows a runner
+    /// stops showing this note without anybody having to remember the sentence exists.
     @ViewBuilder
     private var capabilitySection: some View {
         if !selection.canRunWorkspaces {
             Section {
                 Label {
-                    Text("Bloom can detect and configure \(selection.label), but cannot run a workspace with it yet. Workspaces run on Claude Code.")
+                    Text("Bloom can detect and configure \(selection.label), but cannot run a workspace with it yet. Workspaces run on \(AgentKind.runnableSentence).")
                         .font(Typo.label)
                         .foregroundStyle(Palette.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)

--- a/Sources/Bloom/Views/RepoSettings/RepoSettingsTitleBar.swift
+++ b/Sources/Bloom/Views/RepoSettings/RepoSettingsTitleBar.swift
@@ -30,7 +30,7 @@ import BloomCore
 /// AppKit rather than SwiftUI because SwiftUI models none of the three things this needs.
 /// `windowToolbarStyle` has no case for the preferences style, nothing in SwiftUI un-hides a title
 /// the framework decided to hide, and there is no scene modifier for tabbing at all.
-/// `WindowProxyIcon` reaches for the main window's title bar the same way and for the same reason.
+/// `WindowChrome` reaches for the main window's title bar the same way and for the same reason.
 struct RepoSettingsTitleBar: ViewModifier {
     let repo: Repo
 

--- a/Sources/BloomCore/Bridge/BridgeToolbox.swift
+++ b/Sources/BloomCore/Bridge/BridgeToolbox.swift
@@ -2,11 +2,9 @@ import Foundation
 
 /// Every tool the bridge serves, and the only place a new one is added.
 ///
-/// A list of handlers rather than a switch, because the phases after this one add five more tools
-/// (`workspace_spawn`, `workspace_send`, `workspace_status`, `workspace_read`,
-/// `workspace_report`, `workspace_archive`) and a switch would put each of them in three places:
-/// the listing, the dispatch and the role gate. Here a tool is one type, and it carries its own
-/// gate.
+/// A list of handlers rather than a switch. There are twelve of them now, and a switch would put
+/// each in three places: the listing, the dispatch and the role gate. Here a tool is one type, and
+/// it carries its own gate. See `docs/BRIDGE.md` for the whole surface and who may reach it.
 public struct BridgeToolbox: Sendable {
     public let handlers: [any BridgeToolHandling]
 
@@ -14,9 +12,12 @@ public struct BridgeToolbox: Sendable {
         self.handlers = handlers
     }
 
-    /// What phase one ships. `whoami` alone: it needs no runner, no writes and no parentage, so it
-    /// proves the transport and the identity mapping without any of the machinery the tools that
-    /// follow will need.
+    /// What a `BridgeServer` built without the app serves: everything that needs no seam back
+    /// into the app, which is every test that did not ask for more.
+    ///
+    /// `whoami` came first and came alone, because it needs no runner, no writes and no parentage,
+    /// so it proved the transport and the identity mapping before any of the machinery the rest
+    /// need existed.
     ///
     /// One thing the live run measured that the tools after this one have to answer: **a bridge
     /// call raises a permission question like any other tool call.** On claude 2.1.238, under
@@ -25,13 +26,16 @@ public struct BridgeToolbox: Sendable {
     /// MCP rather than a CLI the agent shells out to was partly that a shell command goes through
     /// the permission machinery; being an MCP tool does not exempt it. A child that has to file
     /// `workspace_report` unattended therefore needs an answer of its own, either a grant Bloom
-    /// makes for its own tools or an allow rule in the child's settings. See `LiveBridgeTests`.
-    /// Everything that needs no seam back into the app. `workspace_start` and `workspace_merge`
-    /// are the exceptions and are added by `AppModel`, because starting a workspace has to reach
-    /// the main-actor graph that runs one and asking one to merge has to reach the same path the
-    /// Merge button takes; see `WorkspaceStarting` and `WorkspaceMergeRequesting`. So this is what
-    /// a `BridgeServer` built without the app serves, which is every test that did not ask for
-    /// more.
+    /// makes for its own tools or an allow rule in the child's settings. `BridgeToolApproval` is
+    /// where that was answered, and its head says which tools Bloom answers for and why the rest
+    /// are not on the list. See `LiveBridgeTests`.
+    ///
+    /// `workspace_start`, `workspace_merge` and the four pane tools are the exceptions and are
+    /// added by `AppModel.bridgeToolbox()`, because starting a workspace has to reach the
+    /// main-actor graph that runs one, asking one to merge has to reach the same path the Merge
+    /// button takes, and a pane is a thing the window owns; see `WorkspaceStarting`,
+    /// `WorkspaceMergeRequesting`, `PaneOpening`, `PaneSplitting`, `PaneClosing` and
+    /// `PaneRenaming`.
     public static let standard = BridgeToolbox(handlers: [
         WhoamiTool(),
         ProjectListTool(),

--- a/Sources/BloomCore/Model/Models.swift
+++ b/Sources/BloomCore/Model/Models.swift
@@ -654,4 +654,18 @@ public enum AgentKind: String, Sendable, Codable, CaseIterable, Identifiable {
     /// Derived rather than listed, so an agent that grows a runner joins this by answering
     /// `canRunWorkspaces` and nothing else has to be remembered.
     public static var runnable: [AgentKind] { allCases.filter(\.canRunWorkspaces) }
+
+    /// The runnable ones named in a sentence, for prose that has to list them.
+    ///
+    /// Derived for the reason `runnable` is, and it exists because the literal that used to do
+    /// this job outlived the fact it stated. The Agents settings screen said "Workspaces run on
+    /// Claude Code" for the whole of the work that made Codex a backend, and went on saying it
+    /// afterwards, because nothing about giving a CLI a runner touches a string in a view. A
+    /// backend that grows one joins this sentence by answering `canRunWorkspaces`.
+    public static var runnableSentence: String {
+        let names = runnable.map(\.label)
+        guard let last = names.last else { return "no agent Bloom can run" }
+        guard names.count > 1 else { return last }
+        return names.dropLast().joined(separator: ", ") + " and " + last
+    }
 }

--- a/Tests/BloomCoreTests/AgentCatalogTests.swift
+++ b/Tests/BloomCoreTests/AgentCatalogTests.swift
@@ -80,6 +80,9 @@ struct AgentCatalogTests {
         #expect(AgentKind.allCases.map(\.executableName) == ["claude", "codex", "cursor-agent", "opencode"])
         // Two backends now, and the two that are not on this list are the ones with no runner.
         #expect(AgentKind.allCases.filter(\.canRunWorkspaces) == [.claudeCode, .codex])
+        // The sentence the settings screen prints, derived so it cannot say Claude Code alone
+        // again once a second backend exists.
+        #expect(AgentKind.runnableSentence == "Claude Code and Codex")
         #expect(AgentKind.claudeCode.loginCommand == "claude /login")
         #expect(AgentKind.codex.loginCommand == "codex login")
         #expect(AgentKind.codex.configPath.hasSuffix("/.codex/config.toml"))

--- a/Tools/house-rules.sh
+++ b/Tools/house-rules.sh
@@ -33,7 +33,7 @@
 # this codebase either stays out of the list or is named in an exception below.
 #
 # **Every search here passes `--untracked`, and that is load bearing.** Six of
-# these seven rules did not, and a plain `git grep` sees only what is tracked, so
+# these eight rules did not, and a plain `git grep` sees only what is tracked, so
 # a brand new file was invisible to all six until somebody staged it. One decoy
 # file inside `Sources/BloomCore` carrying a violation of each raised one finding
 # untracked and six the moment it was added, on identical bytes. That is worst
@@ -255,10 +255,11 @@ done
 echo "==> an id has a type"
 # Every id in Bloom used to be a bare `String`, so `store.update(workspaceID:
 # session.id)` compiled, ran, and updated no row at all. There is no crash and
-# no log line for that, just a workspace that did not archive. `RepoID`,
-# `WorkspaceID`, `SessionID`, `TerminalTabID`, `ReviewCommentID` and
-# `PermissionGrantID` are what stopped it, and the compiler holds the line
-# everywhere they are used.
+# no log line for that, just a workspace that did not archive. The typed ids in
+# Sources/BloomCore/Model/Identifier.swift are what stopped it, eight of them as
+# this is written, and the compiler holds the line everywhere they are used.
+# They are not listed here on purpose: a list that reads as complete and is not
+# is what makes the next reader think their new id is already covered.
 #
 # What the compiler cannot object to is a NEW property declared `var
 # somethingID: String`, because a String is a perfectly good String. That one

--- a/Tools/test-core.sh
+++ b/Tools/test-core.sh
@@ -16,6 +16,10 @@
 #   BLOOM_TEST_RUNS     how many times to run the suite (default 1)
 #   BLOOM_LOCAL_AGENTS  =1 asserts which agent CLIs exist on this machine
 #   BLOOM_LOCAL_SETTINGS=1 parses the .conductor/settings.toml files on this machine
+#   BLOOM_LOCAL_SKILLS  =1 reads the commands, skills and plugins installed on this machine
+#   BLOOM_LOCAL_PROJECT names the checkout BLOOM_LOCAL_SKILLS reads project commands out of. The
+#                       suite runs from the mirror, so its own working directory is the wrong
+#                       answer and there is nothing to default to
 #   BLOOM_LIVE          =1 drives the real `claude` binary. Costs money.
 #   BLOOM_TEST_SWIFT_ARGS  extra flags for `swift test`, split on spaces. For the runs that are
 #                       not the ordinary one: the nightly workflow passes --sanitize=thread and

--- a/docs/AGENTS-INTEGRATION.md
+++ b/docs/AGENTS-INTEGRATION.md
@@ -21,8 +21,10 @@ log, put on the pasteboard, or included in an error message. When a field is mis
 | OpenCode | `opencode` | `opencode --version` | not installed here |
 
 Resolve the executable through `Shell.which(_:)`, which already augments PATH for a GUI launch.
-Two of the four are not installed on this machine, so "not installed" is a first-class state and
-has to look deliberate, not broken.
+The observed output is the shape to parse and not a version to match: both installed CLIs move
+weekly, and the two figures above were already a release behind a fortnight later. Two of the four
+are not installed on this machine, so "not installed" is a first-class state and has to look
+deliberate, not broken.
 
 ## Claude Code
 
@@ -69,10 +71,12 @@ config directory is `~/.cursor` (exists here, holds `hooks.json`). OpenCode's is
 
 ## What Bloom can actually run
 
-Only Claude Code. The stream-json protocol in `PROTOCOL.md` is the Claude Code one, and
-`AgentRunner` speaks it. Codex, Cursor and OpenCode are detected and configurable, and a
-workspace cannot yet be driven by them. The UI must say so plainly rather than implying a
-connected CLI is a usable backend.
+Claude Code and Codex. The stream-json protocol in `PROTOCOL.md` is Claude Code's and
+`AgentRunner` speaks it; the JSON-RPC app-server protocol in `CODEX.md` is Codex's and
+`CodexRunner` speaks it. Both answer to `SessionRunner`, and `AgentKind.canRunWorkspaces` is the
+one place that decides which backends a chat can be started on. Cursor and OpenCode are detected
+and configurable and neither has a runner, so neither is offered anywhere a chat is started. The
+UI must say so plainly rather than implying a connected CLI is a usable backend.
 
 ## Registering Bloom in a client the owner runs themselves
 

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -1,0 +1,274 @@
+# The Bloom bridge
+
+What an agent can ask Bloom to do, and which callers may ask for what. The other direction from
+`AGENTS-INTEGRATION.md`, which is about Bloom reading what the CLIs put on disk; this is the CLIs
+calling back in.
+
+Everything here is read off `Sources/BloomCore/Bridge/`, which is where all of it lives. The heads
+of the files named below carry the reasoning at length, and this is the map over them.
+
+Related: `AGENTS-INTEGRATION.md` (registering Bloom in a client the owner runs themselves),
+`PROTOCOL.md` (Claude Code's stream-json), `CODEX.md` (Codex's app-server).
+
+---
+
+## 1. Why there is a shim at all
+
+Bloom serves MCP over a unix domain socket. Neither CLI can speak to one: Claude Code registers an
+MCP server as a stdio command or an HTTP URL, Codex as a stdio `command` or a streamable HTTP
+`--url`, and that is the whole list on both. HTTP on localhost was refused for a different reason,
+which is that it would be one port for the whole machine, reachable by every local process, and
+impossible to share between Bloom and Bloom Dev, a pair that is a documented permanent arrangement
+rather than a test setup.
+
+So the registered transport is stdio and the socket sits behind it. `bloom-bridge` is the stdio
+process the CLI launches, shipped inside Bloom's own bundle, and it is a line relay and
+deliberately not an MCP implementation:
+
+```
+agent CLI  ──stdio──▶  bloom-bridge  ──unix socket──▶  Bloom
+```
+
+**Every behaviour that lives in the shim is a behaviour that can skew against the app.** Sparkle
+replaces the bundle underneath a running Bloom and the CLI launches whatever binary the path in its
+config names, so a shim that knew anything about tools could be a version behind the app it is
+talking to. A relay changes almost never; the tool surface changes every time a tool is added. So
+`initialize`, `tools/list` and `tools/call` are all answered in the app, in `BridgeDispatch`, where
+the store is reachable.
+
+The shim sends one hello line before any MCP byte crosses, carrying a protocol version, the token
+and the claimed role, and Bloom answers with one welcome line that accepts or refuses. The version
+is compared for **equality and never as a range**, because the skew to design for is a new shim
+meeting an older running Bloom after Sparkle swapped the bundle mid-session. Both directions have
+to fail with a sentence rather than hang: a hung tool call is a hung turn, and a model cannot tell
+one from the other. See `BridgeProtocol` and `BridgeShim`.
+
+The shim exits with distinct statuses because the CLI prints them, and "exited 1" says nothing that
+"Bloom is not running" does not say better: `64` nothing to connect to, `69` could not reach Bloom
+or Bloom went away mid-answer, `70` refused at the handshake.
+
+## 2. Who is calling, and how Bloom knows
+
+Three roles, in `BridgeIdentity.swift`.
+
+| Role | What it is | What it is scoped to |
+| --- | --- | --- |
+| `parent` | A workspace the owner created | Its own worktree, implicitly |
+| `child` | A workspace an agent created | Nothing. It reports and that is all |
+| `owner` | The owner, through a client of their own, sitting in no workspace | Nothing implicitly. Everything is named out loud |
+
+**The role is read from the database at mint time, never from the shim's environment.** The
+environment carries a claimed role, and it is carried for diagnostics only: anything running as the
+user can launch the shim by hand with any role it likes, so a claim that disagrees with the
+database is worth a log line and nothing else. A workspace with a parent is a child, and that is
+the whole test. There is no depth counter, because the limit on nesting is one, so "has a parent"
+**is** the depth and a number kept beside it is a number that can drift.
+
+`owner` is the odd one. The other two are derived from a workspace row and this one is derived from
+nothing: no session, no worktree, no project. **It is not a child**, because a child is penned in
+for being an agent that another agent asked for and nobody weighed. **It is not a parent either**,
+because every tool a parent has is implicitly scoped to the worktree it is sitting in and this
+caller is sitting in none.
+
+Identity is minted by Bloom and handed to the CLI through the shim's environment, never claimed by
+the agent. That is what lets every tool be implicitly scoped: **no tool takes a workspace id as a
+parameter**, so there is nothing for a model to forge, mistype or hold on to after it has gone
+stale.
+
+The token is **not a secret and must not be commented as one**. Any process running as the user can
+read `ps`, the mode 0600 config file and the socket itself, and an agent has the user's whole home
+directory anyway. What actually holds, whoever connects, is server side: parentage read from the
+database, git's own safety reports, and counts. Session tokens are minted per launch and held in
+memory only, so a quit retires them; the owner's standalone token is the one exception and
+`BridgeOwnerToken` sets out at length why a coupling that breaks every time the app restarts is not
+a coupling.
+
+The socket path is derived from the database path through the same fingerprint the tmux socket name
+uses, so Bloom and Bloom Dev can never land on one. The landmine there is `sockaddr_un.sun_path`,
+104 bytes on macOS, which **truncates in silence**: two instances whose paths agree for the first
+103 bytes quietly share one socket, which is the exact failure the fingerprint exists to prevent.
+`BridgeSocketPath` asserts the length rather than trusting that it fits.
+
+## 3. The tools
+
+Twelve, each a type of its own in `Sources/BloomCore/Bridge/`, each carrying its own role gate. A
+list of handlers rather than a switch, because a switch would put every tool in three places: the
+listing, the dispatch and the gate.
+
+| Tool | What it does | parent | child | owner |
+| --- | --- | :---: | :---: | :---: |
+| `whoami` | What this connection is: the workspace and its branch, the worktree path, the project, and whether the workspace was created by the owner or by another agent. From the owner's own client, which copy of Bloom was reached and how much it is holding | ✓ | ✓ | ✓ |
+| `project_list` | Every project in the sidebar: name, path, default branch, live workspace count, whether it is still where Bloom recorded it, whether it is hidden | | | ✓ |
+| `project_add` | Register a git repository that **already exists** as a project | | | ✓ |
+| `project_hide` | Take a project out of the sidebar. A view preference and nothing more | | | ✓ |
+| `project_unhide` | Put it back, in the place it already had | | | ✓ |
+| `workspace_list` | Every workspace, its state, its worktree path, its chats and their cost, what an agent is stopped on, what is queued and why | | | ✓ |
+| `workspace_start` | Cut a worktree on a new branch and put an agent in it with a task | ✓ | | ✓ |
+| `workspace_merge` | Ask a workspace's own agent to merge its pull request | | | ✓ |
+| `pane_open` | Open a chat, a terminal or a browser in a new tab of the caller's own workspace | ✓ | | ✓ |
+| `pane_split` | Put one beside what is on screen rather than behind it | ✓ | | ✓ |
+| `pane_close` | Take one back off the screen | ✓ | | ✓ |
+| `pane_rename` | Give a tab a name the reader can find it by | ✓ | | ✓ |
+
+**A child sees `whoami` and nothing else.** That is not an oversight and not a cost saving: a child
+is a workspace an agent asked for, which nobody weighed, so it reports and that is all.
+
+The gate is enforced twice on purpose. `tools/list` hides what the caller may not use, so a child
+never sees a tool to be tempted by, and `tools/call` refuses it again, so a process speaking raw
+MCP at the socket with a child's token gets nowhere either. A tool that exists but is refused
+answers exactly as an unknown name does, so the refusal cannot be read as a hint that something is
+there.
+
+A refusal is a result with `isError` set and never a JSON-RPC error frame. A JSON-RPC error is a
+transport failure the CLI may retry or surface as a broken server; an errored result is text the
+model reads and can act on. "You are not allowed to do that" is something to tell the model, not
+something to tell the transport.
+
+### The six that need the app, and the six that do not
+
+`BridgeToolbox.standard` holds the six that reach nothing but the store, and it is what a
+`BridgeServer` built without the app serves, which is every test that did not ask for more.
+`AppModel.bridgeToolbox()` adds the other six, because starting a workspace has to reach the
+main-actor graph that runs one, asking for a merge has to reach the same path the Merge button
+takes, and a pane is a thing the window owns. Each of those crosses the line as an injected closure
+(`WorkspaceStarting`, `WorkspaceMergeRequesting`, `PaneOpening`, `PaneSplitting`, `PaneClosing`,
+`PaneRenaming`), so a pane an agent asks for is the pane the menu makes, unchanged and not copied.
+
+`BridgeServer` **never constructs an `AgentRunner`, and nothing added to it ever may.** One runner
+per session is held in main-actor UI object identity, and a handler that built its own would put a
+second CLI process on the same session row and the same worktree, both writing `agent_session_id`
+and both editing the same files. It holds no database connection of its own either: `Store` is an
+actor whose `update` methods re-read inside the actor, so a handler on a background task calls them
+directly, and a second `SQLiteDatabase` on the file is the cross-connection sequence race that
+`UNIQUE(session_id, seq)` exists to survive rather than to invite.
+
+## 4. What an agent cannot reach through it
+
+Nothing here reads or writes a file, runs a command, or touches a repository's contents. The
+worktree path is handed over precisely so the agent uses **its own** tools on an ordinary git
+checkout, which `workspace_list`'s description says out loud.
+
+Nothing archives. `workspace_archive` is not one of the twelve: it removes a worktree and can
+remove a branch with it, and the whole reason Bloom asks before archiving by hand is that the
+answer is sometimes no.
+
+Nothing merges. `workspace_merge` **does not merge**: it composes the request Bloom's own Merge
+button composes and sends it into that workspace's chat as an ordinary message, so the agent runs
+`gh pr merge` there, in front of the owner, under whatever permission mode they set. Its
+description tells the caller not to run `gh pr merge` itself when the tool refuses.
+
+`project_add` registers and does not create. The failure it is written against is not a wrong path,
+it is a helpful agent: told "add my projects", handed a folder git does not recognise and given a
+bare "not a git repository", a model reaches for `git init` and makes a repository where nobody
+asked for one, with whatever was lying in the folder as its first commit. The refusal is written to
+head that off in words rather than to hope.
+
+A parent cannot name a project, because its own is the only one it may act in, and `project` is
+refused rather than ignored if it names one. The owner's client must name one, because nothing else
+says which.
+
+### How many a caller may start
+
+`WorkspaceStartAllowance` holds all three answers in one switch, and they are one rule with one
+variable in it, which is **how much a workspace costs the caller to ask for**.
+
+| Caller | Brake |
+| --- | --- |
+| The Create sheet, a `bloom://` link, the Services menu, a Shortcut | None. Each is a deliberate gesture per workspace |
+| A parent agent | Eight running children at once |
+| The owner's own client | Six starts in fifteen minutes |
+
+The two brakes are shaped differently on purpose. A parent's children are work it is waiting on, so
+what matters is how many are alive at once and a ceiling is right. The owner is a person whose
+workspaces accumulate over weeks, so a ceiling would refuse the eleventh workspace of a busy
+fortnight, which is ordinary use; what is not ordinary is the rate. Neither number is a safety
+limit. Six worktrees and six agents is already real money, and the point of both is that somebody
+notices at six or at eight instead of at forty.
+
+Both are counted from the database rather than kept in memory, so they survive a restart and two
+calls racing cannot both read the same stale number.
+
+Every start is deduplicated by a digest of the call, because a model retries and a retried spawn
+cuts a second worktree. A repeat answers with the workspace that already exists and a note saying
+so, rather than with a second one.
+
+## 5. Which questions Bloom answers for itself
+
+**A bridge call raises a permission question like any other tool call.** Measured: on claude
+2.1.238 under `acceptEdits`, calling `whoami` produced an ask for
+`mcp__bloom-workspace-bridge__whoami` and the turn stopped until it was answered. Being an MCP tool
+does not exempt a call from the permission machinery, which was half the reason the bridge is MCP
+rather than a CLI the agent shells out to. The first `workspace_start` in a project stopped a
+parent's turn on an ask, and with nobody watching that workspace the turn sat waiting and died
+`cancelled` when the app quit, having started nothing. **A feature whose first use hangs unless
+somebody happens to be looking is a feature that does not work.**
+
+So `BridgeToolApproval` names the tools Bloom answers for itself:
+
+| Self-approved | Not |
+| --- | --- |
+| `whoami`, `workspace_start`, `pane_open`, `pane_split`, `pane_close`, `pane_rename` | everything else |
+
+It is a list rather than "anything with our prefix", so a tool added later is opted in by somebody
+thinking about it rather than by inheriting a decision made before it existed.
+
+Answering is not a shortcut round consent, because **Bloom is on both ends of this question**. It
+wrote the tool, it minted the token, it knows which workspace is asking, and it enforces every
+limit itself: the role gate hides `workspace_start` from a child, the handler refuses a caller that
+was itself agent-started, and eight is the ceiling. There is nothing for a person to weigh that
+Bloom has not already decided, and the ask carries no information a person could act on beyond "an
+agent would like to use Bloom". None of that is true of the tools the agent brings with it: `Bash`,
+`Write` and `Edit` reach outside anything Bloom knows about, and nothing here touches them.
+
+The four pane tools are on the list because each adds or changes something the reader can see and
+undo, in the workspace whose agent is asking and nowhere else. `pane_close` refuses the two cases
+that would cost anything: it will not empty the centre column, and it cannot close the review or
+the notes, which hold the reader's own work.
+
+The project tools are not on it, and that is deliberate rather than an omission: the list is for
+tools an agent must be able to call while nobody is watching, and those are called by the owner's
+own client, where the owner is by definition sitting there to answer.
+
+`workspace_merge` draws the line one step further out. It destroys nothing, it sends a turn. But
+what that turn leads to is a call to a server other people share, and unlike a worktree there is
+nothing on the far side to restore. **Bloom answering its own permission question there would be
+Bloom deciding to publish, which is the one decision it has never had.**
+
+A self-approved ask still leaves a settled row in the transcript, saying what happened and who let
+it through. "Allowed automatically" with no reason is the thing that makes people distrust an app's
+permission model.
+
+## 6. How each CLI is told the bridge exists
+
+Two completely different mechanisms, both verified against the installed binaries.
+
+**Claude Code** reads a JSON file named by `--mcp-config`, written mode 0600 in a 0700 directory,
+one per session, rewritten from scratch at every process start because the token in it is minted
+per launch. **A file, never the inline JSON string the same flag also accepts**, because argv is
+visible in `ps` and an agent runs `ps` through its own Bash tool as ordinary behaviour. Never
+`--strict-mcp-config` beside it: that flag shuts every other MCP configuration out, which is right
+for `WorkspaceNamer` and wrong for a chat, where the user's own servers have to survive. Measured
+on 2.1.238 by running a live turn, because `claude mcp list` rejects `--mcp-config` outright and
+nothing short of a turn exercises it: `system/init` listed the user's own servers alongside Bloom's,
+all connected, and the tool reached the model as `mcp__bloom-workspace-bridge__whoami`, hyphens
+carried through.
+
+**Codex** takes `-c mcp_servers.<name>.…` overrides carrying the same values inline. Bloom already
+runs one app-server process per chat, so a per-process override is a per-session registration, the
+same as Claude Code's per-start argv. Never `--strict-config` beside it: a different flag from
+Claude Code's, the same trap, and it makes Codex refuse to start on a user config holding anything
+the build does not recognise.
+
+The server name is `bloom-workspace-bridge`, and it is **a correctness requirement with a test
+behind it** rather than a convention. Codex `-c` overrides do not shadow a colliding
+`mcp_servers.<name>` entry, they deep-merge it leaf by leaf: against a config holding a user's own
+server called `bloom`, overriding `command` and `env` produced Bloom's binary launched with the
+user's `args` and the user's `env` key still present, and `codex mcp list` reported that chimera as
+one healthy server with no warning at all. There is no `-c` form that replaces a whole entry. So
+the only defence is a name nobody would type, and the failure it prevents does not look like a
+naming problem when it happens.
+
+The owner's own standalone registration is a third thing, under a **different** name derived per
+copy of the app, and `AGENTS-INTEGRATION.md` is where that half is written down: what
+`claude mcp add` accepts, why the scope is `user`, and why the name is neither `serverName` nor one
+constant for every copy of Bloom.

--- a/docs/CODEX.md
+++ b/docs/CODEX.md
@@ -27,7 +27,7 @@ uses `codex exec --json`.**
 
 app-server has all three, plus typed lifecycles, token usage, rate limits and thread status. It is
 also what Conductor drives. The reasoning is repeated in the doc comment at the top of
-`Sources/BloomCore/CodexProtocol.swift`, because `exec` will keep looking tempting.
+`Sources/BloomCore/Agent/Codex/CodexProtocol.swift`, because `exec` will keep looking tempting.
 
 ### The protocol describes itself
 
@@ -306,10 +306,12 @@ protocol means and survives an app restart mid-turn.
 
 ### Presenters
 
-`Sources/Bloom/Views/Transcript/ToolPresenter.swift` is 535 lines of Claude Code tool names
+`Sources/BloomCore/Agent/ToolPresenter.swift` is 563 lines of Claude Code tool names
 (`Read`, `Write`, `MultiEdit`, `Bash`, `Glob`, `Grep`, `Task`, `TodoWrite`, `WebFetch`, …) and it
-is the largest single UI cost in this work. **Do not add Codex cases to it.** Codex has no tool
-names at all; it has ten item types. The two vocabularies have nothing in common but the glyphs.
+is the largest single cost in this work. It sat under `Views/` when this was written and is in the
+core now, which is the reason the split below could be tested at all. **Do not add Codex cases to
+it.** Codex has no tool names at all; it has ten item types. The two vocabularies have nothing in
+common but the glyphs.
 
 Split it:
 
@@ -324,14 +326,13 @@ Split it:
   `agentKind`: a row knows what it is, and a transcript drawn from the database has the row before
   it has the session.
 
-Done, in `Views/Transcript/CodexItemPresenter.swift` and `TranscriptPresenter`. The remaining edit
-is one call site in `ToolRowView` and friends, held today: `ToolPresenter.present(` becomes
-`TranscriptPresenter.present(`. The rows that draw it are mostly reusable:
+Done, in `Views/Transcript/CodexItemPresenter.swift`, which also holds the `TranscriptPresenter`
+router that picks a presenter by reading the row's payload. Every call site goes through the
+router; the two `ToolPresenter.present` calls left inside `CodexItemPresenter` are its fallback to
+the Claude Code vocabulary and belong there. The rows that draw it are mostly reusable:
 `ToolRowView`, `ExpandableRow`, `DetailCodeBlock` and `ToolResultView` do not care where the text
 came from. `fileChange` is the nicest case, because its `changes[].diff` is already a unified diff
 and Bloom's `DiffParser` reads that shape.
-
-`Views/Transcript/` is held by another agent. Coordinate before touching it.
 
 ---
 
@@ -426,12 +427,12 @@ flag and Bloom infers it; here it is handed over.
 
 | Place | What it assumes | What to do |
 | --- | --- | --- |
-| `AgentKind.canRunWorkspaces` (`Models.swift:434`) | `self == .claudeCode` | Becomes `self == .claudeCode \|\| self == .codex` **last**, once a Codex chat actually works. It is the switch that makes the rest reachable |
+| `AgentKind.canRunWorkspaces` (`Model/Models.swift`) | Was `self == .claudeCode` | **Done.** It admits `.codex` too, and it was the last switch thrown, which is what made everything above reachable |
 | `SlashCommandIndex` | Documents in its own header that it is Claude Code's list and that a second backend gets its own index | Codex has `skills/list` as a real RPC, so its index is a call rather than a directory walk. A `CodexSkillIndex` beside it, chosen per chat |
 | `WorkspaceNamer` | Shells out to `claude` with Claude-only flags (`--json-schema`, `--tools ""`, `--safe-mode`) and gates on `Shell.which("claude")` | Leave it on Claude Code, and say so. A workspace name is not a chat, so it does not follow the chat's backend. It should fall back to the mechanical name when `claude` is absent, which it already does. Revisit only if a Codex-only machine turns out to be common |
-| `InstallPing.agentName(installed:)` (`InstallPing.swift:319`) | `AgentKind.allCases.first(where: \.canRunWorkspaces)`, i.e. exactly one runnable agent | Becomes a set. The wire name should report what is installed **and** runnable, not the first one. It reports no credential and must keep reporting none |
-| `ContextWindowUsage` (`Views/Center/ContextWindowUsage.swift`) | Reads the limit off `result.modelUsage.<model>.contextWindow` and the used figure off the last `assistant` event's usage | Codex hands both over directly on `thread/tokenUsage/updated`: `modelContextWindow` and the `total` breakdown. Simpler, not harder. Give it a second reader and keep the doc comment explaining why Claude needs two lines and Codex needs one |
-| `AgentsSettingsView.swift:256` | Shows a "cannot run workspaces" note for anything but Claude Code | Follows `canRunWorkspaces` already, so it corrects itself. Its account table for Codex is already written and verified |
+| `InstallPing.agentName(installed:)` (`System/InstallPing.swift`) | `AgentKind.allCases.first(where: \.canRunWorkspaces)`, i.e. exactly one runnable agent | Becomes a set. The wire name should report what is installed **and** runnable, not the first one. It reports no credential and must keep reporting none |
+| `ContextWindowUsage` (`Views/Center/Composer/ContextWindowUsage.swift`) | Reads the limit off `result.modelUsage.<model>.contextWindow` and the used figure off the last `assistant` event's usage | Codex hands both over directly on `thread/tokenUsage/updated`: `modelContextWindow` and the `total` breakdown. Simpler, not harder. Give it a second reader and keep the doc comment explaining why Claude needs two lines and Codex needs one |
+| `AgentsSettingsView` (`Views/Chrome/Settings/`) | Shows a "cannot run workspaces" note for anything that cannot run one | Follows `canRunWorkspaces` already, so it corrects itself. Its account table for Codex is already written and verified |
 | `ComposerOption.models` / `.efforts` | Three Claude models and five flat efforts, hardcoded | See §9 |
 | `AgentRunner`, `AgentEvent` | Claude Code's stream-json, end to end | Stay Claude Code's. A `CodexRunner` beside them |
 | Sidebar status glyph, `WorkspaceRunningGlyph` | Workspace-level busy state | A workspace is busy when **any** of its chats is. Already per workspace, so no change, but check it is aggregating chats and not reading one |
@@ -547,9 +548,10 @@ Each step should land on its own and leave the app working.
 - **Cost wording**, as in step 7.
 - **`SlashCommandIndex`'s Codex sibling**, from the `skills/list` RPC. Codex's slash vocabulary is
   a call rather than a directory walk, so it is a different index, not a flag on that one.
-- **`WorkspaceNamer` stays on Claude Code**, deliberately. A workspace name is not a chat, so it
-  does not follow the chat's backend, and it already degrades to the mechanical name when `claude`
-  is absent. Revisit only if a Codex-only machine turns out to be common.
+
+`WorkspaceNamer` is not on this list, and was for a while. Staying on Claude Code is a decision
+rather than an item, and §8's table is where it is recorded with the other things left out on
+purpose.
 
 ---
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -7,6 +7,11 @@ The phases below are all done, and the figures in this section are the ones that
 each was closed: the suite has grown a long way past the 188 tests named here. What is worth
 keeping is the two lists of bugs, because each one names a mistake that is cheap to make again.
 
+Two things in the record have since been overtaken and are left as they were written. "Non-Claude
+agent backends" is listed as a non-goal below and is not one any more: `docs/CODEX.md` is the Codex
+backend, a chat picks its CLI, and `AgentKind.canRunWorkspaces` admits both. And the architecture
+section says one dependency, which was true before Sparkle arrived for updates; there are two.
+
 ## Status
 
 Every phase below is done and checked against its endgoal. The app builds with zero warnings,

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -15,11 +15,25 @@ claude
   --include-partial-messages
   --verbose
   --permission-mode <auto|acceptEdits|bypassPermissions|plan>
+  --permission-prompt-tool stdio
   --model <opus|sonnet|haiku|...>
+  [--effort <level>]                 only when the session has one
+  [--thinking disabled]              fast mode, and only when it is on
+  [--settings '{"outputStyle":"…"}'] only when a style was chosen
+  [--mcp-config <path>]              the workspace bridge, a file and never inline JSON
   [--resume <agent session id>]
 ```
 
 `--verbose` is required with `-p --output-format stream-json`, otherwise the CLI refuses to run.
+
+`--permission-prompt-tool stdio` is undocumented, absent from `--help`, present in the binary, and
+always on. Without it the CLI answers permission questions on the user's behalf and the answer is
+no, which was every `permission-rule` refusal in every transcript. It does not make the CLI ask
+more: the classifier still approves what it approved before, measured at zero questions over seven
+tool calls in one ordinary turn. The paragraph above `AgentRunner.argv` is where that measurement
+lives, along with why `--settings` takes one object rather than accumulating and why the bridge is
+handed over as a file (argv is visible in `ps`, and an agent runs `ps`).
+
 Working directory is the worktree. Input is NDJSON on stdin, output NDJSON on stdout. stdin stays
 open for the whole session so follow-up turns are just more lines.
 
@@ -166,6 +180,42 @@ busier account in `Tests/fixtures/rate-limits.jsonl`. Three facts, all of which 
 3. **There is no monthly window.** Bloom shows the two it is given and says nothing about a third.
 
 Surface it quietly, never as an error. `AgentQuotaAdapters` is the reader.
+
+### `control_request` / `control_response`
+
+Not an event, a question. With `--permission-prompt-tool stdio` the CLI asks before running a tool
+it is not allowed to run outright, and holds the turn open until an answer arrives on stdin.
+
+```json
+{"type":"control_request","request_id":"…",
+ "request":{"subtype":"can_use_tool","tool_name":"Bash","input":{…},
+            "permission_suggestions":[…]}}
+```
+
+Only `can_use_tool` is lifted out. The other control subtypes are the CLI answering Bloom, or
+asking something Bloom has no business answering, and they stay raw rather than half understood.
+`request` also carries `display_name`, `tool_use_id`, `description`, `decision_reason`,
+`decision_reason_type`, `blocked_path`, `suppress_always_allow_rule`, `requires_user_interaction`
+and `classifier_approvable`, all optional. **`decision_reason` may carry ANSI escapes**, which the
+CLI's own schema says in as many words, so it is stripped before anything renders it.
+
+The answer is one line back:
+
+```json
+{"type":"control_response","response":{"request_id":"…","subtype":"success",
+ "response":{"behavior":"allow"|"deny",…}}}
+```
+
+An allow carries `updatedInput`, which is the input that was asked about and unedited unless the
+tool asked a question the user typed an answer to. A wider scope than once carries
+`updatedPermissions`, which is the CLI's own suggestion aimed at the session. A deny carries
+`message` and `interrupt`. The `request_id` has to match the pending ask or the answer does
+nothing: the CLI refuses a response whose tool disagrees with the question and logs the mismatch.
+`PermissionAsk` reads these and `PermissionAnswer` writes them.
+
+This wire used to fall through to `unknown` and be dropped on the floor, which is exactly what
+"Bloom never asks" looked like from the inside: the CLI was willing to ask and nobody was reading
+the line. A decoder that took the event list above as complete would hang the turn the same way.
 
 ## Rules for the decoder
 


### PR DESCRIPTION
An audit of every document, the Makefile and nine script heads found thirty findings. Twenty-eight applied here.

The one that mattered: `AGENTS-INTEGRATION.md` said only Claude Code can drive a workspace, contradicting `CODEX.md`, and the Agents settings screen printed the same sentence at the user. Both read `canRunWorkspaces` now, the screen through a new derived `AgentKind.runnableSentence` so the literal cannot go stale again.

The rest is ordinary rot: `README.md`'s source tree named thirteen files that have not existed since BloomCore was grouped by subject, CLAUDE.md cited a deleted type as the exemplary comment and listed half the view directories, `house-rules.sh` said seven rules where it enforces eight, and `PROTOCOL.md` was missing five of the flags Bloom passes and the whole `control_request` permission wire.

`docs/BRIDGE.md` is new: twelve tools, three roles, the gate on each, which asks Bloom self-approves and why merging is not one of them.

Two audit findings were rejected. `Store.swift` is 2,603 lines, which is what CLAUDE.md already says, not the 2,729 claimed. `Identifier.swift` declares eight typed ids, not nine.