### PR TITLE
Fix the quick prompt icon picker and give the form room

### DIFF
--- a/Sources/Bloom/Design/QuickPromptGallery.swift
+++ b/Sources/Bloom/Design/QuickPromptGallery.swift
@@ -15,8 +15,13 @@ import BloomCore
 /// Two columns: the list on the left, the form on the right. The form is here because the icon
 /// picker replaced an inline grid, and the two things worth looking at are whether an emoji sits
 /// in the same column as a symbol without reading a size larger, and whether the picker hangs off
-/// the well squarely. Neither is visible from the tests, and both are what the last four rounds of
+/// the well squarely. Neither is visible from the tests, and both are what the last five rounds of
 /// this panel got wrong.
+///
+/// The fifth round added the rest of what a reviewer has to see at once: the form with nothing
+/// hanging off it, the picker on each of its two tabs, a name too long for the row, and the
+/// question Delete asks. Every one of those was reported from a screenshot rather than caught
+/// here, which is what a page missing a state costs.
 struct QuickPromptGallery: View {
     var app: AppModel
 
@@ -81,17 +86,17 @@ struct QuickPromptGallery: View {
             VStack(alignment: .leading, spacing: Metrics.pane) {
                 panel("The first row, highlighted on opening", selected: 0)
                 panel("Nothing written yet", selected: nil, empty: true)
-                form("Name and icon, a symbol chosen", prompt: prompts[0])
+                form("At rest, a symbol chosen", prompt: prompts[0])
                 Spacer(minLength: 0)
             }
 
             VStack(alignment: .leading, spacing: Metrics.pane) {
-                form("An emoji chosen", prompt: prompts[4])
+                form("A name longer than the row it is typed in", prompt: prompts[5])
                 // Both tabs, and the tab each opens on is read off the mark the prompt already
                 // carries, so these two are also the test of that.
-                form("The picker, open on the well", prompt: prompts[0], picking: true)
-                form("The same picker on a prompt marked with an emoji",
-                     prompt: prompts[4], picking: true)
+                form("The picker, open on Icons", prompt: prompts[0], picking: true)
+                form("The picker, open on Emojis", prompt: prompts[4], picking: true)
+                captioned("What Delete asks first") { deleteQuestion }
                 Spacer(minLength: 0)
             }
         }
@@ -99,6 +104,20 @@ struct QuickPromptGallery: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(Palette.surface)
         .environment(app)
+    }
+
+    /// The question Delete asks, drawn through the app's own dialog rather than described.
+    ///
+    /// `PendingDeleteSnapshotGallery` does the same with its own question and for the same reason:
+    /// a sentence about a prompt with no name of its own, or one whose name runs past the width of
+    /// the dialog, is a sentence that has to be seen wrapped rather than counted.
+    private var deleteQuestion: some View {
+        ConfirmationSheet(
+            confirmation: QuickPromptDeletion.confirmation(for: prompts[5]),
+            onConfirm: {},
+            onCancel: {}
+        )
+        .fixedSize()
     }
 
     /// The form, in its own plate, at the width the panel opens at.

--- a/Sources/Bloom/Design/QuickPromptGallery.swift
+++ b/Sources/Bloom/Design/QuickPromptGallery.swift
@@ -86,17 +86,27 @@ struct QuickPromptGallery: View {
             VStack(alignment: .leading, spacing: Metrics.pane) {
                 panel("The first row, highlighted on opening", selected: 0)
                 panel("Nothing written yet", selected: nil, empty: true)
-                form("At rest, a symbol chosen", prompt: prompts[0])
                 Spacer(minLength: 0)
             }
 
             VStack(alignment: .leading, spacing: Metrics.pane) {
+                form("At rest, a symbol chosen", prompt: prompts[0])
                 form("A name longer than the row it is typed in", prompt: prompts[5])
-                // Both tabs, and the tab each opens on is read off the mark the prompt already
-                // carries, so these two are also the test of that.
-                form("The picker, open on Icons", prompt: prompts[0], picking: true)
-                form("The picker, open on Emojis", prompt: prompts[4], picking: true)
                 captioned("What Delete asks first") { deleteQuestion }
+                Spacer(minLength: 0)
+            }
+
+            VStack(alignment: .leading, spacing: Metrics.pane) {
+                // The tab each opens on is read off the mark the prompt already carries, so these
+                // two are the test of that as well as of the card.
+                //
+                // The first is marked with a symbol from the fifth band, which is the case that
+                // used to fail silently: the picker opened at the top of the first band with the
+                // mark it was meant to be showing several hundred points below the fold, because
+                // a lazy grid had not built the row a `ScrollViewReader` was asked to scroll to.
+                form("The picker, open on Icons and scrolled to the mark",
+                     prompt: prompts[6], picking: true)
+                form("The picker, open on Emojis", prompt: prompts[4], picking: true)
                 Spacer(minLength: 0)
             }
         }
@@ -246,7 +256,7 @@ extension Gallery {
     static let quickPrompts = Gallery(
         name: "quick-prompts",
         title: "Quick prompts",
-        size: CGSize(width: 880, height: 1400),
+        size: CGSize(width: 1320, height: 1440),
         needsFocus: false,
         view: { app in AnyView(QuickPromptGallery(app: app)) }
     )

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptDeletion.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptDeletion.swift
@@ -1,0 +1,19 @@
+import Foundation
+import BloomCore
+
+/// The dialog `QuickPromptDeletion` is worn in.
+///
+/// The words are in `BloomCore`, where they can be tested; only the shape is here, because
+/// `Confirmation` is a piece of this app's chrome and the core does not know about dialogs. This is
+/// `ProjectRemoval.confirmation(for:workspaces:runningAgents:)` again, deliberately: the app asks
+/// eleven of these questions and they are meant to look and read alike.
+extension QuickPromptDeletion {
+    static func confirmation(for prompt: QuickPrompt) -> Confirmation {
+        Confirmation(
+            title: title(for: prompt.resolvedName),
+            message: message,
+            confirmLabel: confirmLabel,
+            cancelLabel: cancelLabel
+        )
+    }
+}

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptForm.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptForm.swift
@@ -5,8 +5,7 @@ import BloomCore
 ///
 /// One form for both jobs, because they are the same three fields. Editing adds Delete, on the left
 /// of the row Save is on, which is where a destructive button goes in a Mac form and the only place
-/// this one lives. Deleting something you wrote is worth one deliberate trip rather than one stray
-/// click in a list you opened to pick from.
+/// this one lives. It asks before it deletes: see `QuickPromptDeletion`.
 ///
 /// It is drawn inside the panel the list was in rather than in a sheet of its own: the list and the
 /// form are two states of one popover, so choosing a prompt and editing one never involve two
@@ -18,6 +17,13 @@ import BloomCore
 /// and the name filling the rest of the row, is the shape of the same row in There There, and it
 /// puts the choice behind one press instead of in front of everybody who only wanted to rename
 /// something.
+///
+/// **The picker opens into a gap rather than over the form**, which is what the second round of
+/// this panel got wrong. It used to be an overlay positioned off a measured well, with the panel
+/// padded at the foot by whatever the card overhung by; that arithmetic was right and the result
+/// was still a card sitting on top of the Text field and the Save button. A row in the stack costs
+/// the panel exactly the same height and covers nothing, and it takes the measured well frame, the
+/// measured content height and the reserve sum with it.
 struct QuickPromptForm: View {
     /// The prompt being changed, or nil when this is a new one.
     var editing: QuickPrompt?
@@ -27,12 +33,13 @@ struct QuickPromptForm: View {
     /// Whether the form opens with the picker already up.
     ///
     /// False everywhere but `QuickPromptGallery`, which renders this form offscreen and cannot
-    /// press a button to open anything. The panel shipped four times with something wrong with it
+    /// press a button to open anything. The panel shipped five times with something wrong with it
     /// that one look would have caught, so the state that has to be looked at has to be reachable
     /// without a click.
     var startsPickingMark = false
     var onCancel: @MainActor () -> Void
     var onSave: @MainActor (_ name: String, _ symbol: String, _ text: String) -> Void
+    /// Asks for the prompt to go. The panel owns the question, because the list can ask it too.
     var onDelete: @MainActor () -> Void
 
     @State private var name = ""
@@ -44,13 +51,6 @@ struct QuickPromptForm: View {
     @State private var isPrepared = false
     /// Whether the icon picker is up.
     @State private var isPickingMark = false
-    /// Where the well is, in the form's own coordinates, so the picker can be hung off it rather
-    /// than off the row around it. Measured rather than worked out from the spacing scale, because
-    /// a form whose label heights are guessed at is a picker that drifts a point or two off its
-    /// well the first time a rung of `Typo` moves.
-    @State private var wellFrame: CGRect = .zero
-    /// How tall the form is with nothing hanging off it. See `pickerReserve`.
-    @State private var contentHeight: CGFloat = 0
 
     @FocusState private var isNameFocused: Bool
 
@@ -62,27 +62,30 @@ struct QuickPromptForm: View {
     private static let wellSize: CGFloat = 22
     /// The mark inside it, set well under the well so the plate reads as a plate.
     private static let wellPoints: CGFloat = 15
-    /// The name the well's position is measured in. `nonisolated` because `onGeometryChange` reads
-    /// it from a closure that is not on the main actor, and a `String` on a `MainActor` type is
-    /// isolated to it unless it says otherwise.
-    private nonisolated static let formSpace = "quickPromptForm"
 
     var body: some View {
-        // `Metrics.pane` and `gutter` rather than the tighter rungs the rest of this panel uses.
-        // A list is scanned and wants to be dense; a form is filled in, and at the panel's spacing
-        // the three labels sat on top of their controls and the whole card read as cramped.
-        VStack(alignment: .leading, spacing: Metrics.gutter) {
+        // `Metrics.pane` between the groups, which is the widest rung there is, and the owner asked
+        // for it twice. The form was on `gutter` and read as cramped: it is filled in rather than
+        // scanned, and a panel four groups tall at twelve points apart is a wall of controls. The
+        // labels inside a group stay tight, so the wide gap is what says where one group ends.
+        VStack(alignment: .leading, spacing: Metrics.pane) {
             heading
 
-            field("Name and icon") {
-                HStack(spacing: Metrics.spacing) {
-                    well
+            VStack(alignment: .leading, spacing: Metrics.spacingWide) {
+                field("Name and icon") {
+                    HStack(spacing: Metrics.spacing) {
+                        well
 
-                    TextField("Run the tests", text: $name)
-                        .textFieldStyle(.roundedBorder)
-                        .font(Typo.body)
-                        .focused($isNameFocused)
-                        .accessibilityLabel("Quick prompt name")
+                        TextField("Run the tests", text: $name)
+                            .textFieldStyle(.roundedBorder)
+                            .font(Typo.body)
+                            .focused($isNameFocused)
+                            .accessibilityLabel("Quick prompt name")
+                    }
+                }
+
+                if isPickingMark {
+                    picker
                 }
             }
 
@@ -105,17 +108,19 @@ struct QuickPromptForm: View {
             }
 
             buttons
-                .padding(.top, Metrics.spacingSmall)
         }
-        .coordinateSpace(.named(Self.formSpace))
-        // Measured before the room for the picker is added, so the one cannot feed the other.
-        .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { contentHeight = $0 }
-        .padding(.bottom, pickerReserve)
         .padding(Metrics.pane)
-        // Over the whole panel rather than over the fields, so a click on the padding closes the
-        // picker too. A popover would have had that for nothing; this card is inside the panel, so
-        // it has to be given.
-        .overlay(alignment: .topLeading) { picker }
+        // Behind the form rather than over it, which is the whole of why this is a `background`.
+        // An overlay took the clicks meant for the fields under it; a background takes only the
+        // ones nothing else wanted, which is exactly the click on the panel's own padding that
+        // ought to put the picker away.
+        .background {
+            if isPickingMark {
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture { closePicker() }
+            }
+        }
         .onAppear(perform: prepare)
         // Escape leaves the form and goes back to the list, rather than closing the whole panel and
         // losing what was typed with it. While the picker is up it has Escape first, and gives it
@@ -124,7 +129,10 @@ struct QuickPromptForm: View {
     }
 
     private var heading: some View {
-        VStack(alignment: .leading, spacing: Metrics.spacingHair) {
+        // `spacingSmall`, not `spacingHair`. At one point the subtitle sat on the ascenders of the
+        // title above it and the two read as one wrapped line, which is what the owner meant by the
+        // heading sitting almost on its subtitle.
+        VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
             Text(editing == nil ? "New quick prompt" : "Edit quick prompt")
                 .font(Typo.bodyEmphasis)
                 .foregroundStyle(Palette.textPrimary)
@@ -164,49 +172,19 @@ struct QuickPromptForm: View {
         .buttonStyle(.plain)
         .help("Choose an icon or an emoji")
         .accessibilityLabel("Quick prompt icon")
-        .onGeometryChange(for: CGRect.self) {
-            $0.frame(in: .named(Self.formSpace))
-        } action: { wellFrame = $0 }
     }
 
-    /// The picker, hung under the well, over a layer that swallows the click that dismisses it.
-    @ViewBuilder
+    /// The picker, under the well and narrower than the form, so it reads as a card hung off the
+    /// square that opened it rather than as a second panel the width of the first.
     private var picker: some View {
-        if isPickingMark {
-            ZStack(alignment: .topLeading) {
-                // Not `Color.clear` on its own, which takes no clicks at all.
-                Color.clear
-                    .contentShape(Rectangle())
-                    .onTapGesture { closePicker() }
-
-                QuickPromptMarkPicker(
-                    selection: symbol,
-                    onChoose: { mark in
-                        symbol = mark.stored
-                        closePicker()
-                    },
-                    onClose: closePicker
-                )
-                // The form's own padding, because this layer is outside it and the well was
-                // measured inside it.
-                .offset(
-                    x: wellFrame.minX + Metrics.pane,
-                    y: wellFrame.maxY + Metrics.pane + Metrics.spacingSmall
-                )
-            }
-        }
-    }
-
-    /// How much taller the panel has to be while the picker is up.
-    ///
-    /// **The card cannot hang past the panel's edge, because it is inside it.** A `.popover` of its
-    /// own would float free, and would also take the whole panel with it on the first click: see
-    /// `QuickPromptMarkPicker`. So the form grows by exactly what is missing and by nothing when
-    /// nothing is, which is most of the time only the last thirty or so points.
-    private var pickerReserve: CGFloat {
-        guard isPickingMark, contentHeight > 0 else { return 0 }
-        let need = wellFrame.maxY + Metrics.spacingSmall + QuickPromptMarkPicker.height
-        return max(0, need - contentHeight)
+        QuickPromptMarkPicker(
+            selection: symbol,
+            onChoose: { mark in
+                symbol = mark.stored
+                closePicker()
+            },
+            onClose: closePicker
+        )
     }
 
     private var buttons: some View {

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptMarkPicker.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptMarkPicker.swift
@@ -76,13 +76,13 @@ struct QuickPromptMarkPicker: View {
     private static let markPoints: CGFloat = 18
 
     static let width = CGFloat(columns) * cell + inset * 2
-    /// Five rows of cells, and the padding under them.
+    /// Five rows of cells, and the padding around them.
     ///
     /// Five rather than the seven it was. The card hangs in a gap the form opens for it, so every
     /// row of it is a row the panel grows by, and a popover that grows by three hundred points to
     /// show a grid has taken over the window. Both tabs scroll at five, which is the other half of
     /// it: a band cut off part way down is what tells a reader there is more.
-    private static let gridHeight: CGFloat = 5 * cell + Metrics.spacingWide
+    private static let gridHeight: CGFloat = 5 * cell + Metrics.spacingWide * 2
 
     private var sections: [QuickPromptMarkSection] {
         QuickPromptMarkCatalog.filtered(kind, query: query)
@@ -95,6 +95,12 @@ struct QuickPromptMarkPicker: View {
                 searchRow
             }
             .padding(Self.inset)
+
+            // The two controls are fixed and the grid under them moves, and without a line between
+            // them a band heading scrolled half under the field read as a heading that had been
+            // cut off rather than as one on its way past. The header block's own padding was not
+            // enough to say which of the two it was.
+            Hairline()
 
             grid(sections)
         }
@@ -213,7 +219,7 @@ struct QuickPromptMarkPicker: View {
                         }
                     }
                     .padding(.horizontal, Self.inset)
-                    .padding(.bottom, Self.inset)
+                    .padding(.vertical, Self.inset)
                 }
                 .frame(height: Self.gridHeight)
                 .onChange(of: highlighted) { _, mark in

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptMarkPicker.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptMarkPicker.swift
@@ -11,10 +11,14 @@ import BloomCore
 /// reason it had no well at all. The well is worth having, so what changed is where the card is
 /// drawn, not whether the risk was real.
 ///
-/// It is `MenuPanel`, which is the same card the composer's completion menus float in, positioned
-/// under the well by `QuickPromptForm`. Everything a popover would have given it, a shadow, a
-/// border, the menu material and a click outside that dismisses it, it has; what it gives up is
-/// being able to hang past the edge of the panel, which is why the form makes room underneath.
+/// It is `MenuPanel`, which is the same card the composer's completion menus float in, opened into
+/// a gap `QuickPromptForm` makes under the well. It used to be drawn over the form, and the owner
+/// reported it as a panel that had escaped: it covered the Text field and the Save button, and its
+/// left edge ran into the panel's own rounded corner. A card hung in room made for it covers
+/// nothing, so all the shadow and the border are left to say is that it floats.
+///
+/// **Nothing in the grid is lazy, and that is the bug this file was opened for.** See
+/// `QuickPromptMarkSection.rows(across:)`.
 struct QuickPromptMarkPicker: View {
     /// The mark the prompt carries now, so the picker opens on it rather than at the top.
     var selection: String
@@ -23,89 +27,136 @@ struct QuickPromptMarkPicker: View {
 
     /// Which tab is open. It starts on the one holding the mark the prompt already carries, so
     /// somebody editing a prompt marked with an emoji is not shown a hundred symbols first.
-    @State private var kind = QuickPromptMarkKind.icons
+    @State private var kind: QuickPromptMarkKind
     @State private var query = ""
     /// Where Return would go. Held as the mark itself and never as an index, for the reason
     /// `QuickPromptMenu.selected` writes down: a filtered list renumbers under every keystroke.
     @State private var highlighted: QuickPromptMark?
 
-    /// Eight to a row. Wider rows put the marks further apart than the eye can take in at once,
-    /// and narrower ones turn nine bands into a very long scroll.
-    static let columns = 8
-    /// A cell, and the hit target with it. Thirty two is the smallest square this app asks anybody
-    /// to click at (`Metrics.barHeight`), and the mark inside it is set well under that.
-    private static let cell: CGFloat = 32
+    /// **Both are settled here rather than in an `onAppear`, which is where they were.**
+    ///
+    /// `kind` defaulted to `.icons` and was corrected once the card had appeared, so the first pass
+    /// of every open built the scroll view against nine bands of symbols and then replaced the
+    /// whole of its content. Instrumented, that is exactly what it did: opening the picker on a
+    /// prompt marked with a rocket printed `kind=icons bands=9` and then `kind=emoji bands=1`, one
+    /// frame apart, every time. A scroll view whose content is swapped out from under it the frame
+    /// after it is created is the one event that happens once per open, and the owner's report was
+    /// about a first open. A `@State` given its value in `init` never has that frame.
+    init(
+        selection: String,
+        onChoose: @escaping @MainActor (QuickPromptMark) -> Void,
+        onClose: @escaping @MainActor () -> Void
+    ) {
+        self.selection = selection
+        self.onChoose = onChoose
+        self.onClose = onClose
+
+        let current = QuickPromptMark(stored: selection)
+        let tab = QuickPromptMarkCatalog.kind(of: current)
+        _kind = State(initialValue: tab)
+        _highlighted = State(
+            initialValue: QuickPromptMarkCatalog.settled(
+                QuickPromptMarkCatalog.sections(tab), after: current
+            )
+        )
+    }
+
+    /// Seven to a row. Wider rows put the marks further apart than the eye can take in at once,
+    /// and narrower ones turn nine bands into a very long scroll. It was eight, at a cell smaller
+    /// than the glyph in it wanted; a column came off rather than the card growing, because the
+    /// card now sits inside the form's own width and has nowhere to grow into.
+    static let columns = 7
+    /// A cell, and the hit target with it. Larger than `Metrics.barHeight`, which is the smallest
+    /// square this app asks anybody to click, because the owner read the grid as cramped: at 32
+    /// around a 17 point mark there were seven points of air, and an emoji fills its em box where a
+    /// symbol does not, so the rows read as touching even where the numbers said they were not.
+    private static let cell: CGFloat = 36
     private static let inset: CGFloat = Metrics.spacingWide
     /// The point size a mark is drawn at inside its cell. See `QuickPromptMarkView`.
-    private static let markPoints: CGFloat = 17
+    private static let markPoints: CGFloat = 18
 
     static let width = CGFloat(columns) * cell + inset * 2
-    /// Seven rows of cells and the padding around them, which is exactly what the emoji band comes
-    /// to: at 232 the Emojis tab ended in a finger's width of empty card, because it is one band
-    /// that does not scroll and the height had been picked for the tab that does. The icon tab
-    /// still scrolls, and a band ending part way down is what tells a reader there is more.
-    private static let gridHeight: CGFloat = 7 * cell + Metrics.spacingWide * 2
-    /// What the whole card comes to, which `QuickPromptForm` has to make room for: the tab strip,
-    /// the search field, the rule between them and the grid.
-    static let height = gridHeight + Metrics.rowHeight + Metrics.barHeight
-        + Metrics.spacingSmall * 2 + Metrics.hairline
+    /// Five rows of cells, and the padding under them.
+    ///
+    /// Five rather than the seven it was. The card hangs in a gap the form opens for it, so every
+    /// row of it is a row the panel grows by, and a popover that grows by three hundred points to
+    /// show a grid has taken over the window. Both tabs scroll at five, which is the other half of
+    /// it: a band cut off part way down is what tells a reader there is more.
+    private static let gridHeight: CGFloat = 5 * cell + Metrics.spacingWide
 
     private var sections: [QuickPromptMarkSection] {
         QuickPromptMarkCatalog.filtered(kind, query: query)
     }
 
     var body: some View {
-        let sections = self.sections
-        return MenuPanel {
-            tabs
-            searchRow
-            Hairline()
+        MenuPanel {
+            VStack(alignment: .leading, spacing: Metrics.spacingWide) {
+                tabs
+                searchRow
+            }
+            .padding(Self.inset)
+
             grid(sections)
         }
         .frame(width: Self.width)
-        .onAppear {
-            let current = QuickPromptMark(stored: selection)
-            // Through a local, not through `kind` a line later: reading a `@State` back in the
-            // closure that wrote it is a race nobody should have to think about twice.
-            let tab = QuickPromptMarkCatalog.kind(of: current)
-            kind = tab
-            highlighted = QuickPromptMarkCatalog.settled(
-                QuickPromptMarkCatalog.sections(tab), after: current
-            )
-        }
         .onChange(of: query) { _, _ in
             highlighted = QuickPromptMarkCatalog.settled(self.sections, after: highlighted)
         }
     }
 
-    /// Icons or emoji. Two words rather than a segmented control: `.pickerStyle(.segmented)` is a
-    /// form control, and it read as one, a bordered slab across the top of a card that is
-    /// otherwise a menu. This is the treatment the inspector's own tab row uses.
+    /// Icons or emoji, as a pill on a sunken track.
+    ///
+    /// Not `.pickerStyle(.segmented)`, which is a form control and read as one: a bordered slab
+    /// across the top of a card that is otherwise a menu. It was two bare words before this, and
+    /// the owner read the strip they sat on as an unfinished grey band, because the card's own
+    /// padding was all that separated them from the field under them.
+    ///
+    /// **Local, and it should not stay that way.** `PanelTabs` in `Design/` is this control,
+    /// written for the create sheet's two tabs, and its own note names this picker as the second
+    /// caller. It was not on `main` when this was written. The colours and the two states here are
+    /// its, so adopting it is a deletion rather than a redesign.
     private var tabs: some View {
-        HStack(spacing: Metrics.spacingTight) {
+        HStack(spacing: 0) {
             ForEach(QuickPromptMarkKind.allCases) { tab in
-                Button {
-                    choose(tab: tab)
-                } label: {
-                    Text(tab.title)
-                        .font(kind == tab ? Typo.captionEmphasis : Typo.caption)
-                        .foregroundStyle(kind == tab ? Palette.textPrimary : Palette.textTertiary)
-                        .padding(.horizontal, Metrics.spacingWide)
-                        .padding(.vertical, Metrics.spacingSmall)
-                        .background {
-                            RoundedRectangle(cornerRadius: Metrics.cornerSmall)
-                                .fill(kind == tab ? Palette.selected : Color.clear)
-                        }
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityAddTraits(kind == tab ? .isSelected : [])
+                tabCell(tab)
             }
-            Spacer(minLength: 0)
         }
-        .padding(.horizontal, Self.inset)
-        .padding(.top, Metrics.spacingWide)
-        .frame(height: Metrics.barHeight, alignment: .bottom)
+        .padding(Metrics.spacingTight)
+        .background {
+            RoundedRectangle(cornerRadius: Metrics.corner)
+                .fill(Palette.surfaceSunken)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.corner)
+                .strokeBorder(Palette.border, lineWidth: Metrics.hairline)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("What to mark this prompt with")
+    }
+
+    private func tabCell(_ tab: QuickPromptMarkKind) -> some View {
+        let isSelected = kind == tab
+        return Button {
+            choose(tab: tab)
+        } label: {
+            Text(tab.title)
+                // The weight carries the choice as well as the fill does, which is what keeps the
+                // strip readable for somebody who cannot separate two greys.
+                .font(isSelected ? Typo.labelEmphasis : Typo.label)
+                .foregroundStyle(isSelected ? Palette.textPrimary : Palette.textTertiary)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, Metrics.spacingSmall)
+                .background {
+                    if isSelected {
+                        RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+                            .fill(Palette.selected)
+                    }
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
     /// Switching tabs clears the query with it. The field belongs to the tab under it, and a query
@@ -118,12 +169,17 @@ struct QuickPromptMarkPicker: View {
         highlighted = QuickPromptMarkCatalog.sections(tab).first?.choices.first?.mark
     }
 
+    /// The field, on a plate of its own.
+    ///
+    /// The plate is the whole change. An `NSTextField` with no border and no background, sat under
+    /// a magnifying glass on the card's own ground, had an edge nowhere, and the owner read it as a
+    /// caption rather than as somewhere to type. This is the box `QuickPromptForm` draws round its
+    /// own text editor, out of the same two values and for the same reason.
     private var searchRow: some View {
         HStack(spacing: Metrics.spacing) {
             Image(systemName: "magnifyingglass")
                 .imageScale(.small)
                 .foregroundStyle(Palette.textTertiary)
-                .frame(width: Metrics.repoIcon)
 
             MenuSearchField(
                 text: $query,
@@ -131,10 +187,16 @@ struct QuickPromptMarkPicker: View {
                 onKey: handle(key:),
                 onHorizontal: handle(horizontal:)
             )
-            .frame(height: Metrics.rowHeight)
         }
-        .padding(.horizontal, Self.inset)
-        .padding(.vertical, Metrics.spacingSmall)
+        .padding(.horizontal, Metrics.spacing)
+        .frame(height: Metrics.rowHeight)
+        .background(
+            Palette.surfaceSunken, in: RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+                .strokeBorder(Palette.border, lineWidth: Metrics.hairline)
+        }
     }
 
     @ViewBuilder
@@ -145,13 +207,13 @@ struct QuickPromptMarkPicker: View {
         } else {
             ScrollViewReader { proxy in
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: Metrics.spacingWide, pinnedViews: []) {
+                    VStack(alignment: .leading, spacing: Metrics.gutter) {
                         ForEach(sections) { section in
                             band(section)
                         }
                     }
                     .padding(.horizontal, Self.inset)
-                    .padding(.vertical, Metrics.spacingWide)
+                    .padding(.bottom, Self.inset)
                 }
                 .frame(height: Self.gridHeight)
                 .onChange(of: highlighted) { _, mark in
@@ -163,6 +225,10 @@ struct QuickPromptMarkPicker: View {
                     proxy.scrollTo(mark.stored, anchor: .center)
                 }
             }
+            // A tab change builds a new scroll view rather than swapping the content of the one
+            // that is up. Nothing then has to reason about an offset, a measured height or a row
+            // belonging to the other tab, because none of them survives the change.
+            .id(kind)
         }
     }
 
@@ -174,42 +240,42 @@ struct QuickPromptMarkPicker: View {
                     .foregroundStyle(Palette.textTertiary)
             }
 
-            LazyVGrid(
-                columns: Array(
-                    repeating: GridItem(.fixed(Self.cell), spacing: 0), count: Self.columns
-                ),
-                spacing: 0
-            ) {
-                ForEach(section.choices) { choice in
-                    cell(choice)
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(section.rows(across: Self.columns)) { row in
+                    HStack(spacing: 0) {
+                        ForEach(row.choices) { choice in
+                            cell(choice)
+                        }
+                    }
                 }
             }
         }
     }
 
+    /// One mark, in two states that used to look alike.
+    ///
+    /// **The mark the prompt carries is the loud one and the keyboard is the quiet one**, and it
+    /// was the other way round. A teal ring on one cell and a teal fill on another were on screen
+    /// at once, and a reader could not say which was which. Only one of the two is a fact about the
+    /// prompt; the other is where Return would go, and it moves under every arrow press and every
+    /// twitch of the pointer. So the fact wears the accent fill this app paints a chosen thing in
+    /// everywhere else, and the transient one wears `Palette.hover`, the wash a row gets under the
+    /// pointer, which says nothing louder than "here".
     private func cell(_ choice: QuickPromptMarkChoice) -> some View {
+        let isChosen = choice.mark == QuickPromptMark(stored: selection)
         let isHighlighted = choice.mark == highlighted
-        let isCurrent = choice.mark == QuickPromptMark(stored: selection)
         return Button {
             onChoose(choice.mark)
         } label: {
             QuickPromptMarkView(
                 stored: choice.mark.stored,
                 points: Self.markPoints,
-                tint: isHighlighted ? Palette.selectedEmphasizedText : Palette.textSecondary
+                tint: isChosen ? Palette.selectedEmphasizedText : Palette.textSecondary
             )
             .frame(width: Self.cell, height: Self.cell)
             .background {
                 RoundedRectangle(cornerRadius: Metrics.cornerSmall)
-                    .fill(isHighlighted ? Palette.selectedEmphasized : Color.clear)
-            }
-            // The mark the prompt already carries, when the keyboard is somewhere else. A ring
-            // rather than a second fill: two filled cells read as two things chosen.
-            .overlay {
-                if isCurrent && !isHighlighted {
-                    RoundedRectangle(cornerRadius: Metrics.cornerSmall)
-                        .strokeBorder(Palette.accent, lineWidth: Metrics.hairline)
-                }
+                    .fill(fill(chosen: isChosen, highlighted: isHighlighted))
             }
             .contentShape(Rectangle())
         }
@@ -218,7 +284,12 @@ struct QuickPromptMarkPicker: View {
         .onHover { if $0 { highlighted = choice.mark } }
         .help(choice.label)
         .accessibilityLabel(choice.label)
-        .accessibilityAddTraits(isCurrent ? .isSelected : [])
+        .accessibilityAddTraits(isChosen ? .isSelected : [])
+    }
+
+    private func fill(chosen: Bool, highlighted: Bool) -> Color {
+        if chosen { return Palette.selectedEmphasized }
+        return highlighted ? Palette.hover : Color.clear
     }
 
     // MARK: - Keys

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptMarkPicker.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptMarkPicker.swift
@@ -65,7 +65,7 @@ struct QuickPromptMarkPicker: View {
     /// and narrower ones turn nine bands into a very long scroll. It was eight, at a cell smaller
     /// than the glyph in it wanted; a column came off rather than the card growing, because the
     /// card now sits inside the form's own width and has nowhere to grow into.
-    static let columns = 7
+    private static let columns = 7
     /// A cell, and the hit target with it. Larger than `Metrics.barHeight`, which is the smallest
     /// square this app asks anybody to click, because the owner read the grid as cramped: at 32
     /// around a 17 point mark there were seven points of air, and an emoji fills its em box where a
@@ -75,7 +75,7 @@ struct QuickPromptMarkPicker: View {
     /// The point size a mark is drawn at inside its cell. See `QuickPromptMarkView`.
     private static let markPoints: CGFloat = 18
 
-    static let width = CGFloat(columns) * cell + inset * 2
+    private static let width = CGFloat(columns) * cell + inset * 2
     /// Five rows of cells, and the padding around them.
     ///
     /// Five rather than the seven it was. The card hangs in a gap the form opens for it, so every

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptMenu.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptMenu.swift
@@ -42,6 +42,11 @@ struct QuickPromptMenu: View {
     @State private var contentHeight: CGFloat = 0
     /// The form, when one is open. Two states of one panel rather than a second floating window.
     @State private var editor: Editor?
+    /// The prompt Delete was pressed on, while the question about it is up.
+    ///
+    /// One piece of state for both routes into it, the pencil's form and the row's own context
+    /// menu, because they ask the same question. See `QuickPromptDeletion`.
+    @State private var deleting: QuickPrompt?
 
     /// Which form is up, and what it is about.
     private enum Editor: Equatable {
@@ -84,6 +89,17 @@ struct QuickPromptMenu: View {
         }
         .frame(width: Self.width)
         .task { await catalog.load(from: app.store) }
+        // A quick prompt is a paragraph the owner wrote and there is no undo for it. Delete used to
+        // take the row on the click, from a list opened to pick something out of.
+        .confirmation($deleting) {
+            QuickPromptDeletion.confirmation(for: $0)
+        } onConfirm: { prompt in
+            delete(prompt)
+            // The form was about the prompt that has just gone, so it goes with it. Cancelling
+            // leaves it standing, which is the half that matters: nothing typed is lost by
+            // pressing Delete and changing your mind.
+            if case .existing(let editing) = editor, editing.id == prompt.id { editor = nil }
+        }
     }
 
     // MARK: - The list
@@ -162,7 +178,7 @@ struct QuickPromptMenu: View {
                             onPick: { pick(prompt) },
                             onHover: { selected = prompt },
                             onEdit: { editor = .existing(prompt) },
-                            onDelete: { delete(prompt) }
+                            onDelete: { deleting = prompt }
                         )
                         // Identity is the thing the row names, never its position. See `selected`.
                         .id(prompt.id)
@@ -277,8 +293,7 @@ struct QuickPromptMenu: View {
             onSave: { name, symbol, text in save(editing, name: name, symbol: symbol, text: text) },
             onDelete: {
                 guard let editing else { return }
-                delete(editing)
-                self.editor = nil
+                deleting = editing
             }
         )
     }

--- a/Sources/BloomCore/Transcript/QuickPromptDeletion.swift
+++ b/Sources/BloomCore/Transcript/QuickPromptDeletion.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// The words asked before a quick prompt is thrown away.
+///
+/// **They are here rather than beside the button because a quick prompt is something the owner
+/// wrote and there is no undo for it.** Delete used to remove the row on the click, from the form
+/// and from the row's own context menu, so a stray press on a list opened to pick from cost a
+/// paragraph nobody had a copy of. `ProjectRemoval` is the shape this follows: the sentences live
+/// in the core where a test can read them, and only the dialog they are worn in is the app's.
+///
+/// One question for both routes, for the reason `ProjectRemoval` gives about its three: two
+/// wordings of the same question drift, and the only thing that notices is the person being asked.
+public enum QuickPromptDeletion {
+    /// The one line a reader reliably reads, naming the prompt so the answer is about the right one.
+    ///
+    /// The name is cut rather than left whole. A quick prompt with no name of its own is listed by
+    /// its first line, which runs to `QuickPrompt.previewLength`, and a title that long turns a
+    /// 260 point dialog into six lines of question with the buttons pushed off the bottom.
+    public static func title(for name: String) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "Delete this quick prompt?" }
+        guard trimmed.count > nameLength else { return "Delete \u{201C}\(trimmed)\u{201D}?" }
+        let cut = trimmed.prefix(nameLength).trimmingCharacters(in: .whitespaces)
+        return "Delete \u{201C}\(cut)\u{2026}\u{201D}?"
+    }
+
+    /// About as much of a name as fits on one line of the dialog above.
+    static let nameLength = 40
+
+    /// What the answer does, as consequences rather than as "are you sure?".
+    public static let message =
+        "The prompt goes from every workspace. Nothing already sent is affected, and it cannot be "
+        + "brought back."
+
+    public static let confirmLabel = "Delete Prompt"
+    public static let cancelLabel = "Cancel"
+}

--- a/Sources/BloomCore/Transcript/QuickPromptMarkCatalog.swift
+++ b/Sources/BloomCore/Transcript/QuickPromptMarkCatalog.swift
@@ -31,6 +31,39 @@ public struct QuickPromptMarkSection: Sendable, Hashable, Identifiable {
         self.name = name
         self.choices = choices
     }
+
+    /// The band's choices cut into rows of `columns`, the last one short.
+    ///
+    /// **Here rather than in a `LazyVGrid`, and the grid is what this replaced.** A lazy grid only
+    /// builds the rows that intersect what is on screen, and a row nothing has built carries no
+    /// identity a `ScrollViewReader` can find: `proxy.scrollTo` on it does nothing at all, silently.
+    /// That was measured on the picker rather than argued about. A prompt marked with the last
+    /// symbol in the last band opened the picker at the top of the first band, with the mark it was
+    /// meant to be showing seven hundred points below the fold, and the doc comment saying it opens
+    /// "on it rather than at the top" had been wrong since the day it was written. Rows built here
+    /// are all built, so the target of a scroll always exists.
+    ///
+    /// A hundred and fifty cells is not a list laziness was invented for. The same argument
+    /// `QuickPromptMenu.rows` writes down about its own prompts holds here twice over.
+    public func rows(across columns: Int) -> [QuickPromptMarkRow] {
+        guard columns > 0 else { return [] }
+        return stride(from: 0, to: choices.count, by: columns).map {
+            QuickPromptMarkRow(choices: Array(choices[$0..<min($0 + columns, choices.count)]))
+        }
+    }
+}
+
+/// One line of a band's grid.
+public struct QuickPromptMarkRow: Sendable, Hashable, Identifiable {
+    public let choices: [QuickPromptMarkChoice]
+
+    /// The first mark on the row, which is unique across the catalogue because a mark is offered
+    /// once. `QuickPromptMarkCatalogTests` walks the whole of it to hold that.
+    public var id: String { choices.first?.id ?? "" }
+
+    public init(choices: [QuickPromptMarkChoice]) {
+        self.choices = choices
+    }
 }
 
 /// The picker's two tabs.

--- a/Tests/BloomCoreTests/QuickPromptMarkTests.swift
+++ b/Tests/BloomCoreTests/QuickPromptMarkTests.swift
@@ -253,4 +253,68 @@ struct QuickPromptMarkTests {
             == sections.first?.choices.first?.mark)
         #expect(QuickPromptMarkCatalog.settled([], after: .symbol("bolt")) == nil)
     }
+
+    // MARK: - Rows
+
+    @Test("A band is cut into full rows with a short one at the end")
+    func cutsRows() {
+        let band = QuickPromptMarkSection(
+            name: "Nine", choices: (0..<9).map {
+                QuickPromptMarkChoice(mark: .symbol("bolt.\($0)"), label: "\($0)")
+            }
+        )
+        let rows = band.rows(across: 4)
+        #expect(rows.map(\.choices.count) == [4, 4, 1])
+        #expect(rows.flatMap(\.choices) == band.choices)
+    }
+
+    /// The row's id is what a `ScrollViewReader` is given, so two rows sharing one would scroll to
+    /// whichever SwiftUI reached first.
+    @Test("Every row of every band carries an id of its own")
+    func rowIDsAreDistinct() {
+        let rows = (QuickPromptMarkCatalog.iconSections + QuickPromptMarkCatalog.emojiSections)
+            .flatMap { $0.rows(across: 7) }
+        #expect(Set(rows.map(\.id)).count == rows.count)
+        #expect(rows.allSatisfy { !$0.choices.isEmpty })
+    }
+
+    @Test("A band nothing is left of, and a width of nothing, are both no rows")
+    func cutsNothing() {
+        let band = QuickPromptMarkSection(name: nil, choices: [])
+        #expect(band.rows(across: 7).isEmpty)
+        #expect(QuickPromptMarkCatalog.emojiSections[0].rows(across: 0).isEmpty)
+    }
+
+    // MARK: - Throwing one away
+
+    @Test("The question names the prompt it is about")
+    func asksAboutTheNamedPrompt() {
+        #expect(QuickPromptDeletion.title(for: "Ship it") == "Delete \u{201C}Ship it\u{201D}?")
+        #expect(QuickPromptDeletion.title(for: "  Ship it  ") == "Delete \u{201C}Ship it\u{201D}?")
+    }
+
+    @Test("A prompt with no name of its own is still asked about")
+    func asksAboutTheUnnamedPrompt() {
+        #expect(QuickPromptDeletion.title(for: "") == "Delete this quick prompt?")
+        #expect(QuickPromptDeletion.title(for: "   ") == "Delete this quick prompt?")
+    }
+
+    /// A prompt with no name is listed by its own first line, which runs to seventy two characters.
+    /// The dialog is 260 points wide, so the title is cut rather than allowed to push the buttons
+    /// off the bottom of it.
+    @Test("A name longer than the dialog is cut rather than wrapped")
+    func cutsALongName() {
+        let long = String(repeating: "a", count: QuickPrompt.previewLength)
+        let title = QuickPromptDeletion.title(for: long)
+        #expect(title.contains("\u{2026}"))
+        #expect(title.count < long.count)
+        #expect(!title.contains(long))
+    }
+
+    @Test("The question says what is lost rather than asking whether you are sure")
+    func saysWhatIsLost() {
+        #expect(!QuickPromptDeletion.message.lowercased().contains("are you sure"))
+        #expect(QuickPromptDeletion.message.contains("cannot be brought back"))
+        #expect(QuickPromptDeletion.confirmLabel == "Delete Prompt")
+    }
 }


### PR DESCRIPTION
The mark picker built its scroll view against the Icons tab on every open and corrected itself an
`onAppear` later, so the first frame of every open was the wrong tab with the whole of the scroll
view's content replaced under it. Instrumented, opening it on a prompt marked with an emoji printed
`kind=icons bands=9` then `kind=emoji bands=1`, one frame apart, every time. `kind` is settled in
`init` now, so that frame does not exist.

The grid was a `LazyVGrid` in a `LazyVStack`, and `proxy.scrollTo` cannot find a row nothing has
built: a prompt marked with a symbol from the fifth band opened the picker at the top of the first,
silently, which the gallery now photographs. The bands are cut into rows in the core and drawn
without laziness, and a tab change gets a fresh scroll view rather than a swapped content.

Delete asks first, through `Confirmation`, from the form and from the row's context menu alike. The
words are in `BloomCore`. A `.sheet` really does present from inside the popover; that was measured
rather than assumed.

The card now hangs in a gap the form opens under the well instead of over the Text field and the
Save button, on a pill tab strip and a bordered field rather than a flat grey band, seven columns of
36 instead of eight of 32, and with one convention for selection: the chosen mark wears the accent
fill, the keyboard highlight wears the quiet hover wash. The form's groups are `Metrics.pane` apart
and the subtitle is off the heading's ascenders.

`PanelTabs` on `tab-strip` is the shared control for those tabs and was not on `main`; the strip
here is local, drawn in its colours, and should be deleted in favour of it once that lands.