### PR TITLE
Draw the quick prompts panel like a menu

### DIFF
--- a/Sources/Bloom/Design/Gallery.swift
+++ b/Sources/Bloom/Design/Gallery.swift
@@ -73,6 +73,7 @@ extension Snapshot {
         .subagentRows,
         .paneTabs,
         .sidebarSelection,
+        .quickPrompts,
     ]
 
     /// The page `--gallery` names, falling back to the first rather than failing: a capture run

--- a/Sources/Bloom/Design/QuickPromptGallery.swift
+++ b/Sources/Bloom/Design/QuickPromptGallery.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+import BloomCore
+
+/// The quick prompts panel, at the width it really opens at, in the states it is really in.
+///
+/// It exists because this panel shipped twice with things wrong with it that one look would have
+/// caught: the popover hung off the middle of the composer footer instead of its button, a two line
+/// row was padded like a one line one so the name sat against the top of its own selection, and the
+/// selection ran flush into the panel's rounded corners. None of that is visible from the tests,
+/// which are about ranking and insertion, and the panel is a popover, so the window probes cannot
+/// open it either.
+///
+///     Bloom --snapshot-gallery <dir> --gallery quick-prompts
+///
+/// Rows rather than the whole `QuickPromptMenu`, and that is the limit of what this page can claim.
+/// The menu owns a search field and a store, and neither belongs in an offscreen render; what it
+/// draws underneath is `QuickPromptRow`, and the row is where every one of those mistakes was.
+struct QuickPromptGallery: View {
+    var app: AppModel
+
+    /// Real prompts rather than lorem: the shipped built-in, one with a long name that has to
+    /// truncate, and one with no name at all, which falls back to its own first line.
+    private var prompts: [QuickPrompt] {
+        [
+            QuickPrompt(
+                name: "Explain changes",
+                symbol: "doc.richtext",
+                text: "Explain the changes made in this PR as HTML. Open it as a new tab in this workspace.",
+                sortOrder: 0
+            ),
+            QuickPrompt(
+                name: "Run the tests and fix whatever comes back failing",
+                symbol: "checkmark.seal",
+                text: "Run make test. If anything fails, fix it and run the failing test again on its own.",
+                sortOrder: 1
+            ),
+            QuickPrompt(
+                name: "",
+                symbol: "text.alignleft",
+                text: "Walk me through the diff, file by file, and say why each change is there.",
+                sortOrder: 2
+            ),
+        ]
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.pane) {
+            panel("At rest", selected: nil)
+            panel("Second row highlighted", selected: 1)
+            panel("Nothing written yet", selected: nil, empty: true)
+        }
+        .padding(Metrics.pane)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(Palette.surface)
+        .environment(app)
+    }
+
+    private func panel(_ caption: String, selected: Int?, empty: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingWide) {
+            Text(caption)
+                .font(Typo.caption)
+                .foregroundStyle(Palette.textTertiary)
+
+            VStack(alignment: .leading, spacing: 0) {
+                searchLine
+                Hairline()
+
+                if empty {
+                    VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
+                        Text("Nothing here yet.")
+                            .font(Typo.body)
+                            .foregroundStyle(Palette.textSecondary)
+                        Text("A quick prompt is a few lines you find yourself typing again.")
+                            .font(Typo.caption)
+                            .foregroundStyle(Palette.textTertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, contentInset)
+                    .padding(.vertical, Metrics.gutter)
+                } else {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(Array(prompts.enumerated()), id: \.offset) { index, prompt in
+                            QuickPromptRow(
+                                prompt: prompt,
+                                isSelected: index == selected,
+                                onPick: {}, onHover: {}, onEdit: {}, onDelete: {}
+                            )
+                        }
+                    }
+                    .padding(.horizontal, listInset)
+                    .padding(.vertical, Metrics.spacingSmall)
+                }
+
+                Hairline()
+                newLine
+            }
+            // The panel's own plate, since a popover's chrome is not here to draw it.
+            .frame(width: 320)
+            .background(Palette.surface, in: RoundedRectangle(cornerRadius: Metrics.corner + 2))
+            .overlay {
+                RoundedRectangle(cornerRadius: Metrics.corner + 2)
+                    .strokeBorder(Palette.border, lineWidth: Metrics.hairline)
+            }
+        }
+    }
+
+    /// The same numbers `QuickPromptMenu` uses. Copied rather than shared because the menu keeps
+    /// them private and a gallery is not a reason to publish a view's internals.
+    private var listInset: CGFloat { Metrics.spacingWide }
+    private var contentInset: CGFloat { Metrics.spacingWide + Metrics.spacing }
+
+    private var searchLine: some View {
+        HStack(spacing: Metrics.spacing) {
+            Image(systemName: "magnifyingglass")
+                .imageScale(.small)
+                .foregroundStyle(Palette.textTertiary)
+                .frame(width: Metrics.repoIcon)
+            Text("Search quick prompts")
+                .font(Typo.body)
+                .foregroundStyle(Palette.textTertiary)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, contentInset)
+        .padding(.vertical, Metrics.spacingSmall)
+        .frame(height: Metrics.rowHeight + Metrics.spacingWide)
+    }
+
+    private var newLine: some View {
+        HStack(spacing: Metrics.spacing) {
+            Image(systemName: "plus")
+                .imageScale(.medium)
+                .foregroundStyle(Palette.textSecondary)
+                .frame(width: Metrics.repoIcon, height: Metrics.repoIcon)
+            Text("New quick prompt")
+                .font(Typo.body)
+                .foregroundStyle(Palette.textSecondary)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Metrics.spacing)
+        .frame(height: Metrics.rowHeight)
+        .padding(.horizontal, listInset)
+        .padding(.vertical, Metrics.spacingSmall)
+    }
+}
+
+extension Gallery {
+    /// The registry entry for this page. See `Gallery`.
+    ///
+    /// No field is being typed into, so it needs nobody's keyboard.
+    static let quickPrompts = Gallery(
+        name: "quick-prompts",
+        title: "Quick prompts",
+        size: CGSize(width: 400, height: 760),
+        needsFocus: false,
+        view: { app in AnyView(QuickPromptGallery(app: app)) }
+    )
+}

--- a/Sources/Bloom/Design/QuickPromptGallery.swift
+++ b/Sources/Bloom/Design/QuickPromptGallery.swift
@@ -40,13 +40,30 @@ struct QuickPromptGallery: View {
                 text: "Walk me through the diff, file by file, and say why each change is there.",
                 sortOrder: 2
             ),
+            // Longer than the panel by a wide margin, which is the case that has to truncate
+            // gracefully rather than push the pencil off the edge or wrap into a third line.
+            QuickPrompt(
+                name: "Open a pull request against the release branch and write the description "
+                    + "from the commits rather than from the diff",
+                symbol: "arrow.triangle.pull",
+                text: "Push the branch and open a pull request. Three sentences, no headings.",
+                sortOrder: 3
+            ),
+            // One word with nowhere to break. Truncation has to cut it rather than let it push
+            // everything else out of the row.
+            QuickPrompt(
+                name: "Regenerate\u{200B}TheSnapshotFixturesForEveryGalleryPageInOneGo",
+                symbol: "camera",
+                text: "Run every gallery capture and replace the fixtures under Tests.",
+                sortOrder: 4
+            ),
         ]
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: Metrics.pane) {
             panel("At rest", selected: nil)
-            panel("Second row highlighted", selected: 1)
+            panel("Highlighted, with the pencil in place", selected: 3)
             panel("Nothing written yet", selected: nil, empty: true)
         }
         .padding(Metrics.pane)
@@ -151,7 +168,7 @@ extension Gallery {
     static let quickPrompts = Gallery(
         name: "quick-prompts",
         title: "Quick prompts",
-        size: CGSize(width: 460, height: 780),
+        size: CGSize(width: 460, height: 980),
         needsFocus: false,
         view: { app in AnyView(QuickPromptGallery(app: app)) }
     )

--- a/Sources/Bloom/Design/QuickPromptGallery.swift
+++ b/Sources/Bloom/Design/QuickPromptGallery.swift
@@ -96,7 +96,7 @@ struct QuickPromptGallery: View {
                 newLine
             }
             // The panel's own plate, since a popover's chrome is not here to draw it.
-            .frame(width: 320)
+            .frame(width: 380)
             .background(Palette.surface, in: RoundedRectangle(cornerRadius: Metrics.corner + 2))
             .overlay {
                 RoundedRectangle(cornerRadius: Metrics.corner + 2)
@@ -151,7 +151,7 @@ extension Gallery {
     static let quickPrompts = Gallery(
         name: "quick-prompts",
         title: "Quick prompts",
-        size: CGSize(width: 400, height: 760),
+        size: CGSize(width: 460, height: 780),
         needsFocus: false,
         view: { app in AnyView(QuickPromptGallery(app: app)) }
     )

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptMenu.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptMenu.swift
@@ -34,6 +34,9 @@ struct QuickPromptMenu: View {
     /// that slot and Return inserts something other than what is drawn. `WorkspaceSourcePicker`
     /// carries the same note over the same failure.
     @State private var selected: QuickPrompt?
+    /// Hover for the row that writes a new prompt, which is not part of the ranked list and so has
+    /// no `QuickPromptRow` to keep it.
+    @State private var isNewHovered = false
     /// The form, when one is open. Two states of one panel rather than a second floating window.
     @State private var editor: Editor?
 
@@ -45,6 +48,19 @@ struct QuickPromptMenu: View {
 
     /// Wide enough for a name and a line of the prompt under it without either being cut.
     private static let width: CGFloat = 320
+
+    /// How far the scrolling list holds its rows off the panel's edge.
+    ///
+    /// A selection drawn flush to the edge runs its rounded corners into the panel's own rounding
+    /// and reads as a band painted across the popover rather than as a row picked out of a list.
+    /// Every menu on this Mac insets it. Four points was not enough to see.
+    private static let listInset: CGFloat = Metrics.spacingWide
+    /// A row's own padding inside that.
+    private static let rowInset: CGFloat = Metrics.spacing
+    /// Where a glyph starts, measured from the panel's edge. Everything that is not a row of the
+    /// list (the search field, the row that writes a new prompt) is indented to the same number,
+    /// so the marks down the left are one column rather than three that nearly agree.
+    private static var contentInset: CGFloat { listInset + rowInset }
     /// About eight rows, which is the cap a completion menu keeps in this app.
     private static let listHeight: CGFloat = 260
 
@@ -100,6 +116,7 @@ struct QuickPromptMenu: View {
             Image(systemName: "magnifyingglass")
                 .imageScale(.small)
                 .foregroundStyle(Palette.textTertiary)
+                .frame(width: Metrics.repoIcon)
 
             MenuSearchField(
                 text: $query,
@@ -108,7 +125,7 @@ struct QuickPromptMenu: View {
             )
             .frame(height: Metrics.rowHeight)
         }
-        .padding(.horizontal, Metrics.gutter)
+        .padding(.horizontal, Self.contentInset)
         .padding(.vertical, Metrics.spacingSmall)
         .onChange(of: query) { _, _ in
             // The highlight follows the list rather than staying where it was: a highlight left
@@ -134,7 +151,8 @@ struct QuickPromptMenu: View {
                         .id(prompt.id)
                     }
                 }
-                .padding(Metrics.spacingSmall)
+                .padding(.horizontal, Self.listInset)
+                .padding(.vertical, Metrics.spacingSmall)
             }
             .frame(maxHeight: Self.listHeight)
             .onChange(of: selected) { _, row in
@@ -164,8 +182,8 @@ struct QuickPromptMenu: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, Metrics.gutter)
-            .padding(.vertical, Metrics.spacingWide)
+            .padding(.horizontal, Self.contentInset)
+            .padding(.vertical, Metrics.gutter)
         }
     }
 
@@ -178,9 +196,9 @@ struct QuickPromptMenu: View {
         } label: {
             HStack(spacing: Metrics.spacing) {
                 Image(systemName: "plus")
-                    .imageScale(.small)
-                    .foregroundStyle(Palette.textTertiary)
-                    .frame(width: Metrics.glyph)
+                    .imageScale(.medium)
+                    .foregroundStyle(Palette.textSecondary)
+                    .frame(width: Metrics.repoIcon, height: Metrics.repoIcon)
 
                 Text(newRowTitle)
                     .font(Typo.body)
@@ -189,11 +207,16 @@ struct QuickPromptMenu: View {
 
                 Spacer(minLength: 0)
             }
-            .padding(.horizontal, Metrics.gutter)
+            .padding(.horizontal, Self.rowInset)
             .frame(height: Metrics.rowHeight)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        // It highlights under the pointer because it is a row of this menu, not a footnote under
+        // one. Drawn flat, it was the one thing in the panel that did not answer to being hovered.
+        .rowBackground(isSelected: false, isHovered: isNewHovered, isFocused: true)
+        .onHover { isNewHovered = $0 }
+        .padding(.horizontal, Self.listInset)
         .padding(.vertical, Metrics.spacingSmall)
     }
 

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptMenu.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptMenu.swift
@@ -47,7 +47,10 @@ struct QuickPromptMenu: View {
     }
 
     /// Wide enough for a name and a line of the prompt under it without either being cut.
-    private static let width: CGFloat = 320
+    /// Wider than the composer's other menus, because a row here carries a name somebody wrote
+    /// rather than a file path, and at 320 the useful half of "Run the tests and fix whatever comes
+    /// back failing" was behind an ellipsis.
+    private static let width: CGFloat = 380
 
     /// How far the scrolling list holds its rows off the panel's edge.
     ///

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptRow.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptRow.swift
@@ -43,16 +43,19 @@ struct QuickPromptRow: View {
                         .lineLimit(1)
 
                     // The words themselves, so a name chosen badly six weeks ago is still
-                    // recoverable from the row.
-                    Text(prompt.preview)
-                        .font(Typo.caption)
-                        .foregroundStyle(
-                            isEmphasized
-                                ? Palette.selectedEmphasizedText.opacity(0.75)
-                                : Palette.textTertiary
-                        )
-                        .lineLimit(1)
-                        .truncationMode(.tail)
+                    // recoverable from the row. Absent when the prompt has no name of its own,
+                    // because then the line above IS the preview and the row said it twice.
+                    if prompt.hasSeparatePreview {
+                        Text(prompt.preview)
+                            .font(Typo.caption)
+                            .foregroundStyle(
+                                isEmphasized
+                                    ? Palette.selectedEmphasizedText.opacity(0.75)
+                                    : Palette.textTertiary
+                            )
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
                 }
 
                 Spacer(minLength: Metrics.spacingSmall)

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptRow.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptRow.swift
@@ -27,12 +27,16 @@ struct QuickPromptRow: View {
     var body: some View {
         Button(action: onPick) {
             HStack(spacing: Metrics.spacing) {
+                // Larger than the glyph column the one line lists use, and deliberately. This row
+                // is two lines tall, and `Metrics.glyph` beside it read as a speck someone had
+                // dropped rather than as the mark that tells five prompts apart at a glance, which
+                // is the whole job the icon was added for.
                 Image(systemName: QuickPrompt.resolvedSymbol(prompt.symbol))
-                    .imageScale(.small)
-                    .foregroundStyle(isEmphasized ? Palette.selectedEmphasizedText : Palette.textTertiary)
-                    .frame(width: Metrics.glyph)
+                    .imageScale(.large)
+                    .foregroundStyle(isEmphasized ? Palette.selectedEmphasizedText : Palette.textSecondary)
+                    .frame(width: Metrics.repoIcon, height: Metrics.repoIcon)
 
-                VStack(alignment: .leading, spacing: Metrics.spacingHair) {
+                VStack(alignment: .leading, spacing: Metrics.spacingTight) {
                     Text(prompt.resolvedName)
                         .font(Typo.body)
                         .foregroundStyle(isEmphasized ? Palette.selectedEmphasizedText : Palette.textPrimary)
@@ -58,7 +62,9 @@ struct QuickPromptRow: View {
                 }
             }
             .padding(.horizontal, Metrics.spacing)
-            .padding(.vertical, Metrics.spacingSmall)
+            // Four points was what a one line row takes, and this one is two lines: the name sat
+            // hard against the top of the selection with its ascenders touching the fill.
+            .padding(.vertical, Metrics.spacingWide)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -85,11 +91,16 @@ struct QuickPromptRow: View {
         Button(action: onEdit) {
             Image(systemName: "pencil")
                 .imageScale(.small)
-                .foregroundStyle(isEmphasized ? Palette.selectedEmphasizedText : Palette.textSecondary)
-                .padding(Metrics.spacingTight)
+                .foregroundStyle(
+                    isEmphasized
+                        ? Palette.selectedEmphasizedText.opacity(0.85)
+                        : Palette.textTertiary
+                )
+                .frame(width: Metrics.rowHeight - Metrics.spacingWide,
+                       height: Metrics.rowHeight - Metrics.spacingWide)
                 .background {
                     RoundedRectangle(cornerRadius: Metrics.cornerSmall)
-                        .fill(isEmphasized ? Palette.selectedEmphasizedText.opacity(0.22) : Palette.hover)
+                        .fill(isEmphasized ? Palette.selectedEmphasizedText.opacity(0.18) : Palette.hover)
                 }
                 .contentShape(Rectangle())
         }

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptRow.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptRow.swift
@@ -60,9 +60,13 @@ struct QuickPromptRow: View {
 
                 Spacer(minLength: Metrics.spacingSmall)
 
-                if isHovered || isSelected {
-                    pencil
-                }
+                // The space is always taken, and only the pencil comes and goes. Shown and hidden
+                // by presence, a name long enough to need the room lost forty points of it the
+                // moment the row was arrowed onto: the text reflowed into an ellipsis under the
+                // highlight and back out again as it left, on every press of Down.
+                pencil
+                    .opacity(isHovered || isSelected ? 1 : 0)
+                    .allowsHitTesting(isHovered || isSelected)
             }
             .padding(.horizontal, Metrics.spacing)
             // Four points was what a one line row takes, and this one is two lines: the name sat

--- a/Sources/BloomCore/Transcript/QuickPrompt.swift
+++ b/Sources/BloomCore/Transcript/QuickPrompt.swift
@@ -79,8 +79,9 @@ public struct QuickPrompt: Identifiable, Sendable, Hashable {
         return folded.prefix(Self.previewLength).trimmingCharacters(in: .whitespaces) + "\u{2026}"
     }
 
-    /// About as much as fits on the second line of a 300 point panel row.
-    static let previewLength = 64
+    /// About as much as fits on the second line of the panel's row. See
+    /// `QuickPromptMenu.width`.
+    static let previewLength = 72
 
     /// The name with the whitespace taken off both ends, or a name made from the text when the
     /// owner left the field empty. A row with no name at all is a row nobody can search for.
@@ -88,5 +89,14 @@ public struct QuickPrompt: Identifiable, Sendable, Hashable {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.isEmpty else { return trimmed }
         return preview
+    }
+
+    /// Whether the row has anything to say on a second line.
+    ///
+    /// False for a prompt with no name, because `resolvedName` is already its first line and the
+    /// row drew the same sentence twice, once in the name's weight and once in the preview's. A
+    /// name somebody wrote is a different fact from the words, and only then are there two of them.
+    public var hasSeparatePreview: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }


### PR DESCRIPTION
Four things were wrong with it, and none of them were visible from the tests.

The selection ran flush into the panel's rounded corners, because the list inset its rows by four points and the row padded itself by six. It floats inside the panel now, the way every menu on this Mac draws one.

A two line row was padded like a one line row, so the name sat against the top of its own selection with its ascenders touching the fill.

The icon was the glyph size the one line lists use, which beside two lines of text read as a speck rather than as the mark that tells five prompts apart.

The pencil appeared only on the hovered or highlighted row, so a long name lost forty points of width the moment it was arrowed onto and reflowed into an ellipsis and back out again on every press of Down. The space is reserved now and only the pencil comes and goes.

Also: the panel is 380 wide rather than 320, since a row here carries a name somebody wrote rather than a file path; the search field, the rows and the New quick prompt row share one glyph column instead of three that nearly agreed; that last row highlights under the pointer, because it is a row of the menu and not a footnote under one; and a prompt with no name no longer draws its own first line twice.

QuickPromptGallery is a capture page for all of it. This panel shipped twice with things wrong that one look would have caught, and it is a popover, so no window probe can open it.