### PR TITLE
Ask the session rows whether an agent is running, not only the transcripts

### DIFF
--- a/Sources/Bloom/Design/RunningGlyphGallery.swift
+++ b/Sources/Bloom/Design/RunningGlyphGallery.swift
@@ -60,36 +60,37 @@ struct RunningGlyphGallery: View {
             // A workspace whose agent was mid turn showed `circle.dotted`, the mark for a worktree
             // that matches its base branch, because `WorkspaceStatus.resolve` was handed
             // `isRunning: false` and fell through every test to `.clean`. The report called it "a
-            // hollow dashed ring", and the first hour of reading went into working out which of
-            // the column's two rings that was: `.clean`'s dotted circle, or `.settingUp`'s
-            // spinner. Both are here so nobody has to ask again, and so the distance between the
-            // dot and either ring can be seen rather than described. The state that produced it is
-            // `AgentTurns` in the core.
+            // hollow dashed ring" and an hour went into working out which mark that was, so the
+            // two are drawn side by side: what the mark meant to say, and what it said. The state
+            // that produced it is `AgentTurns` in the core.
+            //
+            // `.settingUp` is deliberately NOT here, and not because it was ruled out by reading.
+            // It is the column's other ring and the obvious third column for this row, and it is a
+            // `ProgressView`, which is a representable: drawn into this page it photographs as
+            // SwiftUI's yellow placeholder in `--snapshot`'s offscreen pass, which is the one pass
+            // an agent can run without putting a window in front of the owner. A page that comes
+            // out as a warning sign says less than a page without the column.
             VStack(alignment: .leading, spacing: 8) {
-                Text("The marks it was mistaken for")
+                Text("The mark it was mistaken for")
                     .font(Typo.label)
                     .foregroundStyle(Palette.textSecondary)
                 HStack(alignment: .top, spacing: 24) {
                     named("Running") { WorkspaceRunningGlyph() }
                     named("No changes") { WorkspaceStatusGlyph(status: .clean) }
-                    named("Setting up") { WorkspaceStatusGlyph(status: .settingUp) }
                 }
             }
 
-            // The same three on the selection fill, because that is where the report saw them and
+            // The same pair on the selection fill, because that is where the report saw them and
             // because every meaning colour in the palette is unreadable there: on a selected row
             // the shape is the whole of what a mark says. See `WorkspaceStatusGlyph.isOnSelection`.
             VStack(alignment: .leading, spacing: 8) {
-                Text("The same three, selected")
+                Text("The same pair, selected")
                     .font(Typo.label)
                     .foregroundStyle(Palette.textSecondary)
                 HStack(alignment: .top, spacing: 24) {
                     named("Running") { WorkspaceRunningGlyph(isOnSelection: true) }
                     named("No changes") {
                         WorkspaceStatusGlyph(status: .clean, isOnSelection: true)
-                    }
-                    named("Setting up") {
-                        WorkspaceStatusGlyph(status: .settingUp, isOnSelection: true)
                     }
                 }
                 .padding(8)

--- a/Sources/Bloom/Design/RunningGlyphGallery.swift
+++ b/Sources/Bloom/Design/RunningGlyphGallery.swift
@@ -55,6 +55,48 @@ struct RunningGlyphGallery: View {
                 }
             }
 
+            // What the sidebar drew INSTEAD, on the day this page was next opened.
+            //
+            // A workspace whose agent was mid turn showed `circle.dotted`, the mark for a worktree
+            // that matches its base branch, because `WorkspaceStatus.resolve` was handed
+            // `isRunning: false` and fell through every test to `.clean`. The report called it "a
+            // hollow dashed ring", and the first hour of reading went into working out which of
+            // the column's two rings that was: `.clean`'s dotted circle, or `.settingUp`'s
+            // spinner. Both are here so nobody has to ask again, and so the distance between the
+            // dot and either ring can be seen rather than described. The state that produced it is
+            // `AgentTurns` in the core.
+            VStack(alignment: .leading, spacing: 8) {
+                Text("The marks it was mistaken for")
+                    .font(Typo.label)
+                    .foregroundStyle(Palette.textSecondary)
+                HStack(alignment: .top, spacing: 24) {
+                    named("Running") { WorkspaceRunningGlyph() }
+                    named("No changes") { WorkspaceStatusGlyph(status: .clean) }
+                    named("Setting up") { WorkspaceStatusGlyph(status: .settingUp) }
+                }
+            }
+
+            // The same three on the selection fill, because that is where the report saw them and
+            // because every meaning colour in the palette is unreadable there: on a selected row
+            // the shape is the whole of what a mark says. See `WorkspaceStatusGlyph.isOnSelection`.
+            VStack(alignment: .leading, spacing: 8) {
+                Text("The same three, selected")
+                    .font(Typo.label)
+                    .foregroundStyle(Palette.textSecondary)
+                HStack(alignment: .top, spacing: 24) {
+                    named("Running") { WorkspaceRunningGlyph(isOnSelection: true) }
+                    named("No changes") {
+                        WorkspaceStatusGlyph(status: .clean, isOnSelection: true)
+                    }
+                    named("Setting up") {
+                        WorkspaceStatusGlyph(status: .settingUp, isOnSelection: true)
+                    }
+                }
+                .padding(8)
+                .background(Palette.accentFill)
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+
             VStack(alignment: .leading, spacing: 8) {
                 Text("Four rows, one heartbeat")
                     .font(Typo.label)
@@ -133,7 +175,9 @@ extension Gallery {
     static let runningGlyph = Gallery(
         name: "running-glyph",
         title: "Running mark",
-        size: CGSize(width: 700, height: 900),
+        // Taller than it was, for the two rows that name what this mark was mistaken for. A page
+        // that clips is a page whose last section nobody knows is there.
+        size: CGSize(width: 700, height: 1240),
         needsFocus: false,
         view: { _ in AnyView(RunningGlyphGallery()) }
     )

--- a/Sources/Bloom/State/AppModel.swift
+++ b/Sources/Bloom/State/AppModel.swift
@@ -37,8 +37,9 @@ struct BloomAlert: Identifiable {
 /// - `AppModel+Naming.swift`, `AppModel+ProjectIcons.swift`, `AppModel+TranscriptSearch.swift`
 ///
 /// The running, waiting and subagent mirrors did NOT leave, and that is deliberate: they would
-/// publish the five properties whose comments rest entirely on having one writer. The answer for
-/// them is an `AgentActivity` object this model owns, which is a redesign rather than a move.
+/// publish the five properties whose comments rest entirely on having one writer. What DID leave
+/// is the rule they hold, which is `AgentTurns` in the core, where it can be tested; the
+/// mirrors here are what that rule is written into.
 @MainActor
 @Observable
 final class AppModel {
@@ -253,6 +254,7 @@ final class AppModel {
 
     private var refreshTask: Task<Void, Never>?
     private var storeObservationTask: Task<Void, Never>?
+    private var sessionObservationTask: Task<Void, Never>?
     private var quotaObservationTask: Task<Void, Never>?
     private var quotaPollTask: Task<Void, Never>?
     /// When the one asker last went out, and whether it is still out. Together they are what
@@ -353,6 +355,7 @@ final class AppModel {
         identityTask = Task { await GitHubIdentity.resolve() }
         startBackgroundRefresh()
         startObservingStore()
+        startObservingSessions()
         startObservingQuotas()
         startPollingQuotas()
         // Last, and nothing waits for it: the window is already drawn by the time this runs, and
@@ -410,6 +413,8 @@ final class AppModel {
         refreshTask = nil
         storeObservationTask?.cancel()
         storeObservationTask = nil
+        sessionObservationTask?.cancel()
+        sessionObservationTask = nil
         quotaObservationTask?.cancel()
         quotaObservationTask = nil
         quotaPollTask?.cancel()
@@ -596,6 +601,30 @@ final class AppModel {
             for await _ in store.changes(of: [.repos, .workspaces]) {
                 guard let self else { return }
                 await self.reload()
+            }
+        }
+    }
+
+    /// Which chats the store says are mid turn, on a feed of their own.
+    ///
+    /// Separate from the one above because `reload` reads the projects and the workspaces and
+    /// neither of them moves when a turn starts, and because the sessions table is written several
+    /// times a turn where the workspace row is written only when its diff stat actually changes.
+    /// That difference is the whole reason this feed exists: the sidebar's running mark used to
+    /// have no invalidation of its own and was carried by the diff stat refresh reassigning
+    /// `workspaces`, so a turn that wrote nothing to the worktree, an agent reading and running
+    /// commands, never moved anything the mark was watching. See `AgentTurns`.
+    ///
+    /// It reads and it publishes, like the feed above. Read the two rules on `StoreChangeHub`
+    /// before adding anything here.
+    private func startObservingSessions() {
+        guard let store else { return }
+        sessionObservationTask?.cancel()
+        sessionObservationTask = Task { [weak self] in
+            await self?.refreshAgentTurns()
+            for await _ in store.changes(of: [.sessions]) {
+                guard let self else { return }
+                await self.refreshAgentTurns()
             }
         }
     }
@@ -829,26 +858,67 @@ final class AppModel {
     /// Writing it is a tracked mutation, so every reader (the strip, Home's summary line, the
     /// sidebar rows, the menu bar item, the Dock badge and the sleep assertion) is invalidated by
     /// the same thing, at the same moment, and none of them needs a private counter.
+    ///
+    /// **What it is built from moved.** It was written from `TranscriptModel.setRunning` alone,
+    /// which is edge triggered, so one recompute that came out wrong stood for the whole turn and
+    /// a chat with no transcript was never counted at all. It is rebuilt whole by
+    /// `recomputeAgentTurns`, from the store's own session rows and from what the live
+    /// transcripts say, on every write to the sessions table as well as on every edge.
     private(set) var runningWorkspaceIDs: Set<WorkspaceID> = []
 
-    /// Told by `TranscriptModel` whenever a turn starts or ends. See `TranscriptModel.setRunning`,
-    /// which is the one place that flag moves.
+    /// What the store last said about every chat that is mid turn or blocked.
     ///
-    /// The answer is recomputed from the workspace's model rather than taken from the caller,
-    /// because a workspace can hold several sessions and one of them finishing does not mean the
-    /// workspace has stopped working.
-    func noteRunningChanged(workspaceID: WorkspaceID) {
-        let isRunning = workspaceModels[workspaceID]?.isRunning ?? false
-        if isRunning {
-            runningWorkspaceIDs.insert(workspaceID)
-        } else {
-            runningWorkspaceIDs.remove(workspaceID)
-        }
+    /// **The half of the answer that survives a missed signal.** The mirrors used to be written
+    /// only by `TranscriptModel.setRunning`, which is edge triggered and idempotent: it writes
+    /// nothing when the flag has not moved, so a single moment where the recompute came out wrong
+    /// stood for the whole turn, and a turn in a chat this launch had never built a transcript for
+    /// was never reported at all. The sidebar drew "No changes" over an agent running three Bash
+    /// calls, for the length of the turn, and the session row said `running` the whole time.
+    ///
+    /// Outside observation, because nothing draws it: it is an input to `recomputeAgentTurns`,
+    /// which writes the two sets everything actually reads.
+    @ObservationIgnored private var storedActivity: [SessionActivity] = []
+
+    /// Re-reads that half. Called on every write to the sessions table, and once at startup, by
+    /// `startObservingSessions`.
+    func refreshAgentTurns() async {
+        guard let store, let rows = try? await store.sessionActivity() else { return }
+        storedActivity = rows
+        recomputeAgentTurns()
+    }
+
+    /// Told by `TranscriptModel` whenever a turn starts or ends, or a question arrives or is
+    /// answered. See `setRunning` and `setAwaitingPermission`, which are the one place each of
+    /// those flags moves.
+    ///
+    /// One seam for both, because both sets are recomputed whole: what changed is not worth
+    /// naming when the answer is rebuilt from every source either way, and two seams that took an
+    /// id invited the caller to believe only that workspace was being reconsidered.
+    func noteAgentTurnsChanged() {
+        recomputeAgentTurns()
+    }
+
+    /// Rebuilds both mirrors from the store's rows and from what the live transcripts say.
+    ///
+    /// The rule is `AgentTurns`, in the core and tested, and the precedence it holds is the
+    /// reason this is not a union: a live transcript decides its own session, because it hears a
+    /// turn end before the row is written, and a session with no transcript is decided by its row,
+    /// because that is the only thing that knows about a chat nobody has opened.
+    ///
+    /// Each set is written only when it has actually moved. An identical value assigned back is
+    /// still a mutation to the Observation runtime, and this runs on every session write.
+    private func recomputeAgentTurns() {
+        let live = workspaceModels.values.flatMap { $0.liveTurns }
+        let running = AgentTurns.workspaces(.running, stored: storedActivity, live: live)
+        let waiting = AgentTurns.workspaces(.awaitingPermission, stored: storedActivity, live: live)
+        if runningWorkspaceIDs != running { runningWorkspaceIDs = running }
+        if waitingWorkspaceIDs != waiting { waitingWorkspaceIDs = waiting }
     }
 
     /// Workspaces whose agent has stopped and is waiting on a person.
     ///
-    /// A real observable set written from one place, for the reason `runningWorkspaceIDs` is one:
+    /// A real observable set, rebuilt beside its sibling above and by the same call, for the
+    /// reason `runningWorkspaceIDs` is one:
     /// the obvious alternative is to walk `workspaceModels`, and that dictionary is
     /// `@ObservationIgnored`, so a reader that walked it would register a dependency on nothing.
     /// That is precisely how the sidebar strip came to say "Idle" for an hour while agents ran.
@@ -884,28 +954,15 @@ final class AppModel {
     /// single byte moves and forgets the rest only if the disk agrees, so those really are two
     /// moments and a single method would have to be called twice with a flag.
     ///
-    /// The model goes before the two marks, and the marks are removed rather than recomputed,
-    /// because `noteRunningChanged` reads the model: once it is nil there is nothing left to ask.
+    /// Its own rows go before the recompute, and that order is the whole of it. This workspace has
+    /// gone, `ON DELETE CASCADE` has taken its sessions with it, and the rows cached here were
+    /// read before any of that: leaving them in would have the recompute report a running agent in
+    /// a workspace that no longer exists until the next write to the sessions table.
     func forgetWorkspace(_ id: WorkspaceID) {
         stopHidingFromSidebar(id)
         workspaceModels[id] = nil
-        runningWorkspaceIDs.remove(id)
-        waitingWorkspaceIDs.remove(id)
-    }
-
-    /// Told by `TranscriptModel` whenever a question arrives or is answered. See
-    /// `TranscriptModel.setAwaitingPermission`, which is the one place that flag moves.
-    ///
-    /// Recomputed from the workspace's model rather than taken from the caller, for the same
-    /// reason as above: a workspace can hold several sessions, and one of them being answered does
-    /// not mean the workspace has stopped waiting.
-    func noteWaitingChanged(workspaceID: WorkspaceID) {
-        let isWaiting = workspaceModels[workspaceID]?.isAwaitingPermission ?? false
-        if isWaiting {
-            waitingWorkspaceIDs.insert(workspaceID)
-        } else {
-            waitingWorkspaceIDs.remove(workspaceID)
-        }
+        storedActivity.removeAll { $0.workspaceID == id }
+        recomputeAgentTurns()
     }
 
     /// Whether a workspace is blocked on a question, without forcing a `WorkspaceModel` into
@@ -1060,11 +1117,16 @@ final class AppModel {
     /// The workspaces those agents are working in, named so the confirmation can say where the
     /// work would be interrupted rather than only how much of it there is.
     ///
-    /// Named from the models rather than from `workspaces`, because a workspace that has just
-    /// been archived is out of that list while its agent is still being wound down.
+    /// The models first, because a workspace that has just been archived is out of `workspaces`
+    /// while its agent is still being wound down, and `workspaces` second, because the mirror is
+    /// no longer built from the models alone: a chat mid turn in a workspace nobody has opened is
+    /// reported by its session row, and there is no model to take a name from. Counted and named
+    /// have to agree, or the confirmation says "2 agents are working" over one line.
     var runningAgentWorkspaceNames: [String] {
         runningWorkspaceIDs
-            .compactMap { workspaceModels[$0]?.workspace.name }
+            .compactMap { id in
+                workspaceModels[id]?.workspace.name ?? workspaces.first { $0.id == id }?.name
+            }
             .sorted()
     }
 

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -646,7 +646,7 @@ final class TranscriptModel {
 
         guard storedIsRunning != value else { return }
         storedIsRunning = value
-        app.noteRunningChanged(workspaceID: workspace.id)
+        app.noteAgentTurnsChanged()
     }
 
     /// The one place `isAwaitingPermission` moves, for the same reasons `setRunning` is the one
@@ -656,7 +656,7 @@ final class TranscriptModel {
     private func setAwaitingPermission(_ value: Bool) {
         guard storedIsAwaitingPermission != value else { return }
         storedIsAwaitingPermission = value
-        app.noteWaitingChanged(workspaceID: workspace.id)
+        app.noteAgentTurnsChanged()
     }
 
     /// Recompute from the questions actually outstanding. Called wherever one is added or settled,

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -436,10 +436,11 @@ final class WorkspaceModel {
     /// Whether this session's agent is in the middle of a turn.
     ///
     /// The live transcript is the truth wherever one exists, and only existing ones are consulted:
-    /// asking for a transcript would build a model for every session the strip drew.
+    /// asking for a transcript would build a model for every session the strip drew. That
+    /// precedence is `AgentTurns`'s now rather than this method's, so the strip, the workspace
+    /// and the sidebar's mirror cannot come to three different conclusions about one chat.
     func isRunning(_ session: Session) -> Bool {
-        if let transcript = transcripts[session.id] { return transcript.isRunning }
-        return session.state == .running
+        AgentTurns.session(.running, state: session.state, live: liveTurn(for: session.id))
     }
 
     func closeSession(_ session: Session) async {
@@ -500,8 +501,33 @@ final class WorkspaceModel {
         transcript(for: session)
     }
 
+    /// Whether any chat here has an agent mid turn.
+    ///
+    /// The rule is `AgentTurns`, which is the same rule `isRunning(_ session:)` above answers
+    /// one session with and the same rule the sidebar's mirror is rebuilt from. It used to be a
+    /// walk of `transcripts` alone, and that is exactly one of the three different answers this
+    /// app had to the one question: a turn in a chat this launch had never built a transcript for
+    /// was not running as far as this property was concerned, however plainly the session row said
+    /// otherwise.
     var isRunning: Bool {
-        transcripts.values.contains { $0.isRunning }
+        AgentTurns.workspace(.running, sessions: sessions, live: liveTurns)
+    }
+
+    /// What this workspace's live transcripts say about their own sessions, for the rule above and
+    /// for `AppModel`'s mirrors. Only the transcripts that exist: asking for one would build a
+    /// model for every session in the strip.
+    var liveTurns: [AgentTurns.Live] {
+        transcripts.keys.compactMap(liveTurn(for:))
+    }
+
+    private func liveTurn(for sessionID: SessionID) -> AgentTurns.Live? {
+        guard let transcript = transcripts[sessionID] else { return nil }
+        return AgentTurns.Live(
+            sessionID: sessionID,
+            workspaceID: workspace.id,
+            isRunning: transcript.isRunning,
+            isAwaitingPermission: transcript.isAwaitingPermission
+        )
     }
 
     /// The ACTIVE chat's subagents, whole.
@@ -528,7 +554,7 @@ final class WorkspaceModel {
 
     /// Whether any session here has an agent stopped and waiting on a person.
     var isAwaitingPermission: Bool {
-        transcripts.values.contains { $0.isAwaitingPermission }
+        AgentTurns.workspace(.awaitingPermission, sessions: sessions, live: liveTurns)
     }
 
     /// Both callers mean the same thing: this workspace, or the whole app, is going away. So the

--- a/Sources/BloomCore/Agent/AgentTurns.swift
+++ b/Sources/BloomCore/Agent/AgentTurns.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+/// One session row, reduced to the three columns that say whether an agent is working in it.
+///
+/// Read out of the store rather than built from a whole `Session`, because the question is asked
+/// about every chat in the database at once and a `Session` carries a title, two token counts, a
+/// cost and a context window that none of it needs.
+public struct SessionActivity: Sendable, Hashable {
+    public var sessionID: SessionID
+    public var workspaceID: WorkspaceID
+    public var state: SessionState
+
+    public init(sessionID: SessionID, workspaceID: WorkspaceID, state: SessionState) {
+        self.sessionID = sessionID
+        self.workspaceID = workspaceID
+        self.state = state
+    }
+}
+
+/// Whether an agent is working in a workspace, and whether one is blocked on a question.
+///
+/// # The bug this was written for
+///
+/// A workspace's sidebar row drew `circle.dotted`, the mark for a worktree with nothing in it,
+/// while the centre column beside it streamed a turn: "Session started", a rate limit line and
+/// three Bash calls, an agent plainly mid turn. The session row in the store said `running`
+/// throughout. `WorkspaceStatus.resolve` was handed `isRunning: false` and correctly fell all the
+/// way through to `.clean`, so the mark was right about the state it was given and the state was
+/// wrong.
+///
+/// It was wrong because the app had **three** answers to "is an agent running here" and the
+/// sidebar read the only one with nothing durable behind it:
+///
+/// - `WorkspaceModel.isRunning` walked the `TranscriptModel`s this launch happens to have built,
+///   and `AppModel.runningWorkspaceIDs` mirrored that. It moved only when a turn started or
+///   ended, from one call site, and nothing anywhere recomputed it. **A single missed edge was
+///   therefore permanent for the rest of the turn**, and a turn in a chat no transcript had been
+///   built for was invisible from the start.
+/// - `WorkspaceModel.isRunning(_ session:)`, which the tab strip reads, already knew better: the
+///   live transcript wherever one exists, the stored row otherwise.
+/// - `WorkspaceLookup.isAgentRunning`, which Shortcuts read, took the stored row alone, and its
+///   own comment says why that is the durable trace: the runner writes `Session.state` on every
+///   move through `SessionLifecycle`, whether or not a window is watching.
+///
+/// So this is the middle answer, in one place, for all three to share. It is level triggered:
+/// handed the store's rows and whatever the live transcripts say, it recomputes the whole answer,
+/// so a missed edge heals on the next session write instead of lasting the turn.
+///
+/// # The precedence, and why it runs that way round
+///
+/// **A live transcript decides its own session, and a session with no transcript is decided by its
+/// row.** The transcript is this process watching the agent's own output, so it hears a turn end
+/// before the row is written; the row is the only thing that knows about a chat the window has
+/// never opened. Neither can stand in for the other, and a plain union would keep a mark lit after
+/// a turn ended, because the row lags the transcript by exactly the write that ends the turn.
+public enum AgentTurns {
+    /// What is being asked about. Both questions have the same shape and the same precedence, and
+    /// writing them twice is how the pair drifts: `awaitingPermission` was added to the sidebar
+    /// months after `running` and had to have every rule restated for it.
+    public enum Kind: String, Sendable, Hashable, CaseIterable {
+        /// An agent has been handed something and has not finished with it.
+        case running
+        /// An agent has stopped and cannot go on until somebody answers.
+        case awaitingPermission
+
+        /// The stored state that means this, so the SQL that reads the rows is built from the same
+        /// table the rule below is. See `Store.sessionActivity`.
+        public var sessionState: SessionState {
+            switch self {
+            case .running: .running
+            case .awaitingPermission: .waiting
+            }
+        }
+    }
+
+    /// What one live transcript says about its own session.
+    ///
+    /// It carries the workspace as well as the session, because a live turn in a chat whose row
+    /// has not caught up yet is exactly the case this type exists for: there is no stored row to
+    /// take the workspace from.
+    public struct Live: Sendable, Hashable {
+        public var sessionID: SessionID
+        public var workspaceID: WorkspaceID
+        public var isRunning: Bool
+        public var isAwaitingPermission: Bool
+
+        public init(
+            sessionID: SessionID,
+            workspaceID: WorkspaceID,
+            isRunning: Bool,
+            isAwaitingPermission: Bool
+        ) {
+            self.sessionID = sessionID
+            self.workspaceID = workspaceID
+            self.isRunning = isRunning
+            self.isAwaitingPermission = isAwaitingPermission
+        }
+
+        /// This transcript's answer to one of the two questions.
+        public func says(_ turn: Kind) -> Bool {
+            switch turn {
+            case .running: isRunning
+            case .awaitingPermission: isAwaitingPermission
+            }
+        }
+    }
+
+    /// One session's answer: the live transcript where the window has built one, its row otherwise.
+    public static func session(_ turn: Kind, state: SessionState, live: Live?) -> Bool {
+        if let live { return live.says(turn) }
+        return state == turn.sessionState
+    }
+
+    /// One workspace's answer, from the rows and the transcripts that workspace holds.
+    ///
+    /// Any session counts. A workspace with four chats runs four turns, and one of them finishing
+    /// does not mean the workspace has stopped working.
+    public static func workspace(_ turn: Kind, sessions: [Session], live: [Live]) -> Bool {
+        let byID = index(live)
+        return sessions.contains { session(turn, state: $0.state, live: byID[$0.id]) }
+    }
+
+    /// Every workspace with at least one session that counts.
+    ///
+    /// - Parameters:
+    ///   - stored: the session rows the store says are mid turn or blocked. Rows in any other
+    ///     state may be left out: a session absent from this list and absent from `live` counts
+    ///     for nothing, which is the same answer including it would give.
+    ///   - live: what every transcript this launch has built says about its own session.
+    public static func workspaces(
+        _ turn: Kind,
+        stored: [SessionActivity],
+        live: [Live]
+    ) -> Set<WorkspaceID> {
+        let byID = index(live)
+        var found: Set<WorkspaceID> = []
+
+        for row in stored where byID[row.sessionID] == nil {
+            if row.state == turn.sessionState { found.insert(row.workspaceID) }
+        }
+        // Second, and unconditionally, so a turn that started before its row was written is
+        // reported from the frame it started on rather than from the frame the runner got round
+        // to saying so.
+        for entry in live where entry.says(turn) {
+            found.insert(entry.workspaceID)
+        }
+
+        return found
+    }
+
+    /// Keyed by session, last one wins, which cannot happen: a session has at most one transcript.
+    private static func index(_ live: [Live]) -> [SessionID: Live] {
+        Dictionary(live.map { ($0.sessionID, $0) }, uniquingKeysWith: { _, latest in latest })
+    }
+}

--- a/Sources/BloomCore/Persistence/Store.swift
+++ b/Sources/BloomCore/Persistence/Store.swift
@@ -1370,6 +1370,42 @@ public actor Store {
         try db.query("SELECT * FROM sessions WHERE id = ?", [.text(id)]).first.map(Self.session(from:))
     }
 
+    /// Every chat the store says is mid turn or blocked, across every active workspace.
+    ///
+    /// The durable half of "is an agent working here". The runner writes `state` on every move it
+    /// makes, whether or not a window is watching, so this answers for a chat nobody has opened
+    /// this launch and it answers again after a missed signal. See `AgentTurns`, which is what
+    /// weighs it against what the live transcripts say, and the sidebar row that spent a whole
+    /// turn drawing "No changes" over a running agent because nothing asked this question.
+    ///
+    /// Three columns rather than whole rows: this runs on every write to the sessions table, and
+    /// a title, two token counts and a cost are not part of the answer.
+    ///
+    /// The states come from `AgentTurns.Kind` rather than being spelled out here, the way
+    /// `resetRunningSessions` builds its clause out of `SessionLifecycle`, so the rows this hands
+    /// back and the rule that reads them cannot come to different conclusions about which states
+    /// count. Archived chats and archived workspaces are left out: neither can have an agent in it,
+    /// and a sidebar that has no row to draw has nothing to say about one.
+    public func sessionActivity() throws -> [SessionActivity] {
+        let states = AgentTurns.Kind.allCases.map(\.sessionState)
+        let placeholders = states.map { _ in "?" }.joined(separator: ", ")
+        return try db.query(
+            """
+            SELECT s.id AS id, s.workspace_id AS workspace_id, s.state AS state
+            FROM sessions s
+            JOIN workspaces w ON w.id = s.workspace_id
+            WHERE s.archived_at IS NULL AND w.state = ? AND s.state IN (\(placeholders))
+            """,
+            [.text(WorkspaceState.active.rawValue)] + states.map { SQLValue.text($0.rawValue) }
+        ).map { row in
+            SessionActivity(
+                sessionID: SessionID(row.string("id") ?? newID()),
+                workspaceID: WorkspaceID(row.string("workspace_id") ?? ""),
+                state: SessionState(rawValue: row.string("state") ?? "idle") ?? .idle
+            )
+        }
+    }
+
     /// Writes a whole session row. This is how a session is created, and it is worth reaching for
     /// only when the value being written was built here and now.
     ///

--- a/Tests/BloomCoreTests/AgentTurnsTests.swift
+++ b/Tests/BloomCoreTests/AgentTurnsTests.swift
@@ -1,0 +1,254 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// Whether an agent is working in a workspace, which the sidebar's mark is the whole of.
+///
+/// Written from a screenshot. Three workspaces under one project: a green tick, a running dot, and
+/// a workspace drawing `circle.dotted`, the mark for a worktree with nothing in it, while the
+/// centre column beside it streamed a turn. The session row said `running` for the whole of it,
+/// and the mark was fed `isRunning: false`, so `WorkspaceStatus.resolve` fell through every test
+/// and landed on `.clean`. The mark was right about what it was told; what it was told was wrong.
+///
+/// So these are about the two sources disagreeing, which is the only interesting thing here: a
+/// live transcript that this launch has built, and the row the runner writes whether or not
+/// anybody is watching.
+@Suite("Agent turns")
+struct AgentTurnsTests {
+    private let workspace = WorkspaceID("w1")
+    private let other = WorkspaceID("w2")
+
+    private func stored(
+        _ session: String,
+        _ state: SessionState,
+        in workspaceID: WorkspaceID? = nil
+    ) -> SessionActivity {
+        SessionActivity(
+            sessionID: SessionID(session),
+            workspaceID: workspaceID ?? workspace,
+            state: state
+        )
+    }
+
+    private func live(
+        _ session: String,
+        running: Bool = false,
+        waiting: Bool = false,
+        in workspaceID: WorkspaceID? = nil
+    ) -> AgentTurns.Live {
+        AgentTurns.Live(
+            sessionID: SessionID(session),
+            workspaceID: workspaceID ?? workspace,
+            isRunning: running,
+            isAwaitingPermission: waiting
+        )
+    }
+
+    // MARK: - The bug
+
+    /// The screenshot, reduced. Nothing has built a transcript for this chat, so the old walk of
+    /// the live transcripts answered no while the row said the agent was mid turn.
+    @Test("a running chat with no live transcript still reports its workspace")
+    func storedRowAloneCounts() {
+        let running = AgentTurns.workspaces(
+            .running, stored: [stored("s1", .running)], live: []
+        )
+        #expect(running == [workspace])
+    }
+
+    /// The other half of the same bug: the turn has started and the runner has not written the row
+    /// yet. The mark has to be on from the frame the turn started, not from the frame the store
+    /// heard about it.
+    @Test("a live turn counts before its row has been written")
+    func liveTurnAloneCounts() {
+        let running = AgentTurns.workspaces(
+            .running, stored: [], live: [live("s1", running: true)]
+        )
+        #expect(running == [workspace])
+    }
+
+    // MARK: - Precedence
+
+    /// The reason this is not a union. The row lags the transcript by exactly the write that ends
+    /// the turn, so a workspace whose agent has just finished would keep its mark until the runner
+    /// got round to saying so.
+    @Test("a live transcript overrules its own stale row")
+    func liveOverrulesStaleRow() {
+        let running = AgentTurns.workspaces(
+            .running, stored: [stored("s1", .running)], live: [live("s1", running: false)]
+        )
+        #expect(running.isEmpty)
+    }
+
+    /// And the other direction, which is the one that matters for the mark going ON: the row says
+    /// idle because nothing has been written yet, and the transcript knows better.
+    @Test("a live transcript overrules an idle row")
+    func liveOverrulesIdleRow() {
+        let running = AgentTurns.workspaces(
+            .running, stored: [stored("s1", .idle)], live: [live("s1", running: true)]
+        )
+        #expect(running == [workspace])
+    }
+
+    /// One session having a transcript says nothing about the others. This is the workspace with
+    /// four chats: the one on screen has finished and one nobody has opened is still going.
+    @Test("a live answer settles its own session and no other")
+    func liveAnswerDoesNotSettleSiblings() {
+        let running = AgentTurns.workspaces(
+            .running,
+            stored: [stored("s1", .running), stored("s2", .running)],
+            live: [live("s1", running: false)]
+        )
+        #expect(running == [workspace])
+    }
+
+    @Test("a workspace with nothing going on is not reported")
+    func quietWorkspace() {
+        let running = AgentTurns.workspaces(
+            .running,
+            stored: [stored("s1", .idle), stored("s2", .waiting)],
+            live: [live("s3", running: false)]
+        )
+        #expect(running.isEmpty)
+    }
+
+    // MARK: - The two questions
+
+    /// A blocked agent is not a working one, and the sidebar draws them differently on purpose:
+    /// `awaitingPermission` outranks `running` precisely because it is the state where time is
+    /// wasted. The two sets must not bleed into each other.
+    @Test("waiting and running are separate answers")
+    func waitingIsNotRunning() {
+        let stored = [stored("s1", .waiting)]
+        #expect(AgentTurns.workspaces(.running, stored: stored, live: []).isEmpty)
+        #expect(AgentTurns.workspaces(.awaitingPermission, stored: stored, live: []) == [workspace])
+    }
+
+    @Test("a live transcript answers both questions for its session")
+    func liveAnswersBoth() {
+        let live = [live("s1", running: false, waiting: true)]
+        #expect(AgentTurns.workspaces(.running, stored: [stored("s1", .running)], live: live).isEmpty)
+        #expect(
+            AgentTurns.workspaces(.awaitingPermission, stored: [stored("s1", .running)], live: live)
+                == [workspace]
+        )
+    }
+
+    // MARK: - Several workspaces
+
+    @Test("each workspace is answered from its own sessions")
+    func workspacesAreSeparate() {
+        let running = AgentTurns.workspaces(
+            .running,
+            stored: [stored("s1", .running), stored("s2", .idle, in: other)],
+            live: [live("s2", running: false, in: other)]
+        )
+        #expect(running == [workspace])
+    }
+
+    @Test("two workspaces working at once are both reported")
+    func bothReported() {
+        let running = AgentTurns.workspaces(
+            .running,
+            stored: [stored("s1", .running)],
+            live: [live("s2", running: true, in: other)]
+        )
+        #expect(running == [workspace, other])
+    }
+
+    // MARK: - One workspace, from what its own model holds
+
+    /// The same rule asked the way `WorkspaceModel` asks it, over the session rows and transcripts
+    /// one workspace holds. Any chat counts: a workspace with four of them runs four turns, and
+    /// one finishing does not mean the workspace has stopped working.
+    @Test("a workspace is working while any of its chats is")
+    func workspaceCountsAnySession() {
+        let sessions = [
+            Session(id: SessionID("s1"), workspaceID: workspace),
+            Session(id: SessionID("s2"), workspaceID: workspace),
+        ]
+        var running = sessions[1]
+        running.apply(.turnStarted)
+
+        #expect(!AgentTurns.workspace(.running, sessions: sessions, live: []))
+        #expect(AgentTurns.workspace(.running, sessions: [sessions[0], running], live: []))
+        #expect(
+            AgentTurns.workspace(.running, sessions: sessions, live: [live("s1", running: true)])
+        )
+    }
+
+    /// A workspace whose rows have not been read yet answers no rather than crashing into a
+    /// default of yes. The empty case is the one every reader hits at launch.
+    @Test("a workspace with no sessions read yet is not working")
+    func workspaceWithNothingRead() {
+        #expect(!AgentTurns.workspace(.running, sessions: [], live: []))
+        #expect(!AgentTurns.workspace(.awaitingPermission, sessions: [], live: []))
+    }
+
+    // MARK: - The states the two questions read
+
+    /// The SQL that reads the rows is built out of this table, so a third turn kind added here
+    /// would be read out of the store without anybody remembering to widen a `WHERE` clause. See
+    /// `Store.sessionActivity`.
+    @Test("every turn kind names the stored state it means")
+    func turnStates() {
+        #expect(AgentTurns.Kind.running.sessionState == .running)
+        #expect(AgentTurns.Kind.awaitingPermission.sessionState == .waiting)
+        #expect(AgentTurns.Kind.allCases.count == 2)
+    }
+}
+
+/// The durable half, read back out of a real database.
+@Suite("Session activity rows", .tags(.persistence), .scratchDirectory)
+struct SessionActivityRowTests {
+    private func seed(_ store: Store, name: String) async throws -> Workspace {
+        let repo = try await store.upsert(Repo(name: name, path: TestScratch.unique("repo-" + name)))
+        return try await store.upsert(Workspace(
+            repoID: repo.id, name: name, branch: "feature/" + name,
+            path: TestScratch.unique("worktree-" + name), baseBranch: "main"
+        ))
+    }
+
+    @Test("only chats that are mid turn or blocked come back")
+    func onlyBusyChats() async throws {
+        let store = try makeTestStore("activity")
+        let workspace = try await seed(store, name: "alpha")
+
+        var running = Session(workspaceID: workspace.id)
+        running.apply(.turnStarted)
+        var waiting = Session(workspaceID: workspace.id)
+        waiting.apply(.turnStarted)
+        waiting.apply(.blocked)
+        let idle = Session(workspaceID: workspace.id)
+
+        for session in [running, waiting, idle] { _ = try await store.upsert(session) }
+
+        let rows = try await store.sessionActivity()
+        #expect(Set(rows.map(\.sessionID)) == [running.id, waiting.id])
+        #expect(rows.allSatisfy { $0.workspaceID == workspace.id })
+        #expect(rows.first { $0.sessionID == waiting.id }?.state == .waiting)
+    }
+
+    /// A closed chat has no agent in it, and neither has an archived workspace. Reporting either
+    /// would put a running mark on a row the sidebar does not draw, and a name in the confirmation
+    /// shown on quit.
+    @Test("a closed chat and an archived workspace are left out")
+    func closedAndArchivedAreLeftOut() async throws {
+        let store = try makeTestStore("activity-archived")
+
+        let live = try await seed(store, name: "live")
+        var closed = Session(workspaceID: live.id)
+        closed.apply(.turnStarted)
+        closed = try await store.upsert(closed)
+        _ = try await store.update(sessionID: closed.id) { $0.archivedAt = Date() }
+
+        var gone = try await seed(store, name: "gone")
+        var stillRunning = Session(workspaceID: gone.id)
+        stillRunning.apply(.turnStarted)
+        _ = try await store.upsert(stillRunning)
+        gone.archive()
+        _ = try await store.upsert(gone)
+
+        #expect(try await store.sessionActivity().isEmpty)
+    }
+}


### PR DESCRIPTION
The hollow dashed ring in the report is `circle.dotted`, which is `WorkspaceStatus.clean`, "No changes". Not a spinner, not selection: read out of the database afterwards, that workspace had `setup_state = succeeded`, `additions = 0`, `deletions = 0`, `unread = 0` and no pull request, so `resolve` fell through every test to the fallback. Its session row said `running` at the time. "Review PR #52", the second ring in the same screenshot, was genuinely clean and idle, so its mark was correct and selection had nothing to do with either.

So the state was wrong, not the drawing. The app had three answers to "is an agent running here" and the sidebar read the only one with nothing durable behind it:

- `WorkspaceModel.isRunning` walked the transcripts this launch happened to have built, mirrored into `AppModel.runningWorkspaceIDs` from one call site that writes nothing when the flag has not moved. Edge triggered with no recovery: one bad recompute stood for the rest of the turn, and a turn in a chat with no transcript was never reported.
- `WorkspaceModel.isRunning(_ session:)`, which the tab strip reads, already fell back to the stored row.
- `WorkspaceLookup.isAgentRunning`, which Shortcuts read, took the stored row alone.

`AgentTurns` in BloomCore is that answer in one place: a live transcript decides its own session, a session with no transcript is decided by its row. Not a union, or a mark would stay lit after a turn ended. `Store.sessionActivity` is the durable half, and `AppModel` re-reads it on every write to the sessions table and rebuilds both mirrors whole, which is what heals a missed edge.

The feed matters because the diff stat refresh stopped reassigning `workspaces` when nothing moved, and that reassignment was what used to redraw these rows for free. An agent that only reads and runs commands writes nothing to the worktree, which is exactly the workspace in the screenshot.

`RunningGlyphGallery` draws the dot beside `.clean`, selected and not, photographed offscreen.
