### PR TITLE
Stop asking git about every workspace every six seconds

### DIFF
--- a/Sources/Bloom/BloomApp.swift
+++ b/Sources/Bloom/BloomApp.swift
@@ -48,6 +48,12 @@ struct BloomApp: App {
         // See `ScrollProbe`.
         if ScrollProbe.isRequested { ScrollProbe.schedule() }
 
+        // And the one that answers "the battery menu says Bloom is using significant energy":
+        // `Bloom --idle-probe <out.json> --idle-worktrees <list>` runs the diff stat pass the six
+        // second loop runs and reports what it cost in process time and in subprocesses. It is the
+        // only one of the family that measures the case where nothing is happening. See `IdleProbe`.
+        if IdleProbe.isRequested { IdleProbe.schedule() }
+
         // And two last ones. `Bloom --menu-probe <out.png>` opens one of the centre pane's split
         // submenus and photographs it, which nothing else can; `Bloom --menu-action <title>`
         // performs a real item of a real menu and reports the windows either side of it, which is

--- a/Sources/Bloom/Design/IdleProbe.swift
+++ b/Sources/Bloom/Design/IdleProbe.swift
@@ -1,0 +1,209 @@
+import AppKit
+import Foundation
+import QuartzCore
+import BloomCore
+
+/// Measures what Bloom costs while nothing is happening.
+///
+/// The fifth of the family, after `FrameProbe`, `SwitchProbe`, `TabProbe` and `ScrollProbe`. All
+/// four of those measure a moment somebody caused: a drag, a switch, a tab, a flick. **None of
+/// them measures the idle case**, and idle is the one the battery menu complains about. An app
+/// listed under "Using Significant Energy" is usually one doing work when nothing is happening,
+/// and until this existed the only evidence available was the battery menu itself, which is a
+/// verdict rather than a number.
+///
+/// # What it measures, and why it is not the timer
+///
+/// It drives the same pass the six second diff stat loop drives, `Git.diffStat` over a list of
+/// worktrees, and reports the process time, the wall time and the subprocess count of each pass.
+///
+/// It drives that pass itself rather than waiting for the loop to fire it, and the reason is the
+/// owner. The loop stands down whenever the window is not frontmost (`NSApp.isActive`), so a probe
+/// that waited for it would have to bring Bloom to the front, and taking the front from somebody
+/// working at this Mac is not a step in a measurement. See "Do not take over the machine" in
+/// `CLAUDE.md`. What is left is the work itself, which is what the loop would have done and what
+/// the fix has to make cheaper.
+///
+/// # Why the subprocess count is taken from inside
+///
+/// Because it cannot be taken from outside. Polling `ps` at 20Hz for a minute against the running
+/// app saw nine children, which reads as an app at rest; a `git rev-parse` lives for about ten
+/// milliseconds, so a sampler at that rate misses most of them. `Shell.spawnCount` is incremented
+/// where the process is actually started and cannot miss one.
+///
+/// The children's CPU is reported separately from this process's own, because that is the whole
+/// story here: Bloom's own thread barely moves while it burns a second of `git` every six.
+/// `RUSAGE_CHILDREN` is only counted for children that have been reaped, which every `Shell.run`
+/// waits for, so the number is complete by the time a pass has finished.
+///
+/// # What it answered
+///
+/// Seventeen of this machine's real worktrees, seven passes, median. The loop used to hand a pass
+/// every workspace in the sidebar and now hands it the two or three `DiffRefreshSchedule` says are
+/// due:
+///
+///     seventeen worktrees   104 processes   2,864ms of process time
+///     three worktrees        12 processes     651ms
+///
+/// A pass every six seconds is 48% of a core against 11%. The `git rev-parse` cache under
+/// `BaselineCache` shows up in the same probe as 6.12 processes per worktree against 4.00, with
+/// the process time unmoved, which is how it was found not to be the fix.
+///
+///     Bloom --idle-probe /tmp/idle.json --idle-worktrees /tmp/trees.txt
+///           [--idle-base main] [--idle-passes 5]
+///
+/// `--idle-worktrees` is a file with one worktree path per line, which is how a run needs no
+/// database and cannot touch the owner's. `ls -d ~/bloom/workspaces/*/*/ > /tmp/trees.txt` is the
+/// list this was written against.
+@MainActor
+enum IdleProbe {
+    static var isRequested: Bool {
+        CommandLine.arguments.contains("--idle-probe")
+    }
+
+    // MARK: - Arguments
+
+    private static func value(for flag: String) -> String? {
+        let arguments = CommandLine.arguments
+        guard let index = arguments.firstIndex(of: flag), index + 1 < arguments.count else {
+            return nil
+        }
+        return arguments[index + 1]
+    }
+
+    private static var outputPath: String {
+        value(for: "--idle-probe") ?? (NSTemporaryDirectory() + "bloom-idle-probe.json")
+    }
+
+    private static var base: String { value(for: "--idle-base") ?? "main" }
+    private static var passes: Int { Int(value(for: "--idle-passes") ?? "") ?? 5 }
+
+    private static var worktrees: [String] {
+        guard let path = value(for: "--idle-worktrees"),
+              let text = try? String(contentsOfFile: path, encoding: .utf8)
+        else { return [] }
+        return text
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .filter { FileManager.default.fileExists(atPath: $0 + "/.git") }
+    }
+
+    // MARK: - Entry
+
+    static func schedule() {
+        Task { @MainActor in await run() }
+    }
+
+    private static func run() async {
+        // Not brought to the front, for the reason at the head of `FrameProbe`.
+        try? await Task.sleep(for: .seconds(3))
+
+        let trees = worktrees
+        guard !trees.isEmpty else { return fail("no worktrees to probe") }
+
+        // A warm pass that is thrown away. The first one pays for `Shell.which` walking PATH, for
+        // git's own caches and for every baseline being worked out for the first time, and
+        // reporting that as the steady state would overstate the cost of a loop that has been
+        // running all day.
+        _ = await pass(trees)
+
+        var reports: [[String: Any]] = []
+        for _ in 0..<passes {
+            reports.append(await pass(trees))
+        }
+
+        write([
+            "worktrees": trees.count,
+            "base": base,
+            "passes": reports,
+            "median": [
+                "wallMs": median(reports.map { $0["wallMs"] as? Double ?? 0 }),
+                "cpuMs": median(reports.map { $0["cpuMs"] as? Double ?? 0 }),
+                "spawns": median(reports.map { Double($0["spawns"] as? Int ?? 0) }),
+                "spawnsPerWorktree": median(
+                    reports.map { Double($0["spawns"] as? Int ?? 0) / Double(trees.count) }
+                ),
+            ],
+        ])
+        exit(0)
+    }
+
+    /// One sweep of `Git.diffStat` over every worktree, exactly as `AppModel.refreshDiffStats`
+    /// runs it: one at a time, because that is what the loop does and a concurrent sweep would
+    /// measure how many cores this Mac has rather than what the loop costs.
+    private static func pass(_ trees: [String]) async -> [String: Any] {
+        let spawnsBefore = Shell.spawnCount
+        let cpuBefore = ProcessCPU.read()
+        let wallBefore = CACurrentMediaTime()
+
+        for tree in trees {
+            _ = try? await Git.diffStat(worktree: tree, base: base)
+        }
+
+        let wall = (CACurrentMediaTime() - wallBefore) * 1000
+        let cpu = ProcessCPU.read() - cpuBefore
+        return [
+            "wallMs": wall,
+            "cpuMs": cpu.total * 1000,
+            "selfCpuMs": cpu.own * 1000,
+            "childCpuMs": cpu.children * 1000,
+            "spawns": Shell.spawnCount - spawnsBefore,
+        ]
+    }
+
+    private static func median(_ values: [Double]) -> Double {
+        guard !values.isEmpty else { return 0 }
+        let sorted = values.sorted()
+        return sorted[sorted.count / 2]
+    }
+
+    // MARK: - Reporting
+
+    private static func fail(_ reason: String) {
+        write(["error": reason])
+        exit(1)
+    }
+
+    private static func write(_ report: [String: Any]) {
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: report, options: [.prettyPrinted, .sortedKeys]
+        ) else { return }
+        try? data.write(to: URL(fileURLWithPath: outputPath))
+        FileHandle.standardError.write(data)
+        FileHandle.standardError.write(Data("\n".utf8))
+    }
+}
+
+/// The process time this app and the children it has reaped have used, in seconds.
+///
+/// `getrusage` rather than `task_info`, because the children are half the answer and only
+/// `RUSAGE_CHILDREN` has them. A pass that spawns four hundred `git` processes moves this app's
+/// own line hardly at all and the children's line by most of a second, and reporting only the
+/// first is how an app that is burning a battery looks innocent in a profile.
+enum ProcessCPU {
+    struct Sample {
+        var own: Double
+        var children: Double
+
+        var total: Double { own + children }
+
+        static func - (lhs: Sample, rhs: Sample) -> Sample {
+            Sample(own: lhs.own - rhs.own, children: lhs.children - rhs.children)
+        }
+    }
+
+    static func read() -> Sample {
+        Sample(own: seconds(of: RUSAGE_SELF), children: seconds(of: RUSAGE_CHILDREN))
+    }
+
+    private static func seconds(of who: Int32) -> Double {
+        var usage = rusage()
+        guard getrusage(who, &usage) == 0 else { return 0 }
+        return interval(usage.ru_utime) + interval(usage.ru_stime)
+    }
+
+    private static func interval(_ value: timeval) -> Double {
+        Double(value.tv_sec) + Double(value.tv_usec) / 1_000_000
+    }
+}

--- a/Sources/Bloom/State/AppModel.swift
+++ b/Sources/Bloom/State/AppModel.swift
@@ -252,6 +252,10 @@ final class AppModel {
     }
 
     private var refreshTask: Task<Void, Never>?
+    /// When each workspace's diff stat was last asked about, for this launch only. Read by
+    /// `DiffRefreshSchedule` to decide which of them this tick is for. Outside observation because
+    /// nothing draws from it and it is written every six seconds.
+    @ObservationIgnored private var lastDiffRefresh: [WorkspaceID: Date] = [:]
     private var storeObservationTask: Task<Void, Never>?
     private var quotaObservationTask: Task<Void, Never>?
     private var quotaPollTask: Task<Void, Never>?
@@ -660,7 +664,25 @@ final class AppModel {
 
     func refreshDiffStats() async {
         guard let manager else { return }
-        for workspace in workspaces {
+
+        // Not every workspace on every tick. `DiffRefreshSchedule` carries the measurement: one
+        // pass over one worktree is seven git processes, and running twenty of them every six
+        // seconds on an idle machine is what put Bloom under "Using Significant Energy".
+        var busy = runningWorkspaceIDs
+        if let selected = selection.workspaceID { busy.insert(selected) }
+        let due = Set(DiffRefreshSchedule.due(
+            workspaces: workspaces.map(\.id),
+            busy: busy,
+            lastRefreshed: lastDiffRefresh,
+            now: Date()
+        ))
+
+        // Keyed on what is here now, so a workspace archived while the app was running stops being
+        // remembered rather than pinning a path that no longer exists.
+        let present = Set(workspaces.map(\.id))
+        lastDiffRefresh = lastDiffRefresh.filter { present.contains($0.key) }
+
+        for workspace in workspaces where due.contains(workspace.id) {
             guard !Task.isCancelled else { return }
             // A worktree that has been removed outside Bloom would make git walk up to the parent
             // repository and answer about the wrong tree.
@@ -668,6 +690,9 @@ final class AppModel {
             await Self.withTimeLimit(.seconds(5)) {
                 await manager.refreshDiffStat(workspace: workspace)
             }
+            // After the pass rather than before it, so a workspace whose git call took four
+            // seconds is not immediately due again on the next tick.
+            lastDiffRefresh[workspace.id] = Date()
         }
         // Nothing is read back here. `Store.updateDiffStat` only writes when one of the three
         // numbers has actually moved, and a write that happens publishes itself, so the sidebar is

--- a/Sources/BloomCore/Git/BaselineCache.swift
+++ b/Sources/BloomCore/Git/BaselineCache.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+/// What `Git.baseline` remembers, so that asking the same question twice costs one process
+/// instead of four.
+///
+/// # The measurement, including the half of it that did not work
+///
+/// The sidebar's diff stat refreshes every six seconds, and each refresh walks
+/// `Git.changedFiles`, which opens with `baseline`. `baseline` is deliberately careful: it
+/// resolves the local base, the remote-tracking base and, when they differ, asks which of the two
+/// divergence points is further along. That is three or four `git` processes before the first
+/// `diff` has run, and `changedFiles` then runs three more.
+///
+/// `IdleProbe` over seventeen of this machine's real worktrees, seven passes, median:
+///
+///     processes per worktree   6.12  ->  4.00
+///     process time per pass    2864ms -> 2949ms
+///
+/// **So this cut a third of the processes and moved the CPU not at all.** The two calls it
+/// removes are `merge-base` and a `rev-parse`, both of which only read the commit graph; the time
+/// is in the three `diff` and `ls-files` calls that walk the worktree, and those still run. It is
+/// kept because it is a strictly cheaper way to ask exactly the same question and every one of
+/// those processes is also two reader threads and a merged environment, and because it costs
+/// nothing to keep. It is not what fixed the battery menu. `DiffRefreshSchedule` is.
+///
+/// # Why a fingerprint rather than a time to live
+///
+/// A merge base is a pure function of the commit graph, and the only parts of that graph the
+/// answer can depend on are the three refs `baseline` reads. So the cache is not keyed on age, it
+/// is keyed on those refs: if `HEAD`, the base and the remote-tracking base all still point at the
+/// same commits, the divergence point is the same commit too, and no amount of elapsed time can
+/// make that false. A stale answer is impossible rather than unlikely.
+///
+/// One `git rev-parse --revs-only HEAD <base> refs/remotes/origin/<base>` is the whole check.
+/// `--revs-only` prints a line per argument it could resolve and silently drops the rest, exiting
+/// zero either way, so a ref that appears or vanishes changes the number of lines and therefore
+/// the fingerprint. The joined lines are the key; which line was which never has to be worked out,
+/// because any difference at all is a miss.
+///
+/// A miss now costs one process more than it used to. That is the right trade: a ref moves when an
+/// agent commits or a fetch lands, which is a handful of times an hour, and the question is asked
+/// every six seconds per workspace.
+enum BaselineFingerprint {
+    /// The refs whose position the merge base depends on, in the order they are asked for.
+    ///
+    /// `base` unqualified rather than `refs/heads/<base>`, because that is what `mergeBase` itself
+    /// resolves and a base that is a tag or a bare sha has to be covered too: a tag that moves
+    /// moves the answer with it.
+    static func arguments(base: String, remote: String) -> [String] {
+        ["rev-parse", "--revs-only", "HEAD", base, "refs/remotes/\(remote)/\(base)"]
+    }
+
+    /// The lines `rev-parse` printed, joined. Whitespace-trimmed per line so a trailing newline
+    /// or a `\r` from a Windows-configured git cannot read as a different graph.
+    ///
+    /// An empty answer is nil rather than an empty fingerprint. `rev-parse` printing nothing means
+    /// it could not resolve a single one of the three, which is a repository that is broken or
+    /// gone, and remembering "the state where nothing resolves" would let two different broken
+    /// worktrees share an entry.
+    static func make(_ output: String) -> String? {
+        let lines = output
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        guard !lines.isEmpty else { return nil }
+        return lines.joined(separator: " ")
+    }
+}
+
+/// The store behind `BaselineFingerprint`, one entry per worktree and base branch.
+///
+/// An actor because `baseline` is called from the refresh loop, from the safety report and from
+/// the review tab at once, and two of those racing on a dictionary is a crash rather than a stale
+/// number.
+///
+/// Bounded, because a worktree is archived and a new one is created several times a day and an
+/// unbounded dictionary keyed on paths is a leak with a slow fuse. `limit` is generous next to any
+/// real sidebar; the eviction is least-recently-used and only runs when the limit is passed, so
+/// the common case never sorts anything.
+actor BaselineCache {
+    static let shared = BaselineCache()
+
+    static let limit = 256
+
+    private struct Key: Hashable {
+        let worktree: String
+        let base: String
+    }
+
+    private struct Entry {
+        let fingerprint: String
+        let baseline: String
+        var usedAt: UInt64
+    }
+
+    private var entries: [Key: Entry] = [:]
+
+    /// A counter rather than a clock, because `Date()` is not guaranteed to differ between two
+    /// entries written in the same loop and an eviction that cannot order its candidates is one
+    /// that throws away a different entry each run.
+    private var clock: UInt64 = 0
+
+    /// The remembered answer, if the three refs are where they were when it was worked out.
+    func baseline(worktree: String, base: String, fingerprint: String) -> String? {
+        let key = Key(worktree: worktree, base: base)
+        guard var entry = entries[key], entry.fingerprint == fingerprint else { return nil }
+        clock += 1
+        entry.usedAt = clock
+        entries[key] = entry
+        return entry.baseline
+    }
+
+    func remember(worktree: String, base: String, fingerprint: String, baseline: String) {
+        clock += 1
+        entries[Key(worktree: worktree, base: base)] = Entry(
+            fingerprint: fingerprint, baseline: baseline, usedAt: clock
+        )
+        guard entries.count > Self.limit else { return }
+        let oldest = entries
+            .sorted { $0.value.usedAt < $1.value.usedAt }
+            .prefix(entries.count - Self.limit)
+        for (key, _) in oldest { entries[key] = nil }
+    }
+
+    /// Read by the suite, which is what pins the bound above.
+    var count: Int { entries.count }
+}

--- a/Sources/BloomCore/Git/Git.swift
+++ b/Sources/BloomCore/Git/Git.swift
@@ -109,6 +109,7 @@ public enum Git {
         process.terminationHandler = { _ in exit.signal() }
 
         try process.run()
+        Shell.countSpawn()
 
         outReader.start()
         errReader.start()
@@ -295,9 +296,39 @@ public enum Git {
     /// simply not a candidate. Only a base that resolves nowhere at all throws, exactly as
     /// `mergeBase` already does, because an empty diff reading as "this workspace changed
     /// nothing" is the failure worth being loud about.
+    ///
+    /// The answer is remembered between calls, keyed on where those refs are rather than on a
+    /// clock, so the three or four processes below run only when one of them has actually moved.
+    /// `BaselineCache` carries the measurement that forced that and the argument for the key.
     public static func baseline(_ base: String, in worktree: String) async throws -> String {
         try validate(ref: base, label: "base branch")
 
+        let refs = await refPositions(base, in: worktree)
+        if let refs,
+           let remembered = await BaselineCache.shared.baseline(
+               worktree: worktree, base: base, fingerprint: refs
+           ) {
+            return remembered
+        }
+
+        let answer = try await resolveBaseline(base, in: worktree)
+        if let refs {
+            await BaselineCache.shared.remember(
+                worktree: worktree, base: base, fingerprint: refs, baseline: answer
+            )
+        }
+        return answer
+    }
+
+    /// Where the three refs are now, as one string. Nil when git could not be asked at all, which
+    /// makes every call a miss rather than letting a broken repository share an entry with another.
+    private static func refPositions(_ base: String, in worktree: String) async -> String? {
+        let arguments = BaselineFingerprint.arguments(base: base, remote: remote)
+        guard let result = try? await run(arguments, in: worktree), result.ok else { return nil }
+        return BaselineFingerprint.make(result.stdout)
+    }
+
+    private static func resolveBaseline(_ base: String, in worktree: String) async throws -> String {
         let local = try? await mergeBase(base, in: worktree)
 
         let tracking = "refs/remotes/\(remote)/\(base)"

--- a/Sources/BloomCore/Presentation/DiffRefreshSchedule.swift
+++ b/Sources/BloomCore/Presentation/DiffRefreshSchedule.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Which workspaces the six second refresh actually asks git about on this tick.
+///
+/// # The measurement that forced this
+///
+/// The loop used to walk every workspace on every tick. One pass over one worktree is six `git`
+/// processes: `baseline` resolves the local base and the remote-tracking base, and `changedFiles`
+/// then runs `diff --name-status`, `diff --numstat` and `ls-files --others`, each of which walks
+/// the worktree. `IdleProbe` over seventeen of this machine's real worktrees, seven passes,
+/// median: 104 processes and 2,864ms of process time for one pass.
+///
+/// **A pass every six seconds is therefore 48% of a core, continuously, on a machine where
+/// nothing is happening.** That is what put Bloom under "Using Significant Energy" in the battery
+/// menu, and it only runs while the window is frontmost, which is why the app looks innocent when
+/// sampled from another application: measured in the background it was 0.1% of a core.
+///
+/// The same probe over the three worktrees a tick now hands it: 12 processes and 651ms, which is
+/// 11% of a core. Nothing about one pass got faster; there are simply five times fewer of them.
+///
+/// # Why a tier rather than a longer interval
+///
+/// The six seconds are not wasted everywhere. A workspace with an agent writing in it changes
+/// several times a minute, and the one on screen is the one whose numbers a reader is watching.
+/// Those two keep the old cadence exactly. What was wrong was applying it to the rest, where the
+/// only thing that can move the count is the user editing files outside Bloom, and a minute-old
+/// number is indistinguishable from a six-second-old one.
+///
+/// # Why a slice rather than "every idle workspace, once a minute"
+///
+/// Letting them all come due together would trade a steady two seconds of process time per tick
+/// for twenty seconds of it in one tick, ten times a minute apart, which is worse: the burst is
+/// what a reader feels. So each tick takes the few oldest instead, sized so that one whole round
+/// of the idle workspaces takes `idleMaxAge`. Twenty idle workspaces at a six second tick and a
+/// sixty second age is two per tick.
+///
+/// A workspace nothing has asked about yet this launch is due immediately whatever the slice says.
+/// That is one burst at launch, which the loop used to do on every tick anyway, and it is the
+/// moment the stored counts are most likely to be stale: the machine may have been asleep for a
+/// day and the worktrees edited from a terminal in between.
+public enum DiffRefreshSchedule {
+    /// How often the loop wakes.
+    public static let tick: TimeInterval = 6
+
+    /// How stale a workspace nothing is writing to is allowed to get.
+    public static let idleMaxAge: TimeInterval = 60
+
+    /// - Parameters:
+    ///   - workspaces: every workspace the loop could ask about, in sidebar order.
+    ///   - busy: the ones that keep the old cadence. The caller puts the workspaces with a running
+    ///     agent and the selected one in here.
+    ///   - lastRefreshed: when each was last asked about, for this launch only. An absent entry
+    ///     means never.
+    /// - Returns: the workspaces to refresh on this tick, busy ones first.
+    public static func due(
+        workspaces: [WorkspaceID],
+        busy: Set<WorkspaceID>,
+        lastRefreshed: [WorkspaceID: Date],
+        now: Date,
+        tick: TimeInterval = tick,
+        idleMaxAge: TimeInterval = idleMaxAge
+    ) -> [WorkspaceID] {
+        var due: [WorkspaceID] = []
+        var stale: [(id: WorkspaceID, age: TimeInterval, place: Int)] = []
+
+        for (place, id) in workspaces.enumerated() {
+            if busy.contains(id) {
+                due.append(id)
+                continue
+            }
+            guard let last = lastRefreshed[id] else {
+                due.append(id)
+                continue
+            }
+            let age = now.timeIntervalSince(last)
+            guard age >= idleMaxAge else { continue }
+            stale.append((id, age, place))
+        }
+
+        guard !stale.isEmpty else { return due }
+
+        // Sized off every idle workspace rather than off the ones that have come due, so the slice
+        // is a steady two or three rather than jumping about as a backlog drains. At least one,
+        // because a sidebar of two workspaces would otherwise round down to none and never refresh.
+        let idleCount = workspaces.count { !busy.contains($0) }
+        let perTick = max(1, Int((Double(idleCount) * tick / idleMaxAge).rounded(.up)))
+
+        // Oldest first, so nothing at the back of a backlog is starved by a shorter list in front
+        // of it. Sidebar order breaks a tie, because `sorted(by:)` is not stable and two
+        // workspaces refreshed in the same tick have exactly equal ages: without the second key
+        // the same input could answer two different ways, and a schedule that is not a function of
+        // its input is one nothing can test.
+        let oldest = stale
+            .sorted { $0.age == $1.age ? $0.place < $1.place : $0.age > $1.age }
+            .prefix(perTick)
+        due.append(contentsOf: oldest.map(\.id))
+        return due
+    }
+}

--- a/Sources/BloomCore/System/Shell.swift
+++ b/Sources/BloomCore/System/Shell.swift
@@ -61,6 +61,30 @@ public enum Shell {
         ]
     }()
 
+    /// How many subprocesses this process has started since launch.
+    ///
+    /// Here rather than in a probe because the number cannot be taken from outside. Polling `ps`
+    /// at 20Hz for a minute against the running app saw nine children where the diff stat loop
+    /// alone starts several a second: a `git rev-parse` lives for about ten milliseconds, so a
+    /// sampler misses almost all of them and reports a number that looks reassuring and is wrong.
+    /// A counter incremented where the process is actually started cannot miss one.
+    ///
+    /// Relaxed ordering, because a count is read after the work it counts has finished and nothing
+    /// is synchronised against it.
+    private static let spawns = Atomic<Int>(0)
+
+    /// Called by every site that starts a process. `Git.runRaw` has its own `Process` for the
+    /// byte-preserving parsers, so it calls this too, and a new spawn site that forgets to is a
+    /// probe that quietly under-reports.
+    static func countSpawn() {
+        spawns.add(1, ordering: .relaxed)
+    }
+
+    /// The running total, for the probes. See `IdleProbe`.
+    public static var spawnCount: Int {
+        spawns.load(ordering: .relaxed)
+    }
+
     public static func environment(extra: [String: String] = [:]) -> [String: String] {
         var env = ProcessInfo.processInfo.environment
         let existing = env["PATH"]?.components(separatedBy: ":") ?? []
@@ -176,6 +200,7 @@ public enum Shell {
         process.terminationHandler = { _ in exit.signal() }
 
         try process.run()
+        Shell.countSpawn()
 
         outReader.start()
         errReader.start()

--- a/Tests/BloomCoreTests/BaselineCacheTests.swift
+++ b/Tests/BloomCoreTests/BaselineCacheTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// What `Git.baseline` is allowed to remember.
+///
+/// The suite exists because the cache trades correctness risk for energy: a merge base that is
+/// remembered one moment too long is the squash-merge bug in `BaselineTests` all over again, with
+/// every merged file shown as this workspace's work. So the two things worth pinning are that the
+/// key changes whenever any ref moves, and that an answer is only ever handed back for a key that
+/// matched exactly.
+@Suite("The remembered base of a workspace diff")
+struct BaselineCacheTests {
+    private let head = "1111111111111111111111111111111111111111"
+    private let local = "2222222222222222222222222222222222222222"
+    private let remote = "3333333333333333333333333333333333333333"
+
+    // MARK: - The key
+
+    @Test("the three refs go to rev-parse in a fixed order")
+    func asks() {
+        #expect(BaselineFingerprint.arguments(base: "main", remote: "origin") == [
+            "rev-parse", "--revs-only", "HEAD", "main", "refs/remotes/origin/main",
+        ])
+    }
+
+    @Test("a ref that moves changes the key")
+    func moves() {
+        let before = BaselineFingerprint.make("\(head)\n\(local)\n\(remote)\n")
+        let after = BaselineFingerprint.make("\(head)\n\(local)\n\(head)\n")
+
+        #expect(before != nil)
+        #expect(before != after)
+    }
+
+    /// The reason `--revs-only` is used rather than `--verify`: it drops what it cannot resolve
+    /// and still exits zero, so a repository that grows an `origin/main` answers differently from
+    /// one that has never had it without anybody having to work out which line was which.
+    @Test("a ref that appears changes the key")
+    func appears() {
+        let withoutRemote = BaselineFingerprint.make("\(head)\n\(local)\n")
+        let withRemote = BaselineFingerprint.make("\(head)\n\(local)\n\(remote)\n")
+
+        #expect(withoutRemote != withRemote)
+    }
+
+    @Test("trailing whitespace is not a different graph")
+    func whitespace() {
+        #expect(
+            BaselineFingerprint.make("\(head)\n\(local)\n")
+                == BaselineFingerprint.make("  \(head)  \n\(local)\n\n")
+        )
+    }
+
+    /// A worktree that has been removed answers nothing at all, and two of those must not share
+    /// an entry: the second would be handed the first one's merge base.
+    @Test("an answer with nothing in it is no key")
+    func empty() {
+        #expect(BaselineFingerprint.make("") == nil)
+        #expect(BaselineFingerprint.make("\n  \n") == nil)
+    }
+
+    // MARK: - The store
+
+    @Test("an answer comes back only for the key it was stored under")
+    func hitAndMiss() async {
+        let cache = BaselineCache()
+        await cache.remember(worktree: "/w", base: "main", fingerprint: "a", baseline: local)
+
+        #expect(await cache.baseline(worktree: "/w", base: "main", fingerprint: "a") == local)
+        #expect(await cache.baseline(worktree: "/w", base: "main", fingerprint: "b") == nil)
+        #expect(await cache.baseline(worktree: "/w", base: "trunk", fingerprint: "a") == nil)
+        #expect(await cache.baseline(worktree: "/other", base: "main", fingerprint: "a") == nil)
+    }
+
+    @Test("a moved ref replaces the entry rather than adding one")
+    func replaces() async {
+        let cache = BaselineCache()
+        await cache.remember(worktree: "/w", base: "main", fingerprint: "a", baseline: local)
+        await cache.remember(worktree: "/w", base: "main", fingerprint: "b", baseline: remote)
+
+        #expect(await cache.count == 1)
+        #expect(await cache.baseline(worktree: "/w", base: "main", fingerprint: "a") == nil)
+        #expect(await cache.baseline(worktree: "/w", base: "main", fingerprint: "b") == remote)
+    }
+
+    /// Keyed on a path, and paths are created and archived all day. Unbounded would be a leak
+    /// with a slow fuse rather than a bug anybody would notice.
+    @Test("the table stays bounded")
+    func bounded() async {
+        let cache = BaselineCache()
+        for index in 0..<(BaselineCache.limit + 20) {
+            await cache.remember(
+                worktree: "/w\(index)", base: "main", fingerprint: "f", baseline: local
+            )
+        }
+
+        #expect(await cache.count == BaselineCache.limit)
+        // The newest survives, which is the one a poll is about to ask for again.
+        let newest = BaselineCache.limit + 19
+        #expect(await cache.baseline(worktree: "/w\(newest)", base: "main", fingerprint: "f") == local)
+    }
+}

--- a/Tests/BloomCoreTests/DiffRefreshScheduleTests.swift
+++ b/Tests/BloomCoreTests/DiffRefreshScheduleTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// Which workspaces the six second diff stat loop asks git about.
+///
+/// The suite exists because the loop used to ask about all of them, and one pass over one worktree
+/// is several `git` processes. Twenty workspaces open therefore meant a steady stream of processes
+/// on a machine where nothing was happening, which is what the battery menu was complaining about.
+/// What has to stay true is that the workspaces somebody is actually watching keep the old
+/// cadence, and that the rest come round in a steady trickle rather than in a burst.
+@Suite("Which workspaces the diff stat poll is for")
+struct DiffRefreshScheduleTests {
+    private func ids(_ count: Int) -> [WorkspaceID] {
+        (0..<count).map { WorkspaceID("w\($0)") }
+    }
+
+    private func justRefreshed(_ ids: [WorkspaceID], at moment: Date) -> [WorkspaceID: Date] {
+        Dictionary(uniqueKeysWithValues: ids.map { ($0, moment) })
+    }
+
+    @Test("a workspace with an agent writing in it is refreshed on every tick")
+    func busyEveryTick() {
+        let all = ids(20)
+        let now = Date()
+
+        let due = DiffRefreshSchedule.due(
+            workspaces: all,
+            busy: [all[3], all[7]],
+            lastRefreshed: justRefreshed(all, at: now),
+            now: now
+        )
+
+        #expect(due.contains(all[3]))
+        #expect(due.contains(all[7]))
+    }
+
+    @Test("a workspace nobody is watching is left alone until it is a minute old")
+    func idleIsLeftAlone() {
+        let all = ids(20)
+        let now = Date()
+
+        let due = DiffRefreshSchedule.due(
+            workspaces: all,
+            busy: [all[0]],
+            lastRefreshed: justRefreshed(all, at: now.addingTimeInterval(-30)),
+            now: now
+        )
+
+        #expect(due == [all[0]])
+    }
+
+    /// The whole point. Twenty idle workspaces at a six second tick and a sixty second age is two
+    /// a tick, not twenty in one tick and none in the next nine.
+    @Test("the idle ones come round in a trickle rather than a burst")
+    func trickle() {
+        let all = ids(20)
+        let now = Date()
+
+        let due = DiffRefreshSchedule.due(
+            workspaces: all,
+            busy: [],
+            lastRefreshed: justRefreshed(all, at: now.addingTimeInterval(-120)),
+            now: now
+        )
+
+        #expect(due.count == 2)
+    }
+
+    @Test("the oldest go first, so nothing at the back of a queue is starved")
+    func oldestFirst() {
+        let all = ids(20)
+        let now = Date()
+        var last = justRefreshed(all, at: now.addingTimeInterval(-61))
+        last[all[11]] = now.addingTimeInterval(-600)
+        last[all[4]] = now.addingTimeInterval(-300)
+
+        let due = DiffRefreshSchedule.due(
+            workspaces: all, busy: [], lastRefreshed: last, now: now
+        )
+
+        #expect(due == [all[11], all[4]])
+    }
+
+    @Test("the same input answers the same way twice")
+    func deterministic() {
+        let all = ids(20)
+        let now = Date()
+        let last = justRefreshed(all, at: now.addingTimeInterval(-61))
+
+        let first = DiffRefreshSchedule.due(
+            workspaces: all, busy: [], lastRefreshed: last, now: now
+        )
+        let second = DiffRefreshSchedule.due(
+            workspaces: all, busy: [], lastRefreshed: last, now: now
+        )
+
+        #expect(first == second)
+    }
+
+    /// A workspace the store has just handed over has no stored count worth trusting, and a
+    /// launch is exactly when the numbers on disk are most likely to be a day old.
+    @Test("a workspace nothing has asked about yet is due whatever the slice says")
+    func neverAsked() {
+        let all = ids(20)
+
+        let due = DiffRefreshSchedule.due(
+            workspaces: all, busy: [], lastRefreshed: [:], now: Date()
+        )
+
+        #expect(due == all)
+    }
+
+    /// Rounding down would leave a small sidebar never refreshing anything at all, which is a
+    /// worse failure than the one being fixed.
+    @Test("a short sidebar still refreshes something")
+    func alwaysOne() {
+        let all = ids(2)
+        let now = Date()
+
+        let due = DiffRefreshSchedule.due(
+            workspaces: all,
+            busy: [],
+            lastRefreshed: justRefreshed(all, at: now.addingTimeInterval(-61)),
+            now: now
+        )
+
+        #expect(due.count == 1)
+    }
+
+    @Test("nothing open asks git nothing")
+    func empty() {
+        #expect(DiffRefreshSchedule.due(
+            workspaces: [], busy: [], lastRefreshed: [:], now: Date()
+        ).isEmpty)
+    }
+
+    /// One whole round of the idle workspaces takes `idleMaxAge`, which is the property the slice
+    /// exists to give. Driven as the loop drives it: a tick, the ones it answered marked as
+    /// refreshed, then the next tick.
+    @Test("every idle workspace comes round within the age it is allowed to reach")
+    func roundTrip() {
+        let all = ids(20)
+        var last = justRefreshed(all, at: Date(timeIntervalSince1970: 0))
+        var now = Date(timeIntervalSince1970: DiffRefreshSchedule.idleMaxAge)
+        var seen: Set<WorkspaceID> = []
+
+        for _ in 0..<Int(DiffRefreshSchedule.idleMaxAge / DiffRefreshSchedule.tick) {
+            let due = DiffRefreshSchedule.due(
+                workspaces: all, busy: [], lastRefreshed: last, now: now
+            )
+            for id in due {
+                seen.insert(id)
+                last[id] = now
+            }
+            now = now.addingTimeInterval(DiffRefreshSchedule.tick)
+        }
+
+        #expect(seen.count == all.count)
+    }
+}


### PR DESCRIPTION
The battery menu listed Bloom under "Using Significant Energy". Sampled from another application the app looked innocent, 0.1% of a core over a minute, which turned out to be the clue: the diff stat loop stands down when the window is not frontmost, so everything it costs is paid while somebody is working in it.

`IdleProbe` is new, the fifth of the probe family and the first to measure the case where nothing is happening. It drives the pass the six second loop drives and counts subprocesses from inside `Shell`, because polling `ps` at 20Hz misses a `git rev-parse` that lives ten milliseconds. Seventeen real worktrees, seven passes, median:

|  | processes per pass | process time per pass | share of one core |
| --- | --- | --- | --- |
| before, 17 workspaces a tick | 104 | 2,864ms | 48% |
| after, 3 workspaces a tick | 12 | 651ms | 11% |

`DiffRefreshSchedule` is the fix. Workspaces with an agent writing in them and the one on screen keep the six second cadence. The rest come round in a slice sized so a whole round takes a minute, which is two a tick on a sidebar of twenty, rather than all twenty in one tick.

`BaselineCache` is the half that did not work, kept and labelled as such in its own header. It remembers the merge base against the position of the three refs it depends on rather than a clock, so a stale answer is impossible rather than unlikely, and it cut processes per worktree from 6.12 to 4.00. It moved the process time not at all: the calls it removes only read the commit graph, and the time is in the diff and ls-files calls that walk the worktree.

    Bloom --idle-probe /tmp/idle.json --idle-worktrees /tmp/trees.txt