### PR TITLE
Hang the quick prompts panel off its own button, and give the form room

### DIFF
--- a/Sources/Bloom/Views/Center/Composer/ComposerFooterView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerFooterView.swift
@@ -96,17 +96,6 @@ struct ComposerFooterView: View {
         .popover(isPresented: $isShowingContextDetail, arrowEdge: .top) {
             if let context { ContextWindowDetail(usage: context) }
         }
-        // Outside the `ViewThatFits` as well, and for the same reason: narrowing the pane must not
-        // take the presenter out of the tree while the panel is up.
-        .popover(isPresented: $isShowingQuickPrompts, arrowEdge: .top) {
-            if let onQuickPrompt {
-                QuickPromptMenu(
-                    catalog: QuickPromptCatalog.shared,
-                    onPick: onQuickPrompt,
-                    onClose: { isShowingQuickPrompts = false }
-                )
-            }
-        }
         .onChange(of: controls.model, initial: true) { _, id in
             remember(id, known: catalog.options(for: controls.agentKind), in: &extraModels)
         }
@@ -253,14 +242,36 @@ struct ComposerFooterView: View {
                     isShowingQuickPrompts = true
                 } label: {
                     ComposerControlLabel(
+                        // Named while there is room, and a glyph alone only when there is not.
+                        // The paperclip beside it can afford to be a glyph forever because
+                        // everybody already knows what a paperclip does; this is a new idea with
+                        // no icon anybody has learned, and unlabelled it is a button people do not
+                        // press. It drops its word on the same step the pickers drop theirs.
                         systemImage: "text.badge.plus",
-                        text: nil,
+                        text: isCompact ? nil : "Quick prompts",
                         isActive: isShowingQuickPrompts
                     )
                 }
                 .buttonStyle(.plain)
                 .help("Insert a quick prompt")
                 .accessibilityLabel("Quick prompts")
+                // On the button, not on the row around it. It was hoisted outside the
+                // `ViewThatFits` alongside the context gauge's, and a popover anchors to the view
+                // it is attached to: from there it hung off the middle of the whole footer, with
+                // its arrow pointing at whichever control happened to be at the centre.
+                //
+                // The gauge's has to be out there, because `showsContext: false` takes the gauge
+                // out of the tree at narrow widths and would take an open popover with it. This
+                // button is in all three variants of the row, so it has nothing to be saved from.
+                .popover(isPresented: $isShowingQuickPrompts, arrowEdge: .top) {
+                    if let onQuickPrompt {
+                        QuickPromptMenu(
+                            catalog: QuickPromptCatalog.shared,
+                            onPick: onQuickPrompt,
+                            onClose: { isShowingQuickPrompts = false }
+                        )
+                    }
+                }
             }
 
             // A paperclip, not the plus that used to sit here: a plus already means "new session"

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptForm.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptForm.swift
@@ -31,10 +31,15 @@ struct QuickPromptForm: View {
 
     @FocusState private var isNameFocused: Bool
 
-    private static let textHeight: CGFloat = 92
+    /// Three lines of the shipped prompt with room for a fourth. It was 92, which fitted the text
+    /// exactly and left the box looking full before anything was typed.
+    private static let textHeight: CGFloat = 108
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Metrics.spacingWide) {
+        // `Metrics.pane` and `gutter` rather than the tighter rungs the rest of this panel uses.
+        // A list is scanned and wants to be dense; a form is filled in, and at the panel's spacing
+        // the three labels sat on top of their controls and the whole card read as cramped.
+        VStack(alignment: .leading, spacing: Metrics.gutter) {
             heading
 
             field("Name") {
@@ -68,8 +73,9 @@ struct QuickPromptForm: View {
             }
 
             buttons
+                .padding(.top, Metrics.spacingSmall)
         }
-        .padding(Metrics.gutter)
+        .padding(Metrics.pane)
         .onAppear(perform: prepare)
         // Escape leaves the form and goes back to the list, rather than closing the whole panel and
         // losing what was typed with it.
@@ -106,8 +112,14 @@ struct QuickPromptForm: View {
     private var buttons: some View {
         HStack(spacing: Metrics.spacingWide) {
             if editing != nil {
-                Button("Delete", role: .destructive, action: onDelete)
-                    .accessibilityLabel("Delete this quick prompt")
+                // `role: .destructive` alone leaves a bordered button on macOS drawn in the
+                // ordinary label colour, so it read as a third neutral button beside Cancel and
+                // Save. Coloured explicitly, which is what `RepoSettingsView` does for Remove
+                // Project and for the same reason.
+                Button(role: .destructive, action: onDelete) {
+                    Text("Delete").foregroundStyle(Palette.negative)
+                }
+                .accessibilityLabel("Delete this quick prompt")
                 Spacer(minLength: Metrics.spacing)
             } else {
                 Spacer(minLength: Metrics.spacing)
@@ -131,7 +143,7 @@ struct QuickPromptForm: View {
     }
 
     private func field(_ label: String, @ViewBuilder content: () -> some View) -> some View {
-        VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
+        VStack(alignment: .leading, spacing: Metrics.spacing) {
             Text(label)
                 .font(Typo.caption)
                 .foregroundStyle(Palette.textTertiary)

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptMenu.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptMenu.swift
@@ -83,9 +83,6 @@ struct QuickPromptMenu: View {
 
             Hairline()
             newRow
-
-            Hairline()
-            keys
         }
         .onAppear {
             // A fresh query every time it opens. The panel is a way of finding one thing, not a
@@ -203,28 +200,6 @@ struct QuickPromptMenu: View {
     private var newRowTitle: String {
         guard matches.isEmpty, !query.isEmpty else { return "New quick prompt" }
         return "New quick prompt named \u{201C}\(query)\u{201D}"
-    }
-
-    private var keys: some View {
-        HStack(spacing: Metrics.gutter) {
-            key("\u{2191}\u{2193}", "row")
-            key("\u{21A9}", "insert")
-            key("esc", "close")
-        }
-        .padding(.horizontal, Metrics.gutter)
-        .padding(.vertical, Metrics.spacingSmall)
-        .accessibilityHidden(true)
-    }
-
-    private func key(_ mark: String, _ what: String) -> some View {
-        HStack(spacing: Metrics.spacingSmall) {
-            Text(mark)
-                .font(Typo.codeTiny)
-                .foregroundStyle(Palette.textSecondary)
-            Text(what)
-                .font(Typo.caption)
-                .foregroundStyle(Palette.textTertiary)
-        }
     }
 
     // MARK: - The form

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptSymbolGrid.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptSymbolGrid.swift
@@ -16,11 +16,11 @@ struct QuickPromptSymbolGrid: View {
     @Binding var symbol: String
 
     private static let columns = Array(
-        repeating: GridItem(.flexible(), spacing: Metrics.spacingSmall), count: 6
+        repeating: GridItem(.flexible(), spacing: Metrics.spacing), count: 6
     )
 
     var body: some View {
-        LazyVGrid(columns: Self.columns, spacing: Metrics.spacingSmall) {
+        LazyVGrid(columns: Self.columns, spacing: Metrics.spacing) {
             ForEach(QuickPrompt.symbols, id: \.self) { name in
                 Button {
                     symbol = name


### PR DESCRIPTION
The popover was attached to the whole footer row rather than to the button, so it hung off the middle of the row with its arrow pointing at whichever control happened to be at the centre. It had been hoisted outside the ViewThatFits alongside the context gauge's popover; the gauge needs that, because a narrow pane takes the gauge out of the tree, and this button is in all three variants of the row so it has nothing to be saved from.

The button says Quick prompts now, and drops to the glyph alone on the same step the pickers drop their words. A paperclip can afford to be a glyph forever because everybody knows what a paperclip does. This is a new idea with an icon nobody has learned.

The keyboard hint strip at the foot of the list is gone.

The form was laid out on the list's spacing, which is right for something scanned and wrong for something filled in. Wider padding, more room between the groups and between a label and its control, and a text box that is not full before anything is typed. Delete is red: role destructive alone leaves a bordered button in the ordinary label colour on macOS, so it read as a third neutral button beside Cancel and Save.