### PR TITLE
Size the quick prompts list, and quieten the row it opens on

### DIFF
--- a/Sources/Bloom/Design/QuickPromptGallery.swift
+++ b/Sources/Bloom/Design/QuickPromptGallery.swift
@@ -62,8 +62,10 @@ struct QuickPromptGallery: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Metrics.pane) {
-            panel("At rest", selected: nil)
-            panel("Highlighted, with the pencil in place", selected: 3)
+            panel("A: accent fill, what ships today", selected: 0)
+            panel("B: the quiet grey AppKit uses when a list has no keyboard", selected: 0,
+                  emphasized: false)
+            panel("At rest, nothing highlighted", selected: nil)
             panel("Nothing written yet", selected: nil, empty: true)
         }
         .padding(Metrics.pane)
@@ -72,7 +74,12 @@ struct QuickPromptGallery: View {
         .environment(app)
     }
 
-    private func panel(_ caption: String, selected: Int?, empty: Bool = false) -> some View {
+    /// `emphasized: false` draws the same row through the same code with the window read as
+    /// inactive, which is exactly how `RowBackground` decides between the accent fill and the quiet
+    /// grey. Nothing about the row is reimplemented here to get the comparison.
+    private func panel(
+        _ caption: String, selected: Int?, empty: Bool = false, emphasized: Bool = true
+    ) -> some View {
         VStack(alignment: .leading, spacing: Metrics.spacingWide) {
             Text(caption)
                 .font(Typo.caption)
@@ -107,6 +114,7 @@ struct QuickPromptGallery: View {
                     }
                     .padding(.horizontal, listInset)
                     .padding(.vertical, Metrics.spacingSmall)
+                    .environment(\.controlActiveState, emphasized ? .key : .inactive)
                 }
 
                 Hairline()
@@ -168,7 +176,7 @@ extension Gallery {
     static let quickPrompts = Gallery(
         name: "quick-prompts",
         title: "Quick prompts",
-        size: CGSize(width: 460, height: 980),
+        size: CGSize(width: 460, height: 1180),
         needsFocus: false,
         view: { app in AnyView(QuickPromptGallery(app: app)) }
     )

--- a/Sources/Bloom/Design/QuickPromptGallery.swift
+++ b/Sources/Bloom/Design/QuickPromptGallery.swift
@@ -62,10 +62,8 @@ struct QuickPromptGallery: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Metrics.pane) {
-            panel("A: accent fill, what ships today", selected: 0)
-            panel("B: the quiet grey AppKit uses when a list has no keyboard", selected: 0,
-                  emphasized: false)
-            panel("At rest, nothing highlighted", selected: nil)
+            panel("The first row, highlighted on opening", selected: 0)
+            panel("Further down the list", selected: 3)
             panel("Nothing written yet", selected: nil, empty: true)
         }
         .padding(Metrics.pane)
@@ -176,7 +174,7 @@ extension Gallery {
     static let quickPrompts = Gallery(
         name: "quick-prompts",
         title: "Quick prompts",
-        size: CGSize(width: 460, height: 1180),
+        size: CGSize(width: 460, height: 1080),
         needsFocus: false,
         view: { app in AnyView(QuickPromptGallery(app: app)) }
     )

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptMenu.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptMenu.swift
@@ -37,6 +37,9 @@ struct QuickPromptMenu: View {
     /// Hover for the row that writes a new prompt, which is not part of the ranked list and so has
     /// no `QuickPromptRow` to keep it.
     @State private var isNewHovered = false
+    /// How tall the rows actually are, so the scroll view can be given a height rather than left
+    /// to take whatever it is offered. See `rows(_:)`.
+    @State private var contentHeight: CGFloat = 0
     /// The form, when one is open. Two states of one panel rather than a second floating window.
     @State private var editor: Editor?
 
@@ -137,10 +140,21 @@ struct QuickPromptMenu: View {
         }
     }
 
+    /// The list, given an explicit height rather than a maximum one.
+    ///
+    /// **A `ScrollView` takes the height it is offered, not the height of what is in it.** Inside a
+    /// popover that meant two different wrong answers on the same panel: on the first open, before
+    /// the popover had settled on a size, the rows were laid out over the search field above them;
+    /// on the second, one prompt sat at the top of three hundred points of empty panel.
+    ///
+    /// So the rows are measured and the scroll view is told what to be, clamped so a long list
+    /// still scrolls instead of growing past the window. `LazyVStack` reports the height of what it
+    /// has realised, which is why this is a plain `VStack`: the list is a handful of prompts
+    /// somebody wrote by hand, and laziness here bought nothing and cost the measurement.
     private func rows(_ matches: QuickPromptMatches) -> some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: 0) {
                     ForEach(matches.prompts) { prompt in
                         QuickPromptRow(
                             prompt: prompt,
@@ -156,8 +170,9 @@ struct QuickPromptMenu: View {
                 }
                 .padding(.horizontal, Self.listInset)
                 .padding(.vertical, Metrics.spacingSmall)
+                .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { contentHeight = $0 }
             }
-            .frame(maxHeight: Self.listHeight)
+            .frame(height: height(for: matches.prompts.count))
             .onChange(of: selected) { _, row in
                 guard let row else { return }
                 proxy.scrollTo(row.id)
@@ -221,6 +236,22 @@ struct QuickPromptMenu: View {
         .onHover { isNewHovered = $0 }
         .padding(.horizontal, Self.listInset)
         .padding(.vertical, Metrics.spacingSmall)
+    }
+
+    /// What the scroll view is told to be.
+    ///
+    /// The measurement wins once there is one, and until then a guess from the row count stands in.
+    /// Without the guess the first frame is one row tall, because `onGeometryChange` cannot report
+    /// a height until after a layout has happened, and the panel visibly grew on opening. The guess
+    /// only has to be close enough that nobody sees the correction.
+    private func height(for count: Int) -> CGFloat {
+        let measured = contentHeight > 0 ? contentHeight : Self.estimatedHeight(rows: count)
+        return min(max(measured, Metrics.rowHeight), Self.listHeight)
+    }
+
+    /// A two line row and the list's own padding, which is what a prompt with a name draws.
+    private static func estimatedHeight(rows: Int) -> CGFloat {
+        CGFloat(rows) * (Metrics.rowHeight + Metrics.gutter) + Metrics.spacingWide
     }
 
     private var newRowTitle: String {

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptRow.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptRow.swift
@@ -105,10 +105,9 @@ struct QuickPromptRow: View {
                 )
                 .frame(width: Metrics.rowHeight - Metrics.spacingWide,
                        height: Metrics.rowHeight - Metrics.spacingWide)
-                .background {
-                    RoundedRectangle(cornerRadius: Metrics.cornerSmall)
-                        .fill(isEmphasized ? Palette.selectedEmphasizedText.opacity(0.18) : Palette.hover)
-                }
+                // No plate. A filled square inside the selection made the row read as a card with
+                // an action on it, and a menu on this Mac does not contain buttons. The glyph
+                // alone, appearing only on the row you are on, is as far as this should go.
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptRow.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptRow.swift
@@ -77,9 +77,17 @@ struct QuickPromptRow: View {
         .buttonStyle(.plain)
         .accessibilityLabel(prompt.resolvedName)
         .accessibilityValue(prompt.preview)
-        // Focused, for the reason spelled out on `SlashCommandRow`: this list really is driven by
-        // the arrow keys, which is the one case AppKit paints in the accent.
-        .rowBackground(isSelected: isSelected, isHovered: isHovered, isFocused: true)
+        // **The quiet fill, not the accent one**, and this is the one place in the composer's menus
+        // that differs. `RowBackground` paints the accent when a list has the keyboard, and here it
+        // has not: the keyboard is in the search field above, and the list is driven by arrows the
+        // field hands down. More to the point, the top row is highlighted the instant the panel
+        // opens, before anybody has done anything, and at full accent that reads as a row already
+        // chosen rather than as the place Return will go. With one prompt in the list the fill
+        // covered most of the panel.
+        //
+        // It is the treatment Spotlight, Raycast and Alfred all use for a resting first hit. Xcode's
+        // Open Quickly is the one that fills it solid, and it is the outlier.
+        .rowBackground(isSelected: isSelected, isHovered: isHovered, isFocused: false)
         .onHover { hovering in
             isHovered = hovering
             if hovering { onHover() }


### PR DESCRIPTION
Two sizing bugs with one cause: a ScrollView takes the height it is offered, not the height of what is in it. On the first open, before the popover had settled on a size, the rows were laid out over the search field. On the second, one prompt sat at the top of 260 points of empty panel. The list is measured now and given a height, clamped so a long one still scrolls.

The LazyVStack became a plain VStack, because a lazy stack reports the height of what it has realised, which defeats the measurement, and laziness bought nothing for a handful of prompts written by hand. The height is seeded from the row count until the measurement arrives, since onGeometryChange cannot report anything before a layout has happened, and without the seed the first frame was one row tall and the panel visibly grew.

The row the panel opens on is drawn in the quiet fill rather than the accent one. RowBackground paints the accent when a list has the keyboard, and this list has not: the keyboard is in the search field and the arrows are handed down to it. The top row is highlighted before anybody has done anything, and at full accent that read as a row already chosen rather than as the place Return will go, which with one prompt covered most of the panel. It is what Spotlight, Raycast and Alfred do for a resting first hit.

The pencil lost its filled plate. A filled square inside the selection made the row read as a card with an action on it, and a menu on this Mac does not contain buttons.

The gallery page grew the hard cases: a name longer than the panel, and one unbroken word with nowhere to break.