### PR TITLE
Tell a sidebar row's whole story without switching to it

### DIFF
--- a/Sources/Bloom/Design/Gallery.swift
+++ b/Sources/Bloom/Design/Gallery.swift
@@ -74,6 +74,7 @@ extension Snapshot {
         .paneTabs,
         .sidebarSelection,
         .quickPrompts,
+        .hoverCard,
     ]
 
     /// The page `--gallery` names, falling back to the first rather than failing: a capture run

--- a/Sources/Bloom/Design/Theme.swift
+++ b/Sources/Bloom/Design/Theme.swift
@@ -725,6 +725,22 @@ enum Motion {
     /// a half.
     static let sweep: Animation = .easeInOut(duration: 3)
 
+    /// How long the pointer has to rest before a card opens under it: the composer's file chip,
+    /// and the sidebar row's.
+    ///
+    /// Not an animation, which is why it stands slightly apart from the rest of this file, and
+    /// here anyway because it is the same kind of decision: how the window responds to a pointer.
+    /// It was a private constant inside `ComposerTextView` and a second one would have been the
+    /// first thing `WorkspaceHoverCardPresenter` wrote, which is how two surfaces end up
+    /// answering one question differently.
+    ///
+    /// The question is whether the pointer is RESTING on something or crossing it. A sidebar row
+    /// is 32 points tall and thirty of them are stacked, so a hand sweeping the pane at a
+    /// comfortable thousand points a second crosses one in about thirty milliseconds: anything
+    /// above a couple of hundred already tells the two apart, and what the rest buys is that a
+    /// deliberate pause somewhere in the middle of a sweep does not open a card either. Longer
+    /// than this and resting on a row starts to feel like nothing is going to happen.
+    static let hoverCardDelay: Duration = .milliseconds(350)
 }
 
 // MARK: - Materials

--- a/Sources/Bloom/Design/WorkspaceHoverCardGallery.swift
+++ b/Sources/Bloom/Design/WorkspaceHoverCardGallery.swift
@@ -210,7 +210,7 @@ extension Gallery {
     static let hoverCard = Gallery(
         name: "hover-card",
         title: "Workspace hover card",
-        size: CGSize(width: 1_120, height: 900),
+        size: CGSize(width: 1_120, height: 620),
         needsFocus: false,
         view: { _ in AnyView(WorkspaceHoverCardGallery()) }
     )

--- a/Sources/Bloom/Design/WorkspaceHoverCardGallery.swift
+++ b/Sources/Bloom/Design/WorkspaceHoverCardGallery.swift
@@ -1,0 +1,217 @@
+import SwiftUI
+import BloomCore
+
+/// The card that opens beside a hovered workspace row, in every state that has an edge on it.
+///
+/// The card is drawn in a panel of its own, which no probe in this folder can photograph and which
+/// no pointer a capture run has can raise. What CAN be photographed is the card itself, and that
+/// is what is worth looking at: the states are all differences of content, so a page of them side
+/// by side answers every question except where the panel lands, and where the panel lands is
+/// `HoverCardPlacement`, which the suite holds.
+///
+/// Each pane is the card at its real 320 point width, over the sidebar's own ground, so a card
+/// and the pane it opens out of can be judged against each other.
+///
+///     Bloom --snapshot-gallery <dir> --gallery hover-card
+struct WorkspaceHoverCardGallery: View {
+    /// A fixed clock, so "6d ago" is six days ago in every capture rather than however long it is
+    /// since somebody wrote this file.
+    private static let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+    private func workspace(
+        name: String,
+        branch: String,
+        additions: Int = 0,
+        deletions: Int = 0,
+        unread: Bool = false,
+        daysAgo: Double = 0
+    ) -> Workspace {
+        let touched = Self.now.addingTimeInterval(-daysAgo * 86_400)
+        return Workspace(
+            repoID: RepoID("bloom"),
+            name: name,
+            branch: branch,
+            path: "/tmp/worktree",
+            baseBranch: "main",
+            createdAt: touched,
+            lastActivityAt: touched,
+            additions: additions,
+            deletions: deletions,
+            changedFiles: additions + deletions > 0 ? 12 : 0,
+            unread: unread
+        )
+    }
+
+    private func pullRequest(
+        number: Int = 362,
+        state: String = "OPEN",
+        checks: PullRequest.Checks,
+        summary: String,
+        isDraft: Bool = false
+    ) -> PullRequest {
+        PullRequest(
+            number: number,
+            title: "Add a hover card to the sidebar",
+            url: "https://github.com/spatie/bloom/pull/\(number)",
+            state: state,
+            isDraft: isDraft,
+            checks: checks,
+            checksSummary: summary
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.pane) {
+            HStack(alignment: .top, spacing: Metrics.pane) {
+                pane("Changes, no pull request", card(
+                    workspace(
+                        name: "Add a hover card to the sidebar",
+                        branch: "freek/hover-card",
+                        additions: 1_418,
+                        deletions: 556,
+                        daysAgo: 6
+                    )
+                ))
+                pane("Checks failing", card(
+                    workspace(
+                        name: "Fix the flaky diff parser test",
+                        branch: "agent/2026-08/fix-the-flaky-diff-parser-test",
+                        additions: 42,
+                        deletions: 9,
+                        daysAgo: 1
+                    ),
+                    pullRequest: pullRequest(
+                        checks: .failing, summary: "1 of 12 required checks failed"
+                    )
+                ))
+                pane("Checks passed", card(
+                    workspace(
+                        name: "Quieten the running mark",
+                        branch: "freek/quiet-running-mark",
+                        additions: 88,
+                        deletions: 210,
+                        daysAgo: 0.4
+                    ),
+                    pullRequest: pullRequest(
+                        number: 2_631, checks: .passing, summary: "12 checks passed"
+                    )
+                ))
+            }
+
+            HStack(alignment: .top, spacing: Metrics.pane) {
+                pane("Nothing changed, never touched", card(
+                    workspace(name: "Look at the release notes", branch: "freek/release-notes")
+                ))
+                pane("A name nobody meant to be a name", card(
+                    workspace(
+                        name: "Show me every place the technologies used in this project are "
+                            + "configured, and say which of them are pinned to a version",
+                        branch: "agent/show-me-every-place-the-technologies-used-in-this-project",
+                        additions: 7,
+                        deletions: 7,
+                        daysAgo: 240
+                    )
+                ))
+                pane("Merged, and long since", card(
+                    workspace(
+                        name: "Draw a file path in a sent turn as a file",
+                        branch: "chat/file-pill-and-merge-scroll",
+                        additions: 2_793,
+                        deletions: 1_044,
+                        daysAgo: 400
+                    ),
+                    pullRequest: pullRequest(
+                        number: 23, state: "MERGED", checks: .passing, summary: "12 checks passed"
+                    )
+                ))
+            }
+
+            HStack(alignment: .top, spacing: Metrics.pane) {
+                pane("Waiting on you", card(
+                    workspace(
+                        name: "Rename the old app everywhere",
+                        branch: "freek/rename",
+                        additions: 12,
+                        deletions: 4,
+                        unread: true,
+                        daysAgo: 0.001
+                    ),
+                    isRunning: true,
+                    isAwaitingPermission: true
+                ))
+                pane("Agent running, pull request open", card(
+                    workspace(
+                        name: "Split AppModel by subject",
+                        branch: "agent/split-app-model",
+                        additions: 903,
+                        deletions: 12,
+                        daysAgo: 0.02
+                    ),
+                    isRunning: true,
+                    pullRequest: pullRequest(checks: .none, summary: "")
+                ))
+                pane("Draft", card(
+                    workspace(
+                        name: "Sketch the ocean chart",
+                        branch: "freek/ocean",
+                        additions: 300,
+                        deletions: 12,
+                        daysAgo: 21
+                    ),
+                    pullRequest: pullRequest(
+                        number: 7, checks: .pending, summary: "3 of 12 checks running",
+                        isDraft: true
+                    )
+                ))
+            }
+        }
+        .padding(Metrics.pane)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        // The ground the card is judged against is whatever it floats over, which in the window is
+        // the centre column rather than the sidebar. The panel's material is `.behindWindow` and
+        // has nothing to blend with offscreen, so this is the honest half of the picture: the
+        // layout, the ink and the truncation.
+        .background(Palette.windowBackground)
+    }
+
+    private func card(
+        _ workspace: Workspace,
+        isRunning: Bool = false,
+        isAwaitingPermission: Bool = false,
+        pullRequest: PullRequest? = nil
+    ) -> WorkspaceHoverCard {
+        WorkspaceHoverCard.make(
+            workspace: workspace,
+            isRunning: isRunning,
+            isAwaitingPermission: isAwaitingPermission,
+            pullRequest: pullRequest,
+            now: Self.now
+        )
+    }
+
+    private func pane(_ title: String, _ card: WorkspaceHoverCard) -> some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingWide) {
+            Text(title)
+                .font(Typo.label)
+                .foregroundStyle(Palette.textSecondary)
+
+            // Drawn exactly as the panel draws it, rim and material and all, and with no shadow,
+            // because the shadow is the panel's rather than the card's.
+            WorkspaceHoverCardView(card: card)
+        }
+        .frame(width: WorkspaceHoverCardView.width, alignment: .leading)
+    }
+}
+
+extension Gallery {
+    /// The registry entry for this page. See `Gallery`.
+    ///
+    /// Nine cards in three rows, at the card's real width.
+    static let hoverCard = Gallery(
+        name: "hover-card",
+        title: "Workspace hover card",
+        size: CGSize(width: 1_120, height: 900),
+        needsFocus: false,
+        view: { _ in AnyView(WorkspaceHoverCardGallery()) }
+    )
+}

--- a/Sources/Bloom/Views/Center/Composer/ComposerTextView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerTextView.swift
@@ -237,7 +237,10 @@ extension ComposerTextView {
     /// How long the pointer has to rest before the card opens. The same delay the chips above the
     /// box used, for the same reason: crossing the line on the way to the send button should show
     /// nothing.
-    private static var hoverDelay: Duration { .milliseconds(350) }
+    ///
+    /// It is `Motion.hoverCardDelay` now rather than a number here, because the sidebar's own
+    /// hover card asks the identical question and two answers to it would be two windows.
+    private static var hoverDelay: Duration { Motion.hoverCardDelay }
 
     override func updateTrackingAreas() {
         super.updateTrackingAreas()

--- a/Sources/Bloom/Views/Sidebar/SidebarWorkspaceRow.swift
+++ b/Sources/Bloom/Views/Sidebar/SidebarWorkspaceRow.swift
@@ -25,6 +25,10 @@ struct SidebarWorkspaceRow: View {
 
     @Environment(AppModel.self) private var app
 
+    /// Where this row is on screen, for the card that opens beside it. Held rather than reported:
+    /// see `SidebarRowAnchor`.
+    @State private var anchor = SidebarRowAnchor()
+
     var body: some View {
         WorkspaceRow(
             workspace: workspace,
@@ -51,6 +55,31 @@ struct SidebarWorkspaceRow: View {
         // nesting left in it is unreadable without knowing which project each row belongs to, and
         // content that has to be asked for is content most people never hear.
         .accessibilityCustomContent(Text("Project"), Text(projectName), importance: .high)
+        // The card that opens beside the row, and the handle that says where the row is.
+        //
+        // Here rather than in `WorkspaceRow`, and this is the same line the type's own note draws:
+        // `WorkspaceRow` is the drawing and stays a pure function of what it is handed, while what
+        // the LIST is told about a row lives here. A card that opens over the whole window on a
+        // hover is squarely the second kind, and it needs the two things only this side has
+        // anyway, which are the model that knows whether an agent is running and the poll that
+        // knows what GitHub said.
+        //
+        // Its own `.onHover`, not the one inside `WorkspaceRow`. Two hover trackers on nested
+        // views both fire, and joining them would mean handing the drawing a callback it has no
+        // use for. Nothing is drawn from this one, so nothing redraws when it changes.
+        .background { SidebarRowAnchorReader(anchor: anchor) }
+        .onHoverChange { inside in
+            if inside {
+                WorkspaceHoverCardPresenter.shared.pointerEntered(
+                    workspace.id, card: hoverCard, anchor: { anchor.screenFrame }
+                )
+            } else {
+                WorkspaceHoverCardPresenter.shared.pointerExited(workspace.id)
+            }
+        }
+        // A row that leaves the pane while its card is up: archived from the menu bar, filtered
+        // out, or its project folded. The pointer never leaves, so no exit ever arrives.
+        .onDisappear { WorkspaceHoverCardPresenter.shared.pointerExited(workspace.id) }
         // Every item in it is `WorkspaceMenuItems`, which Home's rows draw from as well. It used
         // to be a copy of the same six buttons written out here, with a note on the other copy
         // saying what to extract when the two were merged; adding to both was what forced it.
@@ -79,6 +108,26 @@ struct SidebarWorkspaceRow: View {
     /// at stake. See `AppModel.archive(_:deleteBranch:alwaysConfirm:)`.
     private func confirmRowArchive(_ workspace: Workspace) {
         Task { await app.archive(workspace, alwaysConfirm: true) }
+    }
+
+    /// What the card says, built at the moment it opens rather than on every redraw.
+    ///
+    /// **Nothing in here fetches.** `isRunning` is the model's own answer about a turn already in
+    /// progress and the pull request is whatever `WorkspacePullRequests` last polled, which is the
+    /// same two facts the row's status mark is already drawn from. A hover that started a `gh`
+    /// call would put a subprocess behind moving the pointer down a list of thirty rows.
+    ///
+    /// It returns nil for a row being renamed. The field owns the row while it is open, and a
+    /// card over the window showing the name being replaced is a card about a fact that is in the
+    /// middle of changing.
+    private func hoverCard() -> WorkspaceHoverCard? {
+        guard renaming != workspace.id else { return nil }
+        return WorkspaceHoverCard.make(
+            workspace: workspace,
+            isRunning: app.isRunning(workspace),
+            isAwaitingPermission: app.isAwaitingPermission(workspace),
+            pullRequest: WorkspacePullRequests.shared.pullRequest(for: workspace.id)
+        )
     }
 }
 

--- a/Sources/Bloom/Views/Sidebar/WorkspaceHoverCardPresenter.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspaceHoverCardPresenter.swift
@@ -1,0 +1,283 @@
+import AppKit
+import SwiftUI
+import BloomCore
+
+/// Opens and closes the card that stands beside a hovered workspace row.
+///
+/// **A panel of its own rather than a `.popover` or an overlay, and each of the two it is not was
+/// ruled out for a different reason.** An overlay cannot leave the sidebar: the column is an
+/// `NSSplitView` subview and it clips, so a card drawn inside it is a card 260 points wide, which
+/// is the width the row already had. A `.popover` does escape, and it is transient: it closes on
+/// the next click anywhere outside it, and the click that closes it is the click that was meant
+/// to select the row underneath. A hover affordance that eats the first click on the thing it is
+/// hovering is worse than no hover affordance.
+///
+/// So the card is a borderless, non-activating panel that **ignores the mouse entirely**. It
+/// cannot take a click, cannot take the keyboard, and cannot come between the pointer and the
+/// row. That is also the whole of the answer to whether the card carries an action: it cannot,
+/// and it should not, because a button on it would have to be reached across a gap by a pointer
+/// whose leaving the row is the signal to close. The row's own hover controls are what actions
+/// live on, a few points away and already under the pointer.
+///
+/// It is added as a CHILD window of the main window, which is what makes it move with the window,
+/// hide with it and die with it, none of which a free-floating panel does.
+///
+/// Everything it closes on is listed in `watchForDismissal()`. The delay before it opens is
+/// `Motion.hoverCardDelay`, shared with the composer's own chip card so the window has one answer
+/// to "the pointer is resting on this rather than crossing it".
+@MainActor
+final class WorkspaceHoverCardPresenter {
+    static let shared = WorkspaceHoverCardPresenter()
+
+    /// The row the pointer is on, as far as this knows. Cleared by every dismissal, which is what
+    /// makes a dismissal STICK: the pointer has to leave and arrive again, or arrive on another
+    /// row, before anything opens. Without that a card closed by a scroll reopened under a
+    /// stationary pointer the moment the scroll ended.
+    private var hovered: WorkspaceID?
+    /// The wait between the pointer arriving and the card opening.
+    private var pending: Task<Void, Never>?
+    private var panel: NSPanel?
+    private var hosting: NSHostingView<WorkspaceHoverCardView>?
+    private var monitor: Any?
+
+    private init() {
+        watchForDismissal()
+    }
+
+    // MARK: - The pointer
+
+    /// The pointer has arrived on a row.
+    ///
+    /// The card and the anchor are closures rather than values because both are read at the end of
+    /// the delay rather than at the start of it: a workspace whose agent finishes mid-wait should
+    /// open the card it has then, and a row the list has scrolled under the pointer should be
+    /// measured where it ended up.
+    func pointerEntered(
+        _ workspaceID: WorkspaceID,
+        card: @escaping @MainActor () -> WorkspaceHoverCard?,
+        anchor: @escaping @MainActor () -> CGRect?
+    ) {
+        guard hovered != workspaceID else { return }
+        hovered = workspaceID
+        pending?.cancel()
+        // Whatever is up belongs to another row, and crossing from one row to the next should not
+        // leave the old card standing while the new one waits out its delay.
+        hide()
+
+        pending = Task { [weak self] in
+            try? await Task.sleep(for: Motion.hoverCardDelay)
+            guard !Task.isCancelled, let self, self.hovered == workspaceID else { return }
+            guard let card = card(), let anchor = anchor() else { return }
+            self.show(card, at: anchor)
+        }
+    }
+
+    /// The pointer has left a row. Ignored when the card has since moved to another row, because
+    /// SwiftUI delivers the arrival on the new row before the departure from the old one.
+    func pointerExited(_ workspaceID: WorkspaceID) {
+        guard hovered == workspaceID else { return }
+        dismiss()
+    }
+
+    /// Closes the card and stops anything from opening until the pointer moves again.
+    func dismiss() {
+        hovered = nil
+        pending?.cancel()
+        pending = nil
+        hide()
+    }
+
+    // MARK: - The panel
+
+    private func show(_ card: WorkspaceHoverCard, at anchor: CGRect) {
+        // No card over a window that is not the one being worked in. This is the same fact
+        // `didResignKeyNotification` closes on, asked before opening rather than after: a window
+        // can lose key during the wait.
+        guard let parent = NSApp.keyWindow, parent.isVisible else { return }
+        guard let screen = parent.screen ?? NSScreen.main else { return }
+
+        let panel = panel ?? makePanel()
+        self.panel = panel
+
+        let view = WorkspaceHoverCardView(card: card)
+        if let hosting {
+            hosting.rootView = view
+        } else {
+            let hosting = NSHostingView(rootView: view)
+            panel.contentView = hosting
+            self.hosting = hosting
+        }
+
+        // The card sizes itself from its content, so the height is asked for rather than chosen:
+        // a three line workspace name draws a taller card than a one line one, and a panel given
+        // a fixed height would either clip the name or float it in dead space.
+        guard let hosting else { return }
+        hosting.layoutSubtreeIfNeeded()
+        let size = CGSize(
+            width: WorkspaceHoverCardView.width,
+            height: hosting.fittingSize.height
+        )
+
+        panel.setFrame(
+            HoverCardPlacement.frame(anchor: anchor, size: size, visible: screen.visibleFrame),
+            display: false
+        )
+
+        guard panel.parent !== parent else {
+            panel.orderFront(nil)
+            return
+        }
+        panel.parent?.removeChildWindow(panel)
+        // `.above` rather than `orderFront`, so the panel is ordered relative to the window it
+        // belongs to instead of to the whole screen. A card that outranked a modal sheet or
+        // another application's window would be a card floating over somebody else's work.
+        parent.addChildWindow(panel, ordered: .above)
+        fadeIn(panel)
+    }
+
+    private func hide() {
+        guard let panel, panel.isVisible else { return }
+        panel.parent?.removeChildWindow(panel)
+        panel.orderOut(nil)
+    }
+
+    private func makePanel() -> NSPanel {
+        let panel = NSPanel(
+            contentRect: CGRect(origin: .zero, size: CGSize(width: 1, height: 1)),
+            // `.nonactivatingPanel` on top of borderless, because a panel that activated the app
+            // would put a card between the user and whatever they had brought to the front.
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        // The whole reason this is a panel and not a popover. Nothing here can be clicked, so
+        // nothing here can be in the way of clicking the row it describes.
+        panel.ignoresMouseEvents = true
+        panel.isFloatingPanel = true
+        panel.hidesOnDeactivate = true
+        panel.isReleasedWhenClosed = false
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        // AppKit's, drawn around the alpha the card paints, which is why the card carries no
+        // shadow of its own. A SwiftUI shadow inside a transparent window is clipped by the
+        // window's own bounds and comes out as a hard edge on two sides.
+        panel.hasShadow = true
+        panel.animationBehavior = .none
+        // Never in the window cycle and never on a Space of its own: it is furniture belonging to
+        // the window it hangs off, and Cmd+` should not be able to land on it.
+        panel.collectionBehavior = [.transient, .ignoresCycle, .fullScreenAuxiliary]
+        return panel
+    }
+
+    /// A short fade rather than an appearance.
+    ///
+    /// The card is 320 points of material arriving over a transcript somebody is reading, and at
+    /// full alpha in one frame it reads as a window opening rather than as a hint. Shorter than
+    /// `Motion.pane`, because it follows a deliberate 350ms rest and anything slower than the
+    /// hover it answers reads as lag. Skipped entirely for Reduce Motion, which is what that
+    /// setting asks for.
+    private func fadeIn(_ panel: NSPanel) {
+        guard !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion else {
+            panel.alphaValue = 1
+            return
+        }
+        panel.alphaValue = 0
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.12
+            panel.animator().alphaValue = 1
+        }
+    }
+
+    // MARK: - Everything that closes it
+
+    /// The card is a statement about a row under the pointer, so anything that makes that
+    /// statement stale or makes the card the wrong thing to be looking at closes it.
+    ///
+    /// Each of these is a case the card would otherwise survive:
+    ///
+    /// - **A live scroll.** The rows move and the card would go on describing the one that used to
+    ///   be there. It also covers a scroll that has not started moving yet, through the wheel
+    ///   events below, because `willStartLiveScroll` arrives a frame late.
+    /// - **A mouse button going down anywhere.** This is the row being clicked, a row being picked
+    ///   up to reorder the pane, and a right click opening the row's own context menu, and all
+    ///   three want the card gone before anything else happens. It is a monitor rather than three
+    ///   separate observations because a drag has no notification of its own.
+    /// - **A menu opening**, which is the same context menu arriving by another route, plus every
+    ///   menu bar menu.
+    /// - **A sheet arriving**, since a card floating over a modal sheet belongs to a window the
+    ///   user can no longer reach.
+    /// - **The window losing key, and the app losing active.** A card is a hover state, and a
+    ///   hover state that outlives the pointer's window is a card left on screen.
+    private func watchForDismissal() {
+        let centre = NotificationCenter.default
+        for name in [
+            NSScrollView.willStartLiveScrollNotification,
+            NSWindow.didResignKeyNotification,
+            NSWindow.willBeginSheetNotification,
+            NSWindow.willMiniaturizeNotification,
+            NSWindow.willCloseNotification,
+            NSMenu.didBeginTrackingNotification,
+            NSApplication.didResignActiveNotification,
+        ] {
+            centre.addObserver(forName: name, object: nil, queue: .main) { _ in
+                MainActor.assumeIsolated { WorkspaceHoverCardPresenter.shared.dismiss() }
+            }
+        }
+
+        // Local, not global: this only has to know about events going to Bloom, and a global
+        // monitor is a request for the accessibility permission that Bloom has no other reason to
+        // ask for. The event is returned untouched, so nothing here changes what a click does.
+        monitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown, .scrollWheel]
+        ) { event in
+            MainActor.assumeIsolated { WorkspaceHoverCardPresenter.shared.dismiss() }
+            return event
+        }
+    }
+}
+
+// MARK: - Where the row is
+
+/// A handle on a sidebar row's own `NSView`, so the presenter can ask where the row is at the
+/// moment the card opens.
+///
+/// A view rather than a `GeometryReader`, because what is needed is a rectangle in SCREEN
+/// coordinates and SwiftUI has no coordinate space that reaches one: `.global` is the hosting
+/// view's, which under a unified toolbar is neither the window's nor the screen's, and a card
+/// placed from it lands a title bar's height out. `NSView.convert` and
+/// `NSWindow.convertToScreen` are the two conversions that are exact, and this is what makes them
+/// reachable.
+///
+/// Asked on demand rather than reported on every layout pass. A running agent rewrites its diff
+/// stat every six seconds and the pane relays out each time; a probe that pushed a rectangle into
+/// SwiftUI state on each of those would invalidate every row in the sidebar to answer a question
+/// nobody had asked yet.
+@MainActor
+final class SidebarRowAnchor {
+    fileprivate weak var view: NSView?
+
+    /// The row's rectangle on screen, or nil while the row is not in a window, which is every row
+    /// between being made and being laid out.
+    var screenFrame: CGRect? {
+        guard let view, let window = view.window else { return nil }
+        return window.convertToScreen(view.convert(view.bounds, to: nil))
+    }
+}
+
+/// Attaches a `SidebarRowAnchor` to the row it is put behind. Draws nothing.
+struct SidebarRowAnchorReader: NSViewRepresentable {
+    var anchor: SidebarRowAnchor
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        anchor.view = view
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        // Reattached on every update because a `List` recycles its rows: the same SwiftUI row can
+        // be handed a different `NSView`, and an anchor still pointing at the old one measures a
+        // rectangle that is no longer on screen.
+        anchor.view = nsView
+    }
+}

--- a/Sources/Bloom/Views/Sidebar/WorkspaceHoverCardPresenter.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspaceHoverCardPresenter.swift
@@ -38,6 +38,10 @@ final class WorkspaceHoverCardPresenter {
     private var pending: Task<Void, Never>?
     private var panel: NSPanel?
     private var hosting: NSHostingView<WorkspaceHoverCardView>?
+    /// The observers and the event monitor, held for as long as this is: a singleton that lives
+    /// for the life of the app never takes them down, and holding them is what says that on
+    /// purpose rather than by omission.
+    private var observers: [any NSObjectProtocol] = []
     private var monitor: Any?
 
     private init() {
@@ -219,9 +223,10 @@ final class WorkspaceHoverCardPresenter {
             NSMenu.didBeginTrackingNotification,
             NSApplication.didResignActiveNotification,
         ] {
-            centre.addObserver(forName: name, object: nil, queue: .main) { _ in
+            let observer = centre.addObserver(forName: name, object: nil, queue: .main) { _ in
                 MainActor.assumeIsolated { WorkspaceHoverCardPresenter.shared.dismiss() }
             }
+            observers.append(observer)
         }
 
         // Local, not global: this only has to know about events going to Bloom, and a global

--- a/Sources/Bloom/Views/Sidebar/WorkspaceHoverCardView.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspaceHoverCardView.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+import BloomCore
+
+/// The card that opens beside a workspace row while the pointer rests on it.
+///
+/// What it says is `WorkspaceHoverCard`'s, in the core, where the suite holds it. This is the
+/// drawing and nothing else, which is why it takes one value rather than a workspace and a pull
+/// request: a card assembled here would be a card assembled in a target the tests cannot import.
+///
+/// **It takes no clicks, and that is the design rather than a limitation of it.** The panel it is
+/// drawn in ignores the mouse entirely (see `WorkspaceHoverCardPresenter`), so nothing here is a
+/// button, the pull request number is a fact rather than a link, and the pointer never has to
+/// travel off the row and across a gap to reach anything. `AttachmentCard` over the composer made
+/// the same call for the same reason, and it is the reason the sidebar row keeps its own hover
+/// controls: what you can DO to a workspace is on the row, under the pointer already, and what is
+/// TRUE of it is here.
+///
+/// Four lines, in the order the question is asked. The branch and its counts, because that is
+/// what the pane has no room for at all; the name in full, because the pane truncates it; the
+/// state in words beside the pull request, because the mark alone cannot say "1 of 12 checks
+/// failed"; and the age, which is what says whether any of the rest is still true.
+struct WorkspaceHoverCardView: View {
+    var card: WorkspaceHoverCard
+
+    /// Wider than the 260 point sidebar, deliberately. The whole point of the card is having room
+    /// the row does not, and a card the width of the pane it opens out of reads as the pane
+    /// repeated rather than as the pane explained. Wide enough for a two line workspace name at
+    /// reading size, which is what most of them come to.
+    static let width: CGFloat = 320
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingWide) {
+            branchLine
+            title
+            footer
+        }
+        .padding(Metrics.gutter)
+        .frame(width: Self.width, alignment: .leading)
+        // Sized by its content, so a one line name draws a shorter card than a three line one.
+        // The panel asks the hosting view for this height. See the presenter.
+        .fixedSize(horizontal: false, vertical: true)
+        .background(cardBackground)
+        // The card is drawn in a window of its own, which cannot be reached by the pointer or by
+        // VoiceOver. Everything on it is on the row as well, in the row's own accessibility value
+        // and its tooltip, so there is nothing here for a screen reader to lose. See the
+        // presenter for what a keyboard user gets instead.
+        .accessibilityHidden(true)
+    }
+
+    // MARK: - Lines
+
+    /// The branch, with the counts hard against the card's trailing edge.
+    ///
+    /// The branch truncates from the HEAD rather than the tail. Bloom's branch names are prefixed
+    /// (`freek/`, `agent/2026-08/`) and the distinguishing half is the last component, so cutting
+    /// the front is what keeps two workspaces on the same prefix tellable apart. It is the same
+    /// call `AttachmentCard` makes about a path.
+    private var branchLine: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Metrics.spacing) {
+            Text(card.branch)
+                .font(Typo.codeSmall)
+                .foregroundStyle(Palette.textSecondary)
+                .lineLimit(1)
+                .truncationMode(.head)
+
+            Spacer(minLength: Metrics.spacingSmall)
+
+            if let diff = card.diff {
+                // The window's one diff stat, not a second one. It abbreviates past a thousand,
+                // which is what every other pair of counts in the app does, so a card and the row
+                // it opened out of cannot report the same worktree two different ways.
+                DiffStatLabel(additions: diff.additions, deletions: diff.deletions)
+            } else {
+                Text(WorkspaceHoverCard.noChanges)
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textTertiary)
+            }
+        }
+    }
+
+    /// The name, whole, and the mark that the row draws beside it.
+    ///
+    /// The mark is at the trailing edge of this line rather than in the corner above it, which is
+    /// where Conductor puts it. Measured against the alternative on paper: in the corner it sits
+    /// on the branch's line and reads as a fact about the branch, which for `checksFailing` is
+    /// nearly true and for `awaitingPermission` is not true at all. Beside the name it belongs to
+    /// the workspace, which is what it is about, and it is on the same line as the biggest text on
+    /// the card, which is where the eye lands first.
+    ///
+    /// `WorkspaceStatusGlyph` rather than a glyph of its own, so a state that is a pencil in the
+    /// sidebar is a pencil here. Every one of the fourteen shapes and its colour is decided there
+    /// and in `WorkspaceStatus`, and the legend draws from the same type.
+    private var title: some View {
+        HStack(alignment: .top, spacing: Metrics.spacing) {
+            Text(card.title)
+                .font(Typo.title)
+                .foregroundStyle(Palette.textPrimary)
+                // Three, not one. The card exists because the row shows one; a name that runs past
+                // three lines is one somebody pasted a paragraph into, and the card is not the
+                // place to read a paragraph.
+                .lineLimit(3)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            WorkspaceStatusGlyph(status: card.status)
+                // The glyph sizes itself to the sidebar's icon column and is drawn at the cap
+                // height of the caption beside it there. Here it stands next to a heading, so it
+                // is nudged onto that line's baseline rather than the box's top edge.
+                .padding(.top, Metrics.spacingTight)
+        }
+    }
+
+    /// The state in words, the pull request, and how long ago.
+    ///
+    /// The pull request is drawn as `#362` in the same monospaced digits `PullRequestBadge` uses
+    /// and with none of its chrome: no rim, no arrow, no hover fill. That is deliberate and it is
+    /// the honest half of the card taking no clicks. `PullRequestBadge`'s own note says a control
+    /// that looks pressable and is not is the kind of thing people learn to distrust a whole strip
+    /// over, and a badge with an arrow on it inside a window that ignores the mouse would be
+    /// exactly that. The way out to GitHub is the badge itself, one row-click away in the
+    /// inspector strip.
+    private var footer: some View {
+        HStack(alignment: .firstTextBaseline, spacing: Metrics.spacingSmall) {
+            Text(card.state)
+                .font(Typo.captionEmphasis)
+                .foregroundStyle(WorkspaceStatusGlyph.tint(for: card.status))
+                .lineLimit(1)
+                .layoutPriority(1)
+
+            if let detail = card.detail {
+                Text(detail)
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textSecondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            if let pullRequest = card.pullRequest {
+                // `verbatim`, for the reason `PullRequestBadge` writes down: an interpolated `Int`
+                // inside a `LocalizedStringKey` is formatted for the locale, and a machine set to
+                // Dutch drew "#2.631" for a pull request GitHub calls 2631.
+                Text(verbatim: "#\(pullRequest.number)")
+                    .font(Typo.caption)
+                    .monospacedDigit()
+                    .foregroundStyle(Palette.textSecondary)
+                    .layoutPriority(1)
+            }
+
+            Spacer(minLength: Metrics.spacingSmall)
+
+            Text(card.age)
+                .font(Typo.caption)
+                .foregroundStyle(Palette.textTertiary)
+                .layoutPriority(1)
+        }
+    }
+
+    // MARK: - The plate
+
+    /// The card's own ground.
+    ///
+    /// `MenuPanel` is the app's floating card and this is deliberately not it. `MenuPanel` blends
+    /// `.withinWindow` and carries a SwiftUI shadow, both of which are right for something drawn
+    /// inside the composer's window and neither of which is right here: this card IS a window, so
+    /// the material has to blend with what is behind the window rather than with the window, and
+    /// the shadow is AppKit's to draw around the panel's alpha. What is kept is the shape and the
+    /// rim, so the two read as one family.
+    private var cardBackground: some View {
+        VisualEffectBackground(material: .menu, blending: .behindWindow)
+            // Clipped rather than filled through a shape, because the material is a view rather
+            // than a `ShapeStyle` and `background(_:in:)` will not take one.
+            .clipShape(RoundedRectangle(cornerRadius: Metrics.corner))
+            .overlay {
+                RoundedRectangle(cornerRadius: Metrics.corner)
+                    .strokeBorder(Palette.border, lineWidth: Metrics.hairline)
+            }
+    }
+}

--- a/Sources/Bloom/Views/Sidebar/WorkspaceHoverCardView.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspaceHoverCardView.swift
@@ -65,15 +65,17 @@ struct WorkspaceHoverCardView: View {
 
             Spacer(minLength: Metrics.spacingSmall)
 
+            // Nothing at all when there is nothing to count, rather than the words "No changes".
+            // Photographed both ways: the state line two rows down is `WorkspaceStatus.clean`,
+            // whose label is those same two words, so the card said "No changes" twice in a
+            // hundred points of each other and read as a stutter rather than as an empty
+            // worktree. The state line is the one that keeps it, because it is where every other
+            // card puts its verdict.
             if let diff = card.diff {
                 // The window's one diff stat, not a second one. It abbreviates past a thousand,
                 // which is what every other pair of counts in the app does, so a card and the row
                 // it opened out of cannot report the same worktree two different ways.
                 DiffStatLabel(additions: diff.additions, deletions: diff.deletions)
-            } else {
-                Text(WorkspaceHoverCard.noChanges)
-                    .font(Typo.caption)
-                    .foregroundStyle(Palette.textTertiary)
             }
         }
     }
@@ -110,7 +112,14 @@ struct WorkspaceHoverCardView: View {
         }
     }
 
-    /// The state in words, the pull request, and how long ago.
+    /// The state in words with the numbers behind it, and under that the pull request and the age.
+    ///
+    /// **Two lines rather than one, and the picture is what decided it.** All four were on one
+    /// line first, and photographed the failing case read "Checks failing 1 of 12 required checks
+    /// f... #362 1d ago": four unrelated facts fighting over 296 points, with the only one that
+    /// says WHY the checks failed the one that got cut. The state and its detail are one
+    /// sentence, so they keep a line; the number and the age are each a single token and share
+    /// the next.
     ///
     /// The pull request is drawn as `#362` in the same monospaced digits `PullRequestBadge` uses
     /// and with none of its chrome: no rim, no arrow, no hover fill. That is deliberate and it is
@@ -120,38 +129,43 @@ struct WorkspaceHoverCardView: View {
     /// exactly that. The way out to GitHub is the badge itself, one row-click away in the
     /// inspector strip.
     private var footer: some View {
-        HStack(alignment: .firstTextBaseline, spacing: Metrics.spacingSmall) {
-            Text(card.state)
-                .font(Typo.captionEmphasis)
-                .foregroundStyle(WorkspaceStatusGlyph.tint(for: card.status))
-                .lineLimit(1)
-                .layoutPriority(1)
-
-            if let detail = card.detail {
-                Text(detail)
-                    .font(Typo.caption)
-                    .foregroundStyle(Palette.textSecondary)
+        VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
+            HStack(alignment: .firstTextBaseline, spacing: Metrics.spacingSmall) {
+                Text(card.state)
+                    .font(Typo.captionEmphasis)
+                    .foregroundStyle(WorkspaceStatusGlyph.tint(for: card.status))
                     .lineLimit(1)
-                    .truncationMode(.tail)
+                    .layoutPriority(1)
+
+                if let detail = card.detail {
+                    Text(detail)
+                        .font(Typo.caption)
+                        .foregroundStyle(Palette.textSecondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+
+                Spacer(minLength: 0)
             }
 
-            if let pullRequest = card.pullRequest {
-                // `verbatim`, for the reason `PullRequestBadge` writes down: an interpolated `Int`
-                // inside a `LocalizedStringKey` is formatted for the locale, and a machine set to
-                // Dutch drew "#2.631" for a pull request GitHub calls 2631.
-                Text(verbatim: "#\(pullRequest.number)")
+            HStack(alignment: .firstTextBaseline, spacing: Metrics.spacingSmall) {
+                if let pullRequest = card.pullRequest {
+                    // `verbatim`, for the reason `PullRequestBadge` writes down: an interpolated
+                    // `Int` inside a `LocalizedStringKey` is formatted for the locale, and a
+                    // machine set to Dutch drew "#2.631" for a pull request GitHub calls 2631.
+                    Text(verbatim: "#\(pullRequest.number)")
+                        .font(Typo.caption)
+                        .monospacedDigit()
+                        .foregroundStyle(Palette.textSecondary)
+                }
+
+                Spacer(minLength: Metrics.spacingSmall)
+
+                Text(card.age)
                     .font(Typo.caption)
                     .monospacedDigit()
-                    .foregroundStyle(Palette.textSecondary)
-                    .layoutPriority(1)
+                    .foregroundStyle(Palette.textTertiary)
             }
-
-            Spacer(minLength: Metrics.spacingSmall)
-
-            Text(card.age)
-                .font(Typo.caption)
-                .foregroundStyle(Palette.textTertiary)
-                .layoutPriority(1)
         }
     }
 

--- a/Sources/BloomCore/Model/WorkspaceStatus.swift
+++ b/Sources/BloomCore/Model/WorkspaceStatus.swift
@@ -130,8 +130,21 @@ public enum WorkspaceStatus: String, Sendable, Hashable, CaseIterable, Codable {
         guard describesPullRequest, let pullRequest else { return label }
 
         var text = "\(label), pull request #\(pullRequest.number)"
-        let detail = pullRequest.checksSummary
-        if !detail.isEmpty, detail != label { text += ": \(detail)" }
+        if let detail = detail(pullRequest: pullRequest) { text += ": \(detail)" }
         return text
+    }
+
+    /// The numbers behind the state's name, or nil when the name is all there is to say.
+    ///
+    /// Split out of `summary` rather than copied from it, for `WorkspaceHoverCard`, which draws
+    /// the state and its detail as two pieces of text of different weights and so cannot use the
+    /// one sentence. The check that the detail is not simply the label again is the part worth
+    /// having in one place: gh reports "Checks failing" as its own rollup summary often enough
+    /// that a card built on a copy of this would have said it twice.
+    public func detail(pullRequest: PullRequest?) -> String? {
+        guard describesPullRequest, let pullRequest else { return nil }
+        let detail = pullRequest.checksSummary
+        guard !detail.isEmpty, detail != label else { return nil }
+        return detail
     }
 }

--- a/Sources/BloomCore/Presentation/HomeList.swift
+++ b/Sources/BloomCore/Presentation/HomeList.swift
@@ -353,4 +353,19 @@ public enum HomeAge {
 
         return "\(years)y"
     }
+
+    /// The same age with the word on it, for somewhere that has room for the word.
+    ///
+    /// Home's rows do not: they are a dense list under a heading that already says "2 days ago",
+    /// so "ago" on every row of the group says nothing. A card that opens beside one row is the
+    /// opposite case, and "6d" alone there reads as a measurement rather than as a time.
+    ///
+    /// Built on `short` rather than beside it, which is the whole reason it is here and not in
+    /// the card. Every threshold, and the future-dated timestamp a clock change produces, is
+    /// decided once. The one thing it cannot pass through is "now", because "now ago" is not
+    /// English.
+    public static func phrase(for date: Date, now: Date = Date()) -> String {
+        let age = short(for: date, now: now)
+        return age == "now" ? "just now" : "\(age) ago"
+    }
 }

--- a/Sources/BloomCore/Presentation/HoverCardPlacement.swift
+++ b/Sources/BloomCore/Presentation/HoverCardPlacement.swift
@@ -1,0 +1,81 @@
+import CoreGraphics
+
+/// Where the card that opens beside a sidebar row is put, in screen coordinates.
+///
+/// It is a floating panel rather than something drawn inside the window, because the card has to
+/// stand to the RIGHT of a 260 point sidebar and the sidebar is an `NSSplitView` subview, which
+/// clips. So the position cannot be a layout, it has to be a rectangle worked out by hand, and a
+/// rectangle worked out inside a view is a rectangle nothing can check. Three of the four cases
+/// below only happen at the edges of a screen, which is exactly where a hand-checked card is
+/// never looked at.
+///
+/// Everything here is AppKit's coordinate space: y increases upwards and `maxY` is the top edge.
+/// The anchor is the row's own rectangle on screen and the card is placed beside it, not under
+/// the pointer: a card that follows the pointer inside a 32 point row wobbles as the hand
+/// settles, and the thing being described is the row.
+public enum HoverCardPlacement {
+    /// The gap between the row and the card.
+    ///
+    /// Enough that the card reads as a separate surface floating over the centre pane rather than
+    /// as a panel welded to the sidebar's edge, and small enough that the eye carries the row's
+    /// line across to it. The sidebar already ends in a hairline rule, so a card flush against it
+    /// would put a border and a rule half a point apart, which is the smear
+    /// `Metrics.headerButton` was measured to avoid one rung down.
+    public static let gap: CGFloat = 8
+
+    /// How close to the top or bottom of the screen the card may come before it is pushed back
+    /// in. The same margin AppKit keeps a menu off a screen edge by.
+    public static let screenMargin: CGFloat = 8
+
+    /// The card's rectangle for a row at `anchor`, on a screen whose usable area is `visible`.
+    ///
+    /// Three decisions, in this order:
+    ///
+    /// 1. **Right of the row, unless there is no room.** The sidebar is the leftmost column of the
+    ///    window, so the right is where the space is and where the reader's eye already travels.
+    ///    A window pushed against the right edge of a screen, which is where a wide window with a
+    ///    collapsed inspector sits, has none, and there the card flips to the left of the row
+    ///    rather than hanging off the screen. Flipping is preferred to squeezing: a card narrowed
+    ///    to fit is a card that truncates the title, which is the one thing it exists to show.
+    /// 2. **Top aligned with the row.** The row is the subject, and lining the card's first line
+    ///    up with it is what says so. Centring it on the row was tried on paper and reads as the
+    ///    card belonging to the two rows either side as much as to this one.
+    /// 3. **Clamped into the screen, vertically then horizontally.** A card opened on the last row
+    ///    of a full sidebar would otherwise run off the bottom, which is where the age and the
+    ///    pull request number are.
+    ///
+    /// Nothing here consults the window. The card may overlap the transcript, and should: it is a
+    /// card that opens over what you are reading and closes again, exactly as a menu does.
+    public static func frame(
+        anchor: CGRect,
+        size: CGSize,
+        visible: CGRect
+    ) -> CGRect {
+        var origin = CGPoint(
+            x: anchor.maxX + gap,
+            // `maxY` on both sides: the card's top edge on the row's top edge.
+            y: anchor.maxY - size.height
+        )
+
+        // The flip. Measured against the whole card, so a card that would be cut off by one point
+        // moves rather than being clipped by one point.
+        if origin.x + size.width > visible.maxX - screenMargin {
+            let flipped = anchor.minX - gap - size.width
+            // Only when the other side genuinely has room. On a screen too narrow for the card
+            // beside the window at all, flipping trades one overhang for another, and the clamp
+            // below is a better answer than a card that has jumped to the wrong side as well.
+            if flipped >= visible.minX + screenMargin { origin.x = flipped }
+        }
+
+        origin.x = min(origin.x, visible.maxX - screenMargin - size.width)
+        origin.x = max(origin.x, visible.minX + screenMargin)
+
+        // Lifted off the bottom first and pushed down off the top second, so that on a screen too
+        // short for the card at all it is the TOP edge that survives. The title and the branch
+        // are drawn there and the age is at the foot, which is the one line worth losing.
+        origin.y = max(origin.y, visible.minY + screenMargin)
+        origin.y = min(origin.y, visible.maxY - screenMargin - size.height)
+
+        return CGRect(origin: origin, size: size)
+    }
+}

--- a/Sources/BloomCore/Presentation/WorkspaceHoverCard.swift
+++ b/Sources/BloomCore/Presentation/WorkspaceHoverCard.swift
@@ -22,8 +22,10 @@ import Foundation
 public struct WorkspaceHoverCard: Sendable, Hashable {
     /// The counts, or nil when the worktree matches its base and there is nothing to count.
     ///
-    /// Nil rather than two zeroes, because "+0 -0" is a line saying nothing and the card has to
-    /// say something else in its place. See `changes`.
+    /// Nil rather than two zeroes, because "+0 -0" is a line saying nothing. Nothing stands in
+    /// its place either: `state` a line below is `WorkspaceStatus.clean`, whose own label already
+    /// reads "No changes", and the card drew those two words twice before the picture was looked
+    /// at.
     public struct Diff: Sendable, Hashable {
         public var additions: Int
         public var deletions: Int
@@ -91,14 +93,6 @@ public struct WorkspaceHoverCard: Sendable, Hashable {
         self.pullRequest = pullRequest
         self.age = age
     }
-
-    /// What to say where the counts would be when there are none.
-    ///
-    /// The line the counts sit on is the branch's line, and a branch with nothing after it reads
-    /// as a card that failed to load its numbers rather than as a clean worktree. Three words in
-    /// the quiet ink is the whole fix, and it is here rather than in the view so the empty case is
-    /// something the suite can hold.
-    public static let noChanges = "No changes"
 
     /// The card for one sidebar row.
     ///

--- a/Sources/BloomCore/Presentation/WorkspaceHoverCard.swift
+++ b/Sources/BloomCore/Presentation/WorkspaceHoverCard.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+/// Everything the card that opens beside a hovered sidebar row says, decided once.
+///
+/// The pane is 260 points wide and a workspace row gets one line of it, so a name is truncated, a
+/// branch is not drawn at all and the counts yield to the hover controls. That is the right trade
+/// for a column of thirty rows and it leaves a question the pane cannot answer: what IS this one,
+/// and is it worth switching to. Answering it by switching costs a transcript load and the place
+/// you were reading, which is exactly the cost worth avoiding when a dozen agents are running.
+///
+/// So this is the row's own facts, unabbreviated, in the order they are asked for: what branch,
+/// how much changed, what it is called, what state it is in, whether there is a pull request, and
+/// how long since anything happened. **Nothing here is fetched.** Every field comes from a
+/// `Workspace` the sidebar already holds and a `PullRequest` `WorkspacePullRequests` already
+/// polls, because a network call started by moving the pointer is a network call nobody asked
+/// for.
+///
+/// It is a value in the core rather than a `body` in the view for the reason the three targets
+/// exist: the states worth getting right are a workspace with no pull request, one whose checks
+/// have failed, one with nothing changed at all, one nobody has touched, and a title too long to
+/// draw, and none of those can be asserted on from a test target that has no view layer in it.
+public struct WorkspaceHoverCard: Sendable, Hashable {
+    /// The counts, or nil when the worktree matches its base and there is nothing to count.
+    ///
+    /// Nil rather than two zeroes, because "+0 -0" is a line saying nothing and the card has to
+    /// say something else in its place. See `changes`.
+    public struct Diff: Sendable, Hashable {
+        public var additions: Int
+        public var deletions: Int
+
+        public init(additions: Int, deletions: Int) {
+            self.additions = additions
+            self.deletions = deletions
+        }
+    }
+
+    /// The pull request this branch has, reduced to what the card draws.
+    ///
+    /// The URL travels with it even though the card is not clickable, because the card is drawn in
+    /// a window that ignores the mouse and the number is therefore a fact rather than a control.
+    /// Carrying the address anyway is what keeps this value the answer if the card ever grows a
+    /// way to be pressed, and it costs a string.
+    public struct PullRequestRef: Sendable, Hashable {
+        public var number: Int
+        public var title: String
+        public var url: String
+
+        public init(number: Int, title: String, url: String) {
+            self.number = number
+            self.title = title
+            self.url = url
+        }
+    }
+
+    /// The workspace's name, whole. The row truncates it; this is the half of the card that
+    /// exists because the row truncates it, so nothing here shortens it a second time.
+    public var title: String
+    /// The branch, whole, slashes and all. Never abbreviated to its last component: two
+    /// workspaces on `freek/fix-checks` and `agent/fix-checks` would then draw the same line.
+    public var branch: String
+    public var diff: Diff?
+    /// What the mark in the corner is, in the same vocabulary the row's own mark uses, so the two
+    /// cannot say different things about one workspace. See `WorkspaceStatus`.
+    public var status: WorkspaceStatus
+    /// The state in words, because a glyph on a card nobody can hover has no tooltip to fall back
+    /// on. `WorkspaceStatus.label`, so the card, the legend and the filter all read the same.
+    public var state: String
+    /// The numbers behind the state, such as how many checks failed. Nil when the state's own
+    /// words are all there is.
+    public var detail: String?
+    public var pullRequest: PullRequestRef?
+    /// How long since anything happened here, as a phrase. See `HomeAge.phrase`.
+    public var age: String
+
+    public init(
+        title: String,
+        branch: String,
+        diff: Diff? = nil,
+        status: WorkspaceStatus,
+        state: String,
+        detail: String? = nil,
+        pullRequest: PullRequestRef? = nil,
+        age: String
+    ) {
+        self.title = title
+        self.branch = branch
+        self.diff = diff
+        self.status = status
+        self.state = state
+        self.detail = detail
+        self.pullRequest = pullRequest
+        self.age = age
+    }
+
+    /// What to say where the counts would be when there are none.
+    ///
+    /// The line the counts sit on is the branch's line, and a branch with nothing after it reads
+    /// as a card that failed to load its numbers rather than as a clean worktree. Three words in
+    /// the quiet ink is the whole fix, and it is here rather than in the view so the empty case is
+    /// something the suite can hold.
+    public static let noChanges = "No changes"
+
+    /// The card for one sidebar row.
+    ///
+    /// The three things the workspace row cannot know are passed in, exactly as
+    /// `WorkspaceStatus.resolve` takes them: whether an agent has a turn open, whether it is
+    /// blocked on a question, and what GitHub last said. All three are already on hand where this
+    /// is called, and none of them is asked for here.
+    ///
+    /// - Parameter now: the clock, injectable so the age can be asserted on. See `HomeAge`.
+    public static func make(
+        workspace: Workspace,
+        isRunning: Bool = false,
+        isAwaitingPermission: Bool = false,
+        pullRequest: PullRequest? = nil,
+        now: Date = Date()
+    ) -> WorkspaceHoverCard {
+        let status = WorkspaceStatus.resolve(
+            workspace: workspace,
+            isRunning: isRunning,
+            pullRequest: pullRequest,
+            isAwaitingPermission: isAwaitingPermission
+        )
+
+        return WorkspaceHoverCard(
+            title: workspace.name,
+            branch: workspace.branch,
+            // `hasDiff` rather than a count of its own, so the card is holding the same opinion
+            // about an empty worktree that the row's own counts and `WorkspaceStatus` hold.
+            diff: workspace.hasDiff
+                ? Diff(additions: workspace.additions, deletions: workspace.deletions)
+                : nil,
+            status: status,
+            state: status.label,
+            detail: status.detail(pullRequest: pullRequest),
+            // Whatever GitHub last said, whether or not the state above came from it. A workspace
+            // whose agent is mid turn still has its pull request, and "#362" under "Agent
+            // running" is two facts rather than two answers: the state is about now, the number
+            // is about the branch. Suppressing it there would mean the number blinked out every
+            // time a turn started, which is the one moment somebody is most likely to want it.
+            //
+            // A pull request belonging to an earlier life of a reused branch name never reaches
+            // here: `PullRequestOwnership` drops it upstream, which is where that rule lives.
+            pullRequest: pullRequest.map {
+                PullRequestRef(number: $0.number, title: $0.title, url: $0.url)
+            },
+            age: HomeAge.phrase(for: workspace.lastActivityAt, now: now)
+        )
+    }
+}

--- a/Tests/BloomCoreTests/WorkspaceHoverCardTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceHoverCardTests.swift
@@ -75,7 +75,8 @@ struct WorkspaceHoverCardTests {
     }
 
     /// The empty case, and the reason `diff` is optional rather than two zeroes: "+0 -0" is a
-    /// line that says nothing, so the card has to have something else to draw there.
+    /// line that says nothing. The state carries the fact instead, which is why nothing is drawn
+    /// where the counts would be.
     @Test("A workspace with nothing changed carries no counts at all")
     func noChanges() {
         let card = WorkspaceHoverCard.make(workspace: workspace(), now: Self.now)
@@ -83,7 +84,6 @@ struct WorkspaceHoverCardTests {
         #expect(card.diff == nil)
         #expect(card.status == .clean)
         #expect(card.state == "No changes")
-        #expect(WorkspaceHoverCard.noChanges == "No changes")
     }
 
     /// Files touched without a line changing, which is what a rename or a mode change is. The

--- a/Tests/BloomCoreTests/WorkspaceHoverCardTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceHoverCardTests.swift
@@ -1,0 +1,338 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// What the card beside a hovered sidebar row says, and where it is put.
+///
+/// Every date here is built rather than read off the clock, for the reason `HomeListTests` writes
+/// down: a suite that says "six days ago" as an offset from `Date()` passes all afternoon and
+/// fails at midnight.
+@Suite("Workspace hover card")
+struct WorkspaceHoverCardTests {
+    /// The clock every case below is measured from. A fixed instant, so "6d ago" is 6d ago on
+    /// every machine that runs this and in every month.
+    static let now = Date(timeIntervalSince1970: 1_750_000_000)
+
+    private func workspace(
+        name: String = "Add a hover card to the sidebar",
+        branch: String = "freek/hover-card",
+        additions: Int = 0,
+        deletions: Int = 0,
+        changedFiles: Int = 0,
+        unread: Bool = false,
+        lastActivityAt: Date = WorkspaceHoverCardTests.now
+    ) -> Workspace {
+        Workspace(
+            repoID: RepoID("repo"),
+            name: name,
+            branch: branch,
+            path: "/tmp/worktree",
+            baseBranch: "main",
+            createdAt: lastActivityAt,
+            lastActivityAt: lastActivityAt,
+            additions: additions,
+            deletions: deletions,
+            changedFiles: changedFiles,
+            unread: unread
+        )
+    }
+
+    private func pullRequest(
+        number: Int = 362,
+        state: String = "OPEN",
+        checks: PullRequest.Checks = .none,
+        checksSummary: String = "",
+        isDraft: Bool = false
+    ) -> PullRequest {
+        PullRequest(
+            number: number,
+            title: "Add a hover card to the sidebar",
+            url: "https://github.com/spatie/bloom/pull/\(number)",
+            state: state,
+            isDraft: isDraft,
+            checks: checks,
+            checksSummary: checksSummary
+        )
+    }
+
+    // MARK: - What it says
+
+    @Test("A changed workspace with no pull request says so and shows its counts")
+    func changedWithoutPullRequest() {
+        let card = WorkspaceHoverCard.make(
+            workspace: workspace(additions: 1_418, deletions: 556, changedFiles: 12),
+            now: Self.now
+        )
+
+        #expect(card.title == "Add a hover card to the sidebar")
+        #expect(card.branch == "freek/hover-card")
+        #expect(card.diff == WorkspaceHoverCard.Diff(additions: 1_418, deletions: 556))
+        #expect(card.status == .changed)
+        #expect(card.state == "Has changes")
+        #expect(card.detail == nil)
+        #expect(card.pullRequest == nil)
+    }
+
+    /// The empty case, and the reason `diff` is optional rather than two zeroes: "+0 -0" is a
+    /// line that says nothing, so the card has to have something else to draw there.
+    @Test("A workspace with nothing changed carries no counts at all")
+    func noChanges() {
+        let card = WorkspaceHoverCard.make(workspace: workspace(), now: Self.now)
+
+        #expect(card.diff == nil)
+        #expect(card.status == .clean)
+        #expect(card.state == "No changes")
+        #expect(WorkspaceHoverCard.noChanges == "No changes")
+    }
+
+    /// Files touched without a line changing, which is what a rename or a mode change is. The
+    /// card follows `Workspace.hasDiff` rather than `changedFiles`, so it holds exactly the
+    /// opinion the row's own counts hold: two files and nothing to count is not a diff.
+    @Test("Changed files with no changed lines draw no counts")
+    func zeroLineDiff() {
+        let card = WorkspaceHoverCard.make(
+            workspace: workspace(changedFiles: 2), now: Self.now
+        )
+
+        #expect(card.status == .clean)
+        #expect(card.diff == nil)
+    }
+
+    @Test("Failing checks put the count behind the state rather than in place of it")
+    func failingChecks() {
+        let card = WorkspaceHoverCard.make(
+            workspace: workspace(additions: 40, deletions: 3, changedFiles: 2),
+            pullRequest: pullRequest(
+                checks: .failing, checksSummary: "1 of 12 checks failed"
+            ),
+            now: Self.now
+        )
+
+        #expect(card.status == .checksFailing)
+        #expect(card.state == "Checks failing")
+        #expect(card.detail == "1 of 12 checks failed")
+        #expect(card.pullRequest?.number == 362)
+        #expect(card.pullRequest?.url == "https://github.com/spatie/bloom/pull/362")
+    }
+
+    /// gh reports its own rollup summary, and for a failing run it is often the same three words
+    /// the state is already drawn in. The card must not say it twice.
+    @Test("A rollup summary equal to the state is not repeated under it")
+    func detailThatRepeatsTheState() {
+        let card = WorkspaceHoverCard.make(
+            workspace: workspace(additions: 40, deletions: 3, changedFiles: 2),
+            pullRequest: pullRequest(checks: .failing, checksSummary: "Checks failing"),
+            now: Self.now
+        )
+
+        #expect(card.state == "Checks failing")
+        #expect(card.detail == nil)
+    }
+
+    /// The state is about now and the number is about the branch. Suppressing the number while a
+    /// turn runs would blink it out at the one moment somebody most wants to see it.
+    @Test("A running agent keeps the pull request number under a running state")
+    func runningKeepsItsPullRequest() {
+        let card = WorkspaceHoverCard.make(
+            workspace: workspace(additions: 12, deletions: 1, changedFiles: 1),
+            isRunning: true,
+            pullRequest: pullRequest(checks: .passing, checksSummary: "12 checks passed"),
+            now: Self.now
+        )
+
+        #expect(card.status == .running)
+        #expect(card.state == "Agent running")
+        // The detail belongs to the pull request's state, and the state on show is not the pull
+        // request's, so there is nothing to put behind it.
+        #expect(card.detail == nil)
+        #expect(card.pullRequest?.number == 362)
+    }
+
+    @Test("A blocked agent outranks everything else the row could say")
+    func awaitingPermission() {
+        let card = WorkspaceHoverCard.make(
+            workspace: workspace(additions: 4, deletions: 0, changedFiles: 1, unread: true),
+            isRunning: true,
+            isAwaitingPermission: true,
+            now: Self.now
+        )
+
+        #expect(card.status == .awaitingPermission)
+        #expect(card.state == "Waiting on you")
+    }
+
+    // MARK: - The two things the row cannot draw
+
+    /// The card exists because the row truncates. Shortening the name here as well would leave
+    /// the whole affordance with nothing to add.
+    @Test("A title far too long for the row is carried whole")
+    func longTitle() {
+        let long = "Show me every place the technologies used in this project are configured, "
+            + "and say which of them are pinned to a version"
+        let card = WorkspaceHoverCard.make(workspace: workspace(name: long), now: Self.now)
+
+        #expect(card.title == long)
+        #expect(card.title.count == long.count)
+    }
+
+    /// Never reduced to its last component: `freek/fix-checks` and `agent/fix-checks` would then
+    /// draw the same line on two different workspaces.
+    @Test("A branch with slashes in it keeps all of them")
+    func branchWithSlashes() {
+        let card = WorkspaceHoverCard.make(
+            workspace: workspace(branch: "agent/2026-08/fix-the-checks"), now: Self.now
+        )
+
+        #expect(card.branch == "agent/2026-08/fix-the-checks")
+    }
+
+    // MARK: - Age
+
+    @Test("Six days reads as the phrase, not as the measurement")
+    func sixDaysAgo() {
+        let card = WorkspaceHoverCard.make(
+            workspace: workspace(lastActivityAt: Self.now.addingTimeInterval(-6 * 86_400)),
+            now: Self.now
+        )
+
+        #expect(card.age == "6d ago")
+    }
+
+    /// A workspace nobody has touched since it was cut. `lastActivityAt` equals `createdAt`,
+    /// which is the clock, and "now ago" is not English.
+    @Test("A workspace that has never been touched reads as just now")
+    func neverTouched() {
+        let card = WorkspaceHoverCard.make(workspace: workspace(), now: Self.now)
+
+        #expect(card.age == "just now")
+    }
+
+    /// A clock change or a restore from a backup produces a timestamp in the future. `HomeAge`
+    /// already decided what to say about it, and the phrase must not invent a second answer.
+    @Test("A timestamp from the future reads as just now rather than as a negative age")
+    func futureTimestamp() {
+        let card = WorkspaceHoverCard.make(
+            workspace: workspace(lastActivityAt: Self.now.addingTimeInterval(3_600)),
+            now: Self.now
+        )
+
+        #expect(card.age == "just now")
+    }
+
+    /// Every rung of `HomeAge`'s scale, so a change to one of its thresholds cannot quietly
+    /// change what the card reads. Written out as a typed property rather than as a literal in
+    /// the macro's argument list, which on its own was enough to time the type checker out
+    /// inside the `@Test` expansion.
+    static let ageRungs: [(seconds: Double, phrase: String)] = [
+        (30, "just now"),
+        (600, "10m ago"),
+        (7_200, "2h ago"),
+        (86_400 * 3, "3d ago"),
+        (86_400 * 14, "2w ago"),
+        (86_400 * 90, "3mo ago"),
+        (86_400 * 800, "2y ago"),
+    ]
+
+    @Test("Every rung of the age scale gains the word", arguments: ageRungs)
+    func agePhrases(rung: (seconds: Double, phrase: String)) {
+        let card = WorkspaceHoverCard.make(
+            workspace: workspace(lastActivityAt: Self.now.addingTimeInterval(-rung.seconds)),
+            now: Self.now
+        )
+
+        #expect(card.age == rung.phrase)
+    }
+
+    // MARK: - Where it goes
+
+    /// The ordinary case: a window in the middle of a large screen, sidebar row on the left.
+    @Test("The card stands to the right of the row, its top edge on the row's")
+    func placedRightOfTheRow() {
+        let screen = CGRect(x: 0, y: 0, width: 1_920, height: 1_080)
+        let row = CGRect(x: 200, y: 800, width: 240, height: 32)
+
+        let frame = HoverCardPlacement.frame(
+            anchor: row, size: CGSize(width: 300, height: 140), visible: screen
+        )
+
+        #expect(frame.minX == row.maxX + HoverCardPlacement.gap)
+        #expect(frame.maxY == row.maxY)
+    }
+
+    /// A window pushed against the right edge of the screen, which is where a wide window with a
+    /// collapsed inspector sits.
+    @Test("With no room on the right the card flips to the left of the row")
+    func flipsWhenTheRightIsFull() {
+        let screen = CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        let row = CGRect(x: 1_100, y: 400, width: 240, height: 32)
+
+        let frame = HoverCardPlacement.frame(
+            anchor: row, size: CGSize(width: 300, height: 140), visible: screen
+        )
+
+        #expect(frame.maxX == row.minX - HoverCardPlacement.gap)
+        #expect(frame.minX >= screen.minX + HoverCardPlacement.screenMargin)
+    }
+
+    /// A screen with room for the card on neither side. Flipping would trade one overhang for
+    /// another, so the card stays where it was and is pushed back inside instead.
+    @Test("With room on neither side the card is clamped rather than flipped")
+    func clampedWhenNeitherSideFits() {
+        let screen = CGRect(x: 0, y: 0, width: 700, height: 500)
+        let row = CGRect(x: 200, y: 300, width: 240, height: 32)
+
+        let frame = HoverCardPlacement.frame(
+            anchor: row, size: CGSize(width: 300, height: 140), visible: screen
+        )
+
+        #expect(frame.maxX == screen.maxX - HoverCardPlacement.screenMargin)
+        #expect(frame.minX >= screen.minX + HoverCardPlacement.screenMargin)
+    }
+
+    /// The last row of a full sidebar. Running off the bottom would cut off the age and the pull
+    /// request number, which are the two things on the card's last line.
+    @Test("A row near the bottom of the screen pushes the card back up")
+    func clampedAtTheBottom() {
+        let screen = CGRect(x: 0, y: 0, width: 1_920, height: 1_080)
+        let row = CGRect(x: 200, y: 20, width: 240, height: 32)
+
+        let frame = HoverCardPlacement.frame(
+            anchor: row, size: CGSize(width: 300, height: 140), visible: screen
+        )
+
+        #expect(frame.minY == screen.minY + HoverCardPlacement.screenMargin)
+        #expect(frame.maxY <= screen.maxY - HoverCardPlacement.screenMargin)
+    }
+
+    /// A screen whose origin is not zero, which is every second display on this Mac. The margins
+    /// are against that screen's own bounds, not against the desktop's.
+    @Test("A row at the top of a screen with a non-zero origin stays on that screen")
+    func clampedAtTheTopOfASecondScreen() {
+        let screen = CGRect(x: -1_440, y: 200, width: 1_440, height: 900)
+        let row = CGRect(x: -1_300, y: 1_064, width: 240, height: 32)
+
+        let frame = HoverCardPlacement.frame(
+            anchor: row, size: CGSize(width: 300, height: 140), visible: screen
+        )
+
+        #expect(frame.maxY <= screen.maxY - HoverCardPlacement.screenMargin)
+        #expect(frame.minY >= screen.minY + HoverCardPlacement.screenMargin)
+    }
+
+    /// A card taller than the space it is given cannot satisfy both clamps. The TOP edge wins,
+    /// because the title and the branch are drawn on it and the age at the foot is the one line
+    /// worth losing. This is the whole reason the vertical clamps are applied in the order they
+    /// are: the last one applied is the one that holds.
+    @Test("A card taller than the screen keeps its top edge on screen")
+    func tallerThanTheScreen() {
+        let screen = CGRect(x: 0, y: 0, width: 1_920, height: 300)
+        let row = CGRect(x: 200, y: 100, width: 240, height: 32)
+
+        let frame = HoverCardPlacement.frame(
+            anchor: row, size: CGSize(width: 300, height: 600), visible: screen
+        )
+
+        #expect(frame.maxY == screen.maxY - HoverCardPlacement.screenMargin)
+    }
+}


### PR DESCRIPTION
A workspace row gets one line of a 260 point pane, so the name truncates, the branch is not drawn at all and the counts yield to the hover controls. Resting the pointer on a row for 350ms now opens a card beside the sidebar with the branch and its counts, the name in full, the state in words with the numbers behind it, the pull request number and how long ago anything happened.

Nothing is fetched. The counts are the row's own and the pull request is whatever the sidebar's existing poll last saw.

What the card says is `WorkspaceHoverCard` in the core, tested against a workspace with no pull request, one whose checks failed, one with nothing changed, one nobody has touched, a pasted-paragraph name and a branch full of slashes. Where the card lands is `HoverCardPlacement`, also tested, because three of its four cases only happen at the edges of a screen.

Reused rather than rewritten: `HomeAge` for the age (one new line on it, `phrase`), `DiffStatLabel` for the counts, `WorkspaceStatus` and `WorkspaceStatusGlyph` for the mark and its words, and `Motion.hoverCardDelay` for the 350ms, which the composer's chip card was already using as a private constant of its own.

It is a panel that ignores the mouse rather than a `.popover`, because a transient popover eats the click that dismisses it and that click is the one meant to select the row. So the card carries no action: what you can do to a workspace stays on the row under the pointer, and what is true of it is on the card. It closes on a live scroll, any mouse down (which covers a click and a reorder drag), a menu, a sheet, the window losing key and the app losing active.

Pointer only, and deliberately so: everything on the card is on the row already, in its accessibility value and its tooltip, and the panel is hidden from VoiceOver rather than being an element nothing can reach.

Rendered: `--snapshot-gallery --gallery hover-card`, nine states in both appearances. Two defects came out of the first render and are fixed: the clean card said "No changes" twice, and the failing card cut "1 of 12 required checks f..." to fit four facts on one line.