### PR TITLE
Open a transcript link beside the conversation, not only in a tab

### DIFF
--- a/Sources/Bloom/Views/Center/Browser/BrowserTab.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserTab.swift
@@ -12,16 +12,55 @@ import BloomCore
 enum BrowserTab {
     /// Whether the in-app browser could show this at all.
     ///
-    /// A `WKWebView` speaks http and https. A `mailto:` is a perfectly good link for a plain
-    /// click and is not something to open a blank tab onto, so the menu item that would do that
-    /// is absent rather than present and useless. `BrowserAddress` is asked the rest, because
-    /// it is what will actually be handed the string a moment later, and two rules about what
-    /// counts as an address would eventually disagree.
+    /// The rule itself is `BrowserAddress.shows` in the core, because `TranscriptLinkMenu` asks it
+    /// too and two rules about what counts as an address would eventually disagree. Named here as
+    /// well so that the callers reading "can this be opened as a tab" keep the sentence they had.
     static func canOpen(_ url: URL) -> Bool {
-        guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
-            return false
+        BrowserAddress.shows(url)
+    }
+
+    /// Which of `TranscriptLinkMenu`'s three placements a transcript is in.
+    ///
+    /// Here rather than in the transcript for the reason the rest of this type is: a row should not
+    /// have to know how the centre column is arranged. `pane` is nil for a transcript the window
+    /// cannot place, which is the archive sheet; it is checked against the layout of the tab in
+    /// front rather than trusted, because a tab that has been closed or rearranged since the
+    /// transcript was drawn leaves a pane id naming nothing, and `WorkspaceTabsStore.split` would
+    /// then do nothing at all rather than say so.
+    static func placement(of pane: String?, in model: WorkspaceModel?) -> TranscriptLinkPlacement {
+        guard let model else { return .detached }
+        guard let pane, let tab = WorkspaceTabsStore.shared.selectedTab(in: model),
+              WorkspaceTabsStore.shared.layout(of: tab).contains(pane) else { return .column }
+        return .pane
+    }
+
+    /// Splits the pane the transcript is in and opens the address in the half that opens.
+    ///
+    /// **A fresh browser rather than the workspace's existing one, which is the whole difference
+    /// from `open` above.** A `WKWebView` is one live view, so moving the tab `open` reuses into a
+    /// second pane would take the page away from wherever it already was;
+    /// `WorkspaceTabsStore.Arrangement.canHold` refuses that outright, and `PaneSplit` calls the
+    /// same answer `.freshBrowser` when a browser pane is split. It is also what the reader asked
+    /// for: a split is for reading the page beside the conversation that named it, not for moving
+    /// a tab they were already using.
+    ///
+    /// Through `NewPane.open`, which is the door `CenterPaneMenu` and `pane_split` both use, so a
+    /// browser opened from a link is the browser a split normally opens.
+    ///
+    /// There is nothing else for the menu to have gated on. A fresh tab is in no pane yet, so
+    /// `canHold` cannot refuse it, and `SplitLayout` sets no ceiling on how many panes a tab may
+    /// hold. The one way this could do nothing is a pane id naming nothing, which is what
+    /// `placement` above rules out before the items are offered and what the guard below repeats
+    /// for the moment between the menu opening and an item being chosen.
+    static func split(_ url: URL, in model: WorkspaceModel, pane: String, axis: SplitAxis) {
+        guard canOpen(url) else { return }
+        let tabs = WorkspaceTabsStore.shared
+        guard let tab = tabs.selectedTab(in: model), tabs.layout(of: tab).contains(pane) else {
+            return
         }
-        return BrowserAddress.url(from: url.absoluteString) != nil
+        NewPane.open(.browser, in: model, url: url.absoluteString) { content in
+            tabs.split(tab: tab, pane: pane, axis: axis, showing: content)
+        }
     }
 
     /// Opens an address in the workspace's browser tab, in front.

--- a/Sources/Bloom/Views/Transcript/TranscriptLink.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptLink.swift
@@ -172,13 +172,19 @@ enum TranscriptLink {
 
     /// What a transcript row does with an address, in one place so every row does the same.
     ///
-    /// A plain click goes to the system's browser. The in-app tab is only ever reached by
-    /// choosing it from the menu, which is the difference the owner asked for: opening a page is
-    /// an action, and the quieter of the two destinations is the one that has to be asked for.
+    /// A plain click goes to the system's browser. Everywhere in Bloom's own window is only ever
+    /// reached by choosing it from the menu, which is the difference the owner asked for: opening a
+    /// page is an action, and the quieter destinations are the ones that have to be asked for.
+    ///
+    /// `pane` is which pane of the centre column this transcript is drawn in, and nil for one the
+    /// window cannot place. It is what a split divides: beside or below the conversation that
+    /// named the address, rather than beside whichever pane happens to hold the keyboard, because
+    /// a right click in a pane does not move the focus to it and splitting the other half of a
+    /// tab would be the one thing the reader did not ask for.
     @MainActor
-    static func actions(for model: WorkspaceModel?) -> TranscriptLinkActions {
+    static func actions(for model: WorkspaceModel?, pane: String? = nil) -> TranscriptLinkActions {
         TranscriptLinkActions(
-            identity: .workspace(model?.workspace.id),
+            identity: .workspace(model?.workspace.id, pane: pane),
             open: { url, target in
                 switch target {
                 case .externalBrowser:
@@ -187,10 +193,18 @@ enum TranscriptLink {
                 case .browserTab:
                     guard let model else { return }
                     BrowserTab.open(url, in: model)
+                case .split(let axis):
+                    guard let model, let pane else { return }
+                    BrowserTab.split(url, in: model, pane: pane, axis: axis)
                 }
             },
-            canOpenInTab: { url in
-                model != nil && BrowserTab.canOpen(url)
+            // Asked on each right click rather than held, because the column is rearranged while
+            // the transcript stands still: the tab in front, and whether this pane is still one of
+            // its panes, are both true of the moment the menu opens and of no other.
+            items: { url in
+                TranscriptLinkMenu.items(
+                    for: url, placement: BrowserTab.placement(of: pane, in: model)
+                )
             }
         )
     }

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -251,8 +251,15 @@ struct TranscriptListView: View {
     /// What a link in any row of this transcript does. Its own property rather than an expression
     /// in the chain below, which is long enough that one more inline call tips the type checker
     /// off the `ForEach` two hundred lines above it.
+    ///
+    /// The pane comes off `memory`, which already carries it and is already handed down for the
+    /// same reason: it is the one pane's worth of the column this list is allowed to know about.
+    /// Nil for a transcript nobody can scroll back to, which is the archive sheet, and a
+    /// transcript with no pane offers no split because there is nothing to divide.
     private var linkActions: TranscriptLinkActions {
-        TranscriptLink.actions(for: app.existingModel(for: transcript.workspace.id))
+        TranscriptLink.actions(
+            for: app.existingModel(for: transcript.workspace.id), pane: memory?.pane
+        )
     }
 
     /// Already rounded, by `TranscriptGeometry.cap`, and rounded before it reaches this view's

--- a/Sources/Bloom/Views/Transcript/TranscriptTextView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTextView.swift
@@ -2,14 +2,6 @@ import AppKit
 import SwiftUI
 import BloomCore
 
-/// Where a link the reader chose should be opened.
-enum TranscriptLinkTarget {
-    /// The system's default browser, which is what a plain click does.
-    case externalBrowser
-    /// A browser tab in Bloom's own centre column.
-    case browserTab
-}
-
 /// What the transcript can do with an address, handed in rather than decided here.
 ///
 /// **`Equatable` on `identity` and on nothing else, and that is the point of the type.** These go
@@ -21,26 +13,36 @@ enum TranscriptLinkTarget {
 /// builder in the transcript with no cache. The comments on the call site and on
 /// `markdownLinkActions` both claimed the opposite was happening.
 ///
-/// The closures do not need comparing. Every one of them is a pure function of the workspace
-/// model `TranscriptLink.actions(for:)` was handed, plus the one row that adds a file door, so
-/// two values with the same identity do the same things.
+/// The closures do not need comparing. Every one of them is a pure function of the workspace model
+/// and the pane `TranscriptLink.actions(for:pane:)` was handed, plus the one row that adds a file
+/// door, so two values with the same identity do the same things.
 struct TranscriptLinkActions: Sendable, Equatable {
     /// What these actions were built from. The whole of their equality.
+    ///
+    /// The pane is half of it because a split lands in the pane the transcript is drawn in, so two
+    /// halves of a split tab showing the same conversation do two different things with the same
+    /// link and must not compare equal.
     enum Identity: Hashable, Sendable {
         /// The default value, which does nothing at all.
         case inert
-        case workspace(WorkspaceID?)
+        case workspace(WorkspaceID?, pane: String?)
         /// The same, with a file chip's door added. Its own case because a value that can open a
         /// file must never compare equal to one that cannot.
-        case workspaceOpeningFiles(WorkspaceID?)
+        case workspaceOpeningFiles(WorkspaceID?, pane: String?)
     }
 
     var identity: Identity = .inert
 
     var open: @MainActor @Sendable (URL, TranscriptLinkTarget) -> Void = { _, _ in }
-    /// Whether Bloom's own browser could show this address at all. A menu item that opens a blank
-    /// tab is worse than a menu item that is not there.
-    var canOpenInTab: @MainActor @Sendable (URL) -> Bool = { _ in false }
+    /// What this address may be opened into, asked at the moment the menu is raised so that the
+    /// answer is about the column as it is now. The rule is `TranscriptLinkMenu` in the core; this
+    /// is only how the transcript reaches it with what the window can do.
+    ///
+    /// The default answers as a transcript with no column behind it, which is what a value nobody
+    /// has filled in is: the external browser and nothing else.
+    var items: @MainActor @Sendable (URL) -> [TranscriptLinkItem] = {
+        TranscriptLinkMenu.items(for: $0, placement: .detached)
+    }
     /// A file chip drawn inside the run was clicked. Empty by default, and set by the one row that
     /// draws chips, because opening a file needs a workspace and the list's shared actions have
     /// none: see `UserTurnRowView`.
@@ -374,17 +376,19 @@ final class LinkTextView: NSTextView {
     /// The menu over a link, and the ordinary text menu everywhere else.
     ///
     /// Extended rather than replaced: over prose this is whatever AppKit offers a selectable text
-    /// view, which is where Copy and Look Up live, and losing that to gain three link items would
+    /// view, which is where Copy and Look Up live, and losing that to gain four link items would
     /// be a poor trade. AppKit's own link items are dropped, because "Open Link" without saying
-    /// where, next to two items that do say, reads as a third destination.
+    /// where, next to items that do say, reads as one more destination.
+    ///
+    /// Which openings there are is `TranscriptLinkMenu` in the core rather than a chain of `if`s
+    /// here. This draws them.
     override func menu(for event: NSEvent) -> NSMenu? {
         let point = convert(event.locationInWindow, from: nil)
         guard let url = link(at: point) else { return super.menu(for: event) }
 
         let menu = NSMenu()
-        menu.addItem(item("Open in External Browser", url: url, target: .externalBrowser))
-        if actions.canOpenInTab(url) {
-            menu.addItem(item("Open in Browser Tab", url: url, target: .browserTab))
+        for offered in actions.items(url) {
+            menu.addItem(item(offered.title, url: url, target: offered.target))
         }
         menu.addItem(.separator())
         let copy = NSMenuItem(title: "Copy Link", action: #selector(copyLink(_:)), keyEquivalent: "")

--- a/Sources/Bloom/Views/Transcript/UserTurnRowView.swift
+++ b/Sources/Bloom/Views/Transcript/UserTurnRowView.swift
@@ -221,7 +221,9 @@ extension TranscriptLinkActions {
         copy.openFile = open
         // The identity moves with the closure, or a bubble that can open a file would compare
         // equal to the list's value that cannot, and the environment would never see the change.
-        if case let .workspace(id) = identity { copy.identity = .workspaceOpeningFiles(id) }
+        if case let .workspace(id, pane) = identity {
+            copy.identity = .workspaceOpeningFiles(id, pane: pane)
+        }
         return copy
     }
 }

--- a/Sources/BloomCore/System/BrowserAddress.swift
+++ b/Sources/BloomCore/System/BrowserAddress.swift
@@ -21,4 +21,22 @@ public enum BrowserAddress {
         guard isLocal || host.contains(".") else { return nil }
         return URL(string: (isLocal ? "http://" : "https://") + trimmed)
     }
+
+    /// Whether a browser of Bloom's own could show this address at all.
+    ///
+    /// A `WKWebView` speaks http and https. A `mailto:` is a perfectly good link for a plain click
+    /// and is not something to open a blank pane onto, so the items that would do that are absent
+    /// rather than present and useless. The rest is asked of `url(from:)` above, because that is
+    /// what will actually be handed the string a moment later.
+    ///
+    /// This was `BrowserTab.canOpen`, in the app target, which is where the transcript's menu could
+    /// reach it and `TranscriptLinkMenu` could not. `BrowserTab` still carries the one door onto a
+    /// browser tab; the question of what counts as an address it could show is asked here, next to
+    /// the parser that answers it.
+    public static func shows(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased(), scheme == "http" || scheme == "https" else {
+            return false
+        }
+        return self.url(from: url.absoluteString) != nil
+    }
 }

--- a/Sources/BloomCore/Transcript/TranscriptLinkMenu.swift
+++ b/Sources/BloomCore/Transcript/TranscriptLinkMenu.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Where a link the reader chose should be opened.
+///
+/// It sat at the top of `TranscriptTextView` beside the menu that raises it, which is the one
+/// place it could not stay once the list of items became a rule: `TranscriptLinkMenu` answers
+/// with these, so they have to be somewhere the suite can see.
+public enum TranscriptLinkTarget: Sendable, Hashable {
+    /// The system's default browser, which is what a plain click does.
+    case externalBrowser
+    /// A browser tab in Bloom's own centre column.
+    case browserTab
+    /// A browser in the half a split opens: beside the transcript for `.horizontal` and below it
+    /// for `.vertical`. The pane divided is the one the transcript is drawn in, not the column,
+    /// because the point of the item is to read the page next to the conversation that named it.
+    case split(SplitAxis)
+}
+
+/// One item of the menu a right click on a link raises.
+///
+/// The title travels with the target rather than being looked up beside the menu, so a test can
+/// hold the words a reader sees. They are the words the rest of the app already uses: Split Right
+/// and Split Down are what the View menu calls Cmd+\ and Shift+Cmd+\, and "Open in Split Right"
+/// is the pair `TabItemView` offers on a tab. A third vocabulary for the same two directions is
+/// exactly what `PaneSplitTool` says it is avoiding on the wire.
+public struct TranscriptLinkItem: Sendable, Hashable, Identifiable {
+    public var title: String
+    public var target: TranscriptLinkTarget
+
+    /// The target, because a menu never offers the same destination twice.
+    public var id: TranscriptLinkTarget { target }
+
+    public init(title: String, target: TranscriptLinkTarget) {
+        self.title = title
+        self.target = target
+    }
+}
+
+/// How much of the centre column is behind the transcript a link was clicked in.
+///
+/// One value rather than two booleans, because the three states are ordered: a pane implies a
+/// column, and a pair of flags would let a caller describe a pane of no column at all.
+public enum TranscriptLinkPlacement: Sendable, Hashable, CaseIterable {
+    /// A transcript with no centre column behind it. The archive sheet draws one and is gone, and
+    /// the appearance sample in settings draws one belonging to no workspace. Neither has
+    /// anywhere of its own to put a page.
+    case detached
+    /// A workspace's column, but no pane of it a split could divide: the transcript is drawn
+    /// somewhere the window cannot name a pane for, or the tab it belonged to has been closed or
+    /// rearranged out from under it.
+    case column
+    /// A pane of the tab in front, which is the pane a split divides.
+    case pane
+}
+
+/// Which destinations a link in the transcript offers, and in which order.
+///
+/// **A rule rather than a menu, which is why it is here.** `LinkTextView.menu(for:)` used to
+/// decide this inline, and a decision taken inside a view is a decision nothing can test: the one
+/// condition it had, whether Bloom's browser could show the address at all, was a closure the view
+/// called, and the reason that condition existed, that a menu item opening a blank tab is worse
+/// than a menu item that is not there, holds just as much for the two split items that follow it.
+/// The menu draws whatever this answers.
+///
+/// Copy Link is not in the list. It is on every link whatever the window is doing and it opens
+/// nothing, so it stays the view's own item under the separator rather than becoming a target with
+/// no destination that every switch over `TranscriptLinkTarget` would have to ignore.
+public enum TranscriptLinkMenu {
+    /// The openings a link offers, top to bottom.
+    ///
+    /// The external browser is always first and always there. It is the only destination needing
+    /// nothing of Bloom's own, it is what a plain click already does, and an address refused
+    /// everything else (a `mailto:`, most of all) is still a perfectly good thing to hand to the
+    /// system.
+    public static func items(
+        for url: URL, placement: TranscriptLinkPlacement
+    ) -> [TranscriptLinkItem] {
+        var items = [TranscriptLinkItem(title: "Open in External Browser", target: .externalBrowser)]
+
+        // Everything below opens a browser of Bloom's own, so everything below needs an address
+        // one could show. Asked once here rather than per item, because an address that cannot
+        // fill a tab cannot fill half a pane either.
+        guard placement != .detached, BrowserAddress.shows(url) else { return items }
+        items.append(TranscriptLinkItem(title: "Open in Browser Tab", target: .browserTab))
+
+        // A split divides the pane the transcript is in, so it needs one. `.column` is the reader
+        // looking at a transcript the window cannot place: the two items are dropped rather than
+        // shown greyed, which is what `SessionTabsView.splitAction` does with the same pair.
+        guard placement == .pane else { return items }
+        items.append(TranscriptLinkItem(title: "Open in Split Right", target: .split(.horizontal)))
+        items.append(TranscriptLinkItem(title: "Open in Split Down", target: .split(.vertical)))
+        return items
+    }
+}

--- a/Tests/BloomCoreTests/TranscriptLinkMenuTests.swift
+++ b/Tests/BloomCoreTests/TranscriptLinkMenuTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// What a right click on a link in the transcript offers, which used to be a chain of `if`s inside
+/// `LinkTextView.menu(for:)` and so was a menu nothing could read back. Every case here is an item
+/// that would otherwise have been offered and then done nothing.
+@Suite("Transcript link menu")
+struct TranscriptLinkMenuTests {
+    private func items(_ address: String, _ placement: TranscriptLinkPlacement) throws -> [TranscriptLinkItem] {
+        let url = try #require(URL(string: address))
+        return TranscriptLinkMenu.items(for: url, placement: placement)
+    }
+
+    private func titles(_ address: String, _ placement: TranscriptLinkPlacement) throws -> [String] {
+        try items(address, placement).map(\.title)
+    }
+
+    // MARK: - What a pane offers
+
+    @Test("A page in a pane offers the external browser, a tab, and both splits, in that order")
+    func inAPane() throws {
+        #expect(try titles("https://example.com/page", .pane) == [
+            "Open in External Browser",
+            "Open in Browser Tab",
+            "Open in Split Right",
+            "Open in Split Down",
+        ])
+    }
+
+    /// Right is beside and down is stacked. `SplitAxis.horizontal` means side by side, which is the
+    /// half of this everybody reads backwards, so it is pinned rather than assumed.
+    @Test("Split Right is the axis that lays two panes side by side")
+    func theAxesAreTheRightWayRound() throws {
+        let targets = try items("https://example.com", .pane).map(\.target)
+        #expect(targets == [
+            .externalBrowser, .browserTab, .split(.horizontal), .split(.vertical),
+        ])
+    }
+
+    // MARK: - When the splits are dropped
+
+    @Test("A transcript the window cannot name a pane for offers a tab but no split")
+    func aColumnWithNoPane() throws {
+        #expect(try titles("https://example.com/page", .column) == [
+            "Open in External Browser",
+            "Open in Browser Tab",
+        ])
+    }
+
+    @Test("A transcript with no column behind it offers the external browser alone")
+    func detached() throws {
+        for address in ["https://example.com/page", "http://localhost:3100", "mailto:a@b.example"] {
+            #expect(try titles(address, .detached) == ["Open in External Browser"])
+        }
+    }
+
+    /// A `mailto:` is a perfectly good link for a plain click and a blank pane to open onto.
+    @Test("An address no browser of Bloom's own could show offers only the external browser",
+          arguments: ["mailto:owner@example.com", "ftp://example.com/file", "javascript:alert(1)"])
+    func addressesNoPaneCanShow(address: String) throws {
+        for placement in TranscriptLinkPlacement.allCases {
+            #expect(try titles(address, placement) == ["Open in External Browser"])
+        }
+    }
+
+    @Test("A local dev server is a page like any other, splits included")
+    func localhostSplits() throws {
+        #expect(try items("http://localhost:3100/orders", .pane).count == 4)
+    }
+
+    // MARK: - The shape of the answer
+
+    @Test("Every placement offers the external browser, so a link is never a menu of nothing")
+    func theExternalBrowserIsAlwaysThere() throws {
+        for placement in TranscriptLinkPlacement.allCases {
+            #expect(try items("https://example.com", placement).first?.target == .externalBrowser)
+        }
+    }
+
+    @Test("A destination is never offered twice")
+    func noDuplicates() throws {
+        for placement in TranscriptLinkPlacement.allCases {
+            let offered = try items("https://example.com", placement)
+            #expect(Set(offered.map(\.id)).count == offered.count)
+        }
+    }
+
+    /// Each placement offers everything the one before it did. A reader whose column grows a pane
+    /// gains items and never loses one.
+    @Test("The three placements nest")
+    func placementsNest() throws {
+        let detached = try items("https://example.com", .detached)
+        let column = try items("https://example.com", .column)
+        let pane = try items("https://example.com", .pane)
+        #expect(column.starts(with: detached))
+        #expect(pane.starts(with: column))
+    }
+}
+
+/// The one rule about what a browser of Bloom's own can be pointed at, which `BrowserTab.canOpen`
+/// asks before it opens a tab and `TranscriptLinkMenu` asks before it offers one.
+@Suite("Browser address")
+struct BrowserAddressShowsTests {
+    @Test("Web schemes are shown", arguments: [
+        "https://example.com/page",
+        "http://localhost:3100",
+        "HTTPS://EXAMPLE.COM",
+        "http://127.0.0.1:8080/admin",
+    ])
+    func shown(address: String) throws {
+        #expect(BrowserAddress.shows(try #require(URL(string: address))))
+    }
+
+    @Test("Everything else is not", arguments: [
+        "mailto:owner@example.com",
+        "file:///Applications/Something.app",
+        "ftp://example.com/file",
+        "x-apple.systempreferences:com.apple.preference",
+    ])
+    func notShown(address: String) throws {
+        #expect(!BrowserAddress.shows(try #require(URL(string: address))))
+    }
+}


### PR DESCRIPTION
A right click on a link in the transcript offered the external browser and a browser tab. It now also offers **Open in Split Right** and **Open in Split Down**, the words the View menu already binds to Cmd+\ and Shift+Cmd+\ and the pair `TabItemView` offers on a tab.

The split divides the pane the transcript is drawn in, not whichever pane holds the keyboard: a right click does not move the focus, and splitting the other half of a tab is the one thing the reader did not ask for. It opens a fresh browser rather than moving the workspace's existing tab, because a `WKWebView` is one live view and `PaneSplit` already calls that answer `.freshBrowser`.

Which items a link offers is `TranscriptLinkMenu` in the core, with tests. `LinkTextView.menu(for:)` chained ifs, so its one condition was untestable and the two new ones would have been as well; the menu draws whatever the core answers now. The splits are dropped rather than greyed when there is no pane to divide (the archive sheet, or a pane id the tab no longer has), which is what `SessionTabsView` does with the same pair.

The menu, top to bottom: Open in External Browser, Open in Browser Tab, Open in Split Right, Open in Split Down, a separator, Copy Link.
