### PR TITLE
Two more from the review: a negative index and a scheme nobody chose

### DIFF
--- a/Sources/BloomCore/Bridge/PaneOrder.swift
+++ b/Sources/BloomCore/Bridge/PaneOrder.swift
@@ -111,6 +111,23 @@ public struct PaneOrder: Sendable, Equatable {
             )
         }
 
+        // **An agent picks this address, and `pane_open` is self-approved**, so the owner is not
+        // asked before a pane appears. `BrowserAddress` passes anything carrying a scheme straight
+        // through, which is right for an address field a person types into and wrong here: it let
+        // a tool call render `file:///` anywhere on the disk in the owner's own window, with no
+        // prompt and nothing on screen saying where it came from. A browser pane in this app is
+        // for a workspace's dev server, so it takes the two schemes a dev server speaks.
+        //
+        // The address field itself is deliberately not narrowed. A person typing into it is the
+        // one choosing, which is the whole difference.
+        if let url, !url.isEmpty, let scheme = URL(string: url)?.scheme?.lowercased(),
+           scheme != "http", scheme != "https" {
+            return .refused(
+                "A browser pane opens http and https addresses. '\(scheme)' is not one Bloom will "
+                    + "open on your behalf."
+            )
+        }
+
         let focus: Bool
         switch rawFocus {
         case .none, .null: focus = true

--- a/Sources/BloomCore/Persistence/TOML.swift
+++ b/Sources/BloomCore/Persistence/TOML.swift
@@ -429,7 +429,11 @@ public enum TOML {
             }
 
             // An array-of-tables index is addressed by its numeric component.
-            if let index = Int(path[1]), case .array(var elements)? = table[head], index < elements.count {
+            // `index >= 0` is not redundant. `Int("-1")` is -1, and -1 is less than any count,
+            // so a key like `a.-1.b` reached `elements[-1]` and trapped. The path comes out of a
+            // settings file, which is a file a person edits by hand.
+            if let index = Int(path[1]), index >= 0, case .array(var elements)? = table[head],
+               index < elements.count {
                 var element = elements[index].tableValue ?? [:]
                 insert(value, at: Array(path.dropFirst(2)), into: &element)
                 elements[index] = .table(element)

--- a/Tests/BloomCoreTests/PaneToolTests.swift
+++ b/Tests/BloomCoreTests/PaneToolTests.swift
@@ -82,6 +82,33 @@ struct PaneToolTests {
         }
     }
 
+    /// `pane_open` is self-approved, so nobody is asked before the pane appears, and the address
+    /// is chosen by the agent rather than typed by the owner. It used to take any scheme, so a
+    /// tool call could render a local file in the owner's window with no prompt.
+    @Test("a browser pane opens http and https, and refuses anything else")
+    func refusesSchemesTheOwnerDidNotChoose() {
+        for url in ["file:///Users/freek/.ssh/id_rsa", "ftp://example.com", "bloom://open"] {
+            let outcome = PaneOrder.parse(
+                kind: "browser", url: url, focus: nil, tool: "pane_open"
+            )
+            guard case .refused(let why) = outcome else {
+                Issue.record("\(url) was not refused")
+                continue
+            }
+            #expect(why.contains("http and https"))
+        }
+
+        for url in ["http://localhost:3000", "https://runbloom.app"] {
+            guard case .order(let order) = PaneOrder.parse(
+                kind: "browser", url: url, focus: nil, tool: "pane_open"
+            ) else {
+                Issue.record("\(url) was refused")
+                continue
+            }
+            #expect(order.url == url)
+        }
+    }
+
     // MARK: - Focus
 
     /// "Open me a terminal" means the terminal, in front.


### PR DESCRIPTION
TOML.insert trusted Int(path[1]) as an array-of-tables index. Int("-1") is -1, and -1 is less than any count, so a settings key like a.-1.b reached elements[-1] and trapped. That path comes out of a file a person edits by hand.

pane_open took any URL scheme. It is self-approved, so nobody is asked before the pane appears, and the address is chosen by the agent rather than typed by the owner: a tool call could render file:/// anywhere on the disk in the owner's own window with no prompt. A browser pane here is for a workspace's dev server, so the tool takes http and https. The address field a person types into is deliberately unchanged, because there the owner is the one choosing.