### PR TITLE
Move the terminal to SwiftTerm 1.19.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "784c2aec2b7bddd9376380cdfd65a3548b293fbd90feda4802cc781b6950cbef",
+  "originHash" : "ea62e8b834aedea1d6009b51f6badb96ddc3a0437ebc513df3e79a76cd4202b8",
   "pins" : [
     {
       "identity" : "sparkle",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/migueldeicaza/SwiftTerm",
       "state" : {
-        "revision" : "7691f85b222a67a66b58499e1b2647443cf0dda7",
-        "version" : "1.18.0"
+        "revision" : "464df5207fc2432e16c9a23abe538187196daf5f",
+        "version" : "1.19.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,12 @@ let package = Package(
         .library(name: "BloomCore", targets: ["BloomCore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/migueldeicaza/SwiftTerm", from: "1.2.0"),
+        // The terminal panes. The upper bound is not tidiness: SwiftTerm tags 1.20.0 as a
+        // pre-release ("one last before 2.0"), and SwiftPM cannot see that flag because the tag
+        // carries no semver pre-release identifier, so a bare `from:` would resolve to it. 1.19.0
+        // is what upstream marks as the release, and what upstream says comes next is 2.0 with
+        // breaking changes, which this range would have to be opened by hand for anyway.
+        .package(url: "https://github.com/migueldeicaza/SwiftTerm", "1.19.0" ..< "1.20.0"),
         // The updater. Sparkle ships as a binary XCFramework, so `swift build` links the app
         // against it but copies nothing: `Tools/build.sh` embeds `Sparkle.framework` into
         // `Contents/Frameworks` and adds the rpath that finds it there. See `Tools/build.sh`.


### PR DESCRIPTION
`Package.resolved` was on 1.18.0 while upstream's latest release is 1.19.0.

What is in 1.18.0..1.19.0, checked against what the terminal panes use:

- terminal content hidden under the scroller after a font change, which is what Cmd+Plus does here (#577)
- macOS dictation and IME marked text drawn in a real overlay instead of an `NSTextField` (#561)
- DECSET/DECRST 1007 tracked, so a program in the alternate screen gets the wheel it asked for (#633)
- the unknown-DECRQSS log guarded against a non-ASCII payload (#632)
- `keyDown` and `doCommand` reworked around the kitty encoder: the visible effect without kitty flags is that unmodified Page Up and Page Down scroll the pane rather than sending an escape, which is what every other terminal on this Mac does
- window focus tracked through `didBecomeKey` rather than `didBecomeMain`
- SGR 5 blinking text, and a build tool plugin that generates a build info constant

The Metal renderer is off by default and Bloom never turns it on, so the Metal part of the diff is code these panes do not run. Bloom's own surface is `LocalProcessTerminalView`, `LocalProcessTerminalViewDelegate`, `installColors`, the native fore/background, caret and selection colours, `feed`, `send`, `getTerminal().clearScrollback()` and `startProcess`, and none of those signatures moved.

Not 1.20.0: it is tagged as a pre-release ("one last before 2.0"), and because the tag carries no semver pre-release identifier SwiftPM cannot see that flag, so a bare `from:` would have resolved to it. The range is bounded to say so, and it has to be opened by hand for 2.0 anyway, which upstream says is next and is breaking.

The core suite cannot cover this: `BloomCore` never imports SwiftTerm, so `Terminal`, `Ghostty`, `Tmux` and `Shell` all pass and none of them touch the dependency. The app target builds warning free.