### PR TITLE
Add SwiftLint beside the house rules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,8 @@ name: Test
 # and one push should tell you everything that is wrong with it rather than one
 # thing at a time.
 #
-#   lint     the workflows, the shell scripts and the house rules, on Linux.
+#   lint     the workflows, the shell scripts, the house rules and SwiftLint,
+#            all on Linux, because not one of them needs a Mac.
 #   build    swift build, which compiles the app target, Sources/Bloom included.
 #            Tools/test-core.sh mirrors only BloomCore into a throwaway package
 #            with no app target, so a view that stops compiling leaves the whole
@@ -113,6 +114,34 @@ jobs:
       # The rules that are ours rather than the language's. See the script.
       - name: Check the house rules
         run: ./Tools/house-rules.sh
+
+      # And the rules that are the language's rather than ours, which is the other half.
+      # `.swiftlint.yml` is tuned rather than default: the head of that file has the counts every
+      # disabled rule produced and why each one is off.
+      #
+      # On Linux, and that is the point of it being in this job. SwiftLint is SwiftSyntax rather
+      # than SourceKit for every rule that does not need a compiler log, so it needs no Xcode and
+      # no Mac, and it took 0.9 seconds over 920 files on the machine this was written on. Putting
+      # it on the macOS build would have added it to a runner that bills at ten times the rate to
+      # answer a question that does not need one.
+      #
+      # `swiftlint-static` rather than `swiftlint`: the same binary linked against nothing, so the
+      # runner needs no Swift runtime installed to run it. Pinned, because this is a binary from
+      # the internet, and renamed onto the PATH so that CI and a developer run the same script
+      # rather than two commands that have to be kept in step by hand.
+      - name: Lint the Swift
+        env:
+          SWIFTLINT_VERSION: 0.65.1
+        run: |
+          set -euo pipefail
+          command -v zsh >/dev/null || sudo apt-get install -y -qq zsh
+          url="https://github.com/realm/SwiftLint/releases/download/${SWIFTLINT_VERSION}"
+          curl -sSfL -o swiftlint.zip "$url/swiftlint_linux_amd64.zip"
+          mkdir -p swiftlint-bin
+          unzip -q -j swiftlint.zip swiftlint-static -d swiftlint-bin
+          mv swiftlint-bin/swiftlint-static swiftlint-bin/swiftlint
+          chmod +x swiftlint-bin/swiftlint
+          PATH="$PWD/swiftlint-bin:$PATH" ./Tools/swiftlint.sh
 
   # Compiling Sources/Bloom, which is the question "does the app still build".
   #

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -34,6 +34,16 @@
 #   type without the compiler objecting, so read what it says about a double optional rather than
 #   applying it. Both sites carry a `swiftlint:disable:next` saying so.
 #
+# **There is no `custom_rules:` block here and there must not be one.** A custom rule is a regex
+# and SwiftLint matches it through SourceKit, so that a hit inside a string or a comment can be
+# excluded. There is no SourceKit on Linux, so the Linux build says "Skipping enabled rule
+# 'custom_rules' because it requires SourceKit and SourceKit access is prohibited" and carries on
+# green, which is worse than having no rule at all: it passes on this Mac, and the run that gates
+# a merge never looks. `statement_position` is skipped for the same reason and is the only stock
+# rule that is, which is a gap worth knowing about rather than a hole worth filling. A rule of our
+# own belongs in `Tools/house-rules.sh`, which is `git grep` and runs everywhere. The empty catch
+# rule is there.
+#
 # One warning from experience. `swiftlint --fix` is not safe to run unread here. It rewrote
 # `let _ = SwitchTrace.mark(...)` to `_ = SwitchTrace.mark(...)` in three view bodies, which is
 # the documented SwiftUI idiom for a side effect inside a `@ViewBuilder`, and the app stopped
@@ -136,16 +146,3 @@ identifier_name:
   # `x86_64` is Apple's spelling of an architecture, and `as_` and `where_` are Swift keywords
   # that have to be spelled around. Backticks were the alternative and read worse.
   allowed_symbols: ["_"]
-
-custom_rules:
-  # There is no SwiftLint rule for this and there are no violations of it today, which is exactly
-  # when a rule is cheap to add. `no_empty_block` is the near miss: it counts a catch as a
-  # statement block along with every empty `{ }` closure a SwiftUI action passes, so it reports
-  # 103 things here and none of them is a swallowed error.
-  empty_catch:
-    name: "Empty catch"
-    regex: 'catch[^{]*\{[[:space:]]*\}'
-    message: "A catch that does nothing is an error nobody will ever see. Say why, in the block."
-    match_kinds:
-      - keyword
-      - identifier

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,151 @@
+# SwiftLint, tuned. `Tools/swiftlint.sh` runs it, `make swiftlint` is the short name, and the
+# `lint` job in .github/workflows/test.yml runs the same thing on Linux.
+#
+# This sits beside `Tools/house-rules.sh` and does not replace it. The house rules are the
+# conventions no off the shelf linter knows: no em dashes, British spelling, typed ids, a view
+# that does not run a subprocess, only the app target importing a UI framework. SwiftLint is the
+# other half, the things every Swift codebase can get wrong, and the two overlap nowhere.
+#
+# **The default rule set reported 1,634 violations on this tree**, and a rule set that reports
+# 1,634 things is a rule set nobody acts on. So every entry below is a measurement rather than a
+# preference, and the count each disabled rule produced is written next to it, because the next
+# person to wonder whether to turn one back on should not have to run it to find out.
+#
+# What was left in and what it caught, on the run this file was written from:
+#
+#   orphaned_doc_comment found four, and one of them was a real defect: a merge in ae3f9dc had
+#   cut a doc comment in `WorkspaceStartPlanTests` in half and dropped a `// MARK:` into the
+#   wound, leaving three lines documenting nothing at line 244 and the rest of the sentence
+#   stranded fifty lines further down. Nothing else would have said so.
+#
+#   force_try found eleven, every one of them in the suite, none in `Sources`. See
+#   `Tests/.swiftlint.yml` for why the suite is allowed them and `Sources` is not, and for the
+#   one other rule that had to come off there.
+#
+#   discarded_notification_center_observer found three, all deliberate, and all three now carry a
+#   `swiftlint:disable:next` saying why. That is the rule earning its keep: three observers that
+#   are never removed on purpose now say so, and a fourth that is a leak will have to explain
+#   itself.
+#
+#   redundant_nil_coalescing found ten. Eight were `(try? somethingReturningAnOptional()) ?? nil`,
+#   where Swift already flattens `try?` and the coalescing really was doing nothing. Two were not
+#   redundant at all: `await group.next() ?? nil` over a `TaskGroup(of: AgentEvent?.self)` is what
+#   turns `AgentEvent??` into `AgentEvent?`, and deleting it type checks. This rule can change a
+#   type without the compiler objecting, so read what it says about a double optional rather than
+#   applying it. Both sites carry a `swiftlint:disable:next` saying so.
+#
+# One warning from experience. `swiftlint --fix` is not safe to run unread here. It rewrote
+# `let _ = SwitchTrace.mark(...)` to `_ = SwitchTrace.mark(...)` in three view bodies, which is
+# the documented SwiftUI idiom for a side effect inside a `@ViewBuilder`, and the app stopped
+# compiling with "type '()' cannot conform to 'View'". Read the diff.
+
+included:
+  - Sources
+  - Tests
+
+disabled_rules:
+  # Every length and complexity threshold, off for the reason CLAUDE.md gives for having no house
+  # rule about file length: every threshold tried fired on files that were right. `Store` at 2,603
+  # lines is correct and no number tells it apart from an `AppModel` that was not. The counts are
+  # what the defaults produced: file_length 113, type_body_length 65, cyclomatic_complexity 49,
+  # function_body_length 39, function_parameter_count 14, closure_body_length 67, nesting 5.
+  - file_length
+  - type_body_length
+  - function_body_length
+  - closure_body_length
+  - cyclomatic_complexity
+  - function_parameter_count
+  - nesting
+
+  # 248 violations with `ignores_comments: true` already on, and still 49 over two hundred
+  # characters. Almost all of them are a sentence of interface copy or a SwiftUI modifier chain,
+  # so enforcing this would be 248 edits that change no behaviour and improve nothing anyone
+  # reads. The long doc comments CLAUDE.md asks for are a second reason.
+  - line_length
+
+  # 705 violations, and it is the house style rather than a mistake: Swift 6.1 allows a trailing
+  # comma everywhere, and every multi-line literal in this tree has one so that adding a line to
+  # it is a one line diff.
+  - trailing_comma
+
+  # 38 violations. A tuple of three is how `DiffParser`, `SeaChart` and `Store` return a small
+  # answer with no type worth naming, and a struct per return would be worse to read.
+  - large_tuple
+
+  # 81 violations. It wants `String(bytes:encoding:)` over `String(decoding:as: UTF8.self)`. The
+  # failable initialiser is the wrong one here: every use is subprocess output or a file on disk,
+  # where replacing a bad byte and carrying on is right and returning nil is not.
+  - optional_data_string_conversion
+
+  # 13 violations, every one of them the word "master", and every one of them the master build:
+  # `make master`, `Tools/master.sh`, `BuildIdentity.master(commit:)`. It is a build channel, not
+  # a branch. Nothing here is a git default branch, which is `main`.
+  - inclusive_language
+
+  # 5 violations, all of them a call with named callbacks and one trailing content closure, which
+  # is the shape SwiftUI itself uses. Un-trailing the last closure makes each of them longer and
+  # none of them clearer.
+  - multiple_closures_with_trailing_closure
+
+  # 5 violations, and all five are `let _ = SwitchTrace.mark(...)` inside a `@ViewBuilder`, where
+  # `let _ =` is the only spelling that compiles. The rule has an `ignore_swiftui_view_bodies`
+  # option and it is too narrow: it exempts a property literally named `body` and not the
+  # `private var content: some View` that `CenterPaneView` splits its body into. See the warning
+  # in the head of this file for what its autocorrection did.
+  - redundant_discardable_let
+
+  # 10 violations, all in the suite, all `#expect(x == [])`. Two of the ten are behind an optional
+  # chain, where the rewrite is `#expect(x?.isEmpty == true)`, which is worse to read than what it
+  # replaces.
+  - empty_collection_literal
+
+opt_in_rules:
+  # Rules that describe a defect rather than a preference. All of these were at zero when this
+  # file was written except the three noted in the head, so they cost nothing today and are here
+  # to hold the line tomorrow.
+  - discarded_notification_center_observer
+  - unhandled_throwing_task
+  - private_swiftui_state
+  - weak_delegate
+  - overridden_super_call
+  - prohibited_super_call
+  - static_over_final_class
+  - non_overridable_class_declaration
+  - fatal_error_message
+  - explicit_init
+  - yoda_condition
+  - contains_over_filter_is_empty
+  - contains_over_filter_count
+  - contains_over_first_not_nil
+  - first_where
+  - last_where
+  - sorted_first_last
+  - flatmap_over_map_reduce
+  - redundant_nil_coalescing
+  - toggle_bool
+  - joined_default_parameter
+
+identifier_name:
+  # The default floor of three characters fired 188 times on `x`, `y`, `db`, `at` and `to`, which
+  # are the right names for what they hold. What is worth keeping from this rule is the case
+  # convention and a ceiling, so the floor comes off and the rest stays.
+  min_length:
+    warning: 1
+  max_length:
+    warning: 60
+  # `x86_64` is Apple's spelling of an architecture, and `as_` and `where_` are Swift keywords
+  # that have to be spelled around. Backticks were the alternative and read worse.
+  allowed_symbols: ["_"]
+
+custom_rules:
+  # There is no SwiftLint rule for this and there are no violations of it today, which is exactly
+  # when a rule is cheap to add. `no_empty_block` is the near miss: it counts a catch as a
+  # statement block along with every empty `{ }` closure a SwiftUI action passes, so it reports
+  # 103 things here and none of them is a swallowed error.
+  empty_catch:
+    name: "Empty catch"
+    regex: 'catch[^{]*\{[[:space:]]*\}'
+    message: "A catch that does nothing is an error nobody will ever see. Say why, in the block."
+    match_kinds:
+      - keyword
+      - identifier

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ Everything real is a script in `Tools/`; the `Makefile` is the index.
 
     make            list the targets        make lint       Tools/house-rules.sh
     make build      compile every target    make test       the BloomCore suite
+    make swiftlint  Tools/swiftlint.sh
     make app        assemble a debug .app   make run        release .app, launched
     make master     install ~/Applications/Bloom.app  (see the guard below)
     make dev        install ~/Applications/Bloom Dev.app
@@ -65,6 +66,20 @@ widened enum leaving a switch in a view non-exhaustive. Run `make build` before 
 anything that adds a case to an enum.
 
 Zero warnings, and `make lint` green, before anything is committed.
+
+**`make lint` and `make swiftlint` are two different linters and both have to pass.**
+`Tools/house-rules.sh` is the conventions no off the shelf tool knows: no em dashes, British
+spelling, typed ids, a view that does not run a subprocess, only the app target importing a UI
+framework. SwiftLint is the half every Swift codebase shares, and `.swiftlint.yml` is tuned rather
+than default, because the defaults reported 1,634 violations here. The head of that file carries
+the count each disabled rule produced and the reason it is off, so a rule is argued with rather
+than guessed at. Both run in the `lint` job of `.github/workflows/test.yml`, on the Linux runner.
+
+SwiftLint is not installed by anything here. `brew install swiftlint`, or take the binary from the
+releases page; `Tools/swiftlint.sh` says so and stops rather than installing it for you. CI pins
+its own copy. `./Tools/swiftlint.sh --fix` applies what SwiftLint can correct itself, and the
+diff has to be read: it once rewrote `let _ =` inside a `@ViewBuilder` into code that does not
+compile.
 
 ## Where a green answer comes from
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,12 @@ its own copy. `./Tools/swiftlint.sh --fix` applies what SwiftLint can correct it
 diff has to be read: it once rewrote `let _ =` inside a `@ViewBuilder` into code that does not
 compile.
 
+**A rule of ours goes in `Tools/house-rules.sh`, never in a `custom_rules:` block.** SwiftLint
+matches a custom rule through SourceKit, there is no SourceKit on Linux, and the lint job prints
+"Skipping enabled rule 'custom_rules'" and goes green. A rule that passes on the author's Mac and
+is not run by the thing that gates the merge is worse than no rule, so `.swiftlint.yml` has no
+such block and says why.
+
 ## Where a green answer comes from
 
 Run tests locally, and run the ones that cover what you touched:

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@
 # tried to second-guess it would be wrong the first time a file moved.
 
 .DEFAULT_GOAL := help
-.PHONY: help build test app run lint master dev dev-db release dmg
+.PHONY: help build test app run lint swiftlint master dev dev-db release dmg
 
 help: ## Show this list
 	@grep -hE '^[a-z-]+:.*?## ' $(MAKEFILE_LIST) \
-		| awk 'BEGIN {FS = ":.*?## "}; {printf "  make %-9s %s\n", $$1, $$2}'
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  make %-10s %s\n", $$1, $$2}'
 	@echo
 	@echo "  Anything that takes an argument is run directly. See the head of this file."
 
@@ -37,6 +37,9 @@ run: ## Assemble a release Bloom.app and launch it
 
 lint: ## Check the house rules no off the shelf linter knows
 	./Tools/house-rules.sh
+
+swiftlint: ## Check the rules SwiftLint knows, against .swiftlint.yml
+	./Tools/swiftlint.sh
 
 master: ## Build HEAD and install it to ~/Applications/Bloom.app
 	./Tools/master.sh

--- a/Sources/Bloom/Design/RepoIcon.swift
+++ b/Sources/Bloom/Design/RepoIcon.swift
@@ -86,7 +86,7 @@ struct RepoIcon: View {
         Image(nsImage: artwork.image)
             .resizable()
             .interpolation(.high)
-            .aspectRatio(contentMode: .fit)
+            .scaledToFit()
             .frame(width: size, height: size)
             .clipShape(shape)
             // Only around artwork that reaches the edges. It is what separates a pale icon from a

--- a/Sources/Bloom/Design/Snapshot.swift
+++ b/Sources/Bloom/Design/Snapshot.swift
@@ -141,7 +141,6 @@ enum Snapshot {
         exit(0)
     }
 
-
     // MARK: - Driving a window that is going to be filmed
     //
     // None of the four flags below photograph anything. They put the running app into the state
@@ -691,7 +690,6 @@ enum Snapshot {
             exit(0)
         }
     }
-
 
     // MARK: - Gallery capture
 

--- a/Sources/Bloom/State/AppModel+Archive.swift
+++ b/Sources/Bloom/State/AppModel+Archive.swift
@@ -16,7 +16,6 @@ import BloomCore
 
 extension AppModel {
 
-
     /// Every archived workspace with what it still holds, and whether its branch is still here.
     ///
     /// The branch question is asked once per project rather than once per workspace: `branchExists`

--- a/Sources/Bloom/State/AppModel+Naming.swift
+++ b/Sources/Bloom/State/AppModel+Naming.swift
@@ -86,7 +86,7 @@ extension AppModel {
             placeholder: placeholder,
             hasPullRequest: hasPullRequest
         )
-        guard let result = outcome ?? nil, result.didRename else { return }
+        guard let result = outcome, result.didRename else { return }
 
         // The register is written here rather than left to the row, because more than one view
         // can be drawing this name when it lands and they have to scramble in step. `applyName`

--- a/Sources/Bloom/State/AppModel+ProjectIcons.swift
+++ b/Sources/Bloom/State/AppModel+ProjectIcons.swift
@@ -90,7 +90,7 @@ extension AppModel {
             guard answer.changes(row) else { return }
             answer.apply(to: &row)
         }
-        guard let row = stored ?? nil,
+        guard let row = stored,
               row.iconPath == answer.iconPath, row.iconSource == answer.iconSource,
               answer.changes(project)
         else { return false }

--- a/Sources/Bloom/State/AppModel+WorkspaceBridge.swift
+++ b/Sources/Bloom/State/AppModel+WorkspaceBridge.swift
@@ -148,7 +148,7 @@ extension AppModel {
     }
 
     private static let noWorkspaceForPane =
-        "That workspace is not open in Bloom any more, so there is nowhere to put a pane." 
+        "That workspace is not open in Bloom any more, so there is nowhere to put a pane."
 
     /// `pane_open`, through the same door the tab strip's `+` menu uses.
     ///

--- a/Sources/Bloom/State/AppModel.swift
+++ b/Sources/Bloom/State/AppModel.swift
@@ -2,7 +2,6 @@ import AppKit
 import Observation
 import BloomCore
 
-
 struct BloomAlert: Identifiable {
     let id = UUID()
     var title: String
@@ -63,7 +62,6 @@ final class AppModel {
     /// from one clock reading. The menu is built at the moment it opens, so it takes that reading
     /// itself and this stays the durable half.
     private(set) var quotas: [AgentQuota] = []
-
 
     /// Selecting a workspace is the moment its live model should come into existence, rather than
     /// the moment some view body happens to ask for it. Doing it here keeps model creation out of
@@ -365,7 +363,6 @@ final class AppModel {
         // window is already on screen. See `AppModel+TranscriptSearch`.
         startTranscriptIndexBackfill()
     }
-
 
     /// The socket an agent's MCP shim forwards to, listening for as long as the app runs.
     ///
@@ -750,9 +747,7 @@ final class AppModel {
     /// of mid-update mutation this file avoids everywhere else.
     @ObservationIgnored private var cachedArchived: [Workspace]?
 
-
     // MARK: - Clearing out the archive
-
 
     func workspaces(in repo: Repo) -> [Workspace] {
         // `SidebarReorder.drawn` rather than a comparator written here: a restated rule dropped
@@ -1075,12 +1070,9 @@ final class AppModel {
 
     // MARK: - Workspaces
 
-
     // MARK: - Continuing after a merge
 
-
     // MARK: - Undoing an archive
-
 
     // MARK: - Reading an archived workspace, and bringing it back
 
@@ -1090,7 +1082,6 @@ final class AppModel {
     /// `AppModel+Archive.swift`, so this is the one property the split genuinely publishes. Two
     /// seams for an insert and a remove would be more code saying less than the property does.
     var restoring: Set<WorkspaceID> = []
-
 
     /// What the sidebar's drag ends in.
     ///

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -1615,7 +1615,6 @@ final class WorkspaceModel {
     }
 }
 
-
 /// A thread-safe hand-off for streamed output.
 ///
 /// The producer is a subprocess reader on some background thread and the consumer is the main

--- a/Sources/Bloom/Views/Center/Composer/ComposerTextEditor.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerTextEditor.swift
@@ -379,7 +379,6 @@ struct ComposerTextEditor: NSViewRepresentable {
     }
 }
 
-
 /// The one edit the composer makes that nobody typed: a file arriving in the text after it has
 /// been copied into the worktree.
 ///

--- a/Sources/Bloom/Views/Center/Composer/ComposerTextView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerTextView.swift
@@ -231,7 +231,6 @@ private extension NSPasteboardItem {
     }
 }
 
-
 // MARK: - The pointer on a chip
 
 extension ComposerTextView {

--- a/Sources/Bloom/Views/Center/Composer/ReviewCommentChip.swift
+++ b/Sources/Bloom/Views/Center/Composer/ReviewCommentChip.swift
@@ -80,7 +80,7 @@ struct ReviewCommentChip: View {
         } else {
             Image(systemName: "text.bubble")
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: Self.slot, height: Self.slot)
                 .foregroundStyle(Palette.textSecondary)
                 .accessibilityHidden(true)

--- a/Sources/Bloom/Views/Center/Composer/SlashCommandChip.swift
+++ b/Sources/Bloom/Views/Center/Composer/SlashCommandChip.swift
@@ -106,7 +106,7 @@ struct SlashCommandChip: View {
         } else {
             Image(systemName: glyph)
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: Self.slot, height: Self.slot)
                 .foregroundStyle(Palette.textSecondary)
                 .accessibilityHidden(true)
@@ -125,7 +125,7 @@ struct SlashCommandChip: View {
             Button(action: open) {
                 Image(systemName: "arrow.up.forward.square")
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                     .frame(width: Self.slot, height: Self.slot)
                     .foregroundStyle(isHovered ? Palette.textSecondary : .clear)
                     .contentShape(Rectangle())

--- a/Sources/Bloom/Views/Chrome/Feedback/FeedbackSheetParts.swift
+++ b/Sources/Bloom/Views/Chrome/Feedback/FeedbackSheetParts.swift
@@ -13,7 +13,6 @@ enum FeedbackPhase: Equatable {
     var isSending: Bool { self == .sending }
 }
 
-
 /// The heading and the sentence under it, which is the same shape on both sheets.
 struct FeedbackHeader: View {
     var title: String

--- a/Sources/Bloom/Views/Chrome/MenuBar/AgentActivity.swift
+++ b/Sources/Bloom/Views/Chrome/MenuBar/AgentActivity.swift
@@ -55,6 +55,10 @@ final class AgentActivity {
         // agents and drives the running count to zero through the reporter. This covers the gap
         // between those two: a quit that beats SwiftUI to the last update pass still releases
         // here, so the release is provable rather than inferred from process death.
+        // The token is dropped because there is nothing left to remove this from: the observer
+        // is the singleton's own, it fires once as the process ends, and the only thing that
+        // could outlive it is the app itself.
+        // swiftlint:disable:next discarded_notification_center_observer
         NotificationCenter.default.addObserver(
             forName: NSApplication.willTerminateNotification, object: nil, queue: .main
         ) { _ in

--- a/Sources/Bloom/Views/Chrome/TextZoomAvailability.swift
+++ b/Sources/Bloom/Views/Chrome/TextZoomAvailability.swift
@@ -27,6 +27,9 @@ final class TextZoomAvailability {
 
     private init() {
         for name in [NSWindow.didUpdateNotification, UserDefaults.didChangeNotification] {
+            // Registered by the singleton's own initialiser and wanted for as long as the app
+            // runs, so the token would only ever be stored and never used.
+            // swiftlint:disable:next discarded_notification_center_observer
             NotificationCenter.default.addObserver(
                 forName: name, object: nil, queue: .main
             ) { _ in

--- a/Sources/Bloom/Views/Chrome/Window/WindowCloseShortcut.swift
+++ b/Sources/Bloom/Views/Chrome/Window/WindowCloseShortcut.swift
@@ -64,6 +64,9 @@ enum WindowCloseShortcut {
     static func apply() {
         watchForTheKey()
         apply(remaining: attempts)
+        // A process-lifetime observer on an enum with no instances, so there is no owner whose
+        // deinit would remove it and no token worth keeping.
+        // swiftlint:disable:next discarded_notification_center_observer
         NotificationCenter.default.addObserver(
             forName: NSMenu.didBeginTrackingNotification, object: nil, queue: nil
         ) { _ in

--- a/Sources/Bloom/Views/Inspector/DiffLineView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffLineView.swift
@@ -49,7 +49,7 @@ struct DiffLineView: View, Equatable {
     var isCommented: Bool = false
     /// Opens the review comment editor at this line. Nil, the default, draws no `+` at all,
     /// which is what every caller that is not the review's own diff wants.
-    var onComment: ((ReviewSpot) -> Void)? = nil
+    var onComment: ((ReviewSpot) -> Void)?
 
     @State private var isHovered = false
     @FocusState private var isPlusFocused: Bool

--- a/Sources/Bloom/Views/Inspector/FileEditSession.swift
+++ b/Sources/Bloom/Views/Inspector/FileEditSession.swift
@@ -133,8 +133,11 @@ final class FileEditSession {
     nonisolated private static func writing(
         _ text: String, over baseline: EditableFile
     ) -> Result<EditableFile, FileEditorError> {
-        do { return .success(try FileEditor.write(text, over: baseline)) }
-        catch { return .failure(error) }
+        do {
+            return .success(try FileEditor.write(text, over: baseline))
+        } catch {
+            return .failure(error)
+        }
     }
 
     private static func message(for error: FileEditorError) -> String {

--- a/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
@@ -53,8 +53,6 @@ struct PullRequestSummary: View {
 
     private var status: PullRequestStatus { pullRequest.status(local: localWork) }
 
-
-
     /// Whether this strip is asking for something or reporting something.
     ///
     /// Open is a request: there is a button in the band and a state you are waiting on. Merged and

--- a/Sources/Bloom/Views/Tabs/TabStrip.swift
+++ b/Sources/Bloom/Views/Tabs/TabStrip.swift
@@ -144,7 +144,6 @@ struct TabStrip<Leading: View, Tabs: View, Append: View, Trailing: View>: View {
     /// as `width`: a drag must not write state once a frame.
     @State private var overflow = TabStripOverflow()
 
-
     init(
         pane: TabPane = .content,
         selection: AnyHashable? = nil,

--- a/Sources/Bloom/Views/Transcript/TranscriptTextView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTextView.swift
@@ -203,8 +203,7 @@ struct TranscriptTextView: NSViewRepresentable {
     /// three) and which counts the extra line fragment a trailing newline leaves behind.
     private func widestLine(_ layout: NSLayoutManager, in container: NSTextContainer) -> CGFloat {
         var widest: CGFloat = 0
-        layout.enumerateLineFragments(forGlyphRange: layout.glyphRange(for: container)) {
-            _, usedRect, _, _, _ in
+        layout.enumerateLineFragments(forGlyphRange: layout.glyphRange(for: container)) { _, usedRect, _, _, _ in
             widest = max(widest, usedRect.maxX)
         }
         return widest

--- a/Sources/Bloom/Views/Transcript/TurnScan.swift
+++ b/Sources/Bloom/Views/Transcript/TurnScan.swift
@@ -98,7 +98,6 @@ enum TurnScan {
         }
     }
 
-
     /// Rows are stored in sequence order, so finding the turn boundary is a binary search rather
     /// than a walk over every row in the session.
     private static func position(of seq: Int, in rows: [TranscriptRow]) -> Int? {

--- a/Sources/BloomCore/Agent/AgentRunner.swift
+++ b/Sources/BloomCore/Agent/AgentRunner.swift
@@ -1071,5 +1071,3 @@ public extension PermissionMode {
         }
     }
 }
-
-

--- a/Sources/BloomCore/Agent/Codex/CodexRunner.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexRunner.swift
@@ -672,4 +672,3 @@ private final class LiveConnection: Sendable {
         self.client.withLock { $0 = client }
     }
 }
-

--- a/Sources/BloomCore/Agent/Codex/CodexTranslation.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexTranslation.swift
@@ -273,7 +273,6 @@ public struct CodexTranslation: Sendable {
         }
     }
 
-
     // MARK: - Envelopes
 
     /// The bytes a row is stored as.

--- a/Sources/BloomCore/Agent/QuotaAsk.swift
+++ b/Sources/BloomCore/Agent/QuotaAsk.swift
@@ -135,7 +135,7 @@ public struct ClaudeCodeQuotaSource: AgentQuotaSource {
               response["subtype"]?.stringValue == "success",
               let payload = response["response"]
         else { return nil }
-        return (try? JSONEncoder().encode(payload)) ?? nil
+        return (try? JSONEncoder().encode(payload))
     }
 
     private let executable: String

--- a/Sources/BloomCore/Git/Git+Safety.swift
+++ b/Sources/BloomCore/Git/Git+Safety.swift
@@ -403,8 +403,8 @@ extension Git {
         // Exists only in the worktree, so removing the worktree is the end of it.
         guard manager.fileExists(atPath: there) else { return true }
 
-        let mySize = (try? manager.attributesOfItem(atPath: here)[.size] as? Int) ?? nil
-        let theirSize = (try? manager.attributesOfItem(atPath: there)[.size] as? Int) ?? nil
+        let mySize = (try? manager.attributesOfItem(atPath: here)[.size] as? Int)
+        let theirSize = (try? manager.attributesOfItem(atPath: there)[.size] as? Int)
         if let mySize, let theirSize, mySize != theirSize { return true }
 
         guard let mine = manager.contents(atPath: here) else { return true }

--- a/Sources/BloomCore/Model/WorkspaceMarks.swift
+++ b/Sources/BloomCore/Model/WorkspaceMarks.swift
@@ -1,16 +1,16 @@
 import Foundation
 
-/// The two marks a person puts on a workspace by hand.
-///
-/// Everything else a sidebar row draws is reported rather than chosen: the status glyph is what
-/// `WorkspaceStatus` worked out, the diff counts are what `git` said, the unread weight is what a
-/// finishing turn wrote. These two are the opposite. Nothing sets them but the user, nothing
-/// clears them but the user or the one rule written out below, and they exist so a person can say
-/// something about a row that the machine has no way to know.
-///
-/// They live here, in the core, rather than in the menus that offer them, because both lists offer
-/// them and the answer must not depend on which list you right clicked in. `WorkspaceMenuItems`
-/// draws what these decide.
+// The two marks a person puts on a workspace by hand.
+//
+// Everything else a sidebar row draws is reported rather than chosen: the status glyph is what
+// `WorkspaceStatus` worked out, the diff counts are what `git` said, the unread weight is what a
+// finishing turn wrote. These two are the opposite. Nothing sets them but the user, nothing
+// clears them but the user or the one rule written out below, and they exist so a person can say
+// something about a row that the machine has no way to know.
+//
+// They live here, in the core, rather than in the menus that offer them, because both lists offer
+// them and the answer must not depend on which list you right clicked in. `WorkspaceMenuItems`
+// draws what these decide.
 
 // MARK: - The unread mark
 

--- a/Sources/BloomCore/Persistence/Store.swift
+++ b/Sources/BloomCore/Persistence/Store.swift
@@ -1915,7 +1915,6 @@ public actor Store {
         }
     }
 
-
     // MARK: - Agent quotas
 
     /// Every allowance any provider has reported and has not yet turned over.

--- a/Sources/BloomCore/System/StreamingProcess.swift
+++ b/Sources/BloomCore/System/StreamingProcess.swift
@@ -297,8 +297,7 @@ public final class StreamingProcess: Sendable {
         let limit = deadline ?? DispatchTime.now() + Self.eofHardLimit
         let now = DispatchTime.now()
 
-        let (sawEOF, since, stdoutLive, stderrLive) = state.withLock {
-            state -> (Bool, DispatchTime, Bool, Bool) in
+        let (sawEOF, since, stdoutLive, stderrLive) = state.withLock { state -> (Bool, DispatchTime, Bool, Bool) in
             let exited = state.exitedAt ?? now
             state.exitedAt = exited
             // Counted from the exit as well as from the last byte, so a process that fell silent

--- a/Sources/BloomCore/Transcript/MarkdownParser.swift
+++ b/Sources/BloomCore/Transcript/MarkdownParser.swift
@@ -601,9 +601,13 @@ private func isBlank(_ line: String) -> Bool {
 private func leadingSpaces(_ line: String) -> Int {
     var count = 0
     for character in line {
-        if character == " " { count += 1 }
-        else if character == "\t" { count += 4 }
-        else { break }
+        if character == " " {
+            count += 1
+        } else if character == "\t" {
+            count += 4
+        } else {
+            break
+        }
     }
     return count
 }
@@ -612,9 +616,7 @@ private func dropLeadingColumns(_ line: String, _ columns: Int) -> String {
     var consumed = 0
     var position = line.startIndex
     while position < line.endIndex, consumed < columns {
-        if line[position] == " " { consumed += 1 }
-        else if line[position] == "\t" { consumed += 4 }
-        else { break }
+        if line[position] == " " { consumed += 1 } else if line[position] == "\t" { consumed += 4 } else { break }
         position = line.index(after: position)
     }
     return String(line[position...])

--- a/Sources/BloomCore/Transcript/SubagentTranscript.swift
+++ b/Sources/BloomCore/Transcript/SubagentTranscript.swift
@@ -210,8 +210,7 @@ public enum SubagentOutput: Sendable {
     /// the kind is asked for rather than sniffed. Parsing one as the other is what made a
     /// background command's pane empty.
     public static func read(path: String?, kind: SubagentKind = .agent)
-        -> Result<SubagentTranscript, Failure>
-    {
+        -> Result<SubagentTranscript, Failure> {
         guard let path, !path.isEmpty else { return .failure(.noFile) }
         let url = URL(fileURLWithPath: path)
         guard FileManager.default.fileExists(atPath: url.path) else { return .failure(.missing) }

--- a/Sources/BloomCore/Workspace/RepositoryStartPlan.swift
+++ b/Sources/BloomCore/Workspace/RepositoryStartPlan.swift
@@ -1,20 +1,20 @@
 import Foundation
 
-/// What Bloom does about a folder it has been handed, decided before anything is done to it.
-///
-/// Everything in this file is pure. It takes facts that were gathered by looking at the disk and
-/// answers three questions: what should become of this folder, what would be committed if it
-/// became a repository, and is the GitHub name the user typed a name GitHub will accept. The
-/// answers are what the dialog shows, and they are what the tests pin, because the alternative is
-/// a dialog whose promises are only checked by running it against somebody's home directory.
-///
-/// **`FolderVerdict.of` is the one rule, and both doors ask it.** The owner's file panel and
-/// `project_add` over the bridge used to have a policy each, and they did not agree: the panel
-/// added anything git recognised, which meant it would register one of Bloom's own worktrees or
-/// a home directory somebody had run `git init` in, and the bridge refused both. Two lists of
-/// refusals maintained apart is the shape of that bug, so there is one list now. What genuinely
-/// differs is how a refusal reads, which is `sentence` for a person in front of a file panel and
-/// `agentSentence` for a caller that needs to be told whether retrying helps.
+// What Bloom does about a folder it has been handed, decided before anything is done to it.
+//
+// Everything in this file is pure. It takes facts that were gathered by looking at the disk and
+// answers three questions: what should become of this folder, what would be committed if it
+// became a repository, and is the GitHub name the user typed a name GitHub will accept. The
+// answers are what the dialog shows, and they are what the tests pin, because the alternative is
+// a dialog whose promises are only checked by running it against somebody's home directory.
+//
+// **`FolderVerdict.of` is the one rule, and both doors ask it.** The owner's file panel and
+// `project_add` over the bridge used to have a policy each, and they did not agree: the panel
+// added anything git recognised, which meant it would register one of Bloom's own worktrees or
+// a home directory somebody had run `git init` in, and the bridge refused both. Two lists of
+// refusals maintained apart is the shape of that bug, so there is one list now. What genuinely
+// differs is how a refusal reads, which is `sentence` for a person in front of a file panel and
+// `agentSentence` for a caller that needs to be told whether retrying helps.
 
 // MARK: - What the folder is
 

--- a/Sources/BloomCore/Workspace/WorkspaceContinuation.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceContinuation.swift
@@ -298,7 +298,7 @@ public extension WorkspaceManager {
 
         return ContinuationFacts(
             recordedBranch: workspace.branch,
-            checkedOutBranch: await checkedOut ?? nil,
+            checkedOutBranch: await checkedOut,
             baseBranch: workspace.baseBranch,
             isPullRequestMerged: isPullRequestMerged,
             isAgentRunning: isAgentRunning,

--- a/Sources/BloomCore/Workspace/WorkspaceRenaming.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceRenaming.swift
@@ -49,13 +49,13 @@ extension WorkspaceManager {
 
         return BranchRenameFacts(
             recordedBranch: workspace.branch,
-            checkedOutBranch: await checkedOut ?? nil,
+            checkedOutBranch: await checkedOut,
             desiredBranch: desiredBranch,
             // A commit count git refused to give is not evidence that there are none. Treating a
             // failed read as "one commit" is the cautious direction: it refuses the rename rather
             // than performing one on a repository nobody could ask a question of.
             commitsAhead: await ahead ?? 1,
-            hasUpstream: (await upstream ?? nil) != nil,
+            hasUpstream: (await upstream) != nil,
             hasRemoteCounterpart: await remote,
             hasPullRequest: hasPullRequest,
             hasOperationInProgress: await inProgress,

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,0 +1,24 @@
+# Merged over the `.swiftlint.yml` at the root, for files under this directory only. SwiftLint
+# reads the nearest configuration walking up from each file and layers it on the one above, so
+# everything the root says still applies here and this file only says what differs.
+#
+# Two rules differ, and both differ because the suite is not the app.
+disabled_rules:
+  # 11 violations, all of them here and none in `Sources`. Nine are
+  # `try! JSONSerialization.data(withJSONObject:)` over a dictionary literal written three lines
+  # above, and two are `try! #require(...)`. A fixture that cannot be built is a broken test
+  # rather than a condition to handle, and the alternatives are worse: `try?` with a fallback
+  # hides the breakage behind an assertion that fails somewhere else, and threading `throws` out
+  # of the fixture helpers reaches dozens of call sites to say nothing. The rule stays on for
+  # `Sources`, where it is at zero and where a `try!` really would be a crash in front of
+  # somebody.
+  - force_try
+
+  # 9 violations, and the correction it asks for does not compile inside `#expect`. Swift
+  # Testing's macro takes an expression apart to describe it in the failure message, and
+  # `#expect(!models.contains(where: \.hidden))` expands to `Testing.__checkFunctionCall(models,
+  # calling: { $0.contains(where: $1) }, ...)`, where the closure has lost the `rethrows`
+  # inference that made the original fine: "call can throw, but it is not marked with 'try'".
+  # `filter { }.isEmpty` survives the same expansion, so the rule's target is the only spelling
+  # that works here. It stays on for `Sources`, which is at zero and has no macro in the way.
+  - contains_over_filter_is_empty

--- a/Tests/BloomCoreTests/AgentRunnerTests.swift
+++ b/Tests/BloomCoreTests/AgentRunnerTests.swift
@@ -772,7 +772,6 @@ private func fixtureSessionLines() throws -> [String] {
     try bloomFixtureLines("session-basic.jsonl")
 }
 
-
 // MARK: - Permission asks
 
 /// Answering the CLI's permission question, and answering it on the user's behalf.

--- a/Tests/BloomCoreTests/CoreReviewFixTests.swift
+++ b/Tests/BloomCoreTests/CoreReviewFixTests.swift
@@ -66,6 +66,11 @@ struct CodexRunnerPersistenceFailureTests {
                 try? await Task.sleep(for: .seconds(5))
                 return nil
             }
+            // Not redundant, whatever the rule thinks. The group's child result is
+            // `AgentEvent?`, so `next()` hands back `AgentEvent??` and this is what flattens
+            // it. Deleting it type checks, changes the type, and makes a timed-out run print
+            // "Optional(nil)".
+            // swiftlint:disable:next redundant_nil_coalescing
             let winner = await group.next() ?? nil
             group.cancelAll()
             return winner
@@ -119,6 +124,11 @@ struct CodexRunnerPersistenceFailureTests {
                 try? await Task.sleep(for: .seconds(2))
                 return nil
             }
+            // Not redundant, whatever the rule thinks. The group's child result is
+            // `AgentEvent?`, so `next()` hands back `AgentEvent??` and this is what flattens
+            // it. Deleting it type checks, changes the type, and makes a timed-out run print
+            // "Optional(nil)".
+            // swiftlint:disable:next redundant_nil_coalescing
             let winner = await group.next() ?? nil
             group.cancelAll()
             return winner

--- a/Tests/BloomCoreTests/PermissionGrantTests.swift
+++ b/Tests/BloomCoreTests/PermissionGrantTests.swift
@@ -283,7 +283,6 @@ struct PermissionGrantTests {
     }
 }
 
-
 /// A question that outlives the window it was asked in.
 ///
 /// The CLI puts no timer on a `can_use_tool` request: it waits until it is answered, until the

--- a/Tests/BloomCoreTests/RepositoryStarterTests.swift
+++ b/Tests/BloomCoreTests/RepositoryStarterTests.swift
@@ -507,4 +507,3 @@ struct RepositoryStartAbandonmentTests {
             == RepositoryStartStep.allCases.count)
     }
 }
-

--- a/Tests/BloomCoreTests/TestSupport.swift
+++ b/Tests/BloomCoreTests/TestSupport.swift
@@ -326,9 +326,9 @@ final class LineCollector: @unchecked Sendable {
 
 // MARK: - Readable failures
 
+// Same package, so no @retroactive is needed or allowed here.
 /// Without this, a failed archive expectation prints every stored property of the report and
 /// buries the one thing the reader needs: what archiving would have destroyed.
-// Same package, so no @retroactive is needed or allowed here.
 extension WorkspaceSafetyReport: CustomTestStringConvertible {
     public var testDescription: String {
         isSafeToDiscard

--- a/Tests/BloomCoreTests/WorkspaceStartPlanTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceStartPlanTests.swift
@@ -241,9 +241,6 @@ struct TerminalNoteTests {
         }
     }
 
-    /// **The regression this suite exists for.**
-    ///
-    /// The sheet used to say "Named after a sea", "named after a sea" and "named after the sea" in
     // MARK: - What a workspace ends up called
 
     /// The rule exists so the row drawn while the worktree is being cut and the row drawn
@@ -291,6 +288,9 @@ struct TerminalNoteTests {
         #expect(!WorkspaceStartPlan.name(supplied: nil, checkout: nil, prompt: "").isEmpty)
     }
 
+    /// **The regression this suite exists for.**
+    ///
+    /// The sheet used to say "Named after a sea", "named after a sea" and "named after the sea" in
     /// three places at once. The catalogue is still there and still claims, and the chart and the
     /// notice that fires on a first claim are how somebody is meant to find out about it. A create
     /// sheet that explains the mechanism up front spends that discovery to answer a question

--- a/Tools/house-rules.sh
+++ b/Tools/house-rules.sh
@@ -3,7 +3,7 @@
 #
 #   ./Tools/house-rules.sh
 #
-# Eight rules, and every one of them is here because it has already been broken:
+# Nine rules, and every one of them is here because it has already been broken:
 #
 #   1. No em dashes and no en dashes. Anywhere. They arrive by the hundred from
 #      anything that writes prose for you, and once one is in a file the next
@@ -26,22 +26,26 @@
 #   8. A View does not run a subprocess. A decision taken inside a View is a
 #      decision nothing can test, and CLAUDE.md said so for weeks while nothing
 #      checked it; see the rule itself for the helper types that are the way out.
+#   9. A catch says something. This one is here before it has been broken, which
+#      makes it the exception, and it is here because SwiftLint cannot hold it:
+#      its `custom_rules` need SourceKit, there is none on Linux, and the lint
+#      job skips them and stays green. See the rule itself.
 #
 # Exit status is 1 if anything was found, and every finding is printed with the
 # file and line so it can be opened. The word lists are deliberately narrow:
 # a rule that cries wolf gets switched off, so anything with a legitimate use in
 # this codebase either stays out of the list or is named in an exception below.
 #
-# **Every search here passes `--untracked`, and that is load bearing.** Six of
-# these eight rules did not, and a plain `git grep` sees only what is tracked, so
-# a brand new file was invisible to all six until somebody staged it. One decoy
-# file inside `Sources/BloomCore` carrying a violation of each raised one finding
-# untracked and six the moment it was added, on identical bytes. That is worst
-# exactly where it matters: rules 4, 5 and 6 say in their own comments that the
-# compiler holds everything EXCEPT a new file inside the core, and a new file is
-# untracked until it is staged, so `make lint` passed on precisely the thing the
-# rule exists to catch. `--untracked` does not include ignored files, so `.build`
-# and the rest of .gitignore stay out.
+# **Every search here passes `--untracked`, and that is load bearing.** Six of the
+# eight rules that existed then did not, and a plain `git grep` sees only what is
+# tracked, so a brand new file was invisible to all six until somebody staged it.
+# One decoy file inside `Sources/BloomCore` carrying a violation of each raised
+# one finding untracked and six the moment it was added, on identical bytes. That
+# is worst exactly where it matters: rules 4, 5 and 6 say in their own comments
+# that the compiler holds everything EXCEPT a new file inside the core, and a new
+# file is untracked until it is staged, so `make lint` passed on precisely the
+# thing the rule exists to catch. `--untracked` does not include ignored files,
+# so `.build` and the rest of .gitignore stay out.
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -372,6 +376,42 @@ while IFS= read -r hit; do
   fi
 done <<EOF
 $(git grep --untracked -n -I -E 'await (Git|Shell)\.' -- 'Sources/Bloom/Views/*' || true)
+EOF
+
+echo "==> a catch says something"
+# `catch { }` compiles, runs, and is the only way an error in Swift can vanish
+# without anybody being told. There are none in the tree today, which is why this
+# is the one rule here written before the mistake rather than after it: a rule
+# that starts at zero costs nothing to add and everything to add later.
+#
+# It is here rather than in `.swiftlint.yml` because SwiftLint cannot enforce it.
+# `no_empty_block` is the nearest stock rule and it counts every empty `{ }`
+# closure a SwiftUI action passes as the same thing, so it reports 103 findings
+# here and not one of them is a swallowed error. A `custom_rules` regex says
+# exactly this and is skipped on Linux, where the lint job runs, because matching
+# one needs SourceKit: "Skipping enabled rule 'custom_rules' because it requires
+# SourceKit and SourceKit access is prohibited", and then the job goes green. A
+# rule that passes on the author's Mac and is not run by the thing that gates the
+# merge is worse than no rule.
+#
+# Two spellings, because both are how it actually gets typed: the whole thing on
+# one line, and the brace on its own line under it. A catch with a comment in it
+# is not empty and is the way to say the error is deliberately ignored.
+empty_catch_awk='
+  previous ~ /catch[^{]*\{[[:space:]]*$/ && $0 ~ /^[[:space:]]*\}[[:space:]]*$/ {
+    printf "%s:%d:%s\n", FILENAME, NR - 1, previous
+  }
+  /catch[^{]*\{[[:space:]]*\}/ { printf "%s:%d:%s\n", FILENAME, NR, $0 }
+  { previous = $0 }
+'
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  if hits="$(awk "$empty_catch_awk" "$file")" && [ -n "$hits" ]; then
+    echo "$hits" | show
+    report "$file has a catch that does nothing. An error that is deliberately ignored says so in a comment inside the block; one that is not is a failure nobody will ever hear about."
+  fi
+done <<EOF
+$(git grep --untracked -l -I -E 'catch[^{]*\{' -- 'Sources/*' 'Tests/*' || true)
 EOF
 
 echo "==> British spelling"

--- a/Tools/house-rules.sh
+++ b/Tools/house-rules.sh
@@ -397,6 +397,9 @@ echo "==> a catch says something"
 # Two spellings, because both are how it actually gets typed: the whole thing on
 # one line, and the brace on its own line under it. A catch with a comment in it
 # is not empty and is the way to say the error is deliberately ignored.
+# Single quoted, and SC2016 has to be told so: `$0` in here is awk's whole line
+# and not a shell parameter, so expanding it is the one thing this must not do.
+# shellcheck disable=SC2016
 empty_catch_awk='
   previous ~ /catch[^{]*\{[[:space:]]*$/ && $0 ~ /^[[:space:]]*\}[[:space:]]*$/ {
     printf "%s:%d:%s\n", FILENAME, NR - 1, previous

--- a/Tools/swiftlint.sh
+++ b/Tools/swiftlint.sh
@@ -1,5 +1,6 @@
 #!/bin/zsh
-# Runs SwiftLint over Sources and Tests, against the `.swiftlint.yml` at the root.
+# Runs SwiftLint over Sources and Tests, against the `.swiftlint.yml` at the root and the one
+# in `Tests/` layered on top of it for the files under there.
 #
 #   ./Tools/swiftlint.sh              lint everything, which is also `make swiftlint`
 #   ./Tools/swiftlint.sh --fix        apply the corrections SwiftLint can make itself
@@ -9,6 +10,10 @@
 # the conventions no off the shelf tool knows about: no em dashes, British spelling, typed ids, a
 # view that does not run a subprocess. SwiftLint holds the ones every Swift codebase shares. Both
 # run in the `lint` job of .github/workflows/test.yml, on the Linux runner, side by side.
+#
+# **No `--config`, deliberately.** Passing one switches SwiftLint's nested configuration off,
+# and `Tests/.swiftlint.yml` is where two rules that are wrong for a test suite and right for
+# `Sources` come off. Reach for `--config` and the suite is linted as if it were the app.
 #
 # --strict, always, and that is the whole point of the tuned configuration. SwiftLint's own exit
 # status only fails on an error-severity violation, and every rule in `.swiftlint.yml` is at the

--- a/Tools/swiftlint.sh
+++ b/Tools/swiftlint.sh
@@ -1,0 +1,63 @@
+#!/bin/zsh
+# Runs SwiftLint over Sources and Tests, against the `.swiftlint.yml` at the root.
+#
+#   ./Tools/swiftlint.sh              lint everything, which is also `make swiftlint`
+#   ./Tools/swiftlint.sh --fix        apply the corrections SwiftLint can make itself
+#   ./Tools/swiftlint.sh Sources/Bloom/Views   lint one path
+#
+# `make lint` is the other linter and they are not the same thing. `Tools/house-rules.sh` holds
+# the conventions no off the shelf tool knows about: no em dashes, British spelling, typed ids, a
+# view that does not run a subprocess. SwiftLint holds the ones every Swift codebase shares. Both
+# run in the `lint` job of .github/workflows/test.yml, on the Linux runner, side by side.
+#
+# --strict, always, and that is the whole point of the tuned configuration. SwiftLint's own exit
+# status only fails on an error-severity violation, and every rule in `.swiftlint.yml` is at the
+# default warning severity, so without this flag a run that reported fifty things would still
+# exit 0 and CI would go green over them. The configuration is at zero violations, so there is
+# nothing to lose by treating every one of them as fatal, and that is what keeps it at zero.
+#
+# THIS SCRIPT DOES NOT INSTALL ANYTHING.
+#
+# SwiftLint is a 37MB binary from the internet and this is somebody's Mac. If it is not on the
+# PATH the script says how to get it and stops, rather than deciding for you. CI pins a version
+# and downloads it into the runner, which is a machine that is thrown away afterwards; see the
+# `Lint the Swift` step in .github/workflows/test.yml. Locally, `brew install swiftlint` is the
+# short answer, and the release page linked below is the one CI uses.
+#
+# A version skew between here and CI is worth knowing about and is not worth failing over: a
+# newer SwiftLint can add a rule that fires on code this configuration was green on. The version
+# is printed on every run so that "it passed locally" has something to compare against.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if ! command -v swiftlint >/dev/null 2>&1; then
+  cat <<'MISSING'
+SwiftLint is not on the PATH.
+
+  brew install swiftlint
+
+or take the binary from https://github.com/realm/SwiftLint/releases and put it somewhere on the
+PATH. The version CI pins is in the `Lint the Swift` step of .github/workflows/test.yml.
+MISSING
+  exit 1
+fi
+
+echo "==> $(swiftlint version)"
+
+# --fix first, because it is a different subcommand's worth of behaviour rather than a flag on
+# this one, and because a run that rewrites files should not also be the run that decides whether
+# the tree is clean. Read the diff afterwards. SwiftLint's autocorrection has already turned a
+# `let _ = ` inside a `@ViewBuilder` into code that does not compile; the head of `.swiftlint.yml`
+# has the details.
+if [ "${1:-}" = "--fix" ]; then
+  shift
+  swiftlint lint --fix --progress "$@"
+  echo
+  echo "Files were rewritten. Read the diff before committing, and run this again without --fix."
+  exit 0
+fi
+
+swiftlint lint --strict --quiet "$@"
+echo
+echo "SwiftLint passes."


### PR DESCRIPTION
SwiftLint's defaults reported 1,634 violations here, so `.swiftlint.yml` is tuned rather than accepted: every disabled rule carries the count it produced and the reason it is off, and the opt-in list is defect rules rather than taste. It runs in the existing Linux `lint` job, about a second over 920 files, no macOS minutes. `Tools/swiftlint.sh` and `make swiftlint` are the same thing locally; neither installs anything.

It found one real defect on its first run: a merge in ae3f9dc cut a doc comment in `WorkspaceStartPlanTests` in half and dropped a `// MARK:` into the wound, stranding three lines at line 244 and the rest of the sentence fifty lines below.

Left off, with counts: `trailing_comma` 705, `line_length` 248 (with comments already ignored), `identifier_name`'s three-character floor 188, `file_length` 113, `optional_data_string_conversion` 81, `closure_body_length` 67, `type_body_length` 65, `cyclomatic_complexity` 49, `large_tuple` 38, `inclusive_language` 13 (all of them the master build), and a few smaller ones. `force_try` and `contains_over_filter_is_empty` are on for `Sources`, where both are at zero, and off for the suite via `Tests/.swiftlint.yml`, which says why.

Two things worth knowing. `swiftlint --fix` rewrote `let _ = SwitchTrace.mark(...)` inside three view bodies and the app stopped compiling with "type '()' cannot conform to 'View'". And `redundant_nil_coalescing` will delete a `?? nil` that flattens a double optional, which type checks and changes the type. Both are written down where they will be hit.