### PR TITLE
Show the file a sent turn's own pill names, not just its name

### DIFF
--- a/Sources/Bloom/Views/Center/Attachments/AttachmentChip.swift
+++ b/Sources/Bloom/Views/Center/Attachments/AttachmentChip.swift
@@ -91,8 +91,10 @@ struct AttachmentChip: View {
     /// is truncated in the middle, and short enough that four chips fit across a narrow column.
     private static let maxNameWidth: CGFloat = 150
     /// How long the pointer has to rest before the card opens. Short enough to feel like hovering,
-    /// long enough that crossing the row on the way to the send button shows nothing.
-    private static let hoverDelay = Duration.milliseconds(350)
+    /// long enough that crossing the row on the way to the send button shows nothing. Shared with
+    /// the sidebar's card, the composer's and the transcript's, so the whole window answers a
+    /// resting pointer at one speed.
+    private static var hoverDelay: Duration { Motion.hoverCardDelay }
 
     var body: some View {
         HStack(spacing: Metrics.spacingSmall) {

--- a/Sources/Bloom/Views/Transcript/ToolRowHeader.swift
+++ b/Sources/Bloom/Views/Transcript/ToolRowHeader.swift
@@ -42,8 +42,10 @@ struct ToolRowHeader: View {
 
     /// How long the pointer has to rest on a row before its card opens. The same wait
     /// `AttachmentChip` makes for the file card, so the two cards in this pane answer at the same
-    /// speed rather than at two speeds a reader would have to learn.
-    private static let hoverDelay = Duration.milliseconds(350)
+    /// speed rather than at two speeds a reader would have to learn. It is `Motion.hoverCardDelay`
+    /// rather than a number of its own, because the sidebar's card and the composer's ask the
+    /// identical question and four answers to it would be four windows.
+    private static var hoverDelay: Duration { Motion.hoverCardDelay }
 
     /// A chip that repeats the detail replaces it: `Read [notes.txt]` rather than
     /// `Read notes.txt [notes.txt]`.
@@ -297,14 +299,17 @@ struct ToolRowHeader: View {
     /// combined label exactly the way the monospace chips beside it already do, which is the
     /// behaviour this change should not have altered.
     private func fileChip(_ path: String) -> some View {
-        let inside = FilePathGuess.relative(path, to: workspace.path)
-        let attachment = PromptAttachment.sent(path: inside ?? path)
-        let worktree = inside == nil ? "" : workspace.path
+        // The rule is `FileChipTarget` in the core, shared with the pills a sent turn draws inside
+        // its own sentence: two copies of it would be two answers to "can this chip be opened",
+        // four lines apart in the same transcript.
+        let target = FileChipTarget.resolve(path, in: workspace.path)
+        let attachment = PromptAttachment.sent(path: target.path)
+        let worktree = target.worktree
         // Spelled out rather than mapped over the optional, so the closure's actor is written down
         // rather than inferred through two layers of optional.
         let onOpen: (@MainActor () -> Void)?
-        if let inside {
-            onOpen = { open(inside) }
+        if let opens = target.opens {
+            onOpen = { open(opens) }
         } else {
             onOpen = nil
         }

--- a/Sources/Bloom/Views/Transcript/TranscriptTextView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTextView.swift
@@ -47,8 +47,28 @@ struct TranscriptLinkActions: Sendable, Equatable {
     /// draws chips, because opening a file needs a workspace and the list's shared actions have
     /// none: see `UserTurnRowView`.
     var openFile: @MainActor @Sendable (String) -> Void = { _ in }
+    /// The pointer moved onto a file chip inside the run, or off one. Set by the same row and for
+    /// the same reason: the card needs the workspace to know which worktree the path is under.
+    var hoverFile: @MainActor @Sendable (FileChipHover?) -> Void = { _ in }
 
     static func == (lhs: Self, rhs: Self) -> Bool { lhs.identity == rhs.identity }
+}
+
+/// The file chip the pointer is on, and where it is.
+///
+/// **Reported the moment the pointer arrives, with no wait of its own**, which is the opposite of
+/// how the composer's chips do it and is deliberate. `ComposerTextView` waits `Motion.hoverCardDelay`
+/// inside AppKit because it has everything the card needs; a transcript's card is drawn over the
+/// whole pane by `TranscriptHoverOverlay`, so the frame below has to be added to wherever this
+/// text view sits in the window, and the row is the only half that can measure that. It starts
+/// measuring on the arrival and waits the same delay before publishing, so the frame is settled by
+/// the time it is used and nothing is measured behind a bubble nobody is pointing at.
+struct FileChipHover: Equatable, Sendable {
+    var path: String
+    /// In the text view's own coordinates, which are top left origin because a text view is
+    /// flipped. That is the space SwiftUI measures in too, so the row adds its own origin and
+    /// nothing here has to reason about AppKit's y axis.
+    var frame: CGRect
 }
 
 /// Prose in the transcript, drawn by AppKit so that a link in it behaves like a link.
@@ -247,6 +267,10 @@ final class LinkTextView: NSTextView {
     /// it off does not invalidate the layout.
     private var hovered: NSRange?
 
+    /// The file chip the pointer is on, so the row is told once on arrival rather than on every
+    /// move across the same pill.
+    private var hoveredChip: FileChipHover?
+
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
         for area in trackingAreas where area.owner === self {
@@ -263,11 +287,13 @@ final class LinkTextView: NSTextView {
         super.mouseMoved(with: event)
         let point = convert(event.locationInWindow, from: nil)
         hover(linkRange(at: point))
+        let chip = fileChip(at: point)
         // A chip is a door like a link is, and a text view left to itself shows an I-beam over
         // the whole run: the pointer is what says the difference before the click does. The link
         // ranges get theirs from `linkTextAttributes`, which AppKit merges over them; an
         // attachment is not a link and gets nothing, so it is set here.
-        if filePath(at: point) != nil { NSCursor.pointingHand.set() }
+        if chip != nil { NSCursor.pointingHand.set() }
+        hoverChip(chip)
     }
 
     /// Opens the file under the pointer, and otherwise lets the text view do what it does.
@@ -280,16 +306,17 @@ final class LinkTextView: NSTextView {
     /// short line reports the last character on it, so without the bounds test a click in the
     /// white space beside a one-line turn would open its file.
     override func mouseDown(with event: NSEvent) {
-        guard let path = filePath(at: convert(event.locationInWindow, from: nil)) else {
+        guard let chip = fileChip(at: convert(event.locationInWindow, from: nil)) else {
             super.mouseDown(with: event)
             return
         }
-        actions.openFile(path)
+        actions.openFile(chip.path)
     }
 
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
         hover(nil)
+        hoverChip(nil)
     }
 
     private func hover(_ range: NSRange?) {
@@ -303,6 +330,16 @@ final class LinkTextView: NSTextView {
             )
         }
         hovered = range
+    }
+
+    /// Tells the row which chip the pointer is on, once per arrival and once per departure.
+    ///
+    /// The whole value is compared rather than the path alone, so a sentence naming the same file
+    /// twice moves its card from one pill to the other instead of leaving it on the first.
+    private func hoverChip(_ chip: FileChipHover?) {
+        guard chip != hoveredChip else { return }
+        hoveredChip = chip
+        actions.hoverFile(chip)
     }
 
     /// The link under a point, or nothing.
@@ -329,9 +366,17 @@ final class LinkTextView: NSTextView {
         return range
     }
 
-    /// The file chip under a point, or nothing. See `linkRange(at:)`, whose two tests this shares:
-    /// the character index, and the glyph rectangle that says the pointer is really on it.
-    private func filePath(at point: CGPoint) -> String? {
+    /// The file chip under a point, and where that chip is, or nothing. See `linkRange(at:)`, whose
+    /// two tests this shares: the character index, and the glyph rectangle that says the pointer is
+    /// really on it.
+    ///
+    /// The rectangle is returned as well as the path because it is the same rectangle, already
+    /// measured: the hit test cannot be done without it, and the card has to be anchored to
+    /// something. It is put back into the view's coordinates with `textContainerOrigin`, which is
+    /// zero here (the inset and the fragment padding are both set to nothing in `makeNSView`) and
+    /// is added anyway, because a chip drawn a few points out of place would be a silent
+    /// consequence of somebody changing one of those.
+    private func fileChip(at point: CGPoint) -> FileChipHover? {
         guard let layout = layoutManager, let container = textContainer,
               let storage = textStorage, storage.length > 0 else { return nil }
 
@@ -344,7 +389,12 @@ final class LinkTextView: NSTextView {
         let bounds = layout.boundingRect(forGlyphRange: NSRange(location: glyph, length: 1), in: container)
         guard bounds.contains(point) else { return nil }
 
-        return storage.attribute(ComposerChipText.pathKey, at: index, effectiveRange: nil) as? String
+        guard let path = storage.attribute(
+            ComposerChipText.pathKey, at: index, effectiveRange: nil
+        ) as? String else { return nil }
+
+        let origin = textContainerOrigin
+        return FileChipHover(path: path, frame: bounds.offsetBy(dx: origin.x, dy: origin.y))
     }
 
     private func link(at point: CGPoint) -> URL? {

--- a/Sources/Bloom/Views/Transcript/UserTurnRowView.swift
+++ b/Sources/Bloom/Views/Transcript/UserTurnRowView.swift
@@ -46,6 +46,20 @@ struct UserTurnRowView: View {
     /// inside a bubble that would clip it. See `TranscriptHoverOverlay`.
     @Environment(\.transcriptHoverHost) private var hoverHost
 
+    /// The pill inside the sentence the pointer is currently on, reported by `LinkTextView` the
+    /// moment it arrives. Nil for every bubble nobody is pointing at, which is what keeps the
+    /// probe below and the timer beside it off every other row in the transcript.
+    @State private var hovered: FileChipHover?
+    /// Where the sentence is in the window, read only while a pill in it is under the pointer. See
+    /// `chipProbe`.
+    @State private var textFrame: CGRect = .zero
+    @State private var hoverTask: Task<Void, Never>?
+    /// The card this bubble put up, if it is still up. Recorded rather than recomputed, exactly as
+    /// `ToolRowHeader` records its own: what has to be taken down is what was PUT up, and the
+    /// pointer crossing from one chip to the next raises the second before the first is told it
+    /// was left.
+    @State private var published: TranscriptHoverCard?
+
     /// How much of the pane a user turn always leaves empty on its left, so it reads as one side of
     /// a conversation even when it is short.
     ///
@@ -111,6 +125,25 @@ struct UserTurnRowView: View {
         }
         .padding(.horizontal, TranscriptLayout.inset)
         .padding(.vertical, TranscriptLayout.inset)
+        .onChange(of: hovered) { _, chip in
+            hoverTask?.cancel()
+            guard let chip else {
+                withdraw()
+                return
+            }
+            let wanted = card(for: chip.path)
+            hoverTask = Task {
+                try? await Task.sleep(for: Motion.hoverCardDelay)
+                // Zero only if the probe has not been laid out yet, which would put the card in
+                // the pane's top left corner. Saying nothing beats saying it in the wrong place.
+                guard !Task.isCancelled, textFrame != .zero else { return }
+                publish(wanted, at: chip.frame.offsetBy(dx: textFrame.minX, dy: textFrame.minY))
+            }
+        }
+        .onDisappear {
+            hoverTask?.cancel()
+            withdraw()
+        }
     }
 
     /// The words and then the files, which is the order they were written in and the order the
@@ -147,8 +180,9 @@ struct UserTurnRowView: View {
                     // muted slate that sits clearly on Spatie Blue and leaves white text alone.
                     // AppKit cannot read the `colorScheme` this bubble sets, so it is named.
                     selectionColor: Palette.bubbleTextSelection,
-                    actions: linkActions.opening(file: open)
+                    actions: linkActions.opening(file: open, hovering: { hovered = $0 })
                 )
+                .background { chipProbe }
             }
 
             if !reviewChips.isEmpty {
@@ -193,32 +227,89 @@ struct UserTurnRowView: View {
         FileReview.open(path: path, in: model)
     }
 
+    /// Where the sentence sits in the window, measured only while a pill in it is under the
+    /// pointer.
+    ///
+    /// The pill reports its own frame in the text view's coordinates, because AppKit measures from
+    /// the bottom of a window and SwiftUI from the top, and the one number that reconciles them is
+    /// where SwiftUI thinks this view is. Reading it behind every bubble would be a read per
+    /// bubble per layout pass, on the list that re-lays out on every frame of a sidebar drag;
+    /// behind the hovered one it is nothing at all for the rest. It is up well before it is
+    /// needed: `Motion.hoverCardDelay` is a third of a second and this is a layout pass.
+    @ViewBuilder
+    private var chipProbe: some View {
+        if hoverHost != nil, hovered != nil {
+            Color.clear
+                .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: {
+                    textFrame = $0
+                }
+        }
+    }
+
+    /// What the card is asked for. `FileChipTarget` is the rule, in the core, and it is the same
+    /// call a tool row's chip makes: a path inside the worktree is shown relative to it, and one
+    /// outside keeps the absolute path it arrived with and is resolved against nothing.
+    ///
+    /// A file that has since been deleted still gets a card, and the card says so: `AttachmentPreview`
+    /// draws "it is gone" for a path with nothing behind it. That is deliberately the same answer a
+    /// tool row gives, and it is the honest one here, because a sent turn is a record of what was
+    /// asked rather than a picker. See `AttachmentChip.verifiesOnDisk`.
+    private func card(for path: String) -> TranscriptHoverCard {
+        let target = FileChipTarget.resolve(path, in: workspace.path)
+        return .file(attachment: .sent(path: target.path), worktree: target.worktree)
+    }
+
     /// The same card the composer showed while the file was being attached, drawn over the
     /// transcript instead of over the box. A bubble cannot hold it: it is a plate a few hundred
     /// points wide inside a lazy stack inside a scroll view, and it would be clipped at the first
     /// edge it met.
+    ///
+    /// This is the trailer's chips, which are laid out by SwiftUI and measure themselves, so they
+    /// arrive with a window frame already in hand and need none of the timing above.
     private func preview(_ path: String, _ frame: CGRect?) {
-        let file = TranscriptHoverCard.file(
-            attachment: .sent(path: path), worktree: workspace.path
-        )
         guard let frame else {
-            if hoverHost?.request?.card == file { hoverHost?.request = nil }
+            withdraw()
             return
         }
-        hoverHost?.request = TranscriptHoverRequest(card: file, frame: frame)
+        publish(card(for: path), at: frame)
+    }
+
+    private func publish(_ card: TranscriptHoverCard, at frame: CGRect) {
+        published = card
+        hoverHost?.request = TranscriptHoverRequest(card: card, frame: frame)
+    }
+
+    /// Takes this bubble's card down, and only its own.
+    ///
+    /// The comparison is what makes the hide immediate AND safe. The pointer crossing from one
+    /// chip to the next raises the new card before the old chip has been told it was left, so a
+    /// bare `request = nil` would sometimes clear the card that had just gone up.
+    private func withdraw() {
+        defer { published = nil }
+        guard let published, hoverHost?.request?.card == published else { return }
+        hoverHost?.request = nil
     }
 }
 
 extension TranscriptLinkActions {
-    /// The list's shared actions with a door for file chips added.
+    /// The list's shared actions with a door for file chips added, and a way for one of them to
+    /// say the pointer is on it.
     ///
     /// A copy per bubble rather than a fourth closure on the list's one value, because opening a
     /// file needs the workspace and the list is handed a session. It costs one struct on the rows
     /// that draw a bubble, which is a handful in a transcript of hundreds.
+    ///
+    /// Both closures at once because both need the same thing the list cannot give: the workspace,
+    /// for the door and for the worktree the card resolves against. A value that has one always
+    /// has the other, which is why `identity` gains no third case for the pair.
     @MainActor
-    func opening(file open: @escaping @MainActor @Sendable (String) -> Void) -> TranscriptLinkActions {
+    func opening(
+        file open: @escaping @MainActor @Sendable (String) -> Void,
+        hovering hover: @escaping @MainActor @Sendable (FileChipHover?) -> Void
+    ) -> TranscriptLinkActions {
         var copy = self
         copy.openFile = open
+        copy.hoverFile = hover
         // The identity moves with the closure, or a bubble that can open a file would compare
         // equal to the list's value that cannot, and the environment would never see the change.
         if case let .workspace(id, pane) = identity {

--- a/Sources/BloomCore/Transcript/FileChipTarget.swift
+++ b/Sources/BloomCore/Transcript/FileChipTarget.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// What a file chip in a transcript is pointing at: the file the hover card should ask the disk
+/// for, and the path a click on it opens.
+///
+/// The two answers are not the same string, and working out either one needs the worktree, which
+/// is why they are decided together rather than at each chip. A transcript names files in three
+/// forms and they arrive within lines of each other: an agent writes an absolute path, because
+/// Claude Code requires one on every read; the composer writes a worktree relative one, because
+/// that is where the agent is standing; and the owner writes whatever he typed. The review only
+/// resolves a path against the worktree, so a chip naming a file in another checkout, in the home
+/// directory or in a temporary folder has nowhere to open, and `AttachmentCard` needs to be handed
+/// no worktree at all for that one or it would look for it inside this one.
+///
+/// This was worked out inside `ToolRowHeader` and about to be worked out a second time inside
+/// `UserTurnRowView` when the pills in a sent bubble were given the same card the tool rows
+/// already had. Two copies of it would be two answers to "can this chip be opened", four lines
+/// apart in the same transcript.
+///
+/// **Nothing here touches the disk**, for the reason `FilePathGuess` gives at length: a transcript
+/// is hundreds of rows in a lazy list, and whether the file is still there is `AttachmentPreview`'s
+/// question, asked once for the one card that is actually up.
+public struct FileChipTarget: Equatable, Sendable {
+    /// What the card asks for, relative to `worktree` where there is one and absolute where there
+    /// is not.
+    public var path: String
+    /// The worktree `path` is relative to, and empty for a file outside it. Empty rather than the
+    /// workspace's own root, because an absolute path joined onto a root is neither.
+    public var worktree: String
+    /// Where a click goes, worktree relative, and nil where the chip has nowhere to open. The chip
+    /// is still drawn and still previews: it simply does not answer to the pointer.
+    public var opens: String?
+
+    public static func resolve(_ path: String, in worktree: String) -> FileChipTarget {
+        guard let inside = FilePathGuess.relative(path, to: worktree) else {
+            return FileChipTarget(path: path, worktree: "", opens: nil)
+        }
+        return FileChipTarget(path: inside, worktree: worktree, opens: inside)
+    }
+}

--- a/Tests/BloomCoreTests/FileChipTargetTests.swift
+++ b/Tests/BloomCoreTests/FileChipTargetTests.swift
@@ -1,0 +1,80 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+/// Where a file chip's card looks and where its click goes, for the three forms a transcript names
+/// a file in.
+///
+/// The pairing is the whole point: a chip that can be opened is previewed against the worktree,
+/// and a chip that cannot is previewed against nothing and previewed absolutely. Splitting those
+/// two answers is how a card ends up looking for `/Users/other/repo/notes.md` inside this
+/// workspace.
+@Suite("File chip target")
+struct FileChipTargetTests {
+    private static let worktree = "/Users/freek/dev/code/bloom"
+
+    @Test("an absolute path inside the worktree is previewed and opened relative to it")
+    func insideTheWorktree() {
+        let target = FileChipTarget.resolve(Self.worktree + "/Sources/Bloom/App.swift", in: Self.worktree)
+        #expect(target == FileChipTarget(
+            path: "Sources/Bloom/App.swift",
+            worktree: Self.worktree,
+            opens: "Sources/Bloom/App.swift"
+        ))
+    }
+
+    @Test("a relative path is already what both answers want")
+    func alreadyRelative() {
+        let target = FileChipTarget.resolve(".bloom/attachments/9JV/shot.png", in: Self.worktree)
+        #expect(target == FileChipTarget(
+            path: ".bloom/attachments/9JV/shot.png",
+            worktree: Self.worktree,
+            opens: ".bloom/attachments/9JV/shot.png"
+        ))
+    }
+
+    @Test("a leading ./ comes off, because the review resolves neither form differently")
+    func dotSlash() {
+        let target = FileChipTarget.resolve("./Tools/build.sh", in: Self.worktree)
+        #expect(target.path == "Tools/build.sh")
+        #expect(target.opens == "Tools/build.sh")
+    }
+
+    /// The case the whole type exists for. Left to `PromptAttachment.url(in:)` with the workspace's
+    /// root still attached, this would be looked for at `<worktree>/Users/freek/Desktop/shot.png`.
+    @Test("a file outside the worktree keeps its absolute path and is previewed against nothing", arguments: [
+        "/Users/freek/Desktop/shot.png",
+        "/Users/freek/dev/code/other/README.md",
+        "/tmp/T/CleanShot.jpg",
+    ])
+    func outsideTheWorktree(path: String) {
+        let target = FileChipTarget.resolve(path, in: Self.worktree)
+        #expect(target == FileChipTarget(path: path, worktree: "", opens: nil))
+    }
+
+    @Test("a path that climbs out of the worktree has nowhere to open")
+    func climbsOut() {
+        let target = FileChipTarget.resolve("../other/README.md", in: Self.worktree)
+        #expect(target.opens == nil)
+        #expect(target.worktree.isEmpty)
+    }
+
+    /// A workspace whose worktree is not known is every chip's answer at once, and it has to be the
+    /// safe one: nothing is resolved against a root that is not there.
+    @Test("no worktree means no door")
+    func noWorktree() {
+        let target = FileChipTarget.resolve("Sources/Bloom/App.swift", in: "")
+        #expect(target == FileChipTarget(path: "Sources/Bloom/App.swift", worktree: "", opens: nil))
+    }
+
+    /// The file the owner attaches most: a screenshot with spaces and an `@2x` in its name.
+    /// `FilePathGuess.relative` asks only `isWellFormed` of it, so the spaces that stop it being
+    /// GUESSED as a file never stop it being resolved once something else has said it is one.
+    @Test("a screenshot's name survives, spaces and all")
+    func screenshot() {
+        let path = Self.worktree + "/.bloom/attachments/A1/CleanShot 2026-08-24 at 14.46@2x.jpg"
+        let target = FileChipTarget.resolve(path, in: Self.worktree)
+        #expect(target.path == ".bloom/attachments/A1/CleanShot 2026-08-24 at 14.46@2x.jpg")
+        #expect(target.opens == target.path)
+    }
+}


### PR DESCRIPTION
Resting on the file chip in your own sent bubble now floats the same Quick Look card the agent's `Read` row below it already gives.

It had none because the two chips are not the same object. A file in a prompt is a word in the sentence, drawn as an `NSTextAttachment` inside the bubble's text view; the card was wired to `AttachmentChip`, the SwiftUI chip nothing writes into a sent turn any more. `LinkTextView` already hit tested the pill for the pointing hand and the click, so it now reports which pill the pointer is on with the rectangle it had to measure anyway, and the row waits `Motion.hoverCardDelay` and publishes to the existing `TranscriptHoverHost`. No second timer, no second overlay, and the click is untouched.

Which file the card asks for, and whether the chip has anywhere to open, was decided inside `ToolRowHeader` and was about to be decided a second time here. It is `FileChipTarget` in the core now, with tests, and both call sites go through it.

A file that has since been deleted gets a card saying it is gone, the same answer a tool row's chip gives. Review comment chips are left alone.
