### PR TITLE
Draw the source picker's two tabs in Bloom's own colours

### DIFF
--- a/Sources/Bloom/Design/Gallery.swift
+++ b/Sources/Bloom/Design/Gallery.swift
@@ -75,6 +75,7 @@ extension Snapshot {
         .sidebarSelection,
         .quickPrompts,
         .hoverCard,
+        .panelTabs,
     ]
 
     /// The page `--gallery` names, falling back to the first rather than failing: a capture run

--- a/Sources/Bloom/Design/PanelTabs.swift
+++ b/Sources/Bloom/Design/PanelTabs.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+
+/// Two or three words, one of them chosen, filling the width they are given.
+///
+/// **A control of our own rather than `Picker(...).pickerStyle(.segmented)`, and the note that
+/// asked for one is on `InspectorToolbar.tabPicker`.** It records a measurement: `.tint` cannot
+/// reach a SwiftUI segmented picker, because it is an `NSSegmentedControl` whose selected cell is
+/// recoloured only through `selectedSegmentBezelColor`, which there is no supported way to set
+/// from SwiftUI and which AppKit exposes through no `appearance()` proxy either. That note ends by
+/// saying that if a later SDK put the accent back into the selected cell, the answer would be a
+/// control of ours rather than a tint. This is that control.
+///
+/// Two more faults came with the same report, and neither of them is about colour. **A segmented
+/// control sizes to its content**: measured in a 444 point slot, the two labels of
+/// `WorkspaceSourceTab` laid the control out at 387 points, so a panel that put it in a
+/// leading-aligned stack got a strip that stopped short of the right edge, and its two cells were
+/// as unequal as its two labels. Cells here are `maxWidth: .infinity` inside an `HStack`, so the
+/// strip is exactly as wide as it is offered and every cell is the same fraction of it whatever
+/// its label says. **And a segmented control does not truncate**: it overflows and is clipped by
+/// whatever is holding it, which is the other half of "not fully visible". A cell here is a `Text`
+/// with a line limit, so a strip narrower than its words loses the end of a word rather than the
+/// end of a cell.
+///
+/// **The colours are the ones a selected thing already wears elsewhere in this window**, which is
+/// the whole point of not tinting: `Palette.selected`, the quiet fill a resting list row gets, on
+/// a `Palette.surfaceSunken` track. Measured against the app's own floors, which
+/// `PaletteContrastTests` holds: the selected cell stands off its track at 1.20 to 1 in light and
+/// 1.55 in dark, against the 1.2 boundary floor the borders are held to, and the ink on it is
+/// `Palette.textPrimary` at 12.5 to 1 and 8.4 to 1. A resting cell keeps `Palette.textTertiary`,
+/// which clears the 4.5 text floor on the track at 4.52 and 5.65. It is not allowed onto the
+/// selected fill, where it measures 3.76 and 3.64 and would fail, and that is why a chosen cell
+/// lifts its ink rather than only changing what is behind it.
+///
+/// **Three states, and none of them is a colour alone.** A resting cell is tertiary ink on the
+/// track, a hovered one is secondary ink over `Palette.hover`, and the chosen one is primary ink
+/// in medium weight on the fill. The weight is what carries the choice for a reader who cannot
+/// separate the two greys, which is the rule `SeverityVocabularyTests` holds everywhere else in
+/// this app; equal cells are what let it change without moving anything.
+///
+/// Shared rather than local because a second panel wants it: `QuickPromptMarkPicker` draws the
+/// same two words by hand, and the inspector's own tab row is the third of them.
+struct PanelTabs<Tab: Hashable>: View {
+    /// What the strip as a whole is called, for VoiceOver. The cells carry their own words, so
+    /// this is the question they are answers to rather than a repeat of them.
+    var label: String
+    var tabs: [Tab]
+    @Binding var selection: Tab
+    var title: (Tab) -> String
+    /// Which cell to draw as hovered, whatever the pointer is doing.
+    ///
+    /// Nil everywhere in the app, and it is not a styling hook. `PanelTabsGallery` photographs this
+    /// control offscreen, where there is no pointer to fire an `onHover`, so the one state a
+    /// reviewer most needs to compare against the other two is the one a capture cannot reach.
+    /// Stated here rather than reimplemented in the gallery, because a second drawing of a hover
+    /// is a second answer to what a hover looks like.
+    var hovering: Tab?
+
+    init(
+        _ label: String,
+        tabs: [Tab],
+        selection: Binding<Tab>,
+        title: @escaping (Tab) -> String,
+        hovering: Tab? = nil
+    ) {
+        self.label = label
+        self.tabs = tabs
+        self._selection = selection
+        self.title = title
+        self.hovering = hovering
+    }
+
+    /// Which cell the pointer is on, held as the tab and never as an index, for the reason
+    /// `WorkspaceSourcePicker.selected` writes out: a list that reorders leaves an index pointing
+    /// at whatever has since moved into that slot.
+    @State private var pointer: Tab?
+    @Namespace private var pill
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(tabs, id: \.self) { tab in
+                cell(tab)
+            }
+        }
+        .padding(Metrics.spacingTight)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.corner)
+                .fill(Palette.surfaceSunken)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.corner)
+                .strokeBorder(Palette.border, lineWidth: Metrics.hairline)
+        }
+        // Dropped under Reduce Motion rather than slowed, which is what every other call site in
+        // this app does with `Motion`: the setting is about movement, not about speed.
+        .animation(reduceMotion ? nil : Motion.pane, value: selection)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(label)
+    }
+
+    private func cell(_ tab: Tab) -> some View {
+        let isSelected = tab == selection
+        let isHovered = (hovering ?? pointer) == tab && !isSelected
+        return Button {
+            selection = tab
+        } label: {
+            Text(title(tab))
+                .font(isSelected ? Typo.labelEmphasis : Typo.label)
+                .foregroundStyle(ink(selected: isSelected, hovered: isHovered))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, Metrics.spacingSmall)
+                .padding(.horizontal, Metrics.spacingSmall)
+                .background {
+                    if isSelected {
+                        RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+                            .fill(Palette.selected)
+                            // The fill is one view that moves rather than one per cell fading in
+                            // and out, so the choice reads as having travelled to where it now is.
+                            .matchedGeometryEffect(id: "tabstrip.pill", in: pill)
+                    } else if isHovered {
+                        RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+                            .fill(Palette.hover)
+                    }
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { inside in
+            withAnimation(reduceMotion ? nil : Motion.hover) {
+                // Cleared only by the cell that claimed it. Two cells can report in either order
+                // as the pointer crosses the boundary between them, and an unconditional clear
+                // lets the one being left wipe the one being entered.
+                pointer = inside ? tab : (pointer == tab ? nil : pointer)
+            }
+        }
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    /// Three rungs of the ink scale, one per state. Tertiary is the floor of what is meant to be
+    /// read and it only clears its 4.5 on the track, so the two lit states climb rather than
+    /// staying put and letting the fill do all the work. See the type's own note.
+    private func ink(selected: Bool, hovered: Bool) -> Color {
+        if selected { return Palette.textPrimary }
+        return hovered ? Palette.textSecondary : Palette.textTertiary
+    }
+}

--- a/Sources/Bloom/Design/PanelTabs.swift
+++ b/Sources/Bloom/Design/PanelTabs.swift
@@ -32,10 +32,11 @@ import SwiftUI
 /// lifts its ink rather than only changing what is behind it.
 ///
 /// **Three states, and none of them is a colour alone.** A resting cell is tertiary ink on the
-/// track, a hovered one is secondary ink over `Palette.hover`, and the chosen one is primary ink
-/// in medium weight on the fill. The weight is what carries the choice for a reader who cannot
+/// track, a hovered one is primary ink over `Palette.hover`, and the chosen one is primary ink in
+/// medium weight on the fill. The weight is what carries the choice for a reader who cannot
 /// separate the two greys, which is the rule `SeverityVocabularyTests` holds everywhere else in
-/// this app; equal cells are what let it change without moving anything.
+/// this app; equal cells are what let it change without moving anything. Why the hovered cell is
+/// not a rung of its own is on `ink(selected:hovered:)`, and it was a picture that settled it.
 ///
 /// Shared rather than local because a second panel wants it: `QuickPromptMarkPicker` draws the
 /// same two words by hand, and the inspector's own tab row is the third of them.
@@ -139,11 +140,19 @@ struct PanelTabs<Tab: Hashable>: View {
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
-    /// Three rungs of the ink scale, one per state. Tertiary is the floor of what is meant to be
-    /// read and it only clears its 4.5 on the track, so the two lit states climb rather than
-    /// staying put and letting the fill do all the work. See the type's own note.
+    /// Resting ink, or lit ink. Two values rather than three, and the third was tried first.
+    ///
+    /// A hovered cell was `Palette.textSecondary`, on the reasoning that three states want three
+    /// rungs. Photographed, the hovered cell came out DIMMER than the resting one beside it, which
+    /// is the opposite of what a hover means. The scale is not the ladder it looks like:
+    /// `textSecondary` is `secondaryLabelColor`, half ink, which composites to `#808080` on white
+    /// and measures 3.95 to 1, while `Palette.textTertiary` is Bloom's own retuned rung at 4.52.
+    /// The system's second rung is below Bloom's third, and its own doc comment says as much.
+    ///
+    /// So a cell is either resting or lit, and the wash and the weight are what tell hovered from
+    /// chosen. Both are what the fill is for anyway; `Palette.hover` is four percent ink, which
+    /// carries almost nothing on its own.
     private func ink(selected: Bool, hovered: Bool) -> Color {
-        if selected { return Palette.textPrimary }
-        return hovered ? Palette.textSecondary : Palette.textTertiary
+        selected || hovered ? Palette.textPrimary : Palette.textTertiary
     }
 }

--- a/Sources/Bloom/Design/PanelTabsGallery.swift
+++ b/Sources/Bloom/Design/PanelTabsGallery.swift
@@ -22,6 +22,11 @@ struct PanelTabsGallery: View {
 
     private static let panelWidth: CGFloat = 460
 
+    /// The width the panel really offers the strip, and then three that squeeze it. The last is
+    /// narrower than either label on its own, which is where a segmented control stopped drawing
+    /// its second cell at all rather than shortening a word.
+    private static let widths: [CGFloat] = [panelWidth - Metrics.gutter * 2, 320, 220, 150]
+
     var body: some View {
         VStack(alignment: .leading, spacing: Metrics.pane) {
             HStack(alignment: .top, spacing: Metrics.pane) {
@@ -35,8 +40,7 @@ struct PanelTabsGallery: View {
 
             captioned("The strip alone, at four widths") {
                 VStack(alignment: .leading, spacing: Metrics.spacingWide) {
-                    ForEach([Self.panelWidth - Metrics.gutter * 2, 320, 220, 150], id: \.self) {
-                        width in
+                    ForEach(Self.widths, id: \.self) { width in
                         strip(width: width)
                     }
                 }

--- a/Sources/Bloom/Design/PanelTabsGallery.swift
+++ b/Sources/Bloom/Design/PanelTabsGallery.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+import BloomCore
+
+/// `PanelTabs`, at the width it really opens at, in the states it is really in, and inside the
+/// panel it was written for.
+///
+/// It exists because the control it replaced shipped with three faults that one look would have
+/// caught and no test could: a selected cell in the system accent beside a panel of Bloom's teal,
+/// a strip that stopped short of the right edge because a segmented control sizes to its content,
+/// and a label clipped rather than truncated when there was not room. None of the three is visible
+/// from the tests, the panel is a popover so the window probes cannot open it, and two of them are
+/// about width, which is exactly what a picture answers and a ratio does not.
+///
+///     Bloom --snapshot-gallery <dir> --gallery panel-tabs
+///
+/// The bottom half is the strip on its own at four widths, down to one narrower than its own two
+/// labels, because "does it truncate or does it clip" was the fault nobody could name from the
+/// screenshot. Hover is drawn by handing the strip a fixed hovered cell rather than by pretending
+/// to move a pointer, which offscreen there is none of.
+struct PanelTabsGallery: View {
+    var app: AppModel
+
+    private static let panelWidth: CGFloat = 460
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.pane) {
+            HStack(alignment: .top, spacing: Metrics.pane) {
+                captioned("The panel, on the tab that cuts a branch") {
+                    panel(tab: .newBranch)
+                }
+                captioned("The panel, on the tab that carries one on") {
+                    panel(tab: .existingBranch)
+                }
+            }
+
+            captioned("The strip alone, at four widths") {
+                VStack(alignment: .leading, spacing: Metrics.spacingWide) {
+                    ForEach([Self.panelWidth - Metrics.gutter * 2, 320, 220, 150], id: \.self) {
+                        width in
+                        strip(width: width)
+                    }
+                }
+            }
+
+            HStack(alignment: .top, spacing: Metrics.pane) {
+                captioned("Resting, nothing under the pointer") {
+                    strip(width: 300)
+                }
+                captioned("The pointer on the cell that is not chosen") {
+                    strip(width: 300, hovering: true)
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(Metrics.pane)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(Palette.surface)
+        .environment(app)
+    }
+
+    /// The whole head of the panel, drawn from the real strip and the real sentence, so the two
+    /// things this pass changed are photographed together: the strip reaching both gutters, and
+    /// both explanations sitting on one line so the search row does not move when the tab does.
+    private func panel(tab: WorkspaceSourceTab) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            PanelTabsHarness(tab: tab)
+                .padding(.horizontal, Metrics.gutter)
+                .padding(.vertical, Metrics.spacingWide)
+
+            Text(tab.explanation)
+                .font(Typo.caption)
+                .foregroundStyle(Palette.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, Metrics.gutter)
+                .padding(.bottom, Metrics.spacingWide)
+
+            Hairline()
+
+            HStack(spacing: Metrics.spacing) {
+                Image(systemName: "magnifyingglass")
+                    .imageScale(.small)
+                    .foregroundStyle(Palette.textTertiary)
+                Text(tab.searchPlaceholder)
+                    .font(Typo.body)
+                    .foregroundStyle(Palette.textPlaceholder)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, Metrics.gutter)
+            .padding(.vertical, Metrics.spacingSmall)
+            .frame(height: Metrics.rowHeight)
+
+            Hairline()
+        }
+        .frame(width: Self.panelWidth)
+        // The popover's own plate, since a popover's chrome is not here to draw it.
+        .background(Palette.surface, in: RoundedRectangle(cornerRadius: Metrics.corner + 2))
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.corner + 2)
+                .strokeBorder(Palette.border, lineWidth: Metrics.hairline)
+        }
+    }
+
+    private func strip(width: CGFloat, hovering: Bool = false) -> some View {
+        PanelTabsHarness(tab: .newBranch, hovering: hovering ? .existingBranch : nil)
+            .frame(width: width)
+    }
+
+    private func captioned(_ caption: String, @ViewBuilder content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingWide) {
+            Text(caption)
+                .font(Typo.caption)
+                .foregroundStyle(Palette.textTertiary)
+            content()
+        }
+    }
+}
+
+/// A strip with somewhere for its binding to point, and with a hovered cell that can be stated
+/// rather than pointed at.
+///
+/// The hover is a real `onHover`, and offscreen there is no pointer to fire one, so the state a
+/// reviewer most needs to see is the one that cannot be photographed. This drives the same view
+/// through the same code and posts the hover itself.
+private struct PanelTabsHarness: View {
+    var tab: WorkspaceSourceTab
+    var hovering: WorkspaceSourceTab?
+
+    @State private var selection: WorkspaceSourceTab = .newBranch
+
+    var body: some View {
+        PanelTabs(
+            "Start from",
+            tabs: WorkspaceSourceTab.allCases,
+            selection: $selection,
+            title: { $0.title },
+            hovering: hovering
+        )
+        .onAppear { selection = tab }
+    }
+}
+
+extension Gallery {
+    /// The registry entry for this page. See `Gallery`.
+    ///
+    /// No field is being typed into, so it needs nobody's keyboard.
+    static let panelTabs = Gallery(
+        name: "panel-tabs",
+        title: "Panel tabs",
+        size: CGSize(width: 1040, height: 780),
+        needsFocus: false,
+        view: { app in AnyView(PanelTabsGallery(app: app)) }
+    )
+}

--- a/Sources/Bloom/Views/Sidebar/WorkspaceSourcePicker.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspaceSourcePicker.swift
@@ -136,17 +136,17 @@ struct WorkspaceSourcePicker: View {
         }
     }
 
+    /// `PanelTabs` rather than a segmented picker, and its own note carries the three measurements
+    /// that bought it. The one that shows here is the inset: `Metrics.gutter`, the same margin the
+    /// sentence under it and the search row below that already keep, so the strip starts and ends
+    /// on the panel's own lines. The segmented control could not do that at any inset, because it
+    /// sized to its two labels and this stack aligns leading, which is what left it short of the
+    /// right edge with a gap after it.
     private var tabs: some View {
-        Picker("Start from", selection: $tab) {
-            ForEach(WorkspaceSourceTab.allCases) { option in
-                Text(option.title).tag(option)
-            }
-        }
-        .pickerStyle(.segmented)
-        .labelsHidden()
-        .padding(.horizontal, Metrics.spacingSmall)
-        .padding(.top, Metrics.spacingSmall)
-        .padding(.bottom, Metrics.spacingTight)
+        PanelTabs("Start from", tabs: WorkspaceSourceTab.allCases, selection: $tab) { $0.title }
+        .padding(.horizontal, Metrics.gutter)
+        .padding(.top, Metrics.spacingWide)
+        .padding(.bottom, Metrics.spacingWide)
         .onChange(of: tab) { _, _ in
             // The highlight cannot stay in a tab nobody can see, so it settles into the new one.
             selected = matches.settled(after: selected, in: tab)

--- a/Sources/BloomCore/Workspace/WorkspaceSource.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceSource.swift
@@ -302,10 +302,17 @@ public enum WorkspaceSourceTab: String, Sendable, Hashable, CaseIterable, Identi
     /// difference. Both say where a commit ends up and what merging does with it, because that is
     /// the whole distinction: on a new branch the merge is yours to do later, and on an existing
     /// one the merge already belongs to that branch and your commits ride it.
+    ///
+    /// **Both fit on one line at the width the panel opens at, and the first one did not.** It was
+    /// "Commits land on a new branch. Merging it brings them into the branch you pick here.", which
+    /// measured at 436 points, the panel's 460 less its gutters, wraps after "pick" and leaves
+    /// "here." alone on a second line. That cost a word of nothing to read and made the panel a
+    /// line taller on one tab than the other, so switching tabs moved the search field under the
+    /// pointer. One clause instead of two sentences says the same thing inside the width.
     public var explanation: String {
         switch self {
         case .newBranch:
-            "Commits land on a new branch. Merging it brings them into the branch you pick here."
+            "Commits land on a new branch, and merge into the branch you pick here."
         case .existingBranch:
             "Commits land on the branch you pick here, and merge when it does."
         }

--- a/Tests/BloomCoreTests/PaletteContrastTests.swift
+++ b/Tests/BloomCoreTests/PaletteContrastTests.swift
@@ -129,6 +129,41 @@ struct PaletteContrastTests {
         }
     }
 
+    /// The tab strip's own two colours, which is the one control in the window whose fill and ink
+    /// were chosen together rather than inherited from a list row.
+    ///
+    /// `PanelTabs` replaced a segmented picker whose selected cell drew in the system accent, and
+    /// the replacement had to answer a question the picker never asked: what ink goes on
+    /// `Palette.selected`. The obvious answer is the one the resting cells already carry, and it
+    /// is wrong. `textTertiary` measures 3.76 to 1 on that fill in light and 3.64 in dark, under
+    /// the 4.5 floor, which is why a chosen cell lifts to `Palette.textPrimary` instead of only
+    /// changing what is behind it. That failure is asserted rather than described, so retuning
+    /// either pair until it stops being true is something this suite says out loud.
+    @Test("a chosen cell is findable, and cannot keep a resting cell's ink")
+    func thePanelTabsHoldTheirOwnFloors() {
+        for (appearance, isDark) in Self.appearances {
+            let fill = PaletteInk.selected.member(dark: isDark)
+            let track = PaletteInk.surfaceSunken.member(dark: isDark)
+            let onTrack = Contrast.ratio(fill, track)
+            #expect(
+                onTrack >= 1.2,
+                "the chosen cell on its track, \(appearance): \(onTrack.rounded(to: 2)) to 1"
+            )
+
+            let resting = Contrast.ratio(PaletteInk.textTertiary.member(dark: isDark), track)
+            #expect(
+                resting >= Contrast.textFloor,
+                "a resting cell's ink on its track, \(appearance): \(resting.rounded(to: 2)) to 1"
+            )
+
+            let borrowed = Contrast.ratio(PaletteInk.textTertiary.member(dark: isDark), fill)
+            #expect(
+                borrowed < Contrast.textFloor,
+                "a resting cell's ink now clears the chosen fill in \(appearance) at \(borrowed.rounded(to: 2)) to 1, so the lift to the primary label can go"
+            )
+        }
+    }
+
     /// A boundary is not read, so it holds the non-text floor rather than the text one. `border`
     /// is the case the window used to have none of: `separatorColor` composites to a 25 unit step
     /// on white, which the eye reads as nothing.


### PR DESCRIPTION
The create sheet's source picker drew its two tabs with `Picker(...).pickerStyle(.segmented)`, which was wrong on three counts and only one of them was colour.

The selected cell draws in the system accent, and `.tint` cannot reach it: the note on `InspectorToolbar.tabPicker` measured that and said the answer would be a control of ours. It sizes to its content, so in a leading-aligned panel it stopped short of the right edge and split itself as unevenly as its two labels: measured at 387 points inside a 444 point slot. And it clips rather than truncates when there is no room, which is the rest of "not fully visible".

`PanelTabs` is that control, in `Sources/Bloom/Design/` so the quick prompt mark picker can adopt it. Cells are `maxWidth: .infinity`, the chosen one wears `Palette.selected` on a `Palette.surfaceSunken` track, lifts its ink to the primary label and takes a medium weight, and the fill travels with `Motion.pane`, dropped under Reduce Motion. `PaletteContrastTests` now asserts the floors, including the one that forced the lift: `textTertiary` measures 3.76 to 1 on the selected fill, under 4.5.

The new branch tab's sentence wrapped after "pick" at the panel's width and left "here." alone on a line, which made the panel a line taller on one tab than the other and moved the search field under the pointer. One clause now says the same thing inside the width.

`--gallery panel-tabs` covers both tabs, hover, and four widths down to one narrower than either label.

The inspector's own picker is untouched. It should adopt this next: it is the same choice and the same two faults are waiting for it at a narrow inspector width, where it currently drops to a pop-up button instead.