### PR TITLE
Let an agent keep the owner's quick prompts

### DIFF
--- a/Sources/Bloom/State/AppModel+WorkspaceBridge.swift
+++ b/Sources/Bloom/State/AppModel+WorkspaceBridge.swift
@@ -27,14 +27,13 @@ extension AppModel {
     /// Internal because `makeBridge(on:)` stayed in `AppModel.swift`, next to the `bridge` it
     /// is the one writer of. The toolbox is the half worth having here, with the three methods
     /// behind it.
+    ///
+    /// Built on top of `BridgeToolbox.standard` rather than by listing its handlers again. They
+    /// were written out here as well, and a copy of a list is a copy that drifts: a tool added to
+    /// the core toolbox and not to this one would pass every test in the suite, which serves
+    /// `.standard`, and never reach the running app.
     func bridgeToolbox() -> BridgeToolbox {
-        BridgeToolbox(handlers: [
-            WhoamiTool(),
-            ProjectListTool(),
-            ProjectAddTool(),
-            ProjectHideTool(),
-            ProjectUnhideTool(),
-            WorkspaceListTool(),
+        BridgeToolbox(handlers: BridgeToolbox.standard.handlers + [
             WorkspaceStartTool { [weak self] order, project, identity, origin in
                 guard let self else { throw AppNotReady.stillStartingUp }
                 return try await self.startWorkspaceForBridge(

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptCatalog.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptCatalog.swift
@@ -27,6 +27,19 @@ final class QuickPromptCatalog {
     /// than seeding the built-ins twice.
     private var loading: Task<Void, Never>?
 
+    /// The subscription that keeps this list honest about writes it did not make.
+    ///
+    /// Every edit used to come through this type, so the list on screen and the table agreed by
+    /// construction. The bridge's four `quick_prompt_*` tools broke that: they write the row
+    /// directly, correctly, and this list would have gone on showing whatever it read when the
+    /// panel was first opened for the rest of the session, because `load` returns early once
+    /// `isLoaded` is set and nothing else re-read it.
+    ///
+    /// It reads and publishes and never writes, which is the first of the two rules on
+    /// `StoreChangeHub`. Its own writes tick the hub and come back through here as one extra read
+    /// of a table with a handful of rows in it, which is cheaper than working out how to skip them.
+    private var watching: Task<Void, Never>?
+
     /// Reads the list, seeding the built-ins the first time this database has ever been asked.
     ///
     /// The seeding happens here rather than at launch because this is the only place the list is
@@ -46,6 +59,21 @@ final class QuickPromptCatalog {
         loading = task
         await task.value
         loading = nil
+        watch(store)
+    }
+
+    /// Starts listening for writes to `quick_prompt` made anywhere else in this process.
+    ///
+    /// Once, after the first read, rather than at init: this type is a shared singleton built
+    /// before there is a store to listen to, and the panel is the only thing that wants the list.
+    private func watch(_ store: Store) {
+        guard watching == nil else { return }
+        watching = Task { [weak self] in
+            for await _ in store.changes(of: [.quickPrompts]) {
+                guard let self else { return }
+                await self.reload(from: store)
+            }
+        }
     }
 
     /// Re-reads the list, whatever state it is in. What an edit made in another window would need,

--- a/Sources/BloomCore/Bridge/BridgeToolApproval.swift
+++ b/Sources/BloomCore/Bridge/BridgeToolApproval.swift
@@ -28,6 +28,13 @@ import Foundation
 /// remove a branch with it, and the whole reason Bloom asks before archiving by hand is that the
 /// answer is sometimes no. A tool that can lose work is a tool a person answers for.
 ///
+/// `quick_prompt_delete` and `quick_prompt_update` are the two on the bridge today that this
+/// applies to. Neither touches a repository, but both act on a few lines the owner wrote by hand,
+/// Bloom keeps no copy of what was there before, and both are reachable only from the owner's own
+/// client, where there is somebody sitting to answer. That is the whole of why they are allowed at
+/// all and the whole of why they ask. `quick_prompt_list` is on the list below; the other three
+/// are not.
+///
 /// `workspace_merge` is off the list too, and it draws the line one step further out. It destroys
 /// nothing: it sends a turn, and the agent that reads it runs the merge in front of the owner. But
 /// what that turn leads to is a call to a server other people share, and unlike a worktree there
@@ -60,6 +67,14 @@ public enum BridgeToolApproval {
         // typing the old one back. There is nothing here for a person to weigh that they cannot
         // see and reverse in a second.
         "pane_rename",
+        // The only one of the four quick prompt tools on this list, and the only one of them a
+        // parent can call unattended. It reads the owner's own library and changes nothing in it,
+        // so the ask would carry nothing for a person to weigh, and an unanswered ask on a read is
+        // the hang described above for no gain at all. `quick_prompt_create` is deliberately off
+        // the list, because a row lands in a panel nobody is looking at rather than in front of
+        // the reader the way a pane does; `quick_prompt_update` overwrites what the owner wrote
+        // and `quick_prompt_delete` removes it, with no undo on either.
+        "quick_prompt_list",
     ]
 
     /// Whether this ask is Bloom answering itself.

--- a/Sources/BloomCore/Bridge/BridgeToolbox.swift
+++ b/Sources/BloomCore/Bridge/BridgeToolbox.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Every tool the bridge serves, and the only place a new one is added.
 ///
-/// A list of handlers rather than a switch. There are twelve of them now, and a switch would put
+/// A list of handlers rather than a switch. There are sixteen of them now, and a switch would put
 /// each in three places: the listing, the dispatch and the role gate. Here a tool is one type, and
 /// it carries its own gate. See `docs/BRIDGE.md` for the whole surface and who may reach it.
 public struct BridgeToolbox: Sendable {
@@ -43,6 +43,13 @@ public struct BridgeToolbox: Sendable {
         ProjectHideTool(),
         ProjectUnhideTool(),
         WorkspaceListTool(),
+        // A quick prompt is a row in `quick_prompt` and nothing else, so all four reach the store
+        // directly and none of them needs a seam into the window: the panel finds out through the
+        // update hook, the way it would about a write made anywhere else. See `QuickPromptCall`.
+        QuickPromptListTool(),
+        QuickPromptCreateTool(),
+        QuickPromptUpdateTool(),
+        QuickPromptDeleteTool(),
     ])
 
     /// The tools a caller may see. Sorted by name so `tools/list` is stable between calls, which

--- a/Sources/BloomCore/Bridge/QuickPromptTool.swift
+++ b/Sources/BloomCore/Bridge/QuickPromptTool.swift
@@ -1,0 +1,596 @@
+import Foundation
+
+/// The four tools over the owner's quick prompts: `quick_prompt_list`, `quick_prompt_create`,
+/// `quick_prompt_update` and `quick_prompt_delete`.
+///
+/// All four in one file for the reason `ProjectHideTool` holds its pair: they are one feature seen
+/// from four sides, they share the reading of a mark, the resolving of an id and the JSON a prompt
+/// is rendered as, and the way a set like this goes wrong is one of them learning something the
+/// others do not. Read side by side, that cannot happen quietly.
+///
+/// ## Four, because three would be unusable
+///
+/// `quick_prompt_update` and `quick_prompt_delete` both take an id, and an id is not a thing a
+/// model can guess or a person would ever type. Without a list there is nothing to update or
+/// delete by, so the read is not a convenience, it is what makes the other three reachable.
+///
+/// ## No seam into the app, and why that is not an oversight
+///
+/// The pane tools and `workspace_merge` are injected closures because a pane is a thing the window
+/// owns and a merge has to take the same path the Merge button takes. A quick prompt is a row in
+/// `quick_prompt`, and `Store` is an actor a bridge handler on a background task calls directly.
+/// So these four live in `BridgeToolbox.standard`, are testable without a window, and the window
+/// finds out the way it finds out about every other write: `Store`'s update hook publishes the
+/// `quickPrompts` domain and `QuickPromptCatalog` re-reads. An injected main-actor closure here
+/// would have been a second way to write the same row.
+///
+/// ## Why every one of them reads through `seedQuickPrompts`
+///
+/// The panel seeds Bloom's built-ins the first time it is opened, not at launch, so on a copy of
+/// Bloom whose composer panel has never been opened the table is genuinely empty. A tool reading
+/// `quickPrompts()` there would report an empty library, an agent asked to add "Explain changes"
+/// would write a second copy of a prompt Bloom is about to insert, and the owner would open the
+/// panel to two of them. Seeding here costs one settings lookup on a database that has already
+/// been seeded, and it means the tools and the panel always describe the same list.
+enum QuickPromptCall {
+    /// The library as the panel would show it, seeding the built-ins if this database has never
+    /// been asked before. See the note at the head of this file.
+    static func library(_ store: Store) async throws -> [QuickPrompt] {
+        try await store.seedQuickPrompts()
+    }
+
+    /// A create's three arguments, once they have been found to make sense.
+    struct Draft: Sendable, Equatable {
+        var name: String
+        var symbol: String
+        var text: String
+    }
+
+    /// An update's three optional arguments. A field that is nil was not named and keeps the value
+    /// the row already holds; that is the whole of the partial semantics and it is why these are
+    /// optionals rather than a `QuickPrompt` with the gaps filled in from somewhere.
+    struct Edit: Sendable, Equatable {
+        var name: String?
+        var symbol: String?
+        var text: String?
+
+        /// The fields this call names, for the answer. A model that cannot tell a change that
+        /// landed from one that was ignored will make the same call again.
+        var changed: [String] {
+            var fields: [String] = []
+            if name != nil { fields.append("name") }
+            if symbol != nil { fields.append("symbol") }
+            if text != nil { fields.append("text") }
+            return fields
+        }
+    }
+
+    /// Reads the arguments `quick_prompt_create` takes.
+    ///
+    /// Pure and static so the suite can hold every refusal without a database: what a model is
+    /// told when it passes a blank prompt is a sentence somebody has to be able to read back.
+    ///
+    /// **It accepts exactly what the panel's own form accepts**, which is the rule the three
+    /// fields' different treatments of "empty" all come from. The form disables Save on a blank
+    /// text and trims the name and saves it even when it is empty, because a nameless prompt shows
+    /// the start of its text instead. So a blank text is refused here, a blank name is a name
+    /// cleared, and a blank symbol is Bloom's default rather than a hole down the left of the row.
+    static func draft(name: String?, symbol: String?, text: String?) -> Result<Draft, QuickPromptTrouble> {
+        let body = (text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !body.isEmpty else { return .failure(.noText) }
+
+        let chosenMark: String
+        switch mark(symbol) {
+        case .failure(let trouble): return .failure(trouble)
+        case .success(let resolved): chosenMark = resolved ?? QuickPrompt.defaultSymbol
+        }
+
+        return .success(
+            Draft(
+                name: (name ?? "").trimmingCharacters(in: .whitespacesAndNewlines),
+                symbol: chosenMark,
+                text: body
+            )
+        )
+    }
+
+    /// Reads the arguments `quick_prompt_update` takes.
+    ///
+    /// A call that names no field at all is refused rather than answered with "nothing changed",
+    /// because the two calls a model makes after those two answers are different: one is a fixed
+    /// call, the other is the same call again.
+    static func edit(name: String?, symbol: String?, text: String?) -> Result<Edit, QuickPromptTrouble> {
+        var edit = Edit()
+
+        if let name {
+            // Not guarded on emptiness: `""` clears the name, and the row falls back to showing
+            // the start of its text, which is a state the panel's own form can produce.
+            edit.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        if let text {
+            let body = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !body.isEmpty else { return .failure(.blankText(field: "text")) }
+            edit.text = body
+        }
+
+        switch mark(symbol) {
+        case .failure(let trouble): return .failure(trouble)
+        case .success(let resolved): edit.symbol = resolved
+        }
+
+        guard !edit.changed.isEmpty else { return .failure(.nothingToChange) }
+        return .success(edit)
+    }
+
+    /// What goes in the `symbol` column, or nil when the caller named none.
+    ///
+    /// Refused rather than stored, and that is the decision worth recording. `QuickPromptMark`
+    /// deliberately falls back to a default for anything it cannot draw, because a row written
+    /// years ago must still draw something. Letting a tool through that same fallback would store
+    /// the model's guess and draw something else, with nothing said to the caller, so the row the
+    /// owner sees would not be the row the model believes it wrote.
+    static func mark(_ symbol: String?) -> Result<String?, QuickPromptTrouble> {
+        guard let symbol else { return .success(nil) }
+        let trimmed = symbol.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Blank is "I have no mark to give" rather than a mark, and is treated as though the
+        // argument had been left out. There is nothing a blank column could mean: every row draws
+        // something.
+        guard !trimmed.isEmpty else { return .success(nil) }
+        guard QuickPromptMark(stored: trimmed).stored == trimmed else {
+            return .failure(.unknownSymbol(trimmed))
+        }
+        return .success(trimmed)
+    }
+
+    /// The prompt an id names, or why none does.
+    ///
+    /// By id and never by name, unlike the project tools, which resolve a name, a path or an id.
+    /// Two quick prompts may be called the same thing, nothing about a prompt is unique except its
+    /// id, and the two tools that take one overwrite and delete. A near miss on a name there is
+    /// the wrong prompt destroyed rather than a wrong list printed.
+    static func find(
+        id raw: String?, in prompts: [QuickPrompt], tool: String
+    ) -> Result<QuickPrompt, QuickPromptTrouble> {
+        let id = (raw ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !id.isEmpty else { return .failure(.noID(tool: tool)) }
+        guard !prompts.isEmpty else { return .failure(.emptyLibrary(tool: tool)) }
+        guard let found = prompts.first(where: { $0.id.rawValue == id }) else {
+            return .failure(.unknownID(id: id, known: prompts))
+        }
+        return .success(found)
+    }
+
+    /// One prompt, whole. The text is not truncated: a model asked to change a prompt has to be
+    /// able to read the one it is changing, and the preview the panel draws is not the prompt.
+    static func json(_ prompt: QuickPrompt) -> JSONValue {
+        .object([
+            "id": .string(prompt.id.rawValue),
+            "name": .string(prompt.name),
+            "shown_as": .string(prompt.resolvedName),
+            "symbol": .string(prompt.symbol),
+            "text": .string(prompt.text),
+            "sort_order": .integer(prompt.sortOrder),
+            "created_at": .string(prompt.createdAt.formatted(.iso8601)),
+        ])
+    }
+
+    /// The one sentence every tool that changes the library ends on. Written once, because four
+    /// descriptions of where these rows live is four chances to describe it differently.
+    static let panelSentence =
+        "Quick prompts are global: one library, in the panel beside the composer in every "
+            + "workspace, rather than anything belonging to a project or a workspace."
+}
+
+/// `quick_prompt_list`: the owner's library, and the ids the other three take.
+///
+/// **Self-approved, and the only one of the four that is.** `BridgeToolApproval`'s test is whether
+/// a tool has to work while nobody is watching, and this one is offered to `.parent`, which is an
+/// agent that runs for ten minutes on its own. A permission question on a call that reads is the
+/// worst kind of ask: there is nothing for a person to weigh, and an unanswered one hangs the turn.
+///
+/// The one thing it can write is Bloom's own built-in, on a database whose panel has never been
+/// opened, which is exactly what opening the panel would have done. See the head of
+/// `QuickPromptCall`.
+public struct QuickPromptListTool: BridgeToolHandling {
+    public init() {}
+
+    /// A parent and the owner's own client.
+    ///
+    /// The pane tools were taken away from `.owner` because they are scoped to a worktree the
+    /// owner's client is not standing in. The opposite holds here: a quick prompt belongs to no
+    /// workspace and no project, so there is nothing for this caller to be missing, and it is the
+    /// owner's own library that is being read.
+    ///
+    /// `.parent` because an agent asked to save a prompt has to be able to see the ones that are
+    /// already there, and because a parent that could create without reading would write a second
+    /// copy of a prompt the owner already has.
+    ///
+    /// Not `.child`. A child sees `whoami` and nothing else, because it is an agent another agent
+    /// asked for and nobody weighed.
+    public let roles: Set<BridgeRole> = [.parent, .owner]
+
+    public let tool = BridgeTool(
+        name: "quick_prompt_list",
+        description: """
+            The owner's quick prompts: the few lines they keep typing again, kept by Bloom and put \
+            back into the composer from the panel beside it. Each one carries its id, its name, \
+            the mark drawn down the left of its row, and the whole of its text.
+
+            Call this before quick_prompt_update or quick_prompt_delete, because the id it prints \
+            is the only thing either of those takes. It is also what stops you writing a second \
+            copy of a prompt the owner already has.
+
+            \(QuickPromptCall.panelSentence)
+
+            It reads. The only thing it can ever write is Bloom's own built-in prompt, on a copy \
+            of Bloom whose quick prompt panel has never been opened, which is what opening the \
+            panel would have done anyway.
+            """,
+        inputSchema: BridgeTool.noArguments
+    )
+
+    public func call(
+        _ request: MCPRequest,
+        as identity: BridgeIdentity,
+        store: Store
+    ) async -> BridgeToolResult {
+        do {
+            let prompts = try await QuickPromptCall.library(store)
+            return .json(.object([
+                "count": .integer(prompts.count),
+                "prompts": .array(prompts.map(QuickPromptCall.json)),
+                "note": .string(
+                    prompts.isEmpty
+                        ? "Bloom has no quick prompts. quick_prompt_create writes one."
+                        : QuickPromptCall.panelSentence
+                ),
+            ]))
+        } catch {
+            return .failure(
+                QuickPromptTrouble.unexplained(
+                    tool: tool.name, message: error.readableMessage
+                ).sentence
+            )
+        }
+    }
+}
+
+/// `quick_prompt_create`: write a prompt into the owner's library.
+///
+/// **Not self-approved, although it destroys nothing.** A pane an agent opens appears in front of
+/// the reader and is closed with the shortcut every other tab uses, which is what earned those
+/// four their place on `BridgeToolApproval.selfApproved`. A quick prompt is written into a list
+/// that is only ever seen when the panel is opened, so a row nobody asked for is invisible until
+/// the owner goes looking, and the library is a thing they curate. That is worth one ask.
+///
+/// The cost of the ask is the documented one: a call made while nobody is watching hangs the turn.
+/// It is accepted here because this tool is only ever called on the owner's own instruction, in
+/// the chat they just typed it in, which the description says out loud. `workspace_start` is the
+/// opposite case and is on the list for exactly that reason.
+public struct QuickPromptCreateTool: BridgeToolHandling {
+    public init() {}
+
+    /// A parent and the owner's own client, matching `quick_prompt_list`.
+    ///
+    /// `.parent` is the case worth defending. The owner mostly talks to Bloom from inside Bloom,
+    /// so "save that as a quick prompt" is a sentence typed into a workspace chat, and a tool the
+    /// owner cannot reach from where they are is a tool that does not exist. Creating adds a row
+    /// and changes nothing that is there, and the panel it lands in is one click away in the same
+    /// composer.
+    public let roles: Set<BridgeRole> = [.parent, .owner]
+
+    public let tool = BridgeTool(
+        name: "quick_prompt_create",
+        description: """
+            Write a new quick prompt into the owner's library, so it is in the panel beside the \
+            composer from then on.
+
+            Call it when the owner asks you to save something as a quick prompt, and not on your \
+            own initiative. This is their own list in their own words, and a row they did not ask \
+            for is one they have to find and delete.
+
+            'text' is the prompt itself and is required: it is what goes into the composer when \
+            the row is picked. 'name' is what the row is called and is optional; leave it out and \
+            the row shows the start of the text instead. 'symbol' is the mark down the left of \
+            the row: one emoji, or an SF Symbol name Bloom's own picker offers. Leave it out for \
+            Bloom's default.
+
+            \(QuickPromptCall.panelSentence)
+
+            It adds a row and changes nothing that is already there. The owner takes it away again \
+            from the panel, or you can with quick_prompt_delete.
+            """,
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "text": .object([
+                    "type": .string("string"),
+                    "description": .string(
+                        "The words the prompt puts in the composer. It cannot be blank."
+                    ),
+                ]),
+                "name": .object([
+                    "type": .string("string"),
+                    "description": .string(
+                        "What the row is called. Leave it out to show the start of the text."
+                    ),
+                ]),
+                "symbol": .object([
+                    "type": .string("string"),
+                    "description": .string(
+                        "The mark down the left of the row: one emoji, or an SF Symbol name from "
+                            + "Bloom's picker. Leave it out for Bloom's default."
+                    ),
+                ]),
+            ]),
+            "required": .array([.string("text")]),
+        ])
+    )
+
+    public func call(
+        _ request: MCPRequest,
+        as identity: BridgeIdentity,
+        store: Store
+    ) async -> BridgeToolResult {
+        let draft: QuickPromptCall.Draft
+        switch QuickPromptCall.draft(
+            name: request.stringParam("name"),
+            symbol: request.stringParam("symbol"),
+            text: request.stringParam("text")
+        ) {
+        case .failure(let trouble): return .failure(trouble.sentence)
+        case .success(let read): draft = read
+        }
+
+        do {
+            // Seeded first, so a prompt written into a database whose panel has never been opened
+            // does not sit above Bloom's own built-in when the panel finally inserts it.
+            _ = try await QuickPromptCall.library(store)
+            let written = try await store.insert(
+                QuickPrompt(name: draft.name, symbol: draft.symbol, text: draft.text)
+            )
+            var answer = QuickPromptCall.json(written)
+            if case .object(var fields) = answer {
+                fields["note"] = .string(
+                    "It is in the quick prompt panel in every workspace's composer now. Nothing "
+                        + "else changed. quick_prompt_delete removes it again, and there is no "
+                        + "undo on that."
+                )
+                answer = .object(fields)
+            }
+            return .json(answer)
+        } catch {
+            return .failure(
+                QuickPromptTrouble.unexplained(
+                    tool: tool.name, message: error.readableMessage
+                ).sentence
+            )
+        }
+    }
+}
+
+/// `quick_prompt_update`: change a prompt the owner already has, field by field.
+///
+/// **Owner only, and not self-approved.** This overwrites text somebody wrote by hand, in a
+/// library that belongs to no workspace, and Bloom keeps no copy of what was there before. Two
+/// things follow from that.
+///
+/// It is not offered to `.parent`, although listing and creating are, and the difference is who is
+/// in the room. A parent is a workspace agent that runs for ten minutes at a time with nobody
+/// looking, and a global overwrite decided in the middle of one of those is a change the owner
+/// finds weeks later in a project this workspace has nothing to do with. The owner's own client is
+/// a conversation the owner is typing into, which is also why the ask below is answerable.
+///
+/// It is not on `BridgeToolApproval.selfApproved`, for the reason `workspace_merge` is not: the
+/// list is for calls where there is nothing left for a person to weigh, and here there is. The
+/// owner is sitting at the client that can call this, exactly as they are for the project tools.
+public struct QuickPromptUpdateTool: BridgeToolHandling {
+    public init() {}
+
+    public let roles: Set<BridgeRole> = [.owner]
+
+    public let tool = BridgeTool(
+        name: "quick_prompt_update",
+        description: """
+            Change a quick prompt the owner already has, named by the id quick_prompt_list prints.
+
+            Partial, so pass only what you are changing. 'name', 'symbol' and 'text' are each \
+            optional and whatever you leave out keeps the value it already has: changing the name \
+            is a call with 'id' and 'name' and nothing else, and it does not touch the text. \
+            Passing 'name' as an empty string clears the name, and the row goes back to showing \
+            the start of its text. 'text' cannot be blank, because a prompt with no words in it \
+            inserts nothing. A call that names no field at all is refused rather than treated as \
+            a change of nothing.
+
+            There is no undo. What you overwrite was written by hand and Bloom keeps no copy of \
+            it, so read the prompt with quick_prompt_list first and change what the owner asked \
+            you to change and nothing else.
+            """,
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "id": .object([
+                    "type": .string("string"),
+                    "description": .string("Which prompt, by the id quick_prompt_list prints."),
+                ]),
+                "name": .object([
+                    "type": .string("string"),
+                    "description": .string(
+                        "A new name for the row. Leave it out to keep the one it has; pass an "
+                            + "empty string to clear it."
+                    ),
+                ]),
+                "symbol": .object([
+                    "type": .string("string"),
+                    "description": .string(
+                        "A new mark: one emoji, or an SF Symbol name from Bloom's picker. Leave "
+                            + "it out to keep the one it has."
+                    ),
+                ]),
+                "text": .object([
+                    "type": .string("string"),
+                    "description": .string(
+                        "New words for the composer. Leave it out to keep the ones it has. It "
+                            + "cannot be blank."
+                    ),
+                ]),
+            ]),
+            "required": .array([.string("id")]),
+        ])
+    )
+
+    public func call(
+        _ request: MCPRequest,
+        as identity: BridgeIdentity,
+        store: Store
+    ) async -> BridgeToolResult {
+        let edit: QuickPromptCall.Edit
+        switch QuickPromptCall.edit(
+            name: request.stringParam("name"),
+            symbol: request.stringParam("symbol"),
+            text: request.stringParam("text")
+        ) {
+        case .failure(let trouble): return .failure(trouble.sentence)
+        case .success(let read): edit = read
+        }
+
+        do {
+            let prompts = try await QuickPromptCall.library(store)
+            let target: QuickPrompt
+            switch QuickPromptCall.find(
+                id: request.stringParam("id"), in: prompts, tool: tool.name
+            ) {
+            case .failure(let trouble): return .failure(trouble.sentence)
+            case .success(let found): target = found
+            }
+
+            // Through `update` rather than by writing the row back, which is `Store`'s own rule
+            // and is what makes the partial semantics real: the row is re-read inside the actor
+            // and only the fields this call named are assigned, so a field left out keeps
+            // whatever the panel's own form wrote a second ago.
+            let changed = try await store.update(quickPromptID: target.id) { prompt in
+                if let name = edit.name { prompt.name = name }
+                if let symbol = edit.symbol { prompt.symbol = symbol }
+                if let text = edit.text { prompt.text = text }
+            }
+            guard let changed else {
+                return .failure(
+                    QuickPromptTrouble.unknownID(id: target.id.rawValue, known: prompts).sentence
+                )
+            }
+
+            var answer = QuickPromptCall.json(changed)
+            if case .object(var fields) = answer {
+                fields["changed"] = .array(edit.changed.map { .string($0) })
+                fields["note"] = .string(
+                    "The prompt above is the whole row as it stands now. Anything not in "
+                        + "'changed' is untouched, and there is no undo on what was."
+                )
+                answer = .object(fields)
+            }
+            return .json(answer)
+        } catch {
+            return .failure(
+                QuickPromptTrouble.unexplained(
+                    tool: tool.name, message: error.readableMessage
+                ).sentence
+            )
+        }
+    }
+}
+
+/// `quick_prompt_delete`: take a prompt out of the library for good.
+///
+/// **Owner only, and not self-approved**, for the reasons `quick_prompt_update` gives at more
+/// length and one of its own. `BridgeRole.owner` may not do "anything that destroys work, because
+/// the whole reason Bloom asks before archiving is that the answer is sometimes no and there is
+/// nobody on this connection to ask", and this is the closest thing on the bridge to that clause.
+/// It is allowed, and here is the whole of why:
+///
+/// 1. **There is somebody to ask.** The role is the owner at a client they started themselves, and
+///    the tool is off `selfApproved`, so the call stops and asks a person who is sitting there.
+///    That is the same argument the project tools are held to.
+/// 2. **The answer carries the prompt back.** A worktree cannot be handed to a model in a tool
+///    result; a quick prompt is a name, a mark and a few lines, and all three are in the answer.
+///    `quick_prompt_create` writes it back verbatim, which is an undo that costs one call.
+///
+/// **Deleting a built-in behaves exactly as deleting one in the window does**, because it is the
+/// same call: `Store.deleteQuickPrompt`. Nothing here writes `QuickPromptSeed.versionKey`, and
+/// seeding compares that recorded version rather than the rows, so a built-in deleted through this
+/// tool is not seen as missing and no later launch and no later build puts it back. See
+/// `QuickPromptSeed` and `Store.seedQuickPrompts`.
+public struct QuickPromptDeleteTool: BridgeToolHandling {
+    public init() {}
+
+    public let roles: Set<BridgeRole> = [.owner]
+
+    public let tool = BridgeTool(
+        name: "quick_prompt_delete",
+        description: """
+            Remove a quick prompt from the owner's library, named by the id quick_prompt_list \
+            prints.
+
+            There is no undo and Bloom keeps no copy. The answer repeats the whole prompt, its \
+            name, its mark and its text, so quick_prompt_create can write it back if this turns \
+            out to have been the wrong one. That is the only way back.
+
+            Deleting one of Bloom's own built-in prompts is a deletion like any other: it stays \
+            deleted, and no later launch and no later version of Bloom puts it back.
+
+            Only call this when the owner has said to delete that prompt. Never as tidying up, and \
+            never on a prompt you did not just read.
+            """,
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "id": .object([
+                    "type": .string("string"),
+                    "description": .string(
+                        "Which prompt to delete, by the id quick_prompt_list prints."
+                    ),
+                ]),
+            ]),
+            "required": .array([.string("id")]),
+        ])
+    )
+
+    public func call(
+        _ request: MCPRequest,
+        as identity: BridgeIdentity,
+        store: Store
+    ) async -> BridgeToolResult {
+        do {
+            let prompts = try await QuickPromptCall.library(store)
+            let target: QuickPrompt
+            switch QuickPromptCall.find(
+                id: request.stringParam("id"), in: prompts, tool: tool.name
+            ) {
+            case .failure(let trouble): return .failure(trouble.sentence)
+            case .success(let found): target = found
+            }
+
+            try await store.deleteQuickPrompt(id: target.id)
+
+            var answer = QuickPromptCall.json(target)
+            if case .object(var fields) = answer {
+                fields["deleted"] = .bool(true)
+                fields["remaining"] = .integer(prompts.count - 1)
+                fields["note"] = .string(
+                    "That prompt is gone from the panel and there is no undo. The whole of it is "
+                        + "above: quick_prompt_create writes it back if this was the wrong one. "
+                        + "If it was one Bloom shipped with, it stays deleted and no later "
+                        + "version puts it back."
+                )
+                answer = .object(fields)
+            }
+            return .json(answer)
+        } catch {
+            return .failure(
+                QuickPromptTrouble.unexplained(
+                    tool: tool.name, message: error.readableMessage
+                ).sentence
+            )
+        }
+    }
+}

--- a/Sources/BloomCore/Bridge/QuickPromptToolTrouble.swift
+++ b/Sources/BloomCore/Bridge/QuickPromptToolTrouble.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Why one of the four quick prompt tools would not act, in terms a model can act on.
+///
+/// Built to the standard `ProjectHideTrouble` and `WorkspaceStartTrouble` set, and for the same
+/// reason: a model told "invalid input" tries the same call again. Every sentence here names the
+/// argument that was wrong, says whether retrying unchanged can help, and says what would have
+/// worked instead.
+///
+/// The refusals are a type of their own rather than string literals at each site because three of
+/// the four tools share most of them, and a pair of sentences that describe the same failure
+/// differently is how a model learns that two tools disagree about what a quick prompt is.
+///
+/// An `Error` as well as a value, so the readings below can be a `Result` the way `PaneRefusal`
+/// is. Nothing throws it: every site switches on the two cases and answers with the sentence.
+public enum QuickPromptTrouble: Error, Sendable, Equatable {
+    /// `quick_prompt_create` arrived with no text, or with nothing but whitespace in it.
+    case noText
+    /// `quick_prompt_update` was passed `text` and it was blank. Distinct from `noText`, because
+    /// here leaving the argument out is the thing the caller wanted and is worth saying.
+    case blankText(field: String)
+    /// No prompt was named. Both tools that change a row need one.
+    case noID(tool: String)
+    /// An id that matches nothing. Carries the library, so the next call can be right rather than
+    /// another guess.
+    case unknownID(id: String, known: [QuickPrompt])
+    /// There are no quick prompts at all, so there is nothing to change or remove.
+    case emptyLibrary(tool: String)
+    /// `quick_prompt_update` named a prompt and then nothing to do to it.
+    case nothingToChange
+    /// A mark neither view could draw. See `QuickPromptMark`.
+    case unknownSymbol(String)
+    /// Anything the store threw, said plainly.
+    case unexplained(tool: String, message: String)
+
+    public var sentence: String {
+        switch self {
+        case .noText:
+            return """
+                quick_prompt_create needs the 'text' the prompt puts in the composer, and it \
+                cannot be blank: a prompt with no words in it inserts nothing. 'name' and \
+                'symbol' are optional, 'text' is the prompt.
+                """
+
+        case .blankText(let field):
+            return """
+                '\(field)' arrived empty, and a quick prompt with no words in it inserts nothing. \
+                Pass the text the prompt should put in the composer, or leave '\(field)' out \
+                entirely to keep the text this prompt already has.
+                """
+
+        case .noID(let tool):
+            return """
+                \(tool) needs the 'id' of the quick prompt to act on, which is the id \
+                quick_prompt_list prints. It takes an id and not a name, because two prompts can \
+                share a name and picking one of them would be the wrong prompt. Call \
+                quick_prompt_list first.
+                """
+
+        case let .unknownID(id, known):
+            return """
+                Bloom has no quick prompt with the id '\(id)'. It has \(Self.listing(known)). \
+                Retrying with the same id will fail the same way: call quick_prompt_list and use \
+                an id from its answer.
+                """
+
+        case .emptyLibrary(let tool):
+            return """
+                Bloom has no quick prompts, so \(tool) has nothing to act on. Retrying will not \
+                change that. quick_prompt_create is what writes one.
+                """
+
+        case .nothingToChange:
+            return """
+                quick_prompt_update was given a prompt and nothing to do to it. Pass at least one \
+                of 'name', 'symbol' or 'text'. Whatever you leave out keeps the value it already \
+                has, so changing the name alone is a call with 'id' and 'name' and nothing else.
+                """
+
+        case .unknownSymbol(let symbol):
+            return """
+                Bloom cannot draw '\(symbol)' as a quick prompt's mark, and a mark it cannot draw \
+                is a blank down the left of the row. Pass one emoji, or one of the SF Symbol \
+                names Bloom's own picker offers, such as \(Self.symbolExamples). Leave 'symbol' \
+                out for Bloom's default.
+                """
+
+        case let .unexplained(tool, message):
+            return "Bloom could not finish \(tool): \(message)"
+        }
+    }
+
+    /// Three symbol names to steer a model that guessed at one.
+    ///
+    /// Read off the picker's own catalogue rather than written out, so a band renamed there cannot
+    /// leave this refusal recommending a name `QuickPromptMark` would then refuse. Three, because
+    /// the point is to show the shape of a name rather than to publish a hundred of them; a model
+    /// that wants a particular mark has an emoji, which always works.
+    static var symbolExamples: String {
+        let names = ["doc.richtext", "hammer", "text.alignleft"].filter(QuickPrompt.knownSymbols.contains)
+        let usable = names.isEmpty ? Array(QuickPrompt.symbols.prefix(3)) : names
+        return usable.map { "'\($0)'" }.joined(separator: ", ")
+    }
+
+    /// How many prompts a refusal names before it stops and points at the list.
+    ///
+    /// The refusal goes straight into the model's context, and a library of eighty prompts quoted
+    /// in full would be eighty rows of the owner's writing spent on saying "not that id".
+    static let listingLimit = 12
+
+    static func listing(_ prompts: [QuickPrompt]) -> String {
+        guard !prompts.isEmpty else { return "none at all" }
+        let named = prompts.prefix(listingLimit)
+            .map { "'\($0.resolvedName)' (id \($0.id.rawValue))" }
+            .joined(separator: ", ")
+        guard prompts.count > listingLimit else { return named }
+        return "\(named), and \(prompts.count - listingLimit) more"
+    }
+}

--- a/Tests/BloomCoreTests/BridgeServerTests.swift
+++ b/Tests/BloomCoreTests/BridgeServerTests.swift
@@ -80,7 +80,12 @@ struct BridgeServerTests {
         let listed = try await caller.call(#"{"jsonrpc":"2.0","id":"two","method":"tools/list"}"#)
         #expect(listed["id"] == .string("two"))
         let names = listed["result"]?["tools"]?.arrayValue?.compactMap { $0["name"]?.stringValue }
-        #expect(names == ["whoami"])
+        // What a parent sees from a server built without the app, sorted by name because
+        // `tools/list` is. The rest of a parent's surface (`workspace_start` and the four pane
+        // tools) needs a seam into the window and is added by `AppModel.bridgeToolbox()`, which
+        // there is none of here. The two quick prompt tools are on this list because a quick
+        // prompt is a row in the store and nothing else.
+        #expect(names == ["quick_prompt_create", "quick_prompt_list", "whoami"])
 
         let called = try await caller.call(
             #"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"whoami","arguments":{}}}"#

--- a/Tests/BloomCoreTests/QuickPromptStoreTests.swift
+++ b/Tests/BloomCoreTests/QuickPromptStoreTests.swift
@@ -112,6 +112,59 @@ struct QuickPromptStoreTests {
         #expect(after.isEmpty)
     }
 
+    /// The seeding rule, reached the other way: through the bridge rather than through the panel.
+    ///
+    /// Here rather than in a second suite of its own, because it is the same question these tests
+    /// already exist to answer and the answer must not depend on which door the delete came
+    /// through. `quick_prompt_delete` calls `Store.deleteQuickPrompt`, which is what the panel's
+    /// own menu calls, and nothing in the four tools writes `QuickPromptSeed.versionKey`. So a
+    /// built-in deleted by an agent is deleted exactly as one deleted by hand is.
+    @Test("a built-in deleted through the bridge stays deleted, and no tool can reseed it")
+    func deletedThroughTheBridgeStaysDeleted() async throws {
+        let path = TestScratch.unique("quick-prompt-bridge-seed") + ".sqlite"
+        let first = try Store(path: path)
+
+        // The listing is the tool that seeds, because the panel does it on first open and the two
+        // have to describe the same library. See `QuickPromptCall`.
+        let listed = await tool(QuickPromptListTool(), on: first)
+        #expect(!listed.isError)
+        let built = try #require(try await first.quickPrompts().first)
+        #expect(built.name == QuickPromptSeed.all.first?.name)
+
+        let deleted = await tool(
+            QuickPromptDeleteTool(), ["id": .string(built.id.rawValue)], on: first
+        )
+        #expect(!deleted.isError)
+        #expect(try await first.quickPrompts().isEmpty)
+
+        // Asking again is the thing that would resurrect it if the rule were "reconcile the list
+        // against the table" rather than "seed once and record it".
+        _ = await tool(QuickPromptListTool(), on: first)
+        #expect(try await first.quickPrompts().isEmpty)
+
+        // A second `Store` on the same file is the next launch, and the panel seeds again there.
+        let relaunched = try Store(path: path)
+        #expect(try await relaunched.seedQuickPrompts().isEmpty)
+        #expect(
+            try await relaunched.setting(QuickPromptSeed.versionKey)
+                == String(QuickPromptSeed.version)
+        )
+    }
+
+    /// One call, through the same door `BridgeDispatch` uses. The identity is the owner's own
+    /// client, which is the only role that may delete.
+    private func tool(
+        _ handler: any BridgeToolHandling,
+        _ arguments: [String: JSONValue] = [:],
+        on store: Store
+    ) async -> BridgeToolResult {
+        await handler.call(
+            MCPRequest(id: .number(1), method: handler.tool.name, params: .object(arguments)),
+            as: .owner,
+            store: store
+        )
+    }
+
     /// A built-in added later is inserted on its own, without putting back anything that was
     /// deleted before it. Driven through the pure half, because the entries a shipped build seeds
     /// are the ones written down in `QuickPromptSeed`.

--- a/Tests/BloomCoreTests/QuickPromptToolTests.swift
+++ b/Tests/BloomCoreTests/QuickPromptToolTests.swift
@@ -249,7 +249,7 @@ struct QuickPromptToolRoleTests {
         ]))
         #expect(
             Set(BridgeToolbox.standard.tools(for: .parent).map(\.name))
-                .intersection(["quick_prompt_update", "quick_prompt_delete"]).isEmpty
+                .isDisjoint(with: ["quick_prompt_update", "quick_prompt_delete"])
         )
     }
 

--- a/Tests/BloomCoreTests/QuickPromptToolTests.swift
+++ b/Tests/BloomCoreTests/QuickPromptToolTests.swift
@@ -1,0 +1,461 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// Reading the arguments of the four quick prompt tools, which is the half that can be held still
+/// without a database.
+///
+/// Every refusal below is a sentence a model reads and acts on, and "invalid input" is the one
+/// answer that makes it try the same call again. So each test asserts the argument is named and
+/// that something usable is offered in its place.
+@Suite("Asking Bloom about quick prompts")
+struct QuickPromptToolArgumentTests {
+
+    // MARK: - Writing one
+
+    @Test("a create takes the text, and the name and the mark are optional")
+    func createTakesTextAndOptionally() throws {
+        #expect(
+            try QuickPromptCall.draft(name: nil, symbol: nil, text: "Explain this diff.").get()
+                == QuickPromptCall.Draft(
+                    name: "", symbol: QuickPrompt.defaultSymbol, text: "Explain this diff."
+                )
+        )
+        #expect(
+            try QuickPromptCall.draft(
+                name: "  Explain  ", symbol: " doc.richtext ", text: "  Explain this diff.  "
+            ).get()
+                == QuickPromptCall.Draft(
+                    name: "Explain", symbol: "doc.richtext", text: "Explain this diff."
+                )
+        )
+    }
+
+    /// The form beside the composer disables Save on a blank text for the same reason: a prompt
+    /// with no words in it puts nothing in the box, so the row is one nobody can use.
+    @Test("a create with no text is refused rather than writing an empty row")
+    func createNeedsText() {
+        for blank in [nil, "", "   ", "\n"] as [String?] {
+            guard case .failure(let trouble) = QuickPromptCall.draft(
+                name: "Explain", symbol: nil, text: blank
+            ) else {
+                Issue.record("expected a refusal for \(String(describing: blank))"); return
+            }
+            #expect(trouble.sentence.contains("'text'"))
+            #expect(trouble.sentence.contains("quick_prompt_create"))
+        }
+    }
+
+    /// A nameless prompt is a state the panel's own form can produce: the row falls back to the
+    /// start of its text. So an empty name is a name and not a mistake.
+    @Test("a create with no name is a row that shows the start of its text")
+    func createWithoutAName() {
+        let draft = try? QuickPromptCall.draft(name: "   ", symbol: nil, text: "Run the tests.").get()
+        #expect(draft?.name == "")
+        let prompt = QuickPrompt(name: draft?.name ?? "", text: draft?.text ?? "")
+        #expect(prompt.resolvedName == "Run the tests.")
+    }
+
+    // MARK: - The mark
+
+    /// Refused rather than stored. `QuickPromptMark` falls back to a default for anything it
+    /// cannot draw, which is right for a row written years ago and wrong for a tool call: it would
+    /// store the model's guess, draw something else, and say nothing to the caller.
+    @Test("a mark Bloom cannot draw is refused, with marks that work")
+    func anUnknownMarkIsRefused() {
+        guard case .failure(let trouble) = QuickPromptCall.mark("sparkle.wand.of.holding") else {
+            Issue.record("expected a refusal"); return
+        }
+        #expect(trouble.sentence.contains("'sparkle.wand.of.holding'"))
+        #expect(trouble.sentence.contains("emoji"))
+    }
+
+    /// The refusal recommends three symbol names, and a refusal that recommends a name the next
+    /// call would also be refused for is worse than no recommendation at all.
+    @Test("every mark the refusal recommends is one Bloom can draw")
+    func theRecommendedMarksAreReal() {
+        let quoted = QuickPromptTrouble.symbolExamples
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: " '")) }
+        #expect(quoted.count == 3)
+        for name in quoted {
+            #expect(QuickPromptMark(stored: name).stored == name)
+        }
+    }
+
+    @Test("one emoji is a mark, and so is a symbol name from the picker")
+    func emojiAndSymbolsBothWork() throws {
+        #expect(try QuickPromptCall.mark("🚀").get() == "🚀")
+        #expect(try QuickPromptCall.mark(" hammer ").get() == "hammer")
+    }
+
+    /// Blank is "I have no mark to give" rather than a mark. Every row draws something, so there
+    /// is nothing an empty column could mean.
+    @Test("a blank mark is no mark rather than a blank row")
+    func aBlankMarkIsNoMark() throws {
+        #expect(try QuickPromptCall.mark(nil).get() == nil)
+        #expect(try QuickPromptCall.mark("  ").get() == nil)
+        let draft = try? QuickPromptCall.draft(name: nil, symbol: "", text: "x").get()
+        #expect(draft?.symbol == QuickPrompt.defaultSymbol)
+    }
+
+    // MARK: - Changing one
+
+    /// The whole of the partial semantics: a field that was not named keeps what the row holds,
+    /// so changing the name cannot blank the text.
+    @Test("an update names only the fields it changes")
+    func anUpdateIsPartial() throws {
+        #expect(
+            try QuickPromptCall.edit(name: " Explain ", symbol: nil, text: nil).get()
+                == QuickPromptCall.Edit(name: "Explain")
+        )
+        #expect(
+            try QuickPromptCall.edit(name: nil, symbol: "🚀", text: nil).get().changed == ["symbol"]
+        )
+        #expect(
+            try QuickPromptCall.edit(name: "a", symbol: "🚀", text: "b").get().changed
+                == ["name", "symbol", "text"]
+        )
+    }
+
+    /// The one field where empty means something. A row with no name shows the start of its text,
+    /// which is what the form does with a name somebody cleared.
+    @Test("an empty name clears the name, and an empty text is refused")
+    func emptyMeansTwoDifferentThings() throws {
+        #expect(try QuickPromptCall.edit(name: "", symbol: nil, text: nil).get() == QuickPromptCall.Edit(name: ""))
+
+        guard case .failure(let trouble) = QuickPromptCall.edit(name: nil, symbol: nil, text: "  ")
+        else { Issue.record("expected a refusal"); return }
+        #expect(trouble.sentence.contains("'text'"))
+        // And it says what to do instead, because a model that wanted the text left alone has to
+        // find out that leaving the argument out is how.
+        #expect(trouble.sentence.contains("leave"))
+    }
+
+    /// Refused rather than answered with "nothing changed", because the next call a model makes
+    /// after those two answers is different: one is a fixed call, the other is this one again.
+    @Test("an update that changes nothing is refused and lists the fields")
+    func anUpdateWithNothingInIt() {
+        guard case .failure(let trouble) = QuickPromptCall.edit(name: nil, symbol: nil, text: nil)
+        else { Issue.record("expected a refusal"); return }
+        for field in ["'name'", "'symbol'", "'text'"] {
+            #expect(trouble.sentence.contains(field))
+        }
+    }
+
+    // MARK: - Finding one
+
+    private var library: [QuickPrompt] {
+        [
+            QuickPrompt(id: QuickPromptID("one"), name: "Explain changes", text: "Explain."),
+            QuickPrompt(id: QuickPromptID("two"), name: "", text: "Run make test."),
+        ]
+    }
+
+    @Test("a prompt is found by the id the listing prints")
+    func foundByID() throws {
+        #expect(
+            try QuickPromptCall.find(id: " one ", in: library, tool: "quick_prompt_delete").get().id
+                == QuickPromptID("one")
+        )
+    }
+
+    /// By id and never by name. Two prompts can be called the same thing, and the two tools that
+    /// take an id overwrite and delete: a near miss on a name there is the wrong prompt destroyed.
+    @Test("a name is not an id, and the refusal says where ids come from")
+    func aNameIsNotAnID() {
+        guard case .failure(let trouble) = QuickPromptCall.find(
+            id: "Explain changes", in: library, tool: "quick_prompt_delete"
+        ) else { Issue.record("expected a refusal"); return }
+        #expect(trouble.sentence.contains("quick_prompt_list"))
+        // It carries the library, so the next call can be right rather than another guess. The
+        // nameless one is named by what its row shows.
+        #expect(trouble.sentence.contains("'Explain changes' (id one)"))
+        #expect(trouble.sentence.contains("'Run make test.' (id two)"))
+    }
+
+    @Test("a missing id names the argument and the tool that prints one")
+    func aMissingID() {
+        for blank in [nil, "", "  "] as [String?] {
+            guard case .failure(let trouble) = QuickPromptCall.find(
+                id: blank, in: library, tool: "quick_prompt_update"
+            ) else { Issue.record("expected a refusal"); return }
+            #expect(trouble.sentence.contains("'id'"))
+            #expect(trouble.sentence.contains("quick_prompt_update"))
+        }
+    }
+
+    /// Three different facts rather than one. An empty library is not a wrong id, and a model told
+    /// the wrong one of the two goes looking for an id that was never going to exist.
+    @Test("an empty library says so, and points at the tool that writes one")
+    func anEmptyLibrary() {
+        guard case .failure(let trouble) = QuickPromptCall.find(
+            id: "one", in: [], tool: "quick_prompt_delete"
+        ) else { Issue.record("expected a refusal"); return }
+        #expect(trouble.sentence.contains("quick_prompt_create"))
+        #expect(trouble.sentence.contains("Retrying will not change that"))
+    }
+
+    /// The refusal goes straight into the model's context, so a library of eighty is not quoted in
+    /// full to say "not that id".
+    @Test("a long library is not quoted in full")
+    func aLongLibraryIsCut() {
+        let many = (0..<40).map { QuickPrompt(id: QuickPromptID("id\($0)"), name: "p\($0)", text: "t") }
+        guard case .failure(let trouble) = QuickPromptCall.find(
+            id: "nope", in: many, tool: "quick_prompt_update"
+        ) else { Issue.record("expected a refusal"); return }
+        #expect(trouble.sentence.contains("and \(40 - QuickPromptTrouble.listingLimit) more"))
+        #expect(!trouble.sentence.contains("id39"))
+    }
+}
+
+/// Who may reach the owner's library, and which of the four Bloom answers for itself.
+@Suite("Who may touch a quick prompt")
+struct QuickPromptToolRoleTests {
+    /// Reading and writing are offered to a workspace agent; changing and deleting are not.
+    ///
+    /// The pane tools came off `.owner` because they act on the worktree the caller is standing
+    /// in and that role stands in none. A quick prompt belongs to no workspace, so the opposite
+    /// holds and there is nothing for the owner's client to be missing.
+    ///
+    /// `.parent` keeps the two that cannot lose anything, because the owner mostly talks to Bloom
+    /// from inside Bloom and "save that as a quick prompt" is typed into a workspace chat. It does
+    /// not get the two that overwrite and delete: a parent runs for ten minutes with nobody
+    /// looking, and this library is global, so a change decided in the middle of one of those
+    /// turns up weeks later in a project that workspace had nothing to do with.
+    @Test("a parent may read and write, and only the owner may change or delete")
+    func roles() {
+        #expect(QuickPromptListTool().roles == [.parent, .owner])
+        #expect(QuickPromptCreateTool().roles == [.parent, .owner])
+        #expect(QuickPromptUpdateTool().roles == [.owner])
+        #expect(QuickPromptDeleteTool().roles == [.owner])
+    }
+
+    /// The rule that has held since the bridge existed: a child is a workspace an agent asked for
+    /// and nobody weighed, so it reports and that is all.
+    @Test("a child sees whoami and nothing else, quick prompts included")
+    func aChildSeesNothing() {
+        #expect(BridgeToolbox.standard.tools(for: .child).map(\.name) == ["whoami"])
+    }
+
+    /// All four are in the toolbox a `BridgeServer` serves without the app, which is the statement
+    /// that none of them needed a seam into the window: a quick prompt is a row in `quick_prompt`,
+    /// and the panel finds out through the store's update hook.
+    @Test("all four are served without the app, and the owner sees all four")
+    func servedByTheStandardToolbox() {
+        let owned = Set(BridgeToolbox.standard.tools(for: .owner).map(\.name))
+        #expect(owned.isSuperset(of: [
+            "quick_prompt_list", "quick_prompt_create", "quick_prompt_update", "quick_prompt_delete",
+        ]))
+        #expect(
+            Set(BridgeToolbox.standard.tools(for: .parent).map(\.name))
+                .intersection(["quick_prompt_update", "quick_prompt_delete"]).isEmpty
+        )
+    }
+
+    /// Only the read. A permission question on a call that changes nothing carries nothing for a
+    /// person to weigh, and an unanswered one hangs an unattended turn.
+    ///
+    /// The other three ask, and each for its own reason: a created row lands in a panel nobody is
+    /// looking at rather than in front of the reader the way a pane does, and an update or a
+    /// delete takes words the owner wrote by hand with no undo behind it.
+    @Test("Bloom answers for the listing and for none of the other three")
+    func selfApproval() {
+        #expect(BridgeToolApproval.isSelfApproved(
+            toolName: "\(BridgeToolApproval.toolPrefix)quick_prompt_list"
+        ))
+        for tool in ["quick_prompt_create", "quick_prompt_update", "quick_prompt_delete"] {
+            #expect(!BridgeToolApproval.selfApproved.contains(tool))
+        }
+    }
+
+    /// A tool a model has to guess the shape of is a tool it calls wrongly. The listing takes
+    /// nothing at all, and neither writer takes a workspace or a project, because the library is
+    /// global.
+    @Test("the four take between them an id, a name, a mark and a text, and nothing else")
+    func schemas() {
+        #expect(QuickPromptListTool().tool.inputSchema == BridgeTool.noArguments)
+        #expect(properties(of: QuickPromptCreateTool().tool) == ["name", "symbol", "text"])
+        #expect(properties(of: QuickPromptUpdateTool().tool) == ["id", "name", "symbol", "text"])
+        #expect(properties(of: QuickPromptDeleteTool().tool) == ["id"])
+
+        #expect(required(of: QuickPromptCreateTool().tool) == [.string("text")])
+        #expect(required(of: QuickPromptUpdateTool().tool) == [.string("id")])
+        #expect(required(of: QuickPromptDeleteTool().tool) == [.string("id")])
+    }
+
+    /// A model that reads "update" as "replace" blanks the text every time it fixes a name, so the
+    /// description has to say what leaving an argument out does before it is called once.
+    @Test("the update tool says out loud what a field left out does")
+    func theUpdateDescriptionSaysWhatPartialMeans() {
+        let description = QuickPromptUpdateTool().tool.description
+        #expect(description.contains("keeps the value it already has"))
+        #expect(description.contains("no undo"))
+    }
+
+    /// A built-in deleted stays deleted, and the caller has to know that before it deletes one
+    /// rather than afterwards.
+    @Test("the delete tool says there is no undo and that a built-in stays deleted")
+    func theDeleteDescriptionSaysThereIsNoUndo() {
+        let description = QuickPromptDeleteTool().tool.description
+        #expect(description.contains("no undo"))
+        #expect(description.contains("stays deleted"))
+        #expect(description.contains("quick_prompt_create"))
+    }
+
+    private func properties(of tool: BridgeTool) -> Set<String> {
+        guard case .object(let schema) = tool.inputSchema,
+              case .object(let properties)? = schema["properties"]
+        else { Issue.record("no schema for \(tool.name)"); return [] }
+        return Set(properties.keys)
+    }
+
+    private func required(of tool: BridgeTool) -> [JSONValue] {
+        guard case .object(let schema) = tool.inputSchema,
+              case .array(let required)? = schema["required"]
+        else { Issue.record("no required list for \(tool.name)"); return [] }
+        return required
+    }
+}
+
+/// The four tools against a real table, which is where the partial write and the answers are.
+@Suite("Quick prompt tools, end to end", .tags(.persistence), .scratchDirectory)
+struct QuickPromptToolCallTests {
+    private func call(
+        _ handler: any BridgeToolHandling,
+        _ arguments: [String: JSONValue] = [:],
+        as role: BridgeRole = .owner,
+        store: Store
+    ) async -> BridgeToolResult {
+        let identity: BridgeIdentity = role == .owner
+            ? .owner
+            : BridgeIdentity(sessionID: SessionID("s"), workspaceID: WorkspaceID("w"), role: role)
+        return await handler.call(
+            MCPRequest(id: .number(1), method: handler.tool.name, params: .object(arguments)),
+            as: identity,
+            store: store
+        )
+    }
+
+    /// The answer is JSON rendered for a reader, so the suite reads it back the way a client would
+    /// rather than matching substrings against a pretty printed document.
+    private func fields(_ result: BridgeToolResult) -> [String: JSONValue] {
+        guard let data = result.text.data(using: .utf8),
+              let value = try? JSONDecoder().decode(JSONValue.self, from: data),
+              case .object(let fields) = value
+        else { Issue.record("not a JSON object: \(result.text)"); return [:] }
+        return fields
+    }
+
+    @Test("a created prompt is a row the panel would draw")
+    func createsARow() async throws {
+        let store = try makeTestStore("quick-prompt-tools")
+        let result = await call(
+            QuickPromptCreateTool(),
+            ["name": .string("Ship it"), "symbol": .string("🚀"), "text": .string("Open a PR.")],
+            store: store
+        )
+
+        #expect(!result.isError)
+        let written = try await store.quickPrompts().first { $0.name == "Ship it" }
+        #expect(written?.text == "Open a PR.")
+        #expect(written?.symbol == "🚀")
+        #expect(fields(result)["id"] == .string(written?.id.rawValue ?? ""))
+    }
+
+    /// A parent is the caller this exists for: the owner asks for it in the chat they are typing
+    /// in, and a tool they cannot reach from there is a tool that does not exist.
+    @Test("a workspace agent may write one and may read the list")
+    func aParentMayWrite() async throws {
+        let store = try makeTestStore("quick-prompt-tools")
+        let written = await call(
+            QuickPromptCreateTool(), ["text": .string("Explain this diff.")],
+            as: .parent, store: store
+        )
+        #expect(!written.isError)
+
+        let listed = await call(QuickPromptListTool(), as: .parent, store: store)
+        #expect(!listed.isError)
+        #expect(listed.text.contains("Explain this diff."))
+    }
+
+    /// The rule at the head of `Store` reaching the wire: a write changes the columns it names and
+    /// no others, so a model fixing a name cannot blank the words behind it.
+    @Test("changing the name alone leaves the text and the mark exactly as they were")
+    func updatesNarrowly() async throws {
+        let store = try makeTestStore("quick-prompt-tools")
+        let original = try await store.insert(
+            QuickPrompt(name: "Tests", symbol: "hammer", text: "Run make test.")
+        )
+
+        let result = await call(
+            QuickPromptUpdateTool(),
+            ["id": .string(original.id.rawValue), "name": .string("Run the tests")],
+            store: store
+        )
+
+        #expect(!result.isError)
+        #expect(fields(result)["changed"] == .array([.string("name")]))
+        let after = try await store.quickPrompt(id: original.id)
+        #expect(after?.name == "Run the tests")
+        #expect(after?.text == "Run make test.")
+        #expect(after?.symbol == "hammer")
+        #expect(after?.sortOrder == original.sortOrder)
+    }
+
+    @Test("an update to an id Bloom does not have changes nothing and lists what it has")
+    func updatesNothingOnAnUnknownID() async throws {
+        let store = try makeTestStore("quick-prompt-tools")
+        let original = try await store.insert(QuickPrompt(name: "Tests", text: "Run make test."))
+
+        let result = await call(
+            QuickPromptUpdateTool(),
+            ["id": .string("not-an-id"), "text": .string("Something else.")],
+            store: store
+        )
+
+        #expect(result.isError)
+        #expect(result.text.contains("'Tests' (id \(original.id.rawValue))"))
+        #expect(try await store.quickPrompt(id: original.id)?.text == "Run make test.")
+    }
+
+    /// The only way back from a delete, and the reason the role is allowed one at all: the answer
+    /// carries the whole prompt, so `quick_prompt_create` writes it back verbatim.
+    @Test("a delete hands the whole prompt back on its way out")
+    func deleteCarriesThePromptBack() async throws {
+        let store = try makeTestStore("quick-prompt-tools")
+        let original = try await store.insert(
+            QuickPrompt(name: "Tests", symbol: "hammer", text: "Run make test.")
+        )
+
+        let result = await call(
+            QuickPromptDeleteTool(), ["id": .string(original.id.rawValue)], store: store
+        )
+
+        #expect(!result.isError)
+        #expect(fields(result)["text"] == .string("Run make test."))
+        #expect(fields(result)["symbol"] == .string("hammer"))
+        #expect(fields(result)["deleted"] == .bool(true))
+        // Everything except the row this deleted, which on a database nobody has opened the panel
+        // on is Bloom's own built-in, seeded by the read this tool does before it deletes.
+        #expect(try await store.quickPrompt(id: original.id) == nil)
+        #expect(try await store.quickPrompts().count == QuickPromptSeed.all.count)
+    }
+
+    @Test("the listing counts what it prints")
+    func listsEverything() async throws {
+        let store = try makeTestStore("quick-prompt-tools")
+        for name in ["first", "second"] {
+            try await store.insert(QuickPrompt(name: name, text: name))
+        }
+
+        let result = await call(QuickPromptListTool(), store: store)
+        guard case .array(let prompts)? = fields(result)["prompts"] else {
+            Issue.record("no prompts in \(result.text)"); return
+        }
+        // Bloom's own built-in is seeded by the read, so the count is the two written here plus
+        // whatever Bloom ships with. See `QuickPromptCall`.
+        #expect(prompts.count == 2 + QuickPromptSeed.all.count)
+        #expect(fields(result)["count"] == .integer(prompts.count))
+    }
+}

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -91,7 +91,7 @@ uses, so Bloom and Bloom Dev can never land on one. The landmine there is `socka
 
 ## 3. The tools
 
-Twelve, each a type of its own in `Sources/BloomCore/Bridge/`, each carrying its own role gate. A
+Sixteen, each a type of its own in `Sources/BloomCore/Bridge/`, each carrying its own role gate. A
 list of handlers rather than a switch, because a switch would put every tool in three places: the
 listing, the dispatch and the gate.
 
@@ -105,10 +105,14 @@ listing, the dispatch and the gate.
 | `workspace_list` | Every workspace, its state, its worktree path, its chats and their cost, what an agent is stopped on, what is queued and why | | | ✓ |
 | `workspace_start` | Cut a worktree on a new branch and put an agent in it with a task | ✓ | | ✓ |
 | `workspace_merge` | Ask a workspace's own agent to merge its pull request | | | ✓ |
-| `pane_open` | Open a chat, a terminal or a browser in a new tab of the caller's own workspace | ✓ | | ✓ |
-| `pane_split` | Put one beside what is on screen rather than behind it | ✓ | | ✓ |
-| `pane_close` | Take one back off the screen | ✓ | | ✓ |
-| `pane_rename` | Give a tab a name the reader can find it by | ✓ | | ✓ |
+| `pane_open` | Open a chat, a terminal or a browser in a new tab of the caller's own workspace | ✓ | | |
+| `pane_split` | Put one beside what is on screen rather than behind it | ✓ | | |
+| `pane_close` | Take one back off the screen | ✓ | | |
+| `pane_rename` | Give a tab a name the reader can find it by | ✓ | | |
+| `quick_prompt_list` | The owner's own quick prompts, whole, with the ids the other three take | ✓ | | ✓ |
+| `quick_prompt_create` | Write a new quick prompt into that library | ✓ | | ✓ |
+| `quick_prompt_update` | Change one, field by field, leaving the fields it does not name alone | | | ✓ |
+| `quick_prompt_delete` | Take one out of the library for good | | | ✓ |
 
 **A child sees `whoami` and nothing else.** That is not an oversight and not a cost saving: a child
 is a workspace an agent asked for, which nobody weighed, so it reports and that is all.
@@ -124,15 +128,26 @@ transport failure the CLI may retry or surface as a broken server; an errored re
 model reads and can act on. "You are not allowed to do that" is something to tell the model, not
 something to tell the transport.
 
-### The six that need the app, and the six that do not
+### The six that need the app, and the ten that do not
 
-`BridgeToolbox.standard` holds the six that reach nothing but the store, and it is what a
+`BridgeToolbox.standard` holds the ten that reach nothing but the store, and it is what a
 `BridgeServer` built without the app serves, which is every test that did not ask for more.
-`AppModel.bridgeToolbox()` adds the other six, because starting a workspace has to reach the
+`AppModel.bridgeToolbox()` adds the other six to it, because starting a workspace has to reach the
 main-actor graph that runs one, asking for a merge has to reach the same path the Merge button
 takes, and a pane is a thing the window owns. Each of those crosses the line as an injected closure
 (`WorkspaceStarting`, `WorkspaceMergeRequesting`, `PaneOpening`, `PaneSplitting`, `PaneClosing`,
 `PaneRenaming`), so a pane an agent asks for is the pane the menu makes, unchanged and not copied.
+It adds them **to** `.standard` rather than listing its handlers again, because a copy of that list
+is a copy that drifts: a tool added to the core toolbox and not to the app's would pass every test
+in the suite and never reach the running app.
+
+**The four quick prompt tools are the case that shows where the line really is.** They write, and
+they need no seam at all, because a quick prompt is a row in `quick_prompt` and `Store` is an actor
+a handler on a background task calls directly. The window finds out the way it finds out about
+every other write: the update hook publishes the `quickPrompts` domain and `QuickPromptCatalog`
+re-reads. The panel used to read that list once and never again, so a prompt written over the
+bridge was invisible for the rest of the session; it subscribes now. An injected main-actor closure
+here would have been a second way to write the same row.
 
 `BridgeServer` **never constructs an `AgentRunner`, and nothing added to it ever may.** One runner
 per session is held in main-actor UI object identity, and a handler that built its own would put a
@@ -148,7 +163,7 @@ Nothing here reads or writes a file, runs a command, or touches a repository's c
 worktree path is handed over precisely so the agent uses **its own** tools on an ordinary git
 checkout, which `workspace_list`'s description says out loud.
 
-Nothing archives. `workspace_archive` is not one of the twelve: it removes a worktree and can
+Nothing archives. `workspace_archive` is not one of the sixteen: it removes a worktree and can
 remove a branch with it, and the whole reason Bloom asks before archiving by hand is that the
 answer is sometimes no.
 
@@ -166,6 +181,43 @@ head that off in words rather than to hope.
 A parent cannot name a project, because its own is the only one it may act in, and `project` is
 refused rather than ignored if it names one. The owner's client must name one, because nothing else
 says which.
+
+**One thing on the bridge can now be destroyed, and it is a few lines of the owner's own writing.**
+`quick_prompt_update` overwrites a prompt and `quick_prompt_delete` removes one, and Bloom keeps no
+copy of what was there before. Three things hold that in: both are owner only, so the caller is a
+client the owner is typing into rather than an agent running for ten minutes unattended; neither is
+self-approved, so the call stops and asks a person who is sitting there; and the delete's answer
+carries the whole prompt back, name, mark and text, so `quick_prompt_create` writes it again
+verbatim, which is an undo that costs one call. That last one is what a worktree does not have and
+is why archiving is still not here.
+
+A quick prompt deleted over the bridge is deleted exactly as one deleted in the panel is, because
+it is the same call. **A built-in stays deleted.** Bloom seeds its built-ins once and records the
+seed version it reached, rather than reconciling a list against the table, so a prompt the owner
+threw away is not read back as one that is missing. Nothing in the four tools writes that recorded
+version, so no tool can reseed and none of them can resurrect what it deleted. The one write the
+listing can make is the seeding itself, on a copy of Bloom whose panel has never been opened, which
+is exactly what opening the panel would have done: the tools and the panel have to describe the
+same library, or an agent asked to add "Explain changes" writes a second copy of the prompt Bloom
+is about to insert. See `QuickPromptSeed` and `QuickPromptCall`.
+
+The library is **global**, which is why the two that change it are shaped differently from every
+workspace scoped tool. The pane tools came off `.owner` because they act on the worktree the caller
+is standing in and that role stands in none; a quick prompt belongs to no worktree, so there is
+nothing for the owner's client to be missing and the argument runs the other way. `.parent` keeps
+the two that cannot lose anything, because the owner mostly talks to Bloom from inside Bloom and
+"save that as a quick prompt" is a sentence typed into a workspace chat. It does not get the two
+that overwrite and delete: a parent runs unattended, and a change to a global library decided in
+the middle of one of those turns up weeks later in a project that workspace had nothing to do with.
+
+`quick_prompt_update` is partial, and its description says so before it is called once, because a
+model that reads "update" as "replace" blanks the text every time it fixes a name. A field left out
+keeps the value the row holds. `name` passed as an empty string clears the name, which is a state
+the panel's own form can produce: the row falls back to showing the start of its text. `text`
+cannot be blank, because a prompt with no words in it inserts nothing, and that is the same rule
+the form enforces by disabling Save. A call that names no field at all is refused rather than
+answered with "nothing changed", because the next call a model makes after those two answers is a
+different call.
 
 ### How many a caller may start
 
@@ -207,7 +259,7 @@ So `BridgeToolApproval` names the tools Bloom answers for itself:
 
 | Self-approved | Not |
 | --- | --- |
-| `whoami`, `workspace_start`, `pane_open`, `pane_split`, `pane_close`, `pane_rename` | everything else |
+| `whoami`, `workspace_start`, `pane_open`, `pane_split`, `pane_close`, `pane_rename`, `quick_prompt_list` | everything else |
 
 It is a list rather than "anything with our prefix", so a tool added later is opted in by somebody
 thinking about it rather than by inheriting a decision made before it existed.
@@ -228,6 +280,17 @@ the notes, which hold the reader's own work.
 The project tools are not on it, and that is deliberate rather than an omission: the list is for
 tools an agent must be able to call while nobody is watching, and those are called by the owner's
 own client, where the owner is by definition sitting there to answer.
+
+`quick_prompt_list` is on it and the other three quick prompt tools are not, which is the same test
+applied four times. The listing is offered to `.parent`, so it can be called by an agent running on
+its own, and it reads the owner's library and changes nothing in it: the ask would carry nothing for
+a person to weigh and an unanswered one would hang the turn for no gain. `quick_prompt_create`
+writes a row into a panel nobody is looking at, rather than putting something in front of the
+reader the way a pane does, so it is worth one ask; the cost of that ask is the hang described
+above, and it is accepted because the tool is only ever called on the owner's own instruction, in
+the chat they typed it in, which its description says out loud. `quick_prompt_update` and
+`quick_prompt_delete` take words the owner wrote by hand and there is no undo, which is the clause
+`BridgeRole.owner` is written against.
 
 `workspace_merge` draws the line one step further out. It destroys nothing, it sends a turn. But
 what that turn leads to is a call to a server other people share, and unlike a worktree there is


### PR DESCRIPTION
Four bridge tools over the quick prompt library: `quick_prompt_list`, `quick_prompt_create`, `quick_prompt_update`, `quick_prompt_delete`. Four rather than three because without the listing there is no id to update or delete by.

Quick prompts are global, so the roles run the opposite way from the pane tools, which came off `.owner` for being scoped to a worktree that role stands in none of. A parent reads and creates, since "save that as a quick prompt" is typed into a workspace chat. Only the owner's own client updates or deletes, because a parent runs unattended and there is no undo.

Only the listing is self-approved: it reads, and an unanswered ask on a read hangs an unattended turn for nothing. The other three ask.

An update is partial. A field left out keeps what the row holds, an empty `name` clears the name, and a blank `text` is refused, which is exactly what the panel's own form accepts.

Deleting is `Store.deleteQuickPrompt`, the same call the panel makes, and nothing in the four writes the recorded seed version, so a deleted built-in stays deleted and no tool can reseed it.

None of them needed a seam into the app: a quick prompt is a row in `quick_prompt`, and the panel now subscribes to the store's `quickPrompts` domain, which it did not before, so a prompt written over the bridge shows up rather than sitting unseen for the session.

`docs/BRIDGE.md` is updated throughout, count included, and its pane rows lost a stale owner tick.
