### PR TITLE
Stop a pane changing width from rebuilding every row in the session

### DIFF
--- a/Sources/Bloom/Design/PendingDeleteSnapshotGallery.swift
+++ b/Sources/Bloom/Design/PendingDeleteSnapshotGallery.swift
@@ -17,7 +17,16 @@ import BloomCore
 /// for it.
 struct PendingDeleteSnapshotGallery: View {
     /// The width the transcript caps a bubble at in a comfortable window.
+    /// The cap the bubbles below are drawn at, handed down the way the transcript hands it down:
+    /// a `PendingTurnRowView` reads the object rather than taking a number, so a gallery has to
+    /// put one in the environment. See `TranscriptBubbleWidth`.
     private static let bubble: CGFloat = 520
+
+    @State private var bubbleWidth: TranscriptBubbleWidth = {
+        let width = TranscriptBubbleWidth()
+        width.cap = bubble
+        return width
+    }()
 
     private static func delivery(_ body: String) -> Delivery {
         Delivery(targetSessionID: SessionID("s1"), body: body)
@@ -32,7 +41,6 @@ struct PendingDeleteSnapshotGallery: View {
                 PendingTurnRowView(
                     delivery: Self.delivery(Self.typed),
                     hold: .question,
-                    maxWidth: Self.bubble,
                     onDelete: {}
                 )
             }
@@ -41,7 +49,6 @@ struct PendingDeleteSnapshotGallery: View {
                 PendingTurnRowView(
                     delivery: Self.delivery(Self.typed),
                     hold: .question,
-                    maxWidth: Self.bubble,
                     onDelete: {},
                     pointerInside: true
                 )
@@ -55,21 +62,18 @@ struct PendingDeleteSnapshotGallery: View {
                     PendingTurnRowView(
                         delivery: Self.delivery("Also check the migration."),
                         hold: nil,
-                        maxWidth: Self.bubble,
-                        onDelete: {}
+                            onDelete: {}
                     )
                     PendingTurnRowView(
                         delivery: Self.delivery(Self.typed),
                         hold: nil,
-                        maxWidth: Self.bubble,
-                        onDelete: {},
+                            onDelete: {},
                         pointerInside: true
                     )
                     PendingTurnRowView(
                         delivery: Self.delivery("And run the tests when you are done."),
                         hold: .turn,
-                        maxWidth: Self.bubble,
-                        onDelete: {}
+                            onDelete: {}
                     )
                 }
             }
@@ -91,6 +95,7 @@ struct PendingDeleteSnapshotGallery: View {
         }
         .padding(20)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .environment(\.transcriptBubbleWidth, bubbleWidth)
     }
 
     private func sheet(for recovery: PendingMessageDiscard.Recovery) -> some View {

--- a/Sources/Bloom/Views/Transcript/PendingTurnRowView.swift
+++ b/Sources/Bloom/Views/Transcript/PendingTurnRowView.swift
@@ -31,10 +31,13 @@ struct PendingTurnRowView: View {
     /// a divider somebody had left in. At the foot of the run it reads as what it is, which is a
     /// note about everything above it.
     var hold: DeliveryHold?
-    var maxWidth: CGFloat
     /// Asks to delete this one. It asks rather than deletes: the confirmation and the promise
     /// about where the sentence ends up are `PendingMessageDiscard`'s, through `TranscriptModel`.
     var onDelete: @MainActor () -> Void
+    /// The width this bubble may fill. Read from the list's object rather than handed in, for the
+    /// reason `TranscriptBubbleWidth` sets out: a number passed in is a number the list has to
+    /// read, and a list that reads it is a list that is rebuilt whenever the pane changes width.
+    @Environment(\.transcriptBubbleWidth) private var bubbleWidth
     /// Draws the row as though the pointer were on it, for `--snapshot`. An offscreen render has
     /// no pointer, and the state worth photographing here is the one under it.
     var pointerInside = false
@@ -79,7 +82,7 @@ struct PendingTurnRowView: View {
     }
 
     private var bubble: some View {
-        CappedWidth(width: maxWidth) {
+        CappedWidth(width: bubbleWidth?.cap ?? 560) {
             Text(displayText)
                 .font(Typo.body)
                 .lineSpacing(TranscriptLayout.proseLeading)

--- a/Sources/Bloom/Views/Transcript/TranscriptBubbleWidth.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptBubbleWidth.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import Observation
+
+/// The width a speech bubble is allowed to fill, held where changing it costs one row rather than
+/// the whole list.
+///
+/// It used to be a field of `TranscriptGeometry`, which is `@State` in `TranscriptListView`. That
+/// file already explains why the number is quantised: a raw container width moves on every pixel
+/// of a drag, and a `@State` that moves once a frame re-runs the list's body and with it the
+/// `ForEach` over every row the lazy stack has realised. Quantising it to eight points cut that
+/// from once a frame to once every eight points, which was the right fix for the drag it was
+/// measured against and is still an order of magnitude too much for the gesture the owner
+/// complained about next.
+///
+/// **Measured, on a release build at 1440 by 900, resizing a window holding a conversation of
+/// 1,104 rows beside a browser with the changed files up:** four points of travel per frame steps
+/// this value every other frame, and the centre column laid out 1,273 to 1,310 times over 480
+/// steps, 7.5 to 8.7ms a pass. Nineteen percent of that resize was inside `ForEachChild.updateValue`,
+/// which is SwiftUI rebuilding the row values of a list whose body had been invalidated, and six
+/// percent of it was `ObservationCenter.invalidate` tearing down and re-registering the
+/// observation each of those rebuilt rows had.
+///
+/// So the number is moved out of the value the list reads. This is the same bargain
+/// `TranscriptHoverHost` writes down next door, and for the same reason: observation is recorded
+/// where a property is READ during a body. The object's identity never changes, so the list and
+/// every tool row can be handed it and read nothing; only a bubble reads `cap`, so only the
+/// handful of bubbles on screen are invalidated when the pane is made narrower.
+///
+/// It stays quantised. Nothing about moving it here makes a per-pixel value cheap for the rows
+/// that DO read it, and eight points is invisible on a bubble several hundred points wide.
+@MainActor
+@Observable
+final class TranscriptBubbleWidth {
+    /// Already rounded, by `TranscriptGeometry.cap`. See that type for why it is rounded down.
+    var cap: CGFloat = 240
+}
+
+extension EnvironmentValues {
+    /// Nil wherever no transcript is drawing bubbles, which is what the fallback in
+    /// `UserTurnRowView` is for.
+    @Entry var transcriptBubbleWidth: TranscriptBubbleWidth?
+}

--- a/Sources/Bloom/Views/Transcript/TranscriptGeometry.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptGeometry.swift
@@ -7,16 +7,19 @@ import Foundation
 /// content size and where it sits between them, and asking it directly is both cheaper and immune
 /// to the "the probe stopped being built" edge cases a preference-based measurement has.
 ///
-/// **It holds the bubble cap rather than the width it was worked out from, and that is a
-/// performance decision rather than a tidiness one.** This value is `@State` in `TranscriptListView`,
-/// so every change to it re-runs that view's body and with it the `ForEach` over every row the
-/// lazy stack has realised. A raw container width changes on every pixel of a sidebar drag, which
-/// is once a frame, for a number whose only use is capping the width of a speech bubble. Rounded
-/// to `step`, it changes about once every eleven points instead, and the drag stops rebuilding the
-/// list to move a bubble's edge by one point.
+/// **Everything in it is quantised, and that is a performance decision rather than a tidiness
+/// one.** This value is `@State` in `TranscriptListView`, so every change to it re-runs that
+/// view's body and with it the `ForEach` over every row the lazy stack has realised. A raw
+/// container width changes on every pixel of a drag, which is once a frame, and a raw offset
+/// changes on every frame of a scroll.
+///
+/// The bubble cap used to be one of these fields and no longer is. Quantising it took a drag from
+/// invalidating the list once a frame to once every eight points, which was the right fix for the
+/// gesture it was measured against and still an order of magnitude too much for a window resize:
+/// see `TranscriptBubbleWidth`, which holds it now, and which carries that measurement. `cap` is
+/// still here, because rounding it is still what keeps the writes down; what moved is who pays for
+/// one.
 struct TranscriptGeometry: Equatable {
-    /// The widest a user bubble may be, already rounded. Not the container width: see above.
-    var bubbleCap: CGFloat = 240
     /// How tall the pane is, rounded down to `heightStep`, for the one thing in the transcript
     /// that is sized as a share of it: the running setup tail. See `SetupTailWindow`.
     ///

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -46,6 +46,11 @@ struct TranscriptListView: View {
     /// written to, the pane's own memory, which lasts as long as the launch and no longer.
     @State private var expanded: Set<Int> = []
     @State private var geometry = TranscriptGeometry()
+    /// The width a bubble may fill, which used to be a field of `geometry` above. It is an object
+    /// held here and read only by the views that draw a bubble, so a pane changing width no longer
+    /// re-runs this body and rebuilds every row the lazy stack has realised. See
+    /// `TranscriptBubbleWidth`, which carries the measurement that moved it.
+    @State private var bubbleWidth = TranscriptBubbleWidth()
     @State private var didPosition = false
 
     /// The chip or the row the pointer is resting on, shared with every row in the list.
@@ -262,11 +267,6 @@ struct TranscriptListView: View {
         )
     }
 
-    /// Already rounded, by `TranscriptGeometry.cap`, and rounded before it reaches this view's
-    /// state rather than after. A cap that changed on every pixel of a drag failed the row
-    /// equality check on every realised row, once a frame.
-    private var maxBubbleWidth: CGFloat { geometry.bubbleCap }
-
     var body: some View {
         // The first pass of this body after a tab switch, which is where the rebuilt list starts.
         // Stamped once per timeline, so the passes that follow it cost nothing to ignore.
@@ -275,6 +275,22 @@ struct TranscriptListView: View {
         // Read once for the pass rather than once per footer: resolving it walks the row list,
         // and every realised footer would otherwise pay for its own walk. See `TranscriptModel`.
         let stoppedTurnSeq = transcript.stoppedTurnSeq
+        // The five below are read here for a different reason, and it is the more expensive one.
+        // Each is a property of an `@Observable`, and observation is recorded where a property is
+        // READ: read inside the `ForEach`'s closure, every row registers its own edge on it, and
+        // SwiftUI tears that edge down and puts it back every time the child is rebuilt. Measured
+        // on a release build resizing a window over a 1,104 row conversation, six percent of the
+        // whole gesture was inside `ObservationCenter.invalidate` doing exactly that. Read once
+        // here, they are plain values by the time a row is built, and the list holds one edge on
+        // each instead of one per realised row.
+        //
+        // `projectName` is also worth a line of its own: it reaches `AppModel.repo(for:)`, which
+        // is a linear scan, and it was on the scroll path once per realised row per pass.
+        let workspace = transcript.workspace
+        let projectName = transcript.projectName
+        let rows = transcript.rows
+        let permissionMode = transcript.session.permissionMode
+        let recoveredRuns = transcript.recoveredRuns
         // Only so the delete confirmation below has a binding to the model's own state. The
         // question cannot live in this view: see `TranscriptModel.discarding`.
         @Bindable var transcript = transcript
@@ -298,7 +314,7 @@ struct TranscriptListView: View {
                         // The one row in this list sized as a share of the pane rather than of its
                         // own contents. Already rounded, by `TranscriptGeometry.height`, and
                         // rounded before it reaches this view's state for the reason the bubble cap
-                        // is: see `maxBubbleWidth`.
+                        // is quantised: see `TranscriptGeometry`.
                         paneHeight: geometry.paneHeight,
                         onVisibilityChange: { showsSetup = $0 },
                         onShowLogEnd: { wasAsked in
@@ -321,16 +337,16 @@ struct TranscriptListView: View {
                             // reads as belonging to the turn above rather than to the one below.
                             // See `TranscriptLayout.turnGap`.
                             TurnFooterView(
-                                rows: transcript.rows,
+                                rows: rows,
                                 row: row,
-                                worktree: transcript.workspace.path,
-                                permissionMode: transcript.session.permissionMode,
+                                worktree: workspace.path,
+                                permissionMode: permissionMode,
                                 // Only the turn the stop was about, which is at most one of them.
                                 // See `TranscriptModel.stoppedTurnSeq`.
                                 wasStopped: row.seq == stoppedTurnSeq,
                                 // What is left of a wait this turn spent on somebody else's
                                 // outage, or nothing, which is almost always.
-                                recovered: transcript.recoveredRuns[row.seq]
+                                recovered: recoveredRuns[row.seq]
                             )
                             .arrivingRow(isArriving(row))
                             .padding(.horizontal, TranscriptLayout.inset)
@@ -339,11 +355,10 @@ struct TranscriptListView: View {
                         } else {
                             TranscriptRowView(
                                 row: row,
-                                workspace: transcript.workspace,
+                                workspace: workspace,
                                 isExpanded: expanded.contains(row.seq),
                                 isNested: row.parentToolUseID != nil,
-                                maxBubbleWidth: maxBubbleWidth,
-                                projectName: transcript.projectName,
+                                projectName: projectName,
                                 onToggle: { toggle(row.seq) },
                                 onAnswer: { requestID, decision in
                                     Task { await transcript.answer(requestID: requestID, decision: decision) }
@@ -372,8 +387,7 @@ struct TranscriptListView: View {
                             UserTurnRowView(
                                 text: review.message,
                                 reviewChips: review.chips,
-                                workspace: transcript.workspace,
-                                maxWidth: maxBubbleWidth
+                                workspace: workspace
                             )
                             // The owner's own bubble settles in like every other row that turns
                             // up. It is the one thing on this screen the reader made happen, and
@@ -392,8 +406,7 @@ struct TranscriptListView: View {
                             UserTurnRowView(
                                 text: turn.body,
                                 attachments: turn.paths,
-                                workspace: transcript.workspace,
-                                maxWidth: maxBubbleWidth
+                                workspace: workspace
                             )
                             .arrivingRow(true)
                             .padding(.horizontal, TranscriptLayout.inset)
@@ -417,7 +430,6 @@ struct TranscriptListView: View {
                             hold: delivery.id == transcript.waitingDeliveries.last?.id
                                 ? transcript.deliveryHold
                                 : nil,
-                            maxWidth: maxBubbleWidth,
                             onDelete: { transcript.askToDiscard(delivery) }
                         )
                         .padding(.horizontal, TranscriptLayout.inset)
@@ -469,6 +481,13 @@ struct TranscriptListView: View {
             // someone back down as they read something further up is the single most irritating
             // thing a live log can do.
             .defaultScrollAnchor(geometry.isNearBottom ? .bottom : nil, for: .sizeChanges)
+            // Its own subscription, for the reason the raw offset below has one: what this
+            // writes is an object rather than state, so nothing in this body is invalidated by it
+            // and the rows that draw a bubble are. Folded into the projection above it would put
+            // the cap back into `@State` and undo the whole of `TranscriptBubbleWidth`.
+            .onScrollGeometryChange(for: CGFloat.self, of: Self.bubbleCapOf) { _, new in
+                bubbleWidth.cap = new
+            }
             .onScrollGeometryChange(for: TranscriptGeometry.self, of: Self.measure) { _, new in
                 geometry = new
                 // The state, every time, rather than only on a transition of it.
@@ -698,6 +717,11 @@ struct TranscriptListView: View {
             // rather than passed as a closure through five layers of view. A closure would be a
             // new closure on every pass over the list and would invalidate every row that read it.
             .environment(\.transcriptHoverHost, hoverHost)
+            // And the cap a bubble is drawn at, for the same reason and by the same mechanism:
+            // handing down the OBJECT is a read of a reference that never changes, so this body
+            // takes no dependency on the width at all, and only the views that read `cap` are
+            // invalidated when the pane is made narrower. See `TranscriptBubbleWidth`.
+            .environment(\.transcriptBubbleWidth, bubbleWidth)
             // What a link in any row of this transcript does when it is pressed or chosen from a
             // menu. Said once for the whole list rather than per row, and comparable: this is a
             // computed property, so it really is a fresh struct on every pass, and until
@@ -770,18 +794,26 @@ struct TranscriptListView: View {
     /// gets wrong, and both of them float the jump pill over a conversation whose last line is
     /// already on screen: content that fits in the pane, and a pane with no height to fit it in.
     ///
-    /// The bubble cap is worked out here, inside the projection, rather than in the body from a
-    /// stored width. `onScrollGeometryChange` only calls its handler when the projected value
-    /// changes, so rounding on this side of the line means a drag stops writing state, and stops
-    /// re-running the list body, for the eleven points of travel between one cap and the next.
+    /// The bubble cap is no longer one of these. It is `bubbleCapOf` below, on a subscription of
+    /// its own, because it is the one value here that moves on every eight points of a resize and
+    /// the only one a handful of rows read: see `TranscriptBubbleWidth`.
+    /// The width a bubble may fill, rounded on this side of the line.
+    ///
+    /// `onScrollGeometryChange` only calls its handler when the projected value changes, so the
+    /// rounding is what makes a drag write the object once every eight points rather than once a
+    /// frame. That was the whole reason the cap was quantised when it lived in `measure` above,
+    /// and it is still the reason here; what changed is who pays when it does move.
+    private static func bubbleCapOf(_ scroll: ScrollGeometry) -> CGFloat {
+        TranscriptGeometry.cap(
+            width: scroll.containerSize.width,
+            share: bubbleShare,
+            gutter: Metrics.gutter,
+            floor: bubbleFloor
+        )
+    }
+
     private static func measure(_ scroll: ScrollGeometry) -> TranscriptGeometry {
         TranscriptGeometry(
-            bubbleCap: TranscriptGeometry.cap(
-                width: scroll.containerSize.width,
-                share: bubbleShare,
-                gutter: Metrics.gutter,
-                floor: bubbleFloor
-            ),
             paneHeight: TranscriptGeometry.height(scroll.containerSize.height),
             isNearBottom: ScrollEnd.isAtEnd(
                 contentHeight: scroll.contentSize.height,
@@ -954,13 +986,17 @@ struct TranscriptListView: View {
 
     /// What this pane is now, or nothing if it has not been laid out yet.
     ///
-    /// `bubbleCap` rather than the container width, because that is the number this view actually
-    /// holds and it is a step function of the width: see `TranscriptGeometry`, which explains why
-    /// the raw width is deliberately not kept. `paneHeight` is nought until the first layout, and
-    /// that is what tells an unmeasured pane apart from a narrow one.
+    /// The bubble cap rather than the container width, because that is the number this view
+    /// actually holds and it is a step function of the width: see `TranscriptGeometry`, which
+    /// explains why the raw width is deliberately not kept. `paneHeight` is nought until the first
+    /// layout, and that is what tells an unmeasured pane apart from a narrow one.
+    ///
+    /// Read off the object rather than out of `geometry` since the cap moved there. Both callers
+    /// are outside `body`, so this reads `cap` without subscribing this view to it, which is the
+    /// whole point of the object.
     private var currentMeasure: TranscriptPaneState.Measure? {
         guard geometry.paneHeight > 0 else { return nil }
-        return TranscriptPaneState.Measure(width: geometry.bubbleCap, fontScale: fontScale)
+        return TranscriptPaneState.Measure(width: bubbleWidth.cap, fontScale: fontScale)
     }
 
     /// Writes down where the reader is, for the pane to find when it is built again.

--- a/Sources/Bloom/Views/Transcript/TranscriptRowView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptRowView.swift
@@ -42,20 +42,6 @@ struct TranscriptRowView: View, Equatable {
             && lhs.row.parentToolUseID == rhs.row.parentToolUseID
             && lhs.isExpanded == rhs.isExpanded
             && lhs.isNested == rhs.isNested
-            // Only a `.user` row reads it. `maxBubbleWidth` caps a speech bubble and reaches
-            // `UserTurnRowView` from the two branches of `content` that draw one; every other kind
-            // of row is handed it and never looks.
-            //
-            // It was compared for all of them, and it is the one field here that moves during a
-            // drag: `TranscriptGeometry.cap` steps every eight points, so widening the inspector
-            // failed this comparison on most frames and rebuilt every realised row, tool rows and
-            // prose rows included, for a number none of them draw with. The layout those rows owe
-            // the new width is unavoidable and is not what this is about; rebuilding the view tree
-            // to produce it is.
-            //
-            // Scoped rather than dropped, because dropping it would leave a bubble at the width it
-            // was built for while the pane moved out from under it.
-            && (lhs.row.kind != .user || lhs.maxBubbleWidth == rhs.maxBubbleWidth)
             && lhs.workspace.id == rhs.workspace.id
             && lhs.workspace.path == rhs.workspace.path
             // A question being answered has to redraw the row that asked it, and the decision is
@@ -72,9 +58,6 @@ struct TranscriptRowView: View, Equatable {
     var workspace: Workspace
     var isExpanded = false
     var isNested = false
-    /// The width a user bubble is allowed to fill, handed down because the enclosing scroll view
-    /// already measured it and a per row measurement would not size to its content.
-    var maxBubbleWidth: CGFloat = 560
     /// What the project is called, so a permission row can name where a rule would apply. Handed
     /// down for the same reason `workspace` is: it is constant for a whole transcript.
     var projectName: String = ""
@@ -111,8 +94,7 @@ struct TranscriptRowView: View, Equatable {
                 UserTurnRowView(
                     text: review.message,
                     reviewChips: review.chips,
-                    workspace: workspace,
-                    maxWidth: maxBubbleWidth
+                    workspace: workspace
                 )
             } else {
                 // Attachments reach the agent as paths in the prompt text, which is the only
@@ -125,8 +107,7 @@ struct TranscriptRowView: View, Equatable {
                 UserTurnRowView(
                     text: turn.body,
                     attachments: turn.paths,
-                    workspace: workspace,
-                    maxWidth: maxBubbleWidth
+                    workspace: workspace
                 )
             }
 

--- a/Sources/Bloom/Views/Transcript/UserTurnRowView.swift
+++ b/Sources/Bloom/Views/Transcript/UserTurnRowView.swift
@@ -31,7 +31,6 @@ struct UserTurnRowView: View {
     var reviewChips: [ReviewTurnRecord.Chip] = []
     /// Which worktree those paths are relative to, and which review the chips open into.
     var workspace: Workspace
-    var maxWidth: CGFloat
 
     @Environment(AppModel.self) private var app
     /// The list's one value, set in `TranscriptListView`, rather than actions built per bubble:
@@ -45,6 +44,17 @@ struct UserTurnRowView: View {
     /// Where a hovered chip says it is, so the card is drawn over the scroll view rather than
     /// inside a bubble that would clip it. See `TranscriptHoverOverlay`.
     @Environment(\.transcriptHoverHost) private var hoverHost
+    /// The width this bubble may fill, read from the object the list hands down rather than from a
+    /// number the list passes in. See `TranscriptBubbleWidth`: reading it HERE is what keeps a pane
+    /// being made narrower from invalidating every tool row in the session.
+    @Environment(\.transcriptBubbleWidth) private var bubbleWidth
+
+    /// What a bubble drawn outside a transcript is capped at, which is every use of this view that
+    /// is not the list: nothing else puts one up today, and a bubble with no cap at all would run
+    /// the full width of whatever it landed in.
+    private static let uncappedFallback: CGFloat = 560
+
+    private var maxWidth: CGFloat { bubbleWidth?.cap ?? Self.uncappedFallback }
 
     /// The pill inside the sentence the pointer is currently on, reported by `LinkTextView` the
     /// moment it arrives. Nil for every bubble nobody is pointing at, which is what keeps the


### PR DESCRIPTION
Stacked on #42, which is the probe the numbers below come from.

The bubble cap was a field of `TranscriptGeometry`, which is `@State` on the list, so a number that caps a speech bubble re-ran the body that holds a `ForEach` over every realised row. Quantising it to eight points was the right fix for a divider drag and is still an order of magnitude too much for a resize: four points of travel a frame steps it every other frame. It is an object in the environment now, the way `TranscriptHoverHost` already is, so only the views that draw a bubble read it.

Five observable properties were also read inside the `ForEach` closure, so each realised row registered its own observation edge on each of them and SwiftUI rebuilt that edge every time the child was rebuilt. They are read once above the scroll view now. `projectName` reaches `AppModel.repo(for:)`, a linear scan.

Resize, 1440x900, 1,104 rows beside a browser, 44 changed files, two runs of each:

| | before | after |
| --- | --- | --- |
| median | 48.7 to 55.3ms | 39.2 to 39.4ms |
| p95 | 94 to 117ms | 79 to 81ms |
| p99 | 126 to 146ms | 112 to 114ms |
| CPU per step | 44.7 to 52.5ms | 38.7 to 38.8ms |
| centre column layout | 7.5 to 8.7ms a pass | 6.6ms a pass |

`ObservationCenter.invalidate` under `ForEachChild.updateValue` went from 321 samples to 10.

Scrolling moved less, which is expected since a scroll does not change the width: p95 20.1 to 19.0ms, p99 29.0 to 25.5ms, late frames 16.3% to 15.4%. A tab switch did not move at all.