### PR TITLE
Give the browser pane a Mac browser's toolbar, and follow a pushState

### DIFF
--- a/Sources/Bloom/Design/BrowserToolbarGallery.swift
+++ b/Sources/Bloom/Design/BrowserToolbarGallery.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+import BloomCore
+
+/// The browser pane's toolbar in each state its controls can be in, on one page.
+///
+/// It exists because the bar is a set of controls whose shape is the thing under review: which
+/// arrows can be pressed, whether the third glyph is Reload or Stop, and whether there is anything
+/// to share. One pane shows one of those at a time, and no screen in the app puts a page four
+/// links deep beside a pane that has never been anywhere.
+///
+/// Drawn from `BrowserToolbarView` rather than from a browser pane, which is why that view was
+/// split out: a pane needs a live `BrowserSession` behind it, and an offscreen render paints
+/// SwiftUI's yellow placeholder over the `WKWebView` under it in any case.
+///
+/// `Bloom --snapshot-gallery <dir> --gallery browser-toolbar`.
+struct BrowserToolbarGallery: View {
+    /// The width a browser pane sits at in one half of a split centre column, which is the
+    /// narrowest the bar normally has to hold its shape at.
+    private static let pane: CGFloat = 520
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            row(
+                "A pane nobody has pointed anywhere",
+                "Split open on nothing. Both arrows dead, nothing to reload and nothing to share.",
+                BrowserToolbar()
+            )
+            row(
+                "The dev server, just opened",
+                "Somewhere to be, so Reload and Share come alive. Still no history either way.",
+                BrowserToolbar(page: page("http://localhost:3100/", "Bloom"))
+            )
+            row(
+                "Four links deep",
+                "Back can be pressed, and a right click on it offers the pages it would walk past.",
+                BrowserToolbar(page: page("http://localhost:3100/settings", "Settings"), canGoBack: true)
+            )
+            row(
+                "Gone back, so there is a page ahead as well",
+                "The one state that puts both arrows in the same bar.",
+                BrowserToolbar(
+                    page: page("http://localhost:3100/", "Bloom"),
+                    canGoBack: true,
+                    canGoForward: true
+                )
+            )
+            row(
+                "Loading",
+                "Reload becomes Stop in place, so nothing beside it moves for the second it takes.",
+                BrowserToolbar(
+                    page: page("https://spatie.be/docs", "Docs"),
+                    canGoBack: true,
+                    isLoading: true
+                )
+            )
+            row(
+                "A screenshot on its way to the composer",
+                "The camera goes quiet rather than attaching the same page twice.",
+                BrowserToolbar(page: page("http://localhost:3100/", "Bloom"), isCapturing: true)
+            )
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func page(_ address: String, _ title: String) -> BrowserTabTitle.BrowserPage {
+        BrowserTabTitle.BrowserPage(address: address, title: title)
+    }
+
+    private func row(_ title: String, _ note: String, _ toolbar: BrowserToolbar) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(Typo.label)
+                .foregroundStyle(Palette.textSecondary)
+            Text(note)
+                .font(Typo.caption)
+                .foregroundStyle(Palette.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+            BarRow(toolbar: toolbar)
+                .frame(width: Self.pane)
+                .overlay(alignment: .bottom) { Hairline() }
+        }
+    }
+
+    /// One bar, with the state a real pane keeps beside it.
+    ///
+    /// The address and the focus have to be owned by something, because the field is bound to them
+    /// and the ring is drawn off them, so the page holds one small view per row rather than one
+    /// `@State` shared by six bars showing six different addresses.
+    private struct BarRow: View {
+        var toolbar: BrowserToolbar
+
+        @State private var address = ""
+        @FocusState private var isFocused: Bool
+
+        var body: some View {
+            BrowserToolbarView(
+                toolbar: toolbar,
+                address: $address,
+                addressFocus: $isFocused,
+                isRingVisible: false,
+                backHistory: toolbar.canGoBack ? Self.history : [],
+                forwardHistory: toolbar.canGoForward ? BrowserToolbar.forwardMenu(Self.pages) : []
+            )
+            .task { address = toolbar.page.address }
+        }
+
+        private static let pages = [
+            BrowserTabTitle.BrowserPage(address: "http://localhost:3100/", title: "Bloom"),
+            BrowserTabTitle.BrowserPage(address: "http://localhost:3100/workspaces", title: "Workspaces"),
+        ]
+
+        private static let history = BrowserToolbar.backMenu(pages)
+    }
+}
+
+extension Gallery {
+    /// The registry entry for this page. See `Gallery`.
+    ///
+    /// It does not need the keys. The one state that would, a focused address field drawing its
+    /// ring, is the field `HomeBar` already has a page for, and taking the keyboard off whoever is
+    /// at this Mac to photograph a two point border is not a trade worth making.
+    static let browserToolbar = Gallery(
+        name: "browser-toolbar",
+        title: "Browser toolbar",
+        size: CGSize(width: 570, height: 640),
+        needsFocus: false,
+        view: { _ in AnyView(BrowserToolbarGallery()) }
+    )
+}

--- a/Sources/Bloom/Design/Gallery.swift
+++ b/Sources/Bloom/Design/Gallery.swift
@@ -76,6 +76,7 @@ extension Snapshot {
         .quickPrompts,
         .hoverCard,
         .panelTabs,
+        .browserToolbar,
     ]
 
     /// The page `--gallery` names, falling back to the first rather than failing: a capture run

--- a/Sources/Bloom/Design/Theme.swift
+++ b/Sources/Bloom/Design/Theme.swift
@@ -157,6 +157,22 @@ enum Palette {
     /// a quarter, which is why a placeholder written as `textTertiary` reads as disabled.
     static let textPlaceholder = Color(nsColor: .placeholderTextColor)
 
+    /// A control that is there and cannot be pressed.
+    ///
+    /// Semantic, and it is the exception `textTertiary` above argues for rather than a fourth rung
+    /// of Bloom's own. That note says the system's third rung is what the system means for a
+    /// disabled control and that Bloom's tertiary is deliberately not it, which leaves nothing in
+    /// this file for a control that really is disabled. Written as `textTertiary`, the browser
+    /// toolbar's Back arrow was a shade off the Forward arrow beside it and read as pressable at
+    /// every size the pane is drawn at, which is measured off `BrowserToolbarGallery` rather than
+    /// argued: the first row of that page has both arrows dead and looked exactly like the second,
+    /// which has neither.
+    ///
+    /// `disabledControlTextColor` rather than `tertiaryLabelColor`, though they are close, because
+    /// this is a control and not a label, and it is the one AppKit moves when the user turns on
+    /// Increase Contrast.
+    static let textDisabled = Color(nsColor: .disabledControlTextColor)
+
     // MARK: Text editing
     //
     // The three colours AppKit uses inside a text view. Each of them tracks something the accent

--- a/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
@@ -229,11 +229,21 @@ final class BrowserSession {
         self.page = next
     }
 
+    /// Reads the whole of the web view's state and writes back only what moved.
+    ///
+    /// **Only what moved, because `@Observable` does not compare.** Setting a property to the value
+    /// it already holds still tells every view reading it to redraw, and one navigation now calls
+    /// this five times: the delegate on start, commit and finish, and KVO on each of the four
+    /// properties it watches. Writing all four every time made a single page load a dozen redraws
+    /// of the centre column for three actual changes. `adopt` has always compared, for the same
+    /// reason and one level down.
     fileprivate func refresh() {
-        canGoBack = webView.canGoBack
-        canGoForward = webView.canGoForward
-        isLoading = webView.isLoading
-        if let url = webView.url { currentURL = url }
+        if canGoBack != webView.canGoBack { canGoBack = webView.canGoBack }
+        if canGoForward != webView.canGoForward { canGoForward = webView.canGoForward }
+        if isLoading != webView.isLoading { isLoading = webView.isLoading }
+        // Nil is a web view that has not loaded anything rather than a page at no address, so the
+        // tab keeps the address it was opened on. See `reload`, which is the other half of that.
+        if let url = webView.url, url != currentURL { currentURL = url }
         adopt(BrowserTabTitle.BrowserPage(address: displayAddress))
     }
 

--- a/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
@@ -49,10 +49,32 @@ final class BrowserSession {
     private(set) var page = BrowserTabTitle.BrowserPage()
 
     @ObservationIgnored private let navigation = NavigationObserver()
-    /// KVO on `title`, because there is no delegate callback for it: `didFinish` fires before the
-    /// title of a page that sets it from script, and a page that changes its own title while you
-    /// are reading it fires nothing at all.
-    @ObservationIgnored private var titleObservation: NSKeyValueObservation?
+
+    /// KVO on everything the toolbar reads, because the navigation delegate does not see every
+    /// navigation.
+    ///
+    /// It started as KVO on `title` alone, since there is no delegate callback for a title:
+    /// `didFinish` fires before the title of a page that sets it from script, and a page that
+    /// renames itself while you are reading it fires nothing at all.
+    ///
+    /// **The address needed exactly the same treatment and did not have it, which is the bug.** A
+    /// single page app navigates with `history.pushState`, which is a SAME DOCUMENT navigation:
+    /// WebKit updates `url` and the back list, and neither `didCommit` nor `didFinish` fires,
+    /// because no document was loaded. There is no public delegate callback for one either, and
+    /// this was checked rather than assumed: `WKNavigationDelegate` has nothing with "same
+    /// document" in its name. So the field sat on `/login` while the reader walked four pages into
+    /// an Inertia site, and the tab strip beside it kept up perfectly, because the title was on
+    /// KVO and the address was not.
+    ///
+    /// `canGoBack` and `canGoForward` were stale in the same way and for the same reason: a
+    /// `pushState` pushes a back entry without loading anything, so Back was dead on a page you
+    /// really could go back from. `isLoading` is watched with them because the header documents it
+    /// as KVO compliant alongside the other three and one line is cheaper than the argument about
+    /// which callbacks cover it.
+    ///
+    /// The delegate stays. It is what reports a failure, and having both is two mechanisms
+    /// agreeing rather than a duplicate: `refresh` reads the web view and writes what changed.
+    @ObservationIgnored private var observations: [NSKeyValueObservation] = []
 
     init(url: String) {
         Self.preferInspectorDocked()
@@ -67,13 +89,30 @@ final class BrowserSession {
         webView.underPageBackgroundColor = NSColor(Palette.surface)
         navigation.owner = self
         webView.navigationDelegate = navigation
-        titleObservation = webView.observe(\.title, options: [.initial, .new]) { [weak self] view, _ in
-            // On the main thread, measured rather than assumed: WebKit posts every one of these
-            // from there, which is also the only thread its properties may be read on.
-            MainActor.assumeIsolated {
-                self?.adopt(BrowserTabTitle.BrowserPage(title: view.title ?? ""))
-            }
-        }
+        observations = [
+            webView.observe(\.title, options: [.initial, .new]) { [weak self] view, _ in
+                // On the main thread, measured rather than assumed: WebKit posts every one of
+                // these from there, which is also the only thread its properties may be read on.
+                MainActor.assumeIsolated {
+                    self?.adopt(BrowserTabTitle.BrowserPage(title: view.title ?? ""))
+                }
+            },
+            // No `.initial` on these four, unlike the title: the three lines below set the same
+            // facts from the address this tab is opening on, and an initial notification would
+            // land before them and read an empty web view.
+            webView.observe(\.url) { [weak self] _, _ in
+                MainActor.assumeIsolated { self?.refresh() }
+            },
+            webView.observe(\.canGoBack) { [weak self] _, _ in
+                MainActor.assumeIsolated { self?.refresh() }
+            },
+            webView.observe(\.canGoForward) { [weak self] _, _ in
+                MainActor.assumeIsolated { self?.refresh() }
+            },
+            webView.observe(\.isLoading) { [weak self] _, _ in
+                MainActor.assumeIsolated { self?.refresh() }
+            },
+        ]
         // Shown in the address field from the first frame, before anything has been fetched.
         currentURL = BrowserAddress.url(from: url)
         page = BrowserTabTitle.BrowserPage(address: displayAddress)
@@ -90,6 +129,31 @@ final class BrowserSession {
 
     func goBack() { webView.goBack() }
     func goForward() { webView.goForward() }
+
+    /// The pages behind this one, nearest first, as the menu under the Back arrow draws them.
+    ///
+    /// Read off `WKBackForwardList` on demand rather than mirrored into a property: the list is
+    /// not observable, so a stored copy would need a writer on every navigation and would be one
+    /// more thing to get out of step with the web view. Every navigation already moves `page` or
+    /// `isLoading`, both of which are observed, so the toolbar is rebuilt and asks again.
+    var backHistory: [BrowserToolbar.HistoryEntry] {
+        BrowserToolbar.backMenu(webView.backForwardList.backList.map(Self.page))
+    }
+
+    var forwardHistory: [BrowserToolbar.HistoryEntry] {
+        BrowserToolbar.forwardMenu(webView.backForwardList.forwardList.map(Self.page))
+    }
+
+    /// Somewhere further back or further forward than one step. The distance is
+    /// `BrowserToolbar.HistoryEntry.id`, which is WebKit's own index into this list.
+    func go(back distance: Int) {
+        guard let item = webView.backForwardList.item(at: distance) else { return }
+        webView.go(to: item)
+    }
+
+    private static func page(_ item: WKBackForwardListItem) -> BrowserTabTitle.BrowserPage {
+        BrowserTabTitle.BrowserPage(address: item.url.absoluteString, title: item.title ?? "")
+    }
 
     func reload() {
         // A dev server that was not up when the tab opened has no page to reload, so an empty
@@ -134,7 +198,7 @@ final class BrowserSession {
     }
 
     func stop() {
-        titleObservation = nil
+        observations = []
         webView.stopLoading()
         webView.navigationDelegate = nil
         // The page view rather than the web view, so an attached inspector comes out of the window

--- a/Sources/Bloom/Views/Center/Browser/BrowserShareButton.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserShareButton.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import AppKit
+import BloomCore
+
+/// The browser toolbar's Share control, which opens the system's own sheet.
+///
+/// **`NSSharingServicePicker` rather than a menu of ours.** It is the sheet Safari, Finder, Mail
+/// and Notes all put behind this glyph: AirDrop, Messages, Mail, Notes, Reminders, Add to Reading
+/// List and whatever else the user has turned on in System Settings, in their order, with their
+/// icons, kept up to date by the system and never by us. A hand built menu would be a list of the
+/// four services we happened to think of, wrong on the day somebody installs a fifth, and it would
+/// have to carry out each handoff itself besides.
+///
+/// **Shown from the control's own rectangle**, so the sheet points at the button that opened it
+/// rather than at the middle of the window. That needs an `NSView` sitting where the button is,
+/// which SwiftUI does not hand out, so an empty one is parked behind the button and the picker is
+/// shown relative to that. What is shared, and why the page's title travels on the URL rather than
+/// beside it, is `BrowserToolbar.shareable`.
+struct BrowserShareButton: View {
+    var control: BrowserToolbar.Control
+    var shareable: BrowserToolbar.Shareable?
+
+    @State private var anchor = SharePickerAnchor()
+
+    var body: some View {
+        BrowserToolbarButton(control: control) { anchor.present(shareable) }
+            .background(SharePickerAnchorView(anchor: anchor))
+    }
+}
+
+/// The rectangle the sheet points at, and the picker it points with.
+///
+/// Presented from the button's action rather than from the representable's update, because
+/// `updateNSView` runs inside SwiftUI's own layout pass: a sheet put up from in there is anchored
+/// to a view whose frame is still being decided, and it lands where the button was rather than
+/// where it is.
+@MainActor
+final class SharePickerAnchor {
+    /// Weak, because the view is owned by the hierarchy SwiftUI made for the representable, and
+    /// this outlives one of those every time the toolbar is rebuilt.
+    fileprivate weak var view: NSView?
+
+    /// Somewhere to keep the picker while its sheet is up.
+    ///
+    /// `show(relativeTo:of:preferredEdge:)` returns immediately and the sheet outlives the call,
+    /// so a picker made as a local in the button's action is one released while the reader is
+    /// still looking at it.
+    private var picker: NSSharingServicePicker?
+
+    /// Nothing happens for a pane that has not been anywhere, which is also when the button is
+    /// disabled, and nothing happens for a view not yet in a window, which is a capture page.
+    func present(_ shareable: BrowserToolbar.Shareable?) {
+        guard let shareable, let view, view.window != nil else { return }
+
+        // One item, not two. See `BrowserToolbar.shareable`: the picker offers only the services
+        // that can take every item it is handed, so a title passed as a second item would cost the
+        // sheet every service that accepts a URL and nothing else, Add to Reading List included.
+        let item = NSPreviewRepresentingActivityItem(
+            item: shareable.url, title: shareable.name, image: nil, icon: nil
+        )
+        let picker = NSSharingServicePicker(items: [item])
+        self.picker = picker
+        // Below the control, which is where a sheet hung off a toolbar button drops on this
+        // platform. The anchor is the button's own background, so its bounds are the button's.
+        picker.show(relativeTo: view.bounds, of: view, preferredEdge: .minY)
+    }
+}
+
+/// An empty AppKit view whose only job is to have a frame the picker can be aimed at.
+private struct SharePickerAnchorView: NSViewRepresentable {
+    let anchor: SharePickerAnchor
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        anchor.view = view
+        return view
+    }
+
+    /// Set again on every update, because SwiftUI is free to hand the representable a new backing
+    /// view, and a stale one has no window and would silently swallow the press.
+    func updateNSView(_ nsView: NSView, context: Context) {
+        anchor.view = nsView
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
@@ -32,10 +32,6 @@ struct BrowserTabView: View {
     /// See `ControlActiveState.showsFocusRing`: a ring belongs in the key window only.
     @Environment(\.controlActiveState) private var activeState
 
-    /// Drawn inside the field's own edge rather than outside it, so the toolbar does not have to
-    /// give the ring clearance. See `HomeBar.focusRingWidth`.
-    private static let focusRingWidth: CGFloat = 2
-
     private var tabs: CenterTabStore { .shared }
     private var session: BrowserSession { tabs.browser(for: tab) }
 
@@ -82,59 +78,35 @@ struct BrowserTabView: View {
         }
     }
 
+    /// What the bar offers, given what the page can do. Every one of those answers is
+    /// `BrowserToolbar` in the core, so this view holds no rule of its own: it wires the buttons
+    /// to the session and draws what it is told. See `BrowserToolbarView`.
     private func toolbar(_ session: BrowserSession) -> some View {
-        HStack(spacing: Metrics.spacing) {
-            control("chevron.backward", title: "Back", enabled: session.canGoBack, action: session.goBack)
-            control(
-                "chevron.forward", title: "Forward",
-                enabled: session.canGoForward, action: session.goForward
-            )
-            control(
-                session.isLoading ? "xmark" : "arrow.clockwise",
-                title: session.isLoading ? "Stop" : "Reload",
-                enabled: true
-            ) {
+        BrowserToolbarView(
+            toolbar: BrowserToolbar(
+                page: session.page,
+                canGoBack: session.canGoBack,
+                canGoForward: session.canGoForward,
+                isLoading: session.isLoading,
+                isCapturing: isCapturing
+            ),
+            address: $address,
+            addressFocus: $isAddressFocused,
+            isRingVisible: isRingVisible,
+            backHistory: session.backHistory,
+            forwardHistory: session.forwardHistory,
+            goBack: session.goBack,
+            goForward: session.goForward,
+            goToHistory: { session.go(back: $0) },
+            reloadOrStop: {
                 if session.isLoading { session.webView.stopLoading() } else { session.reload() }
+            },
+            capture: capture,
+            submit: {
+                session.load(address)
+                isAddressFocused = false
             }
-
-            // Left of the address rather than right of it, with the other three: they are all
-            // things you do to the page, and the address field is where the page is. Its own group
-            // on the right would have read as belonging to the field.
-            control(
-                "camera",
-                title: "Send a Screenshot to the Agent",
-                enabled: !isCapturing,
-                action: capture
-            )
-
-            TextField("Address", text: $address)
-                .textFieldStyle(.plain)
-                .font(Typo.label)
-                .focused($isAddressFocused)
-                .autocorrectionDisabled()
-                .padding(.horizontal, Metrics.spacingWide)
-                .padding(.vertical, Metrics.spacingSmall)
-                .background(Palette.surfaceRaised, in: .rect(cornerRadius: Metrics.cornerSmall))
-                // A hand-built field gets no focus ring from AppKit, and an address bar that looks
-                // identical whether or not it has the keyboard is the single most reliable way to
-                // make a Mac window feel like a web page. The same overlay `HomeBar`'s search field
-                // uses, in the same colour macOS draws a real one in, so it follows Full Keyboard
-                // Access and Increase Contrast with it.
-                .overlay {
-                    RoundedRectangle(cornerRadius: Metrics.cornerSmall)
-                        .strokeBorder(
-                            isRingVisible ? Palette.focusRing : Palette.border,
-                            lineWidth: isRingVisible ? Self.focusRingWidth : Metrics.hairline
-                        )
-                }
-                .onSubmit {
-                    session.load(address)
-                    isAddressFocused = false
-                }
-        }
-        .padding(.horizontal, Metrics.inset)
-        .frame(height: Metrics.barHeight)
-        .background(Palette.surfaceSunken)
+        )
     }
 
     // MARK: - Screenshot
@@ -201,7 +173,9 @@ struct BrowserTabView: View {
         let menu = paneMenu?() ?? NSMenu()
         guard !isCapturing else { return menu }
 
-        let title = "Send a Screenshot to the Agent"
+        // The same words as the toolbar's own camera, taken from the one place that says them, so
+        // the glyph and the menu item cannot drift into naming the same thing two ways.
+        let title = BrowserToolbar().screenshot.name
         let target = SnapshotMenuTarget(perform: capture)
         let item = NSMenuItem(
             title: title, action: #selector(SnapshotMenuTarget.fire), keyEquivalent: ""
@@ -214,24 +188,6 @@ struct BrowserTabView: View {
         return menu
     }
 
-    private func control(
-        _ symbol: String,
-        title: String,
-        enabled: Bool,
-        action: @escaping @MainActor () -> Void
-    ) -> some View {
-        Button(action: action) {
-            Label(title, systemImage: symbol)
-                .labelStyle(.iconOnly)
-                .font(Typo.label)
-                .foregroundStyle(enabled ? Palette.textSecondary : Palette.textTertiary)
-                .frame(width: Metrics.rowHeight, height: Metrics.glyph)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.borderless)
-        .disabled(!enabled)
-        .help(title)
-    }
 }
 
 /// What answers the page menu's screenshot item. A closure cannot be an `NSMenuItem` action, and

--- a/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+import BloomCore
+
+/// One button in the browser pane's bar.
+///
+/// **`.accessoryBar`, which is what the rest of this app's strips of small controls already use.**
+/// `SidebarStatusBar` and `InspectorLayout.inspectorBarControl` both reached for it and both wrote
+/// down why: it is the system's own style for a row of small controls along the edge of a pane, it
+/// brings one hit box, one hover fill and one pressed state to the whole set, and it leaves the
+/// glyph at label weight where `.borderless` draws it in the accent colour. This bar was the last
+/// one in the window still hand rolling that with a fixed frame and two foreground colours, which
+/// is exactly the "app's approximation of a Mac control" the pane is meant to stop looking like.
+///
+/// The disabled colour stays explicit. `.accessoryBar` dims a disabled label, but the browser's
+/// arrows are disabled most of the time on a fresh page, and `Palette.textTertiary` is the rung
+/// this window uses for a control that is there and cannot be pressed.
+struct BrowserToolbarButton: View {
+    var control: BrowserToolbar.Control
+    var action: @MainActor () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Label(control.name, systemImage: control.symbol)
+                .labelStyle(.iconOnly)
+                .foregroundStyle(control.isEnabled ? Palette.textSecondary : Palette.textTertiary)
+        }
+        .buttonStyle(.accessoryBar)
+        .disabled(!control.isEnabled)
+        .help(control.help)
+    }
+}
+
+/// The browser pane's toolbar: what you do to the page, where the page is, and the share sheet.
+///
+/// Its own view rather than a method on `BrowserTabView` so that it can be drawn from a fixture.
+/// The pane's toolbar needs a live `BrowserSession` behind it, which owns a `WKWebView`, and a
+/// gallery page can neither make one nor photograph it. See `BrowserToolbarGallery`.
+///
+/// **Left to right: back, forward, reload or stop, the camera, the address, share.** That is
+/// Safari's order, with the two exceptions this app has reasons for. The camera is left of the
+/// address with the other things you do to the page, which is `BrowserTabView`'s own note and
+/// still holds. Share is right of the address because that is where every Mac browser puts it: the
+/// controls left of the field move you between pages, and the ones right of it hand the page you
+/// are on to something else.
+struct BrowserToolbarView: View {
+    var toolbar: BrowserToolbar
+    /// What the field shows, which is not where the page is. See `BrowserTabView.address`.
+    @Binding var address: String
+    var addressFocus: FocusState<Bool>.Binding
+    /// Whether the ring should be drawn at all: focused, and in the window the keys are going to.
+    var isRingVisible: Bool
+    /// The pages behind and ahead of this one, nearest first, named by `BrowserToolbar`.
+    var backHistory: [BrowserToolbar.HistoryEntry] = []
+    var forwardHistory: [BrowserToolbar.HistoryEntry] = []
+
+    var goBack: @MainActor () -> Void = {}
+    var goForward: @MainActor () -> Void = {}
+    /// Somewhere further back or further forward than one step, by the distance on the entry.
+    var goToHistory: @MainActor (Int) -> Void = { _ in }
+    var reloadOrStop: @MainActor () -> Void = {}
+    var capture: @MainActor () -> Void = {}
+    var submit: @MainActor () -> Void = {}
+
+    /// Drawn inside the field's own edge rather than outside it, so the toolbar does not have to
+    /// give the ring clearance. See `HomeBar.focusRingWidth`.
+    private static let focusRingWidth: CGFloat = 2
+
+    var body: some View {
+        HStack(spacing: Metrics.spacing) {
+            // **The pair, joined by air rather than by a plate.** Safari draws back and forward as
+            // one control with a shared background, and the honest way to say that here is the
+            // spacing scale: nothing is between these two and a group's worth of it is on either
+            // side, which is what `Metrics.spacing` and `spacingWide` are named for. A shared fill
+            // was tried on paper and rejected: `Palette.surfaceRaised` is this window's raised
+            // control, meaning a selected segment or a chip, so a filled pill around two of the
+            // five glyphs in this bar would read as the pair being switched on. The bar has one
+            // filled thing in it and it is the address field, which is a place to type.
+            HStack(spacing: 0) {
+                BrowserToolbarButton(control: toolbar.back, action: goBack)
+                    .modifier(HistoryMenu(entries: backHistory, go: goToHistory))
+                BrowserToolbarButton(control: toolbar.forward, action: goForward)
+                    .modifier(HistoryMenu(entries: forwardHistory, go: goToHistory))
+            }
+
+            BrowserToolbarButton(control: toolbar.reload, action: reloadOrStop)
+
+            // Left of the address rather than right of it, with the other three: they are all
+            // things you do to the page, and the address field is where the page is. Its own group
+            // on the right would have read as belonging to the field.
+            BrowserToolbarButton(control: toolbar.screenshot, action: capture)
+
+            addressField
+
+            BrowserShareButton(control: toolbar.share, shareable: toolbar.shareable)
+        }
+        .padding(.horizontal, Metrics.spacingSmall)
+        .frame(height: Metrics.barHeight)
+        .background(Palette.surfaceSunken)
+    }
+
+    private var addressField: some View {
+        TextField("Address", text: $address)
+            .textFieldStyle(.plain)
+            .font(Typo.label)
+            .focused(addressFocus)
+            .autocorrectionDisabled()
+            .padding(.horizontal, Metrics.spacingWide)
+            .padding(.vertical, Metrics.spacingSmall)
+            .background(Palette.surfaceRaised, in: .rect(cornerRadius: Metrics.cornerSmall))
+            // A hand-built field gets no focus ring from AppKit, and an address bar that looks
+            // identical whether or not it has the keyboard is the single most reliable way to make
+            // a Mac window feel like a web page. The same overlay `HomeBar`'s search field uses, in
+            // the same colour macOS draws a real one in, so it follows Full Keyboard Access and
+            // Increase Contrast with it.
+            .overlay {
+                RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+                    .strokeBorder(
+                        isRingVisible ? Palette.focusRing : Palette.border,
+                        lineWidth: isRingVisible ? Self.focusRingWidth : Metrics.hairline
+                    )
+            }
+            .onSubmit(submit)
+    }
+}
+
+/// The pages an arrow can jump past, under a right click on it.
+///
+/// The one affordance that most makes a pair of arrows read as a browser's rather than as two
+/// buttons: a reader who has clicked four links deep asks to go back to the page they started on,
+/// not to click Back four times. Right click only. Safari opens the same menu on a press and hold
+/// as well, and there is no way to ask a SwiftUI `Button` for that without rebuilding the control
+/// in AppKit, which would cost this bar the system style every other control in it is drawn with.
+///
+/// A modifier rather than a `.contextMenu` written twice, because an empty menu is a menu: SwiftUI
+/// will happily open a blank one on an arrow whose history is empty, so the whole thing is left off
+/// instead. That is never a control losing a menu it had, since an arrow with no history behind it
+/// is an arrow that cannot be pressed either.
+private struct HistoryMenu: ViewModifier {
+    var entries: [BrowserToolbar.HistoryEntry]
+    var go: @MainActor (Int) -> Void
+
+    func body(content: Content) -> some View {
+        if entries.isEmpty {
+            content
+        } else {
+            content.contextMenu {
+                ForEach(entries) { entry in
+                    Button(entry.name) { go(entry.id) }
+                }
+            }
+        }
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
@@ -11,9 +11,11 @@ import BloomCore
 /// one in the window still hand rolling that with a fixed frame and two foreground colours, which
 /// is exactly the "app's approximation of a Mac control" the pane is meant to stop looking like.
 ///
-/// The disabled colour stays explicit. `.accessoryBar` dims a disabled label, but the browser's
-/// arrows are disabled most of the time on a fresh page, and `Palette.textTertiary` is the rung
-/// this window uses for a control that is there and cannot be pressed.
+/// The disabled colour stays explicit, because a foreground style set here is a style
+/// `.accessoryBar` will not dim on its own: with `Palette.textTertiary`, which is the rung this
+/// window uses for small print, a dead Back arrow was a shade off the live Forward arrow next to it
+/// and read as pressable. `Palette.textDisabled` is the system's own answer for a control that is
+/// there and cannot be pressed, and its note carries what that page showed.
 struct BrowserToolbarButton: View {
     var control: BrowserToolbar.Control
     var action: @MainActor () -> Void
@@ -22,7 +24,7 @@ struct BrowserToolbarButton: View {
         Button(action: action) {
             Label(control.name, systemImage: control.symbol)
                 .labelStyle(.iconOnly)
-                .foregroundStyle(control.isEnabled ? Palette.textSecondary : Palette.textTertiary)
+                .foregroundStyle(control.isEnabled ? Palette.textSecondary : Palette.textDisabled)
         }
         .buttonStyle(.accessoryBar)
         .disabled(!control.isEnabled)
@@ -66,15 +68,19 @@ struct BrowserToolbarView: View {
     private static let focusRingWidth: CGFloat = 2
 
     var body: some View {
-        HStack(spacing: Metrics.spacing) {
+        HStack(spacing: Metrics.spacingWide) {
             // **The pair, joined by air rather than by a plate.** Safari draws back and forward as
-            // one control with a shared background, and the honest way to say that here is the
-            // spacing scale: nothing is between these two and a group's worth of it is on either
-            // side, which is what `Metrics.spacing` and `spacingWide` are named for. A shared fill
-            // was tried on paper and rejected: `Palette.surfaceRaised` is this window's raised
-            // control, meaning a selected segment or a chip, so a filled pill around two of the
-            // five glyphs in this bar would read as the pair being switched on. The bar has one
-            // filled thing in it and it is the address field, which is a place to type.
+            // one control, and the honest way to say that in this window is the spacing scale:
+            // nothing at all between these two, and `spacingWide`, which is named for the gap
+            // between the groups a row falls into, on either side of the pair.
+            //
+            // A shared fill was the other option and it was rejected. `Palette.surfaceRaised` is
+            // this window's raised control, meaning a selected segment or a chip, so a filled pill
+            // around two of the five glyphs in this bar would read as those two being switched on.
+            // The bar has exactly one filled thing in it and it is the address field, which is a
+            // place to type rather than a pair of buttons. What that costs is honest: the pair is
+            // a group and not a single control, and a reader who is looking for Safari's one piece
+            // of chrome will notice.
             HStack(spacing: 0) {
                 BrowserToolbarButton(control: toolbar.back, action: goBack)
                     .modifier(HistoryMenu(entries: backHistory, go: goToHistory))

--- a/Sources/BloomCore/System/BrowserToolbar.swift
+++ b/Sources/BloomCore/System/BrowserToolbar.swift
@@ -1,0 +1,232 @@
+import Foundation
+
+/// What the browser pane's toolbar offers, given what the page under it can do.
+///
+/// Here rather than in the view for the reason `BrowserAddress` next door is: whether Forward can
+/// be pressed, whether there is anything to share, what each control is called and what its
+/// tooltip says are all rules, and a rule taken inside a `View` is a rule nothing can test. The
+/// view draws what this answers and decides none of it.
+///
+/// It sits beside `BrowserAddress` and `BrowserTabTitle` rather than in `Presentation/` because
+/// those two are the browser's other rules and a reader looking for what the browser decides
+/// should find the three of them together.
+///
+/// ## There is no tab component to reach for
+///
+/// The question comes back every time somebody looks at Safari beside this pane, so the answer is
+/// written down where they will be reading. **AppKit's only public tab bar is the window one.**
+/// `NSWindowTabGroup` gathers whole `NSWindow`s into one stack, and `NSWindowTab` describes one
+/// window's entry in it: neither can draw a strip inside a view, and there is no `NSTabBar`.
+/// `NSTabView` is a different control altogether, the one behind a preferences window's segments.
+/// Safari's tab bar is not shipped as a control at all.
+///
+/// It would be the wrong thing here in any case. A browser pane is already one tab of the centre
+/// column's strip, so a Safari strip inside it would be tabs inside tabs, and the tab the reader
+/// would reach for first is the one already at the top of the window.
+public struct BrowserToolbar: Equatable, Sendable {
+    /// One button in the bar: what it draws, what it is called, and whether it can be pressed.
+    public struct Control: Equatable, Sendable {
+        /// The SF Symbol, which is the one every Mac browser uses for this control. Symbol names
+        /// live in the core already: see `PaneGlyph`.
+        public var symbol: String
+        /// The short name, which is what VoiceOver reads and what a menu item would be called.
+        public var name: String
+        /// The tooltip, which is a sentence rather than the name again. A glyph with no word
+        /// beside it is discoverable by hovering it, so the hover has to say something the glyph
+        /// does not.
+        public var help: String
+        public var isEnabled: Bool
+
+        public init(symbol: String, name: String, help: String, isEnabled: Bool) {
+            self.symbol = symbol
+            self.name = name
+            self.help = help
+            self.isEnabled = isEnabled
+        }
+    }
+
+    /// Where the page is and what it says it is called.
+    public var page: BrowserTabTitle.BrowserPage
+    public var canGoBack: Bool
+    public var canGoForward: Bool
+    public var isLoading: Bool
+    /// A screenshot is already on its way to the composer, so the camera goes quiet rather than
+    /// attaching the same page twice. See `BrowserTabView.capture`.
+    public var isCapturing: Bool
+
+    public init(
+        page: BrowserTabTitle.BrowserPage = BrowserTabTitle.BrowserPage(),
+        canGoBack: Bool = false,
+        canGoForward: Bool = false,
+        isLoading: Bool = false,
+        isCapturing: Bool = false
+    ) {
+        self.page = page
+        self.canGoBack = canGoBack
+        self.canGoForward = canGoForward
+        self.isLoading = isLoading
+        self.isCapturing = isCapturing
+    }
+
+    /// Where the page is, as an address the rest of the app agrees is one. Nil for a pane split
+    /// open on nothing, which is the one state where most of this bar has nothing to act on.
+    public var destination: URL? {
+        BrowserAddress.url(from: page.address)
+    }
+
+    // MARK: - The controls
+
+    public var back: Control {
+        Control(
+            symbol: "chevron.backward",
+            name: "Back",
+            help: "Show the previous page",
+            isEnabled: canGoBack
+        )
+    }
+
+    public var forward: Control {
+        Control(
+            symbol: "chevron.forward",
+            name: "Forward",
+            help: "Show the next page",
+            isEnabled: canGoForward
+        )
+    }
+
+    /// One control in two states rather than two controls beside each other.
+    ///
+    /// Stop and Reload are never both useful, and a bar that grew a sixth button for the second a
+    /// page takes to load would shift everything to the right of it twice per navigation. Every
+    /// browser on this platform swaps the glyph in place instead.
+    public var reload: Control {
+        if isLoading {
+            return Control(
+                symbol: "xmark",
+                name: "Stop",
+                help: "Stop loading this page",
+                isEnabled: true
+            )
+        }
+        // A pane nobody has pointed anywhere has no page to reload, and a button that does
+        // nothing when pressed is worse than one that says so.
+        return Control(
+            symbol: "arrow.clockwise",
+            name: "Reload",
+            help: "Reload this page",
+            isEnabled: destination != nil
+        )
+    }
+
+    /// The name is the sentence, here and in the page's own context menu, because this is the one
+    /// control in the bar that does something no other browser does and so cannot be guessed from
+    /// its glyph.
+    public var screenshot: Control {
+        Control(
+            symbol: "camera",
+            name: "Send a Screenshot to the Agent",
+            help: "Send a screenshot of this page to the agent",
+            isEnabled: !isCapturing
+        )
+    }
+
+    public var share: Control {
+        Control(
+            symbol: "square.and.arrow.up",
+            name: "Share",
+            help: "Share this page",
+            isEnabled: shareable != nil
+        )
+    }
+
+    // MARK: - Sharing
+
+    /// What the system's share sheet is handed, or nil when the pane has not been anywhere yet.
+    public struct Shareable: Equatable, Sendable {
+        public var url: URL
+        /// What the sheet's preview calls it: the page's own title, or the host, or the address.
+        public var name: String
+
+        public init(url: URL, name: String) {
+            self.url = url
+            self.name = name
+        }
+    }
+
+    /// **The URL alone, with the title carried on it rather than beside it.**
+    ///
+    /// `NSSharingServicePicker` offers only the services that can handle every item it is given,
+    /// and Add to Reading List takes URLs and nothing else, so passing the page's title as a
+    /// second item would quietly cut the sheet down to the services that accept a string as well.
+    /// The title still belongs on the sheet, which is what names the thing being shared at the top
+    /// of it, so it travels as the preview's title on a single item. See `BrowserShareButton`.
+    public var shareable: Shareable? {
+        guard let url = destination else { return nil }
+        return Shareable(
+            url: url,
+            name: BrowserTabTitle.title(
+                page: page.title, address: page.address, fallback: url.absoluteString
+            )
+        )
+    }
+
+    // MARK: - The history behind the arrows
+
+    /// The most of the back or forward list a menu offers.
+    ///
+    /// A browser holds everything visited since the tab opened, and a menu of two hundred pages is
+    /// one you scroll rather than read. Ten is about what Safari shows and comfortably more than
+    /// the "I clicked past it" the menu exists for.
+    public static let historyLimit = 10
+
+    /// One entry of the back or forward list, as the menu under the arrow draws it.
+    public struct HistoryEntry: Equatable, Sendable, Identifiable {
+        /// How far from the page on screen, negative back and positive forward, which is exactly
+        /// what `WKBackForwardList.item(at:)` is indexed by. It is the identity as well, because
+        /// no two entries of one list sit at the same distance.
+        public var id: Int
+        public var name: String
+
+        public init(id: Int, name: String) {
+            self.id = id
+            self.name = name
+        }
+    }
+
+    /// The pages behind this one, nearest first, which is the order a back menu is read in.
+    ///
+    /// - Parameter pages: WebKit's `backList`, which is handed over oldest first.
+    public static func backMenu(_ pages: [BrowserTabTitle.BrowserPage]) -> [HistoryEntry] {
+        entries(Array(pages.reversed()), distance: { -($0 + 1) })
+    }
+
+    /// The pages ahead of this one, nearest first.
+    ///
+    /// - Parameter pages: WebKit's `forwardList`, which is already handed over nearest first.
+    public static func forwardMenu(_ pages: [BrowserTabTitle.BrowserPage]) -> [HistoryEntry] {
+        entries(pages, distance: { $0 + 1 })
+    }
+
+    /// Named by the same chain the tab strip names a page by, so a page reads the same in the
+    /// menu, on the tab and in the share sheet. The tab's own fallback is no use here, since a
+    /// history entry is not a tab, so the address stands in for it.
+    ///
+    /// An entry with nothing to call itself at all is dropped rather than drawn as a blank menu
+    /// item. Filtering after the numbering, so the distances still point at the right pages.
+    private static func entries(
+        _ pages: [BrowserTabTitle.BrowserPage], distance: (Int) -> Int
+    ) -> [HistoryEntry] {
+        pages
+            .prefix(historyLimit)
+            .enumerated()
+            .map { offset, page in
+                HistoryEntry(
+                    id: distance(offset),
+                    name: BrowserTabTitle.title(
+                        page: page.title, address: page.address, fallback: page.address
+                    )
+                )
+            }
+            .filter { !$0.name.isEmpty }
+    }
+}

--- a/Tests/BloomCoreTests/BrowserTabTitleTests.swift
+++ b/Tests/BloomCoreTests/BrowserTabTitleTests.swift
@@ -133,6 +133,24 @@ struct BrowserTabTitleTests {
         #expect(next == page("http://localhost:3000/", "Settings"))
     }
 
+    /// The bug this covers: an Inertia site navigated with `history.pushState`, the tab strip
+    /// followed it because the title is on KVO, and the address field sat on `/login` because the
+    /// url was not. `BrowserSession` watches both now, so both halves arrive here, and what has to
+    /// hold is that the address moves while the name the site has already given the tab stays up
+    /// for the moment before the new one arrives.
+    @Test("A client side navigation moves the address and keeps the name up")
+    func followsAPushState() {
+        let next = BrowserTabTitle.advance(
+            from: page("https://there-there-6.test/login", "Log in"),
+            to: page("https://there-there-6.test/tickets/429")
+        )
+        #expect(next == page("https://there-there-6.test/tickets/429", "Log in"))
+
+        // And the title the site sets a beat later, with no navigation beside it, replaces it.
+        let named = BrowserTabTitle.advance(from: next, to: page("", "#429 Large CSV support"))
+        #expect(named == page("https://there-there-6.test/tickets/429", "#429 Large CSV support"))
+    }
+
     @Test("A page with no address at all keeps the one the tab has")
     func keepsTheAddressWhenNoneIsGiven() {
         let next = BrowserTabTitle.advance(from: page("https://spatie.be/", "Spatie"), to: page(""))

--- a/Tests/BloomCoreTests/BrowserToolbarTests.swift
+++ b/Tests/BloomCoreTests/BrowserToolbarTests.swift
@@ -1,0 +1,174 @@
+import Testing
+@testable import BloomCore
+
+/// What the browser pane's toolbar offers, which used to be five ternaries inside a `View`.
+@Suite("Browser toolbar")
+struct BrowserToolbarTests {
+    private static func toolbar(
+        address: String = "http://localhost:3100/",
+        title: String = "",
+        canGoBack: Bool = false,
+        canGoForward: Bool = false,
+        isLoading: Bool = false,
+        isCapturing: Bool = false
+    ) -> BrowserToolbar {
+        BrowserToolbar(
+            page: BrowserTabTitle.BrowserPage(address: address, title: title),
+            canGoBack: canGoBack,
+            canGoForward: canGoForward,
+            isLoading: isLoading,
+            isCapturing: isCapturing
+        )
+    }
+
+    // MARK: - Going back and forward
+
+    @Test("The arrows can be pressed exactly when the page has somewhere to go")
+    func arrowsFollowTheHistory() {
+        let empty = Self.toolbar()
+        #expect(!empty.back.isEnabled)
+        #expect(!empty.forward.isEnabled)
+
+        let both = Self.toolbar(canGoBack: true, canGoForward: true)
+        #expect(both.back.isEnabled)
+        #expect(both.forward.isEnabled)
+    }
+
+    @Test("The arrows are the glyphs every Mac browser uses")
+    func arrowsAreTheNativeGlyphs() {
+        let toolbar = Self.toolbar()
+        #expect(toolbar.back.symbol == "chevron.backward")
+        #expect(toolbar.forward.symbol == "chevron.forward")
+    }
+
+    @Test("Every control's tooltip says something its name does not")
+    func tooltipsAreNotTheNameAgain() {
+        let toolbar = Self.toolbar(canGoBack: true)
+        for control in [toolbar.back, toolbar.forward, toolbar.reload, toolbar.share] {
+            #expect(control.help != control.name)
+            #expect(!control.help.isEmpty)
+        }
+    }
+
+    // MARK: - Reload and stop
+
+    @Test("Loading turns the one control into Stop")
+    func loadingBecomesStop() {
+        let loading = Self.toolbar(isLoading: true)
+        #expect(loading.reload.name == "Stop")
+        #expect(loading.reload.symbol == "xmark")
+        #expect(loading.reload.isEnabled)
+
+        let idle = Self.toolbar()
+        #expect(idle.reload.name == "Reload")
+        #expect(idle.reload.symbol == "arrow.clockwise")
+        #expect(idle.reload.isEnabled)
+    }
+
+    @Test("A pane nobody has pointed anywhere has nothing to reload")
+    func reloadNeedsAPage() {
+        #expect(!Self.toolbar(address: "").reload.isEnabled)
+    }
+
+    @Test("A pane with no page can still be stopped, because it can still be loading one")
+    func stopSurvivesAnEmptyAddress() {
+        #expect(Self.toolbar(address: "", isLoading: true).reload.isEnabled)
+    }
+
+    // MARK: - The camera
+
+    @Test("The camera goes quiet while a capture is in flight")
+    func cameraWaitsForItsCapture() {
+        #expect(Self.toolbar().screenshot.isEnabled)
+        #expect(!Self.toolbar(isCapturing: true).screenshot.isEnabled)
+    }
+
+    // MARK: - Sharing
+
+    @Test("A pane with nowhere to be has nothing to share")
+    func nothingToShare() {
+        let blank = Self.toolbar(address: "")
+        #expect(blank.shareable == nil)
+        #expect(!blank.share.isEnabled)
+    }
+
+    @Test("What is shared is the page's own address")
+    func sharesTheAddress() {
+        let toolbar = Self.toolbar(address: "https://spatie.be/docs", title: "Docs")
+        #expect(toolbar.share.isEnabled)
+        #expect(toolbar.shareable?.url.absoluteString == "https://spatie.be/docs")
+    }
+
+    @Test("The sheet's preview is named by the page, then by the host")
+    func previewIsNamedByThePage() {
+        #expect(
+            Self.toolbar(address: "https://spatie.be/docs", title: "Docs").shareable?.name == "Docs"
+        )
+        #expect(
+            Self.toolbar(address: "https://www.spatie.be/docs").shareable?.name == "spatie.be"
+        )
+    }
+
+    @Test("A typed address is turned into a real one before it is shared")
+    func typedAddressesAreResolved() {
+        #expect(Self.toolbar(address: "localhost:3100").shareable?.url.scheme == "http")
+        #expect(Self.toolbar(address: "spatie.be").shareable?.url.scheme == "https")
+    }
+
+    // MARK: - The history behind the arrows
+
+    private static func page(_ address: String, _ title: String = "") -> BrowserTabTitle.BrowserPage {
+        BrowserTabTitle.BrowserPage(address: address, title: title)
+    }
+
+    @Test("The back menu reads nearest first, whatever order WebKit hands it over in")
+    func backMenuIsNearestFirst() {
+        let menu = BrowserToolbar.backMenu([
+            Self.page("https://a.example/", "Oldest"),
+            Self.page("https://b.example/", "Middle"),
+            Self.page("https://c.example/", "Nearest"),
+        ])
+        #expect(menu.map(\.name) == ["Nearest", "Middle", "Oldest"])
+        #expect(menu.map(\.id) == [-1, -2, -3])
+    }
+
+    @Test("The forward menu is already nearest first and is numbered the other way")
+    func forwardMenuIsNumberedForwards() {
+        let menu = BrowserToolbar.forwardMenu([
+            Self.page("https://a.example/", "Next"),
+            Self.page("https://b.example/", "After that"),
+        ])
+        #expect(menu.map(\.name) == ["Next", "After that"])
+        #expect(menu.map(\.id) == [1, 2])
+    }
+
+    @Test("A page with no title of its own is named by its host")
+    func historyFallsBackToTheHost() {
+        let menu = BrowserToolbar.forwardMenu([Self.page("https://www.spatie.be/docs")])
+        #expect(menu.map(\.name) == ["spatie.be"])
+    }
+
+    @Test("A menu is capped rather than holding everything the tab has visited")
+    func historyIsCapped() {
+        let pages = (0..<40).map { Self.page("https://example.com/\($0)", "Page \($0)") }
+        #expect(BrowserToolbar.backMenu(pages).count == BrowserToolbar.historyLimit)
+        #expect(BrowserToolbar.forwardMenu(pages).count == BrowserToolbar.historyLimit)
+    }
+
+    @Test("An entry with nothing to call itself is dropped, and the rest keep their distances")
+    func namelessEntriesAreDropped() {
+        let menu = BrowserToolbar.forwardMenu([
+            Self.page("https://a.example/", "First"),
+            Self.page(""),
+            Self.page("https://c.example/", "Third"),
+        ])
+        #expect(menu.map(\.name) == ["First", "Third"])
+        #expect(menu.map(\.id) == [1, 3])
+    }
+
+    @Test("An empty history is an empty menu rather than one blank item")
+    func emptyHistoryIsEmpty() {
+        #expect(BrowserToolbar.backMenu([]).isEmpty)
+        #expect(BrowserToolbar.forwardMenu([]).isEmpty)
+    }
+}


### PR DESCRIPTION
Share is the system's own sheet. `NSSharingServicePicker`, shown from the button's own rectangle so it points at the control, holding one item: the page's URL wrapped in an `NSPreviewRepresentingActivityItem` so the title names the preview without becoming a second item. A second item would cut the sheet down to the services that take a string as well as a URL, Add to Reading List included.

Back and forward are grouped by the spacing scale rather than by a shared plate, and the argument is on the view: `Palette.surfaceRaised` means a selected segment or a chip here, so a pill around two of five glyphs would read as those two being switched on. Every button in the bar moves to `.accessoryBar`, which is what `SidebarStatusBar` and the inspector's strips already use and already argue for. A right click on either arrow offers the pages it would walk past.

What the bar offers is `BrowserToolbar` in the core: which controls can be pressed, what each is called, what its tooltip says, what there is to share, and how a history menu is named and numbered. The view holds no rule. The answer to "use the real tab component" is written down there too, with what `NSWindowTabGroup` and `NSWindowTab` actually are.

A disabled glyph gets `Palette.textDisabled`. `textTertiary`'s own note says it is deliberately not the disabled rung, and the gallery page showed the result: a row with both arrows dead looked exactly like the row above it, which has neither.

And the address field follows a client side navigation now. `history.pushState` is a same document navigation, so WebKit updates `url` and the back list and no delegate callback fires. The field sat on `/login` while an Inertia site walked four pages on and the tab strip beside it kept up, because the title was on KVO and the url was not. `url`, `canGoBack`, `canGoForward` and `isLoading` join it.

New gallery page: `--gallery browser-toolbar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uag98HMrLkrJRksGeVurmx