### PR TITLE
Four bugs found by reviewing the whole app

### DIFF
--- a/Sources/BloomCore/Agent/Codex/CodexRunner.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexRunner.swift
@@ -147,7 +147,36 @@ public actor CodexRunner: SessionRunner {
     /// is expected to survive.
     public nonisolated func cancelNow() {
         handle.markCancelled()
-        Task { await self.interrupt() }
+        Task { await self.stopTurn() }
+    }
+
+    /// Stop, as the button means it: file the questions and then interrupt the turn.
+    ///
+    /// **This used to interrupt and nothing else.** `shutdown` already drained the pending asks
+    /// and wrote down why, and Stop is the other half of the same moment: a question left pending
+    /// keeps its buttons on a row nobody can answer any more, and the next launch's sweep files it
+    /// as "Bloom was not running when this was asked", which is untrue and is not what the person
+    /// saw. The Claude Code side has answered them on this path all along, which is why the two
+    /// backends disagreed about what Stop did.
+    ///
+    /// Answered before the interrupt rather than after, for the reason `AgentRunner.cancelNow`
+    /// gives: an answer written after the thing that closes the turn is an answer the model never
+    /// receives.
+    private func stopTurn() async {
+        await filePendingAsks()
+        await interrupt()
+    }
+
+    /// Answers every question this turn can no longer answer, and files it as stopped.
+    ///
+    /// One copy, called from `stopTurn` and from `shutdown`. They are the same event seen from two
+    /// distances (the turn ended, the chat ended) and they were two pieces of code, one of which
+    /// was missing.
+    private func filePendingAsks() async {
+        for ask in pending.drain() {
+            await write(answerTo: ask, decision: .decline)
+            await close(ask, as: PermissionAskOutcome.stopped, note: "")
+        }
     }
 
     /// The chat is going away: quit, close, or the worktree being archived. Kill the server.
@@ -211,10 +240,7 @@ public actor CodexRunner: SessionRunner {
     /// The chat can be sent to again afterwards: the thread id is stored, so the next turn
     /// reconnects and resumes rather than starting a new conversation.
     public func shutdown() async {
-        for ask in pending.drain() {
-            await write(answerTo: ask, decision: .decline)
-            await close(ask, as: PermissionAskOutcome.stopped, note: "")
-        }
+        await filePendingAsks()
         // Stated here as well as in `interrupt`, because a chat can be closed while it is idle
         // and can be closed while it is mid turn. `SessionLifecycle` refuses a stop on a session
         // with no turn open, so the one that did not happen writes nothing.

--- a/Sources/BloomCore/Git/Git.swift
+++ b/Sources/BloomCore/Git/Git.swift
@@ -102,15 +102,19 @@ public enum Git {
         outReader.stackSize = 512 * 1_024
         errReader.stackSize = 512 * 1_024
 
+        // Installed before `run()`, never after. See `ProcessExitGate`: a git call that finishes
+        // before the handler exists never calls it, and this wait would never end. Most git calls
+        // here pass no timeout, so nothing would break the hang afterwards either.
+        let exit = ProcessExitGate()
+        process.terminationHandler = { _ in exit.signal() }
+
         try process.run()
 
         outReader.start()
         errReader.start()
 
         await withTaskCancellationHandler {
-            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                process.terminationHandler = { _ in continuation.resume() }
-            }
+            await exit.wait()
         } onCancel: {
             if process.isRunning { process.terminate() }
         }

--- a/Sources/BloomCore/System/ProcessExitGate.swift
+++ b/Sources/BloomCore/System/ProcessExitGate.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Synchronization
+
+/// Waits for a child process to exit, without caring whether it has already.
+///
+/// **The bug this exists for.** `Shell.run` and `Git.runRaw` both did the obvious thing: call
+/// `process.run()`, get the pipes and the stdin write out of the way, and then suspend on a
+/// continuation resumed from `terminationHandler`. Foundation calls that handler when the child
+/// exits, and only if it is installed at the time. A child that has already exited by the time the
+/// line setting it is reached never calls it, the continuation is never resumed, and the awaiting
+/// task hangs for the lifetime of the app. `withTaskCancellationHandler` cannot rescue it either,
+/// because its `onCancel` guards on `isRunning` and the process is long gone.
+///
+/// The window is small and it is not theoretical: it is every fast command under load, which on
+/// this app means most of them. `git rev-parse`, `git status` on a small worktree, `gh --version`.
+/// Most local git calls pass no timeout, so there is nothing to break the hang afterwards.
+///
+/// So the handler is installed **before** `run()`, which is what `StreamingProcess` has always
+/// done, and this holds the little bit of state that makes that safe: whoever gets there first
+/// wins. If the child exits before anybody waits, the exit is remembered and `wait()` returns at
+/// once. If somebody waits first, the continuation is parked and the exit resumes it.
+final class ProcessExitGate: Sendable {
+    private struct State {
+        var hasExited = false
+        var waiter: CheckedContinuation<Void, Never>?
+    }
+
+    private let state = Mutex(State())
+
+    /// Called from `terminationHandler`, possibly on a Foundation thread, possibly before anybody
+    /// is waiting and possibly more than once. Resuming a continuation twice is a crash, so the
+    /// waiter is taken out of the state under the lock and resumed outside it.
+    func signal() {
+        let waiter = state.withLock { state -> CheckedContinuation<Void, Never>? in
+            state.hasExited = true
+            defer { state.waiter = nil }
+            return state.waiter
+        }
+        waiter?.resume()
+    }
+
+    /// Returns when the child has exited, including when it exited before this was called.
+    func wait() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let alreadyExited = state.withLock { state -> Bool in
+                if state.hasExited { return true }
+                state.waiter = continuation
+                return false
+            }
+            // Outside the lock: resuming a continuation can run arbitrary code on this thread.
+            if alreadyExited { continuation.resume() }
+        }
+    }
+}

--- a/Sources/BloomCore/System/Shell.swift
+++ b/Sources/BloomCore/System/Shell.swift
@@ -170,6 +170,11 @@ public enum Shell {
         outReader.stackSize = 512 * 1_024
         errReader.stackSize = 512 * 1_024
 
+        // Installed before `run()`, never after. See `ProcessExitGate`: a child that exits before
+        // the handler exists never calls it, and the wait below would never end.
+        let exit = ProcessExitGate()
+        process.terminationHandler = { _ in exit.signal() }
+
         try process.run()
 
         outReader.start()
@@ -188,9 +193,7 @@ public enum Shell {
         }
 
         await withTaskCancellationHandler {
-            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                process.terminationHandler = { _ in continuation.resume() }
-            }
+            await exit.wait()
         } onCancel: {
             if process.isRunning { process.terminate() }
         }

--- a/Sources/BloomCore/Workspace/WorkspaceManager.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceManager.swift
@@ -549,6 +549,10 @@ public struct WorkspaceManager: Sendable {
         // written where the destructive work starts rather than where the row is finally saved.
         guard workspace.state == .active else { return }
 
+        // Read before anything is removed, because the removal below is what makes it false.
+        // See the branch delete near the end of this method for what it guards.
+        let worktreeWasOnDisk = FileManager.default.fileExists(atPath: workspace.path)
+
         let settings = SettingsLoader.load(repo: repo.path)
         let shouldDeleteBranch = deleteBranch ?? settings.deleteBranchOnArchive
 
@@ -606,7 +610,23 @@ public struct WorkspaceManager: Sendable {
 
         try await Git.removeWorktree(repo: repo.path, path: workspace.path, force: force)
 
-        if shouldDeleteBranch {
+        // **Only when the worktree was really there.** Deleting a branch is the one step here
+        // that does not touch the worktree at all, so it is the one step that still happens when
+        // the worktree is not on disk, and that is exactly when nothing is protecting it: the
+        // safety report finds no worktree, reads as "nothing at stake", and the confirmation the
+        // owner would have answered never appears.
+        //
+        // `make dev-db` is how this was found. It points the copied workspace rows at a root that
+        // does not exist so the dev copy cannot delete a real worktree, and deliberately leaves
+        // `repos.path` real so there is something to read a diff from. A branch delete needs only
+        // the repository, so archiving in Bloom Dev with `delete_branch_on_archive` set deleted a
+        // branch in the owner's own repository, silently.
+        //
+        // It is the right rule for the real app too. What this setting is for is tidying up the
+        // branch belonging to a worktree Bloom has just removed. A worktree Bloom never found is a
+        // state Bloom did not make, and a branch left behind can be deleted by hand later, where a
+        // branch deleted here cannot be brought back.
+        if shouldDeleteBranch, worktreeWasOnDisk {
             do {
                 try await Git.deleteBranch(workspace.branch, in: repo.path)
             } catch {

--- a/Sources/BloomCore/Workspace/WorkspaceStartFailure.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceStartFailure.swift
@@ -48,7 +48,6 @@ public enum WorkspaceStartTrouble: Sendable, Equatable {
                 """
 
         case let .baseBranchMissing(branch, project, wasRequested, branches):
-            let whichBranches = Self.listing(branches)
             let opening = wasRequested
                 ? "Bloom could not start that workspace because the project '\(project)' has no "
                     + "branch called '\(branch)'."
@@ -59,6 +58,12 @@ public enum WorkspaceStartTrouble: Sendable, Equatable {
                 return opening + " It has no branches at all, so there is nothing to cut from. "
                     + "Do not retry with another name. Say so and carry on with your own work."
             }
+            // Below the guard, not above it. It used to be the first line of this case, three
+            // lines before the emptiness check written to protect it, and `listing` reached
+            // `shown[-1]` on an empty list and killed the app. Reached whenever a project has
+            // commits but no local branches, and whenever `Git.branches` throws and a `try?` turns
+            // that into an empty array, which is the same call that produced this failure.
+            let whichBranches = Self.listing(branches)
             let hasOne = branches.count == 1
             return opening
                 + (hasOne ? " Its only branch is \(whichBranches)." : " Its branches are \(whichBranches).")
@@ -115,10 +120,19 @@ public enum WorkspaceStartTrouble: Sendable, Equatable {
 
     /// Named branches, capped. A repository with two hundred branches would otherwise spend the
     /// whole tool result listing them, and the caller only needs enough to pick one.
+    /// Total over its input, including the empty list.
+    ///
+    /// The caller guards emptiness and used to do it three lines too late, which trapped. The
+    /// guard is in the right place now and this answers for nothing anyway, because a sentence
+    /// built from no branches is a sentence with no business being built. Two agreeing mechanisms,
+    /// because the one that was supposed to be enough was not.
     private static func listing(_ branches: [String]) -> String {
         let shown = branches.prefix(10).map { "'\($0)'" }
         let rest = branches.count - shown.count
-        var text = shown.count == 1 ? shown[0] : shown.dropLast().joined(separator: ", ") + " and " + shown[shown.count - 1]
+        guard let last = shown.last else { return "" }
+        var text = shown.count == 1
+            ? last
+            : shown.dropLast().joined(separator: ", ") + " and " + last
         if rest > 0 { text += ", and \(rest) more" }
         return text
     }

--- a/Tests/BloomCoreTests/ArchiveGateTests.swift
+++ b/Tests/BloomCoreTests/ArchiveGateTests.swift
@@ -117,6 +117,31 @@ struct ArchiveGateTests {
         #expect(await Git.branchExists(workspace.branch, in: repo.path))
     }
 
+    /// The branch delete is the one step of an archive that does not touch the worktree, so it is
+    /// the one step that still ran when the worktree was not there. That is also the moment
+    /// nothing is guarding it: the safety report finds no worktree, reads as "nothing at stake",
+    /// and the confirmation the owner would have answered never appears.
+    ///
+    /// Found through `make dev-db`, which points the copied workspace rows at a root that does not
+    /// exist and leaves `repos.path` real, so archiving in Bloom Dev deleted a branch in the
+    /// owner's own repository.
+    @Test("a workspace whose worktree is gone keeps its branch", .tags(.destructive))
+    func aMissingWorktreeKeepsItsBranch() async throws {
+        let (repo, registered, manager, workspace) = try await makeWorkspace()
+        defer { repo.cleanUp() }
+
+        // Remove the worktree behind Bloom's back, which is the state a detached dev database is
+        // in for every one of its rows.
+        try await Git.removeWorktree(repo: repo.path, path: workspace.path, force: true)
+        #expect(FileManager.default.fileExists(atPath: workspace.path) == false)
+        #expect(await Git.branchExists(workspace.branch, in: repo.path))
+
+        try await manager.archive(workspace: workspace, repo: registered, deleteBranch: true)
+
+        // Archived, and the branch is still there to be deleted by hand if that is really wanted.
+        #expect(await Git.branchExists(workspace.branch, in: repo.path))
+    }
+
     @Test("a squash merged branch is refused by git alone and cleared by GitHub", .tags(.destructive))
     func squashMergeIsClearedByThePullRequest() async throws {
         let (repo, registered, manager, workspace) = try await makeWorkspace()

--- a/Tests/BloomCoreTests/ProcessExitGateTests.swift
+++ b/Tests/BloomCoreTests/ProcessExitGateTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// The hang this type exists to stop.
+///
+/// `Shell.run` and `Git.runRaw` installed `terminationHandler` after `process.run()`, so a child
+/// that exited inside that window never called it and the awaiting task never resumed. Most git
+/// calls pass no timeout, so nothing broke the hang afterwards.
+@Suite("Waiting for a process that may already have exited")
+struct ProcessExitGateTests {
+    @Test("a signal that arrives before anybody waits is remembered")
+    func signalBeforeWait() async {
+        let gate = ProcessExitGate()
+        gate.signal()
+        // Would hang forever if the exit were not remembered, which is the bug.
+        await gate.wait()
+    }
+
+    @Test("a waiter parked first is resumed by the signal")
+    func waitBeforeSignal() async {
+        let gate = ProcessExitGate()
+        async let waited: Void = gate.wait()
+        // Give the waiter a chance to park before the signal lands.
+        try? await Task.sleep(for: .milliseconds(20))
+        gate.signal()
+        await waited
+    }
+
+    @Test("signalling twice does not resume a continuation twice")
+    func signalIsIdempotent() async {
+        let gate = ProcessExitGate()
+        async let waited: Void = gate.wait()
+        try? await Task.sleep(for: .milliseconds(20))
+        gate.signal()
+        // A second resume of the same continuation traps, so reaching the end is the assertion.
+        gate.signal()
+        await waited
+        gate.signal()
+    }
+
+    @Test("a real short lived process is waited on rather than hung on")
+    func realProcessThatExitsImmediately() async throws {
+        // `true` exits about as fast as anything can, which is the case that used to lose the
+        // race with the line installing the handler.
+        for _ in 0..<25 {
+            let result = try await Shell.run("/usr/bin/true", [])
+            #expect(result.ok)
+        }
+    }
+}

--- a/Tests/BloomCoreTests/WorkspaceStartFailureTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceStartFailureTests.swift
@@ -161,6 +161,35 @@ struct WorkspaceStartFailureTests {
         }
     }
 
+    /// The case that used to kill the app.
+    ///
+    /// `listing` was called three lines above the guard written to protect it, so a project with
+    /// commits and no local branches reached `shown[-1]` and trapped. The suite covered one branch
+    /// and twenty five and never zero, which is the only count that crashed. Reachable from an
+    /// agent's `workspace_start`, and also whenever `Git.branches` throws and a `try?` turns that
+    /// into an empty array.
+    @Test("a project with no branches at all is a sentence rather than a crash")
+    func noBranchesAtAll() {
+        let sentence = WorkspaceStartTrouble.baseBranchMissing(
+            branch: "main", project: "flare", wasRequested: false, branches: []
+        ).sentence
+
+        #expect(sentence.contains("no branches at all"))
+        #expect(sentence.contains("Do not retry"))
+        #expect(!sentence.isEmpty)
+    }
+
+    @Test("one branch reads as one, and two read as a pair")
+    func listsSmallCounts() {
+        func sentence(_ branches: [String]) -> String {
+            WorkspaceStartTrouble.baseBranchMissing(
+                branch: "nope", project: "flare", wasRequested: true, branches: branches
+            ).sentence
+        }
+        #expect(sentence(["main"]).contains("Its only branch is 'main'."))
+        #expect(sentence(["main", "wip"]).contains("Its branches are 'main' and 'wip'."))
+    }
+
     /// A repository with two hundred branches would otherwise spend the whole tool result listing
     /// them.
     @Test("the branch listing is capped")


### PR DESCRIPTION
A crash. WorkspaceStartTrouble.listing was called three lines above the guard written to protect it, so a project with commits and no local branches reached shown[-1] and killed the app. Reachable from an agent's workspace_start, and whenever Git.branches throws and a try? turns that into an empty array. The suite covered one branch and twenty five, never zero.

A hang. Shell.run and Git.runRaw installed terminationHandler after process.run(), so a child that exited inside that window never called it and the awaiting task never resumed. Most git calls pass no timeout, so nothing broke the hang afterwards. The handler goes in before the launch now, as StreamingProcess has always done, and ProcessExitGate holds the bit of state that makes that safe.

A branch delete with nothing guarding it. It is the one step of an archive that does not touch the worktree, so it is the one step that still happened when the worktree was not on disk, which is exactly when the safety report reads as nothing at stake and no confirmation appears. Found through make dev-db: the dev copy detaches the workspace paths and leaves repos.path real, so archiving in Bloom Dev deleted a branch in a real repository.

Stop on a Codex chat abandoned its pending permission questions. shutdown already answered them and said why; cancelNow only interrupted, so the buttons stayed on a row nobody could answer and the next launch filed them as Bloom not having been running. One copy now, called from both.