### PR TITLE
Take a session's JSON off the main thread, and stop two caches thrashing

### DIFF
--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -247,17 +247,38 @@ final class TranscriptModel {
         // rows and at most a handful of them are questions.
         let decisions = (try? await store.permissionAskDecisions(sessionID: session.id)) ?? [:]
 
-        var built: [TranscriptRow] = []
-        var index: [String: Int] = [:]
-        for message in messages {
-            Self.absorb(message, decisions: decisions, into: &built, indexByRefID: &index)
-        }
-        rows = built
-        indexByRefID = index
+        // Off the main actor, and not for tidiness. The fold below is the one place in the app
+        // that JSON-parses a whole session in one go: `ParentProbe.parentToolUseID` materialises
+        // every message's payload to read one top level key, `ToolResultSummary.decode` does it
+        // again for every tool result, which is the largest payload in the file, and
+        // `PermissionAsk.decode` a third time for every question. Measured with `--switch-probe`
+        // on a release build against the 1,306 message workspace: 35ms of main thread between
+        // `transcript.read.start` and `transcript.rows.built`, in the middle of the wait between
+        // clicking a workspace in the sidebar and seeing it.
+        //
+        // It is safe to move because it was already written to be moved. `absorb` is static and
+        // folds into a list handed to it rather than into the model's own, which is what the
+        // paragraph at the head of this function is about, so nothing observable exists until the
+        // assignment below.
+        let built = await Task.detached(priority: .userInitiated) {
+            var rows: [TranscriptRow] = []
+            var index: [String: Int] = [:]
+            for message in messages {
+                Self.absorb(message, decisions: decisions, into: &rows, indexByRefID: &index)
+            }
+            return (rows: rows, index: index)
+        }.value
+
+        rows = built.rows
+        indexByRefID = built.index
+        // Stays on the main actor, because it reads `TranscriptEventCache` and that cache is the
+        // main actor's. It can afford to: it walks backwards and stops as soon as it has both
+        // numbers, which is within a few rows of the end whatever the session's length.
+        //
         // The one place the whole list is walked, because it is also the one place there is a
         // whole list to walk. Everything after this folds in what arrived. Nothing is held from
         // before: this is a session being read from the start.
-        contextUsage = ContextWindowUsage.latest(in: built)
+        contextUsage = ContextWindowUsage.latest(in: built.rows)
         SwitchTrace.mark("transcript.rows.built", workspace: workspace.id)
         SwitchTrace.markOnScreen("transcript.rows.built", workspace: workspace.id)
 
@@ -274,7 +295,9 @@ final class TranscriptModel {
     /// Handed the list and the reference index it is folding into rather than reaching for the
     /// model's own, so that the same rule can build a whole session's rows somewhere nothing can
     /// see them. See `read(from:)` for why that matters.
-    private static func absorb(
+    /// Nonisolated, so `read(from:)` can run the whole session's worth of it off the main actor.
+    /// It touches nothing but its arguments, which is what made the move a two line change.
+    nonisolated private static func absorb(
         _ message: Message,
         decisions: [String: String],
         into rows: inout [TranscriptRow],

--- a/Sources/Bloom/Views/Transcript/TranscriptPresentationCache.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptPresentationCache.swift
@@ -16,11 +16,24 @@ import BloomCore
 ///
 /// The cost limit the event cache carries has no equivalent here. A `ToolPresentation` is a glyph
 /// name, two short strings and a handful of chips, all of them already truncated to a line, so the
-/// count limit is the whole of what needs bounding.
+/// count is the whole of what needs bounding. Only the number was wrong.
 @MainActor
 enum TranscriptPresentationCache {
-    /// Comfortably more than a screen of rows, and the same figure `TranscriptEventCache` holds.
-    private static let limit = 256
+    /// **Every tool row a long session can hold, rather than a screen of them.**
+    ///
+    /// It was 256, on the argument that this is "the same figure `TranscriptEventCache` holds".
+    /// That figure had already been retired next door, and for a reason that applies here word for
+    /// word: the workspace this was measured against holds 1,306 messages, so one scroll from the
+    /// bottom of it to the top evicted every entry and recomputed all of them on the way back.
+    /// What is recomputed is `TranscriptPresenter.present`, which for a Codex workspace decodes
+    /// the whole item out of the call's input and for a `Write` counts the lines of the entire
+    /// file the agent wrote.
+    ///
+    /// A count rather than a cost, unlike the event cache, because the thing being held really is
+    /// small and bounded: the strings in a `ToolPresentation` are already cut to one line before
+    /// they get here, so eight thousand of them is a couple of megabytes at worst, where eight
+    /// thousand payloads would be the transcript itself.
+    private static let limit = 8_192
 
     private static let values: NSCache<NSNumber, ToolPresentationBox> = {
         let cache = NSCache<NSNumber, ToolPresentationBox>()

--- a/Sources/Bloom/Views/Transcript/TranscriptTextView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTextView.swift
@@ -129,6 +129,28 @@ struct TranscriptTextView: NSViewRepresentable {
         // would find a second, different set, and it runs on the text as it is laid out.
         view.isAutomaticLinkDetectionEnabled = false
         view.isAutomaticDataDetectionEnabled = false
+        // And no spell checker. Measured with `--scroll-probe` and `sample` over a 1,104 row
+        // conversation, `NSTextCheckingOperation` was running on three worker threads at once at
+        // USER_INTERACTIVE quality of service, 383 samples of a twelve second scroll, almost all
+        // of it inside `NSSpellChecker.userReplacementsDictionary` doing a linear
+        // `containsObject:` over the user's replacement list. Every text view the lazy stack
+        // realises starts one.
+        //
+        // **Be clear about what this bought, because it is not smoothness.** Frame times either
+        // side of the change are the same to within noise on an idle Mac with cores to spare:
+        // p95 19.0ms and 19.4ms, p99 25.5ms and 26.6ms over four sweeps. What it removes is about
+        // four tenths of a second of CPU per twelve seconds of scrolling, at the highest quality
+        // of service the system has, on a laptop that is usually on battery. `TranscriptEventCache`
+        // records the same shape of finding for the same reason.
+        //
+        // Nothing is lost either way. This view is `isEditable = false`: it draws an agent's
+        // answer and a sentence the user has already sent, neither of which anybody can correct
+        // here, so a red underline under the agent's spelling is an offer with nothing behind it.
+        // `SourceEditor` turns the same four off for the same reason.
+        view.isContinuousSpellCheckingEnabled = false
+        view.isGrammarCheckingEnabled = false
+        view.isAutomaticSpellingCorrectionEnabled = false
+        view.isAutomaticTextReplacementEnabled = false
         view.usesFontPanel = false
         view.usesFindBar = false
         // A text view inside a scroll view of SwiftUI's making must never scroll itself.


### PR DESCRIPTION
Stacked on #43.

**Reading a session parsed the whole of it on the main actor.** `absorb` runs `ParentProbe.parentToolUseID` (a full `JSONSerialization` of every payload to read one top level key), `ToolResultSummary.decode` (again, on the largest payload in the file) and `PermissionAsk.decode`. It was already written to be movable, so this is `nonisolated` on the fold plus a detached hop. `ContextWindowUsage.latest` stays on the main actor: it reads the event cache and stops a few rows from the end.

`--switch-probe`, release, 1440x900, cold open of the 1,306 message workspace: the longest main thread block between the click and the window fell from 135ms to 98 and 110ms over two runs. The smaller workspace, 110ms to 98 and 98ms.

**`TranscriptPresentationCache` held 256 entries** against a 1,306 message transcript, with a comment pointing at a figure `TranscriptEventCache` had already retired for exactly this reason. One scroll to the top evicted everything.

**The transcript's text views were being spell checked.** Three worker threads at USER_INTERACTIVE, 383 samples of a twelve second scroll, on views that are `isEditable = false`.

Neither of the last two moved a frame time, and both files now say so: p95 19.0ms before and 19.3ms after, p99 25.5 and 26.0, inside the run to run spread. They remove waste rather than judder. The tail is in `LazySubviewPlacements.placeSubviews`.