### PR TITLE
Give a browser pane a UI delegate, so a new window and a file input work

### DIFF
--- a/Sources/Bloom/Views/Center/Browser/BrowserPaneHost.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserPaneHost.swift
@@ -1,0 +1,26 @@
+import Foundation
+import BloomCore
+
+/// What a browser session can ask the window around it for.
+///
+/// A `BrowserSession` owns a web view and knows where the page is. It does not know which
+/// workspace it belongs to, which tab it is, or how the centre column is arranged, and it must not
+/// learn: the session outlives every view that draws it and is reached from a shared store, so a
+/// reference to a `WorkspaceModel` held here would keep one alive for as long as the tab exists
+/// and would be wrong the first time a tab moved.
+///
+/// So the two things a page can make happen outside its own pane are closures, handed down by the
+/// pane that is drawing the session, on every update rather than once. That is the same shape and
+/// the same reason as `BrowserWebView.paneMenu`: a tab can be dragged into another pane, and what
+/// a pane can do belongs to the pane.
+///
+/// Both default to doing nothing, which is what a session drawn by nobody should do. `MenuProbe`
+/// builds one of these sessions with no pane at all around it.
+@MainActor
+struct BrowserPaneHost {
+    /// Open a browser tab on this address, in front. `BrowserTab.openWindow` is the one door.
+    var openTab: (URL) -> Void = { _ in }
+    /// Tell the reader something Bloom decided on their behalf. There is one of these so far, and
+    /// it is a page being refused more windows than `BrowserPopups` allows.
+    var report: (BrowserPopups.Notice) -> Void = { _ in }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
@@ -49,6 +49,19 @@ final class BrowserSession {
     private(set) var page = BrowserTabTitle.BrowserPage()
 
     @ObservationIgnored private let navigation = NavigationObserver()
+    @ObservationIgnored private let ui = BrowserUIObserver()
+
+    /// What this pane can ask the window around it for, which the session cannot do itself. Set by
+    /// the pane drawing it, on every update. See `BrowserPaneHost`.
+    ///
+    /// `@ObservationIgnored` because it is assigned from inside SwiftUI's own update pass: a
+    /// tracked write from there invalidates the view that is mid update, which is the recursion
+    /// `AppModel.model(for:)` documents at length.
+    @ObservationIgnored var host = BrowserPaneHost()
+
+    /// How many windows the page in this session may open, and what happens when it asks for more.
+    /// The rule is in the core; this is the count for this one page.
+    @ObservationIgnored private var popups = BrowserPopups()
 
     /// KVO on everything the toolbar reads, because the navigation delegate does not see every
     /// navigation.
@@ -89,6 +102,8 @@ final class BrowserSession {
         webView.underPageBackgroundColor = NSColor(Palette.surface)
         navigation.owner = self
         webView.navigationDelegate = navigation
+        ui.owner = self
+        webView.uiDelegate = ui
         observations = [
             webView.observe(\.title, options: [.initial, .new]) { [weak self] view, _ in
                 // On the main thread, measured rather than assumed: WebKit posts every one of
@@ -260,10 +275,30 @@ final class BrowserSession {
         }
     }
 
+    /// The page asked for a window of its own, through `target="_blank"` or `window.open`.
+    ///
+    /// The whole decision is `BrowserPopups` in the core, so this is the wiring and nothing else:
+    /// a tab in front, silence, or one sentence to the reader. See `BrowserUIObserver` for why the
+    /// answer is a Bloom tab rather than a panel of WebKit's own.
+    func openWindow(_ url: URL?) {
+        switch popups.request(url) {
+        case .open(let url):
+            host.openTab(url)
+        case .refuse:
+            break
+        case .refuseAndSay(let notice):
+            host.report(notice)
+        }
+    }
+
     func stop() {
         observations = []
         webView.stopLoading()
         webView.navigationDelegate = nil
+        // With the navigation delegate, and for the same reason: a page whose pane has gone must
+        // not be able to put a tab in front of the reader or a panel over the window.
+        webView.uiDelegate = nil
+        host = BrowserPaneHost()
         // The page view rather than the web view, so an attached inspector comes out of the window
         // with the page instead of being left in the wrapper on its own. Releasing this session
         // would get there anyway, WebKit takes an inspector down with the page it is inspecting,

--- a/Sources/Bloom/Views/Center/Browser/BrowserTab.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserTab.swift
@@ -74,6 +74,26 @@ enum BrowserTab {
     /// conversations the strip is mostly for. It is the same argument `CenterTab` already makes
     /// for the review tab, and the way to a second browser is unchanged: the strip's `+` menu
     /// still adds one, and this reuses whichever browser tab is last in the strip.
+    /// Opens the window a page asked for, as a browser tab of the workspace's, in front.
+    ///
+    /// **A new tab every time, which is the one place this disagrees with `open` below.** That one
+    /// is a reader choosing an address out of a transcript, where a tab per link would bury the
+    /// conversations the strip is mostly for. This is a page that has said the document it is
+    /// showing should stay where it is, so pointing the workspace's existing browser at somewhere
+    /// else would be the single outcome `target="_blank"` rules out.
+    ///
+    /// Through `CenterTabStore.add` and `WorkspaceTabsStore.reveal` like everything else in this
+    /// type, so a window a page opened is exactly the tab a browser tab normally is: closable,
+    /// nameable, splittable, and with the same address field over it. How many of these a page may
+    /// have is `BrowserPopups`, which has already answered by the time this is called.
+    static func openWindow(_ url: URL, in model: WorkspaceModel) {
+        guard canOpen(url) else { return }
+        let tab = CenterTabStore.shared.add(
+            kind: .browser, workspaceID: model.workspace.id, url: url.absoluteString
+        )
+        WorkspaceTabsStore.shared.reveal(.tool(tab.id), in: model)
+    }
+
     static func open(_ url: URL, in model: WorkspaceModel) {
         guard canOpen(url) else { return }
         let address = url.absoluteString

--- a/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
@@ -44,7 +44,7 @@ struct BrowserTabView: View {
         VStack(spacing: 0) {
             toolbar(session)
             Hairline()
-            BrowserWebView(session: session, paneMenu: pageMenu)
+            BrowserWebView(session: session, paneMenu: pageMenu, host: host)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .background(Palette.surface)
@@ -105,6 +105,24 @@ struct BrowserTabView: View {
             submit: {
                 session.load(address)
                 isAddressFocused = false
+            }
+        )
+    }
+
+    /// What the page in this pane may ask the window for.
+    ///
+    /// Built here rather than on the session because this is the level that knows which workspace
+    /// the tab belongs to, and a session must not learn that: it outlives every view that draws it.
+    /// The model is captured weakly, so a browser tab left open on a workspace nobody has selected
+    /// for an hour is not what keeps that workspace's model alive.
+    private var host: BrowserPaneHost {
+        BrowserPaneHost(
+            openTab: { [weak model] url in
+                guard let model else { return }
+                BrowserTab.openWindow(url, in: model)
+            },
+            report: { [weak app] notice in
+                app?.alert = BloomAlert(title: notice.title, message: notice.message)
             }
         )
     }

--- a/Sources/Bloom/Views/Center/Browser/BrowserUIDelegate.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserUIDelegate.swift
@@ -1,0 +1,107 @@
+import AppKit
+import WebKit
+import BloomCore
+
+/// The things a page asks the application for, rather than the network: a window of its own, and
+/// a file off this Mac.
+///
+/// **A browser pane had no `WKUIDelegate` at all**, and WebKit's answer to a missing one is to do
+/// nothing without saying so. Every `target="_blank"` link and every `window.open` returned null
+/// and left the reader looking at a page where a click had visibly failed; every
+/// `<input type="file">` opened no panel. For a pane whose whole job is the dev server running in
+/// the worktree next door, those are the everyday cases rather than the exotic ones.
+///
+/// Kept off `BrowserSession` for the reason `NavigationObserver` is: `uiDelegate` is the sort of
+/// reference that outlives what it points at, and a separate object makes the weak link back
+/// explicit. It is one object per session, so a delegate is never shared between two pages.
+///
+/// ## What this does not implement, on purpose
+///
+/// Adopting a UI delegate is adopting a list of things a page may ask for, and the ones left out
+/// are left out deliberately. `requestMediaCapturePermissionFor` is absent, so a page still cannot
+/// reach the camera or the microphone: WebKit denies capture when the delegate does not answer,
+/// and this pane is the owner's own browser logged in as him. `webViewDidClose` is absent because
+/// nothing here ever hands WebKit a web view it created, so no page has a window of its own to
+/// close. The argument behind both is the head of `BrowserPaneCommand`: a page asking for
+/// something is not a page being granted whatever it likes.
+@MainActor
+final class BrowserUIObserver: NSObject, WKUIDelegate {
+    weak var owner: BrowserSession?
+
+    // MARK: - A window of its own
+
+    /// `target="_blank"` and `window.open`.
+    ///
+    /// **Nil is returned and a Bloom browser tab is opened instead, which is a decision rather
+    /// than a shortcut.** The other answer is to hand WebKit a real second `WKWebView` in a panel
+    /// of its own, which is the only way `window.opener` and `postMessage` keep working, and which
+    /// is what an OAuth popup wants. It was not taken: a floating panel is not a thing this window
+    /// has anywhere else, it would sit above the pane the reader is working in with no tab strip,
+    /// no address field and no way to split it, and a page could put one there without a click.
+    /// A browser tab is what every other route into this column produces, it is closable,
+    /// nameable, splittable and inspectable like any other, and it is the answer the reader can
+    /// already reason about. What it costs is honest and worth stating: a sign-in popup that
+    /// expects to talk back to its opener will not, because the tab is not its opener.
+    ///
+    /// **In front, because the reader asked for it by name**, which is the same argument
+    /// `BrowserTab.open` writes down. A link that opened a page behind the one you were reading
+    /// reads as having done nothing, which is the bug this method exists to fix.
+    ///
+    /// **A new tab rather than the workspace's existing browser**, which is the one place this
+    /// disagrees with `BrowserTab.open`. That one is a reader choosing an address out of a
+    /// transcript and not wanting a tab per link; this is a page that has said the current
+    /// document should stay where it is, and pointing the pane it asked from at somewhere else
+    /// would be the one outcome the page has ruled out.
+    ///
+    /// How many a page may have is `BrowserPopups`, in the core, where it can be tested.
+    func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures: WKWindowFeatures
+    ) -> WKWebView? {
+        owner?.openWindow(navigationAction.request.url)
+        return nil
+    }
+
+    // MARK: - A file off this Mac
+
+    /// `<input type="file">`.
+    ///
+    /// **The `async` spelling of the delegate method rather than the completion handler.** WebKit
+    /// hangs the file input forever if the handler is never called and calls `NSInternalInconsistencyException`
+    /// if it is called twice, and neither of those can happen here: the compiler resumes the
+    /// continuation exactly once whatever path this returns by.
+    ///
+    /// `NSOpenPanel.present` rather than `runModal`, for the reason that extension gives: a modal
+    /// run loop stops every other workspace's transcript from streaming for as long as the panel
+    /// is open, and this is an app whose whole point is several agents working at once.
+    ///
+    /// WebKit only asks this after a click on the input, so there is no new reach here for a page
+    /// that nobody is looking at. What the reader chooses is readable by the page, which is what
+    /// choosing a file in any browser means.
+    func webView(
+        _ webView: WKWebView,
+        runOpenPanelWith parameters: WKOpenPanelParameters,
+        initiatedByFrame frame: WKFrameInfo
+    ) async -> [URL]? {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = parameters.allowsDirectories
+        panel.allowsMultipleSelection = parameters.allowsMultipleSelection
+        panel.canCreateDirectories = false
+        panel.prompt = "Upload"
+        panel.message = BrowserPageOrigin.uploadMessage(
+            from: Self.name(of: frame.securityOrigin),
+            allowsMultiple: parameters.allowsMultipleSelection
+        )
+        guard await panel.present() == .OK else { return nil }
+        return panel.urls
+    }
+
+    /// The page's origin as a name, which is Bloom's half of anything a page raises. The rule is
+    /// `BrowserPageOrigin` in the core; this is only the three properties off WebKit's own type.
+    private static func name(of origin: WKSecurityOrigin) -> String? {
+        BrowserPageOrigin.name(scheme: origin.protocol, host: origin.host, port: origin.port)
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserWebView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserWebView.swift
@@ -90,16 +90,24 @@ struct BrowserWebView: NSViewRepresentable {
     /// The pane's own menu, to go under the page's. Set on every update rather than once, because
     /// the tab can be dragged into another pane and the menu belongs to the pane, not the tab.
     var paneMenu: (@MainActor () -> NSMenu)?
+    /// What the page can ask the window for, handed down for the same reason and on the same
+    /// schedule as the menu above. See `BrowserPaneHost`.
+    var host = BrowserPaneHost()
 
     func makeNSView(context: Context) -> BrowserHostView {
-        let host = BrowserHostView()
-        host.attach(session.pageView)
-        session.webView.paneMenu = paneMenu
-        return host
+        let view = BrowserHostView()
+        view.attach(session.pageView)
+        wire()
+        return view
     }
 
     func updateNSView(_ nsView: BrowserHostView, context: Context) {
         nsView.attach(session.pageView)
+        wire()
+    }
+
+    private func wire() {
         session.webView.paneMenu = paneMenu
+        session.host = host
     }
 }

--- a/Sources/BloomCore/System/BrowserPageOrigin.swift
+++ b/Sources/BloomCore/System/BrowserPageOrigin.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Who is asking, said the way a browser says it.
+///
+/// A page can raise two things that look like they came from Bloom: a file panel, and (once the
+/// dialogs land) an alert. Both are chrome the reader trusts, and a page that writes "Bloom needs
+/// your password" into one of them is doing the oldest trick there is. Every browser answers this
+/// the same way, by naming the origin on the panel itself, and that is what this is for: the
+/// sentence the reader sees says which site asked, in Bloom's words, above whatever the page
+/// wrote.
+///
+/// It takes the three parts rather than a `WKSecurityOrigin` because the core imports no UI
+/// framework and WebKit is one. The app pulls `protocol`, `host` and `port` off the frame and
+/// hands them over.
+public enum BrowserPageOrigin {
+    /// What to call the page asking, which is host and port and nothing else.
+    ///
+    /// **No scheme and no path.** A path is where a page can write anything it likes (a site can
+    /// serve `/Bloom Support: enter your token/` and have it appear in the sentence), and the
+    /// scheme is noise next to a dev server the reader started themselves. Host and port are the
+    /// two parts a page cannot forge, and the port is what tells one worktree's server from
+    /// another's, which is the distinction that matters most in this window.
+    ///
+    /// The port is dropped when it is the default for the scheme, because "example.com:443" is
+    /// how nothing on the platform writes it. An origin with no host at all is not a site: it is
+    /// a document loaded from a string or a file, and there is no name to give it.
+    public static func name(scheme: String, host: String, port: Int) -> String? {
+        let host = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !host.isEmpty else { return nil }
+
+        let scheme = scheme.lowercased()
+        let isDefaultPort = (scheme == "https" && (port == 443 || port == 0))
+            || (scheme == "http" && (port == 80 || port == 0))
+        return isDefaultPort ? host : "\(host):\(port)"
+    }
+
+    /// The line above a file panel a page raised.
+    ///
+    /// It names the page, for the reason above, and it says what happens next rather than what to
+    /// click: a file chosen here is a file handed to that site, and a reader who has forgotten
+    /// which tab put the panel up should be able to read that off the panel.
+    public static func uploadMessage(from name: String?, allowsMultiple: Bool) -> String {
+        let what = allowsMultiple ? "the files" : "the file"
+        guard let name else { return "Choose \(what) you want to give this page." }
+        return "Choose \(what) you want to give \(name)."
+    }
+}

--- a/Sources/BloomCore/System/BrowserPopups.swift
+++ b/Sources/BloomCore/System/BrowserPopups.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// What happens when a page in a browser pane asks for a window of its own.
+///
+/// A `target="_blank"` link and a `window.open` call arrive at the same place, and until now that
+/// place did nothing at all: `WKUIDelegate.createWebViewWith` was never implemented, so WebKit
+/// took the default answer of nil and the click looked broken. Bloom's answer is a second browser
+/// tab in the same workspace, and this is the rule that decides whether the page gets one.
+///
+/// **It is a rate limit rather than a permission**, and the difference is the point. A reader
+/// clicking links that open in a new tab is doing the ordinary thing and must not be asked about
+/// it; a page in a loop calling `window.open` a thousand times must not be able to fill the strip
+/// with a thousand tabs. Those two are told apart by how fast they arrive and by nothing else,
+/// because there is no signal in `WKNavigationAction` that says a human pressed the mouse. Five in
+/// five seconds is above anything a hand does and far below what a loop does in one frame.
+///
+/// **The first refusal says so and the rest are silent.** A loop that is refused a thousand times
+/// would otherwise put up a thousand alerts, which is the same denial of service by another door.
+/// So the notice is carried on the first refusal after a run of allowed openings and on no other,
+/// and the count is reset by an opening being allowed again, which is what a reader clicking a
+/// link a minute later does.
+///
+/// **A scheme a browser pane cannot show is refused quietly.** `window.open("mailto:...")` and
+/// anything with a custom scheme are not addresses this pane can hold, and handing one to
+/// `NSWorkspace` instead would let a page launch applications on this Mac by writing one line of
+/// script. That is a capability the pane has never had and this is not the change that grants it.
+/// The test is `BrowserAddress.shows`, which is the same one the transcript's link menu asks.
+public struct BrowserPopups: Sendable, Equatable {
+    /// What to tell the reader, when there is anything to tell them.
+    public struct Notice: Sendable, Equatable {
+        public var title: String
+        public var message: String
+
+        public init(title: String, message: String) {
+            self.title = title
+            self.message = message
+        }
+    }
+
+    public enum Decision: Sendable, Equatable {
+        /// Open a browser tab on this address, in front.
+        case open(URL)
+        /// Nothing happens and nothing is said.
+        case refuse
+        /// Nothing happens, and the reader is told once why.
+        case refuseAndSay(Notice)
+    }
+
+    /// How many windows a page may open in `window` seconds.
+    public var limit: Int
+    /// The length of the rolling window the limit is counted over, in seconds.
+    public var window: TimeInterval
+
+    /// When each of the recent openings was allowed, oldest first. Pruned on every request, so it
+    /// never holds more than `limit` entries.
+    private var openings: [Date] = []
+    /// Whether the reader has already been told about this run of refusals.
+    private var hasSaidSo = false
+
+    public init(limit: Int = 5, window: TimeInterval = 5) {
+        self.limit = limit
+        self.window = window
+    }
+
+    /// Asks whether a page may open `url` in a tab of its own, and records the answer.
+    ///
+    /// `now` is passed in rather than read here so the suite can drive the clock. Every caller in
+    /// the app passes `Date()`.
+    public mutating func request(_ url: URL?, at now: Date = Date()) -> Decision {
+        // A page that calls `window.open()` with no address gets an empty window in a browser, and
+        // an empty window is not a thing this pane can be: a browser tab pointed nowhere shows an
+        // address field the page cannot then reach. Nothing to show, so nothing happens.
+        guard let url, BrowserAddress.shows(url) else { return .refuse }
+
+        openings.removeAll { now.timeIntervalSince($0) >= window }
+        guard openings.count < limit else {
+            guard !hasSaidSo else { return .refuse }
+            hasSaidSo = true
+            return .refuseAndSay(Self.notice(for: url))
+        }
+
+        openings.append(now)
+        hasSaidSo = false
+        return .open(url)
+    }
+
+    /// The sentence the first refusal carries.
+    ///
+    /// It names the host rather than the whole address, because the address of the thousandth
+    /// window a loop asked for says nothing and a dialog is not the place for a query string. It
+    /// says what Bloom did rather than what the page did, because "a page tried to" reads as an
+    /// accusation the reader has to act on and there is nothing for them to do.
+    private static func notice(for url: URL) -> Notice {
+        let host = url.host() ?? "That page"
+        return Notice(
+            title: "Bloom stopped \(host) opening more tabs",
+            message: """
+                This page asked for several browser tabs at once, which is what a page in a loop \
+                does. Bloom opened the first few and refused the rest. Reload the page if you were \
+                expecting them.
+                """
+        )
+    }
+}

--- a/Tests/BloomCoreTests/BrowserPageOriginTests.swift
+++ b/Tests/BloomCoreTests/BrowserPageOriginTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// Who a page says it is, on the panels a page can raise.
+@Suite("Browser page origin")
+struct BrowserPageOriginTests {
+    @Test("A dev server is named by host and port, which is what tells two worktrees apart")
+    func aDevServerKeepsItsPort() {
+        #expect(BrowserPageOrigin.name(scheme: "http", host: "localhost", port: 3100)
+            == "localhost:3100")
+    }
+
+    @Test("The default port for the scheme is left off")
+    func theDefaultPortIsDropped() {
+        #expect(BrowserPageOrigin.name(scheme: "https", host: "example.com", port: 443)
+            == "example.com")
+        #expect(BrowserPageOrigin.name(scheme: "http", host: "example.com", port: 80)
+            == "example.com")
+        #expect(BrowserPageOrigin.name(scheme: "https", host: "example.com", port: 0)
+            == "example.com")
+        #expect(BrowserPageOrigin.name(scheme: "https", host: "example.com", port: 8443)
+            == "example.com:8443")
+    }
+
+    @Test("A document with no host is not a site and has no name")
+    func anOpaqueOriginHasNoName() {
+        #expect(BrowserPageOrigin.name(scheme: "file", host: "", port: 0) == nil)
+        #expect(BrowserPageOrigin.name(scheme: "", host: "  ", port: 0) == nil)
+    }
+
+    @Test("The file panel says who is asking and what happens to what is chosen")
+    func theUploadMessageNamesThePage() {
+        let one = BrowserPageOrigin.uploadMessage(from: "localhost:3100", allowsMultiple: false)
+        #expect(one == "Choose the file you want to give localhost:3100.")
+
+        let many = BrowserPageOrigin.uploadMessage(from: "localhost:3100", allowsMultiple: true)
+        #expect(many == "Choose the files you want to give localhost:3100.")
+    }
+
+    @Test("A page with no name still gets a sentence")
+    func theUploadMessageSurvivesAnUnnamedPage() {
+        let message = BrowserPageOrigin.uploadMessage(from: nil, allowsMultiple: false)
+        #expect(message == "Choose the file you want to give this page.")
+    }
+}

--- a/Tests/BloomCoreTests/BrowserPopupsTests.swift
+++ b/Tests/BloomCoreTests/BrowserPopupsTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// What a page gets when it asks for a window of its own, and what a page in a loop gets.
+@Suite("Browser popups")
+struct BrowserPopupsTests {
+    private static let start = Date(timeIntervalSince1970: 1_700_000_000)
+    private static let page = URL(string: "http://localhost:3100/next")!
+
+    @Test("An ordinary link that opens in a new tab gets one")
+    func aLinkOpens() {
+        var popups = BrowserPopups()
+        #expect(popups.request(Self.page, at: Self.start) == .open(Self.page))
+    }
+
+    @Test("A page cannot open more than the limit in one burst")
+    func aBurstIsCapped() {
+        var popups = BrowserPopups(limit: 3, window: 5)
+        for step in 0..<3 {
+            let at = Self.start.addingTimeInterval(Double(step) / 100)
+            #expect(popups.request(Self.page, at: at) == .open(Self.page))
+        }
+
+        let fourth = popups.request(Self.page, at: Self.start.addingTimeInterval(0.04))
+        guard case .refuseAndSay = fourth else {
+            Issue.record("the fourth window in a burst should be refused, got \(fourth)")
+            return
+        }
+    }
+
+    @Test("Only the first refusal in a run says anything, so a loop puts up one dialog")
+    func onlyTheFirstRefusalSpeaks() {
+        var popups = BrowserPopups(limit: 1, window: 5)
+        #expect(popups.request(Self.page, at: Self.start) == .open(Self.page))
+
+        let first = popups.request(Self.page, at: Self.start.addingTimeInterval(0.01))
+        guard case .refuseAndSay = first else {
+            Issue.record("the first refusal should carry a notice, got \(first)")
+            return
+        }
+        for step in 2..<200 {
+            let at = Self.start.addingTimeInterval(Double(step) / 100)
+            #expect(popups.request(Self.page, at: at) == .refuse)
+        }
+    }
+
+    @Test("The notice names the host and nothing else of the address")
+    func theNoticeNamesTheHost() {
+        var popups = BrowserPopups(limit: 0, window: 5)
+        let url = URL(string: "https://example.com/a/very/long/path?token=secret")!
+        guard case .refuseAndSay(let notice) = popups.request(url, at: Self.start) else {
+            Issue.record("a limit of none should refuse and say so")
+            return
+        }
+        #expect(notice.title.contains("example.com"))
+        #expect(!notice.title.contains("secret"))
+        #expect(!notice.message.contains("secret"))
+    }
+
+    @Test("A reader clicking a link a minute later is not held to the last refusal")
+    func theWindowRolls() {
+        var popups = BrowserPopups(limit: 1, window: 5)
+        #expect(popups.request(Self.page, at: Self.start) == .open(Self.page))
+        #expect(popups.request(Self.page, at: Self.start.addingTimeInterval(1)) != .open(Self.page))
+        #expect(popups.request(Self.page, at: Self.start.addingTimeInterval(60)) == .open(Self.page))
+    }
+
+    @Test("An allowed opening arms the notice again, so a second loop is also reported")
+    func aSecondLoopIsAlsoReported() {
+        var popups = BrowserPopups(limit: 1, window: 5)
+        _ = popups.request(Self.page, at: Self.start)
+        _ = popups.request(Self.page, at: Self.start.addingTimeInterval(0.01))
+        #expect(popups.request(Self.page, at: Self.start.addingTimeInterval(60)) == .open(Self.page))
+
+        let again = popups.request(Self.page, at: Self.start.addingTimeInterval(60.01))
+        guard case .refuseAndSay = again else {
+            Issue.record("a fresh run of refusals should say so once, got \(again)")
+            return
+        }
+    }
+
+    @Test("A scheme the pane cannot show is refused without a word")
+    func anUnshowableSchemeIsQuiet() {
+        var popups = BrowserPopups()
+        #expect(popups.request(URL(string: "mailto:someone@example.com"), at: Self.start) == .refuse)
+        #expect(popups.request(URL(string: "bloom://open/workspace"), at: Self.start) == .refuse)
+        #expect(popups.request(URL(string: "file:///etc/passwd"), at: Self.start) == .refuse)
+    }
+
+    @Test("A refused scheme costs the page nothing from its allowance")
+    func aRefusedSchemeIsNotCounted() {
+        var popups = BrowserPopups(limit: 1, window: 5)
+        #expect(popups.request(URL(string: "mailto:someone@example.com"), at: Self.start) == .refuse)
+        #expect(popups.request(Self.page, at: Self.start) == .open(Self.page))
+    }
+
+    @Test("window.open with no address does nothing")
+    func anEmptyWindowIsRefused() {
+        var popups = BrowserPopups()
+        #expect(popups.request(nil, at: Self.start) == .refuse)
+    }
+}


### PR DESCRIPTION
The browser pane had no `WKUIDelegate`, so `target="_blank"`, `window.open` and `<input type="file">` all did nothing at all, with no error and no navigation.

A window a page asks for now becomes a Bloom browser tab, in front, rather than a `WKWebView` in a panel of WebKit's own. `BrowserPopups` in the core caps that at five in five seconds, above anything a hand does and far below what a loop does in one frame; the first refusal in a run says so and the rest are silent, so a loop puts up one dialog rather than a thousand. A scheme the pane cannot show is refused quietly rather than handed to `NSWorkspace`.

The file panel is the `async` spelling of the delegate method, so it resumes exactly once whatever path it returns by, and `NSOpenPanel.present` rather than `runModal`. It names the page asking, through `BrowserPageOrigin`.

Media capture stays absent on purpose, so a page still cannot reach the camera or the microphone.

First of four: the dialogs, downloads and find in page follow on top of this.