### PR TITLE
Point the menu bar at the row the user is looking at

### DIFF
--- a/Sources/Bloom/State/AppModel.swift
+++ b/Sources/Bloom/State/AppModel.swift
@@ -824,11 +824,12 @@ final class AppModel {
         return workspaceModels[id]?.workspace
     }
 
-    /// The workspace a menu item should act on, archived or not.
+    /// The workspace the window is about, archived or not.
     ///
-    /// Only for the items that still mean something once the worktree is gone, which is Copy
-    /// Branch Name and nothing else. Opening an editor or a Finder window on a path that no
-    /// longer exists is not one of them.
+    /// What the title says, so that reading an archived transcript names it rather than falling
+    /// back to "Bloom". The Workspace menu no longer asks: what a menu item acts on is
+    /// `WorkspaceMenuSubject`, which also hears about a row highlighted on Home or in the Archive,
+    /// and which decides per item whether an archived workspace can answer it at all.
     var menuWorkspace: Workspace? {
         selectedWorkspace ?? selectedArchivedWorkspace
     }

--- a/Sources/Bloom/Views/Archive/ArchiveView.swift
+++ b/Sources/Bloom/Views/Archive/ArchiveView.swift
@@ -43,6 +43,18 @@ struct ArchiveView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Palette.windowBackground)
+        // What the Workspace menu acts on while this screen is up. The sidebar's selection here is
+        // `.archive`, which names no workspace, so a row highlighted in this list used to leave
+        // Restore and Copy Branch Name greyed out with the workspace they name under the pointer.
+        // Only a single selection publishes: a menu item that acts on one workspace has nothing to
+        // say about eight ticked rows, and the Delete below is what those are for.
+        .focusedValue(\.focusedWorkspaceRow, focusedRow)
+        // Delete on the selection, which is this screen's own verb. It goes through the same
+        // confirmation the menu and the row both use, because there is no undo for this one.
+        .onDeleteCommand {
+            guard !selected.isEmpty else { return }
+            confirming = ArchiveDeletion(cleanup.selected(selected, order: order))
+        }
         .task(id: app.archivedRevision) { await load() }
         .confirmation($confirming) { deletion in
             Confirmation(
@@ -92,6 +104,13 @@ struct ArchiveView: View {
         .padding(.horizontal, Metrics.gutter)
         .frame(height: Metrics.barHeight)
         .tabStripMaterial()
+    }
+
+    /// The one highlighted row, offered to the menu bar. See `FocusedMenuValues`.
+    private var focusedRow: FocusedWorkspaceRow? {
+        guard selected.count == 1, let id = selected.first,
+              let footprint = cleanup.footprints.first(where: { $0.id == id }) else { return nil }
+        return FocusedWorkspaceRow(workspace: footprint.workspace, isArchived: true)
     }
 
     private var summaryOfEverything: String {

--- a/Sources/Bloom/Views/Center/Panes/ReviewPaneView.swift
+++ b/Sources/Bloom/Views/Center/Panes/ReviewPaneView.swift
@@ -70,7 +70,6 @@ struct ReviewPaneView: View {
         }
         .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { paneHeight = $0 }
         .background(Palette.surface)
-        .background { shortcuts }
         // A pane can be pointed at a session this launch has never opened, so the transcript is
         // built here rather than assumed, exactly as `CenterPaneView.prepare` does for a chat.
         .task(id: model.activeSession?.id) {
@@ -134,26 +133,4 @@ struct ReviewPaneView: View {
         }
     }
 
-    /// The walk through a change, without the mouse.
-    ///
-    /// Hidden buttons rather than menu commands, for the reason spelled out in `SessionTabsView`:
-    /// the app's menu bar is built elsewhere, and a key equivalent is only offered to the menu bar
-    /// and to the view hierarchy. These are in the hierarchy, and only while a review is actually
-    /// on screen, so the same keys mean nothing while the reader is in a conversation.
-    ///
-    /// Cmd+Option+J and K rather than Conductor's bare j and k. Bare letters are its choice
-    /// because it can suppress them while an input has focus; a SwiftUI window has text fields in
-    /// three columns at once and no such gate, and a review that ate every j typed into the
-    /// composer would be worse than no shortcut at all.
-    private var shortcuts: some View {
-        ZStack {
-            Button("Next Changed File") { FileReview.step(1, in: model) }
-                .keyboardShortcut("j", modifiers: [.command, .option])
-            Button("Previous Changed File") { FileReview.step(-1, in: model) }
-                .keyboardShortcut("k", modifiers: [.command, .option])
-        }
-        .frame(width: 0, height: 0)
-        .opacity(0)
-        .accessibilityHidden(true)
-    }
 }

--- a/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
+++ b/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
@@ -18,6 +18,13 @@ struct BloomCommands: Commands {
     /// Nil in every scene but the main window. See `MainWindowFocus`.
     @FocusedValue(\.isMainWindowFocused) private var isMainWindowFocused: Bool?
 
+    /// The row Home or the Archive has highlighted, which is what the Workspace menu acts on when
+    /// the sidebar is not pointing at a workspace itself. See `FocusedMenuValues`.
+    @FocusedValue(\.focusedWorkspaceRow) private var focusedRow: FocusedWorkspaceRow?
+
+    /// The focused window's Save, when it has one. See `FocusedMenuValues`.
+    @FocusedValue(\.saveAction) private var saveAction: SaveAction?
+
     init(model: AppModel) {
         self.model = model
     }
@@ -141,28 +148,52 @@ struct BloomCommands: Commands {
 
             Divider()
 
-            // Cmd+W belongs to the session, not the window. Bloom has no Save item, so a group
-            // anchored after `.saveItem` is dropped whole and Cmd+W falls through to the system
-            // Close, which used to end the process and every agent with it.
+            // Cmd+W belongs to the tab, not the window, and this used to be Close Session, which
+            // is not the same claim. It closed the workspace's active conversation whatever was in
+            // front, so on a browser, a review or the notes it ended a chat in some other pane,
+            // silently whenever that chat was idle. Four kinds of tab could be opened from the
+            // keyboard and none of them could be closed.
             //
-            // It belongs to the session in the MAIN window, though, which is why it is scoped
-            // to that scene below. The menu bar is shared with Settings and with each project's
-            // settings window, and unscoped this item both closed the wrong thing from those
-            // windows and left them with no working Cmd+W of their own.
-            Button("Close Session") {
-                guard let workspace = model.selectedModel,
-                      let session = workspace.activeSession else { return }
-                CloseSessionAlert.shared.close(session, in: workspace)
+            // There is no Close Session beside it, because a conversation IS a tab in this strip
+            // and closing one still asks what `SessionClosure` asks. The obvious second half,
+            // moving Close Session to Shift+Cmd+W, is not available: that key is the window's own
+            // Close and has to stay so. See `WindowDismissal` and `TabClosure`.
+            //
+            // It belongs to the tab in the MAIN window, though, which is why it is scoped to that
+            // scene below. The menu bar is shared with Settings and with each project's settings
+            // window, and unscoped this item both closed the wrong thing from those windows and
+            // left them with no working Cmd+W of their own.
+            Button("Close Tab") {
+                closeSelectedTab()
             }
             .keyboardShortcut("w", modifiers: .command)
-            // Scoped to the main window as well as to there being a session, because this item
-            // holds Cmd+W for the whole app. See `MainWindowFocus`.
-            .disabled(isMainWindowFocused != true || model.selectedModel?.activeSession == nil)
+            // Scoped to the main window as well as to there being a tab, because this item holds
+            // Cmd+W for the whole app. See `MainWindowFocus`.
+            .disabled(isMainWindowFocused != true || closableTab == nil)
 
             Divider()
 
             Button("Add Project Folder…", action: addProjectFolder)
             .keyboardShortcut("o", modifiers: [.command, .shift])
+        }
+
+        // The item this file used to say did not exist. Two views bind Cmd+S (the project settings
+        // window's save bar and the inspector's file editor) and the menu bar advertised neither,
+        // which is a key equivalent nobody can discover.
+        //
+        // `.saveItem` is where every Mac app puts it, under the Close group, and having a real one
+        // there also gives that placement something to anchor against for the first time.
+        //
+        // The key is on the item as well as on the button that publishes the action, which is a tie
+        // AppKit settles in the view hierarchy's favour: the button wins and this item never fires
+        // from the keyboard. That is fine and is why both exist. What this adds is the row, its
+        // key drawn where people look for it, and a target for the pointer. Where nothing has
+        // published a Save the item is disabled, and a disabled item does not consume its key, so a
+        // view that still keeps Cmd+S to itself keeps working. See `FocusedMenuValues`.
+        CommandGroup(replacing: .saveItem) {
+            Button("Save") { saveAction?.perform() }
+                .keyboardShortcut("s", modifiers: .command)
+                .disabled(saveAction?.isEnabled != true)
         }
 
         CommandGroup(after: .pasteboard) {
@@ -224,6 +255,24 @@ struct BloomCommands: Commands {
             Button("Next Tab") { cycleCentreTab(by: 1) }
                 .keyboardShortcut("]", modifiers: [.command, .shift])
                 .disabled(!canCycleCentreTabs)
+
+            goToTabMenu
+
+            Divider()
+
+            // The walk through a change, which used to be two invisible buttons inside
+            // `ReviewPaneView` carrying Cmd+Option+J and K with no menu item anywhere. The four tab
+            // keys made this move first and wrote down the measurement: a key registered on a
+            // hidden button and on a menu item is not a tie, the button wins and the item never
+            // fires, so it has to be one or the other. Here it is the menu, which greys itself out
+            // when there is nothing to step through and says the keys out loud.
+            Button("Next Changed File") { stepChangedFile(1) }
+                .keyboardShortcut("j", modifiers: [.command, .option])
+                .disabled(!canStepChangedFiles)
+
+            Button("Previous Changed File") { stepChangedFile(-1) }
+                .keyboardShortcut("k", modifiers: [.command, .option])
+                .disabled(!canStepChangedFiles)
 
             Divider()
         }
@@ -296,12 +345,33 @@ struct BloomCommands: Commands {
                 .disabled(!zoom.canResetSize)
         }
 
+        // Every item here used to be gated on `AppModel.selectedWorkspace`, which is the sidebar's
+        // selection and nothing else. On Home the selection is `.home` and in the Archive it is
+        // `.archive`, so a row highlighted in either list left this whole menu greyed out while the
+        // user was pointing straight at the workspace it names. What each item acts on now is
+        // `WorkspaceMenuSubject` in the core, resolved from the selection and from whichever list
+        // has published a row, with the precedence and the archived cases held by its tests.
         CommandMenu("Workspace") {
+            // Rename had no menu item at all: it existed on the row context menus alone, which a
+            // keyboard-only user reaches only through VoiceOver. No key equivalent, because Finder
+            // gives Rename none either and both lists already spend Return on opening a row.
+            Button("Rename") {
+                guard let workspace = workspace(for: .rename) else { return }
+                NotificationCenter.default.post(
+                    name: .bloomRenameWorkspace, object: nil,
+                    userInfo: [Notification.bloomWorkspaceIDKey: workspace.id.rawValue]
+                )
+            }
+            .disabled(workspace(for: .rename) == nil)
+
+            Divider()
+
             Button("Archive Workspace") {
-                archiveSelectedWorkspace()
+                guard let workspace = workspace(for: .archive) else { return }
+                archive(workspace)
             }
             .keyboardShortcut(.delete, modifiers: .command)
-            .disabled(model.selectedWorkspace == nil)
+            .disabled(workspace(for: .archive) == nil)
 
             // The way back, which the menu bar had no item for at all. Before this the only path
             // to `restoreArchived` in the whole app was the undo registered by the archive that
@@ -309,38 +379,36 @@ struct BloomCommands: Commands {
             // anywhere. See `ArchivedWorkspaceView` for why reading it and restoring it are two
             // different things.
             Button("Restore Workspace") {
-                restoreArchivedWorkspace()
+                guard let workspace = restorableWorkspace else { return }
+                Task { await model.restore(workspace) }
             }
-            .disabled(
-                model.selectedArchivedWorkspace == nil
-                    || model.selectedArchivedWorkspace.map { model.restoring.contains($0.id) } == true
-            )
+            .disabled(restorableWorkspace == nil)
 
             Divider()
 
             Button("Open in Editor") {
-                guard let workspace = model.selectedWorkspace else { return }
+                guard let workspace = workspace(for: .openInEditor) else { return }
                 Reveal.inEditor(workspace.path)
             }
             .keyboardShortcut("e", modifiers: [.command, .shift])
-            .disabled(model.selectedWorkspace == nil)
+            .disabled(workspace(for: .openInEditor) == nil)
 
             Button("Reveal in Finder") {
-                guard let workspace = model.selectedWorkspace else { return }
+                guard let workspace = workspace(for: .revealInFinder) else { return }
                 Reveal.inFinder(workspace.path)
             }
             .keyboardShortcut("r", modifiers: [.command, .shift])
-            .disabled(model.selectedWorkspace == nil)
+            .disabled(workspace(for: .revealInFinder) == nil)
 
-            // `menuWorkspace`, not `selectedWorkspace`: a branch name is the one thing on this
-            // menu that still means something once the worktree has been removed, and it is what
-            // somebody reading an archived workspace reaches for.
+            // The one item an archived workspace still answers to. A branch name means something
+            // once the worktree has gone, and opening an editor on a path that is not there does
+            // not: that pair is the whole of `WorkspaceMenuSubject.allows`.
             Button("Copy Branch Name") {
-                guard let workspace = model.menuWorkspace else { return }
+                guard let workspace = workspace(for: .copyBranchName) else { return }
                 Clipboard.copy(workspace.branch)
             }
             .keyboardShortcut("c", modifiers: [.command, .shift])
-            .disabled(model.menuWorkspace == nil)
+            .disabled(workspace(for: .copyBranchName) == nil)
 
             Divider()
 
@@ -348,11 +416,14 @@ struct BloomCommands: Commands {
 
             runScriptsMenu
 
+            // The subject's own model rather than the selected one, so a row highlighted on Home
+            // stops the agent that row is about. It is `existingModel`, which only reads: a
+            // workspace this launch has never opened has no transcript to stop anyway.
             Button("Stop Agent") {
-                model.selectedModel?.activeTranscript?.stop()
+                subjectModel?.activeTranscript?.stop()
             }
             .keyboardShortcut(".", modifiers: .command)
-            .disabled(model.selectedModel?.activeTranscript?.isRunning != true)
+            .disabled(subjectModel?.activeTranscript?.isRunning != true)
         }
 
         CommandGroup(replacing: .help) {
@@ -503,6 +574,102 @@ struct BloomCommands: Commands {
         WorkspaceTabsStore.shared.selectNextTab(offset: offset, in: workspace)
     }
 
+    /// Cmd+1 to Cmd+9, and the only place in the app a tab can be reached by name from the
+    /// keyboard.
+    ///
+    /// Bloom bound neither these nor Ctrl+Tab: the full shortcut grep found 74 bindings and not one
+    /// digit, so in a strip of five tabs the fifth was four presses of Cmd+Shift+]. Safari,
+    /// Terminal and Xcode all bind them, and all give 9 to the last tab rather than to the ninth.
+    ///
+    /// A submenu that lists the tabs by their own names rather than nine items called Tab 1, which
+    /// is how Terminal's Window menu draws the same keys, and it means the menu answers "what is
+    /// open in this workspace" as well as carrying the shortcut. Which number reaches which tab is
+    /// `TabCycle.numbered` in the core.
+    @ViewBuilder
+    private var goToTabMenu: some View {
+        if let workspace = model.selectedModel {
+            let entries = WorkspaceTabsStore.shared.entries(in: workspace)
+            Menu("Go to Tab") {
+                ForEach(TabCycle.numbered(entries), id: \.tab) { entry in
+                    tabItem(entry.tab, ordinal: entry.ordinal, in: workspace)
+                }
+            }
+            .disabled(entries.isEmpty)
+        }
+    }
+
+    @ViewBuilder
+    private func tabItem(_ tab: PaneContent, ordinal: Int?, in workspace: WorkspaceModel) -> some View {
+        let button = Button(tabTitle(tab, in: workspace)) {
+            WorkspaceTabsStore.shared.select(tab, in: workspace)
+        }
+        if let ordinal {
+            button.keyboardShortcut(KeyEquivalent(Character("\(ordinal)")), modifiers: .command)
+        } else {
+            button
+        }
+    }
+
+    /// What a tab is called in the strip, so the menu and the strip cannot say two different names
+    /// for one tab.
+    private func tabTitle(_ tab: PaneContent, in workspace: WorkspaceModel) -> String {
+        switch tab {
+        case .chat(let id):
+            let title = workspace.sessions.first { $0.id == id }?.title ?? ""
+            return title.isEmpty ? "Untitled" : title
+        case .tool(let id):
+            guard let tool = CenterTabStore.shared.tabs(for: workspace.workspace.id)
+                .first(where: { $0.id == id }) else { return "Tab" }
+            return CenterTabStore.shared.displayTitle(of: tool, in: workspace)
+        }
+    }
+
+    // MARK: - Closing what is in front
+
+    /// What Cmd+W would close: the tab in front, or the pane of it the keyboard is in. See
+    /// `TabClosure`, which is the rule and which the tests hold.
+    private var closableTab: PaneContent? {
+        guard let workspace = model.selectedModel else { return nil }
+        let tabs = WorkspaceTabsStore.shared
+        guard let tab = tabs.selectedTab(in: workspace) else { return nil }
+        return TabClosure.target(
+            selectedTab: tab,
+            focusedPaneContent: tabs.content(of: tabs.focusedPane(of: tab), in: tab)
+        )
+    }
+
+    /// Closing a conversation still goes through `CloseSessionAlert`, which asks when there is
+    /// something to lose by it and never asks when there is not. That is the whole of what the old
+    /// Close Session did, so nothing about a chat closes more quietly than it used to.
+    private func closeSelectedTab() {
+        guard let workspace = model.selectedModel, let target = closableTab else { return }
+        switch target {
+        case .chat(let id):
+            guard let session = workspace.sessions.first(where: { $0.id == id }) else { return }
+            CloseSessionAlert.shared.close(session, in: workspace)
+        case .tool(let id):
+            guard let tab = CenterTabStore.shared.tabs(for: workspace.workspace.id)
+                .first(where: { $0.id == id }) else { return }
+            Task { await CenterTabStore.shared.close(tab) }
+        }
+    }
+
+    // MARK: - Walking a review
+
+    /// Greyed when there is no review open or nothing changed in the worktree, which is the state
+    /// the two hidden buttons expressed by not existing.
+    private var canStepChangedFiles: Bool {
+        guard let workspace = model.selectedModel, !workspace.changedFiles.isEmpty else {
+            return false
+        }
+        return CenterTabStore.shared.review(for: workspace.workspace.id) != nil
+    }
+
+    private func stepChangedFile(_ delta: Int) {
+        guard let workspace = model.selectedModel else { return }
+        FileReview.step(delta, in: workspace)
+    }
+
     private func closeCentrePane() {
         guard let workspace = model.selectedModel else { return }
         let tabs = WorkspaceTabsStore.shared
@@ -540,6 +707,42 @@ struct BloomCommands: Commands {
         }
     }
 
+    // MARK: - What the Workspace menu is about
+
+    /// The workspace the menu acts on, live or archived, decided by `WorkspaceMenuSubject`.
+    private var subject: WorkspaceMenuSubject? {
+        WorkspaceMenuSubject.resolve(selection: model.selection, focusedRow: focusedRow?.row)
+    }
+
+    /// The workspace an item may act on, or nil, which is the same answer the item's `disabled`
+    /// reads. Asked twice per item on purpose: the action and the greying must not be able to
+    /// disagree, and both are a dictionary lookup over values already in memory.
+    private func workspace(for action: WorkspaceMenuAction) -> Workspace? {
+        guard let subject, subject.allows(action) else { return nil }
+        // The row a list published carries the workspace itself, which is the only way to reach an
+        // ARCHIVED one: `AppModel` deliberately holds live workspaces alone, so an archived row
+        // highlighted on Home is nowhere else in memory.
+        if let focusedRow, focusedRow.workspace.id == subject.id { return focusedRow.workspace }
+        return [model.selectedWorkspace, model.selectedArchivedWorkspace]
+            .compactMap { $0 }
+            .first { $0.id == subject.id }
+    }
+
+    /// Restore, which additionally has to say no while one is already running.
+    private var restorableWorkspace: Workspace? {
+        guard let workspace = workspace(for: .restore),
+              !model.restoring.contains(workspace.id) else { return nil }
+        return workspace
+    }
+
+    /// The live model behind the subject, when this launch has one. Only Stop Agent asks: setup
+    /// and the run scripts need a workspace whose settings have been read, which is the one the
+    /// window is actually showing.
+    private var subjectModel: WorkspaceModel? {
+        guard let id = subject?.liveID else { return nil }
+        return model.existingModel(for: id)
+    }
+
     /// Straight through to `AppModel.archive`, exactly as the sidebar's context menu and the
     /// window title's menu do.
     ///
@@ -549,13 +752,7 @@ struct BloomCommands: Commands {
     /// being read. `AppModel.archive` runs a git safety check and only stops when there is
     /// something specific to lose, and then it says what. Keeping both meant this shortcut alone
     /// asked twice on the dangerous archive and asked a useless question on the safe one.
-    private func archiveSelectedWorkspace() {
-        guard let workspace = model.selectedWorkspace else { return }
+    private func archive(_ workspace: Workspace) {
         Task { await model.archive(workspace) }
-    }
-
-    private func restoreArchivedWorkspace() {
-        guard let workspace = model.selectedArchivedWorkspace else { return }
-        Task { await model.restore(workspace) }
     }
 }

--- a/Sources/Bloom/Views/Chrome/App/FocusedMenuValues.swift
+++ b/Sources/Bloom/Views/Chrome/App/FocusedMenuValues.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import BloomCore
+
+/// What the menu bar reads off whatever currently holds the keyboard.
+///
+/// `BloomCommands` is one body, shared by every window and every screen the app has, so an item
+/// that reads `AppModel` alone can only ever be about the sidebar's selection. That is the whole of
+/// why the Workspace menu went dead on Home and in the Archive: a row was visibly highlighted in a
+/// list and the menu had no way of hearing about it. `@FocusedValue` is the channel that carries
+/// it, published by the list on screen and read by the item that acts on it, which is how Mail and
+/// Finder key a menu to whichever list has focus.
+///
+/// `MainWindowFocus` is the same mechanism aimed at a different question, and it stays its own
+/// file: which SCENE has the keyboard, rather than what inside it is selected.
+extension FocusedValues {
+    /// The workspace a list has highlighted, when that list is not the sidebar.
+    ///
+    /// Published by Home and by the Archive, which are the two screens whose selection is their own
+    /// rather than the app's: writing `AppModel.selection` from either would navigate away from the
+    /// list and open every row the arrow keys passed. `WorkspaceMenuSubject` in the core is the rule
+    /// that decides which of the two answers, and its tests hold the precedence.
+    @Entry var focusedWorkspaceRow: FocusedWorkspaceRow?
+
+    /// What Save means right now, for the one window that has an explicit Save.
+    ///
+    /// Nil in every scene that has nothing to write, which is what greys the item out. Any view
+    /// that binds Cmd+S should publish this as well: a view that keeps the key to itself is a key
+    /// equivalent the menu bar cannot advertise, and unadvertised is undiscoverable.
+    @Entry var saveAction: SaveAction?
+}
+
+/// A row a list has highlighted, carrying the workspace itself.
+///
+/// The value rather than the id, because Home lists archived workspaces and `AppModel` deliberately
+/// does not hold those: it lists live ones so the sidebar can never show a worktree that is no
+/// longer there. Home has already loaded the row it is drawing, so it is the only place that can
+/// hand the menu something to act on without a database read.
+struct FocusedWorkspaceRow: Equatable {
+    var workspace: Workspace
+    var isArchived: Bool
+
+    /// The half of it the core's rule needs.
+    var row: WorkspaceMenuSubject.FocusedRow {
+        WorkspaceMenuSubject.FocusedRow(id: workspace.id, isArchived: isArchived)
+    }
+}
+
+/// One window's Save, offered to the menu bar.
+///
+/// Identified by what it saves rather than by a closure alone, so two publishers cannot compare
+/// equal and leave the item stuck reading the wrong window's state.
+struct SaveAction: Equatable {
+    /// What is being saved, for the item's own accessibility and for equality.
+    var subject: String
+    var isEnabled: Bool
+    var perform: @MainActor () -> Void
+
+    static func == (lhs: SaveAction, rhs: SaveAction) -> Bool {
+        lhs.subject == rhs.subject && lhs.isEnabled == rhs.isEnabled
+    }
+}

--- a/Sources/Bloom/Views/Home/HomeView.swift
+++ b/Sources/Bloom/Views/Home/HomeView.swift
@@ -84,6 +84,20 @@ struct HomeView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Palette.windowBackground)
+        // What the Workspace menu acts on while this screen is up. Home's selection is its own,
+        // not the app's, so before this the menu bar had no way of hearing about a row that was
+        // visibly highlighted: Archive, Reveal in Finder, Open in Editor and Copy Branch Name all
+        // greyed out on the screen that lists every workspace on the Mac. On the whole pane rather
+        // than on the list, so the row still answers while the keyboard is in the search field, as
+        // it does in Mail. See `FocusedMenuValues`.
+        .focusedValue(\.focusedWorkspaceRow, focusedRow)
+        // Rename from the menu bar. Ignored for a workspace this list is not drawing, so the
+        // sidebar and Home can both listen to one post.
+        .onReceive(NotificationCenter.default.publisher(for: .bloomRenameWorkspace)) { note in
+            guard let raw = note.userInfo?[Notification.bloomWorkspaceIDKey] as? String,
+                  let row = row(for: WorkspaceID(raw)), !row.isArchived else { return }
+            renaming = row.id
+        }
         // Keyed on the revision rather than on the workspace list, which is reassigned every few
         // seconds by the diff stat refresh while this is a database read. `AppModel` bumps the
         // revision from the archive and the restore themselves, so this reloads when the answer
@@ -182,6 +196,14 @@ struct HomeView: View {
             guard let selected, let row = row(for: selected) else { return .ignored }
             open(row)
             return .handled
+        }
+        // Delete on the highlighted row, which is what Mail does with the same key and what this
+        // list answered with nothing at all. Live rows only: an archived row's worktree has
+        // already gone, and destroying its record is the Archive screen's own gesture, behind a
+        // confirmation, because there is no undo for that one.
+        .onDeleteCommand {
+            guard let selected, let row = row(for: selected), !row.isArchived else { return }
+            Task { await app.archive(row.workspace) }
         }
     }
 
@@ -333,6 +355,14 @@ struct HomeView: View {
             if let match = group.rows.first(where: { $0.id == id }) { return match }
         }
         return nil
+    }
+
+    /// The highlighted row, offered to the menu bar. It carries the workspace itself because an
+    /// archived one is nowhere else in memory: `AppModel` holds live workspaces alone, and this
+    /// screen is the only one that lists both. See `FocusedMenuValues`.
+    private var focusedRow: FocusedWorkspaceRow? {
+        guard let selected, let row = row(for: selected) else { return nil }
+        return FocusedWorkspaceRow(workspace: row.workspace, isArchived: row.isArchived)
     }
 
     // MARK: - Actions

--- a/Sources/Bloom/Views/RepoSettings/RepoSettingsSaveBar.swift
+++ b/Sources/Bloom/Views/RepoSettings/RepoSettingsSaveBar.swift
@@ -33,6 +33,17 @@ struct RepoSettingsSaveBar: View {
         .padding(.horizontal, Metrics.pane)
         .padding(.vertical, Metrics.inset)
         .background(Palette.surface)
+        // The same Save, offered to the menu bar, which had no Save item at all while this view
+        // held Cmd+S: a key equivalent nothing advertises is one nobody finds. The button keeps the
+        // key, because a hierarchy button beats a menu item for it either way; what the menu gets
+        // is the row, its shortcut drawn beside it, and a target for the pointer. See
+        // `FocusedMenuValues`.
+        .focusedValue(
+            \.saveAction,
+            SaveAction(subject: "project settings", isEnabled: model.isDirty) {
+                Task { await model.save() }
+            }
+        )
     }
 
     @ViewBuilder

--- a/Sources/Bloom/Views/RootView.swift
+++ b/Sources/Bloom/Views/RootView.swift
@@ -304,10 +304,19 @@ extension Notification.Name {
     static let bloomNewWorkspace = Notification.Name("bloom.newWorkspace")
     /// Posted only by `Snapshot`, and only in a debug build. See the handler above.
     static let bloomStartTerminalWorkspace = Notification.Name("bloom.startTerminalWorkspace")
+    /// The Workspace menu's Rename, aimed at whichever list is drawing that row.
+    ///
+    /// A notification rather than a flag on `AppModel`, for the same reason the create sheet is
+    /// one: the field belongs to a row inside a list, the list owns the one field that can be open
+    /// at a time, and a menu item cannot reach into either. Both lists listen, and each ignores a
+    /// workspace it is not drawing, so the post can be made without knowing which is on screen.
+    static let bloomRenameWorkspace = Notification.Name("bloom.renameWorkspace")
 }
 
 extension Notification {
     /// Whether a `bloomNewWorkspace` post wants the sheet opened on the pull request route. Absent
     /// on every other post, which is the ordinary new branch opening.
     static let bloomPullRequestKey = "bloom.newWorkspace.pullRequest"
+    /// Which workspace a `bloomRenameWorkspace` post is about, as its raw id.
+    static let bloomWorkspaceIDKey = "bloom.workspaceID"
 }

--- a/Sources/Bloom/Views/Sidebar/SidebarProjectsHeader.swift
+++ b/Sources/Bloom/Views/Sidebar/SidebarProjectsHeader.swift
@@ -49,11 +49,11 @@ struct SidebarProjectsHeader: View {
             }
             .buttonStyle(.plain)
             .foregroundStyle(isHovered ? Palette.textPrimary : Palette.textSecondary)
-            // The shortcut hangs off the button rather than off `BloomCommands`, which is where a
-            // menu bar item would carry it. Command Option A collides with nothing Bloom binds
-            // (I, F, J, K, Up and Down carry that pair today) and with nothing macOS reserves.
-            .keyboardShortcut("a", modifiers: [.command, .option])
-            .help("Add a project folder (⌥⌘A)")
+            // No key equivalent of its own. It used to carry Cmd+Option+A, which was a second key
+            // for a command the File menu already advertises as Shift+Cmd+O, registered on a
+            // hidden button where nothing could announce it. One command with one key, drawn in
+            // the menu bar, beats two keys with one of them undiscoverable. See `BloomCommands`.
+            .help("Add a project folder (⇧⌘O)")
         }
         .contentShape(Rectangle())
         .onHoverChange { isHovered = $0 }

--- a/Sources/Bloom/Views/Sidebar/SidebarView.swift
+++ b/Sources/Bloom/Views/Sidebar/SidebarView.swift
@@ -294,6 +294,26 @@ struct SidebarView: View {
                 .fadesArrivals)
         }
         .onChange(of: listSelection) { _, _ in commitSelection() }
+        // Delete on a selected row, which every Mac list that can delete binds and which
+        // `onDeleteCommand` appeared nowhere in this app to answer. It is the menu item's own
+        // action rather than a second path to the same place: `AppModel.archive` runs the git
+        // safety check, says what is at stake when there is anything, and registers the undo, so
+        // the reflex costs no more here than Shift+Cmd+Delete does from the menu.
+        .onDeleteCommand {
+            guard let id = app.selection.workspaceID,
+                  let workspace = app.workspaces.first(where: { $0.id == id }) else { return }
+            Task { await app.archive(workspace) }
+        }
+        // Rename from the menu bar, which reaches the field this list owns. A workspace this pane
+        // is not drawing is ignored, so Home and the sidebar can both listen to one post.
+        .onReceive(NotificationCenter.default.publisher(for: .bloomRenameWorkspace)) { note in
+            guard let raw = note.userInfo?[Notification.bloomWorkspaceIDKey] as? String else {
+                return
+            }
+            let id = WorkspaceID(raw)
+            guard app.workspaces.contains(where: { $0.id == id }) else { return }
+            renaming = id
+        }
         // Moving off a row has to close whatever field was open on it, or the rename would carry
         // on editing a workspace that is no longer on screen.
         .onChange(of: app.selection, initial: true) { _, target in

--- a/Sources/BloomCore/Presentation/TabClosure.swift
+++ b/Sources/BloomCore/Presentation/TabClosure.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// What Cmd+W closes in the centre column.
+///
+/// **The bug this is written from.** Cmd+W was Close Session, gated on the workspace having a
+/// conversation rather than on what the user was looking at. So on a browser, a review or the
+/// notes it closed a chat in some other pane, silently when that chat was idle, and four kinds of
+/// tab could be opened from the keyboard while none of them could be closed. A Mac app closes what
+/// is in front.
+///
+/// **Why there is no separate Close Session any more.** A conversation is a tab in the same strip
+/// as a terminal and a page, so Close Tab already names it. Moving Close Session to Shift+Cmd+W,
+/// which is the obvious second half, is not available: that key is the window's own Close and has
+/// to stay so, for the reason `WindowDismissal` gives. Closing a chat tab still goes through the
+/// question `SessionClosure` asks, so nothing is lost more quietly than it was.
+///
+/// **A split tab closes the pane the keyboard is in, not the tree.** A tab's panes each hold a
+/// whole conversation or a whole shell, and closing four of them on one keystroke is not what
+/// anybody means by closing a tab. Cmd+Ctrl+W is the neighbouring item that takes a pane out of
+/// the arrangement while leaving what it was showing alive; this one ends the thing itself.
+public enum TabClosure {
+    /// The content Cmd+W acts on, or nothing when the workspace has no tab at all.
+    ///
+    /// - Parameters:
+    ///   - selectedTab: the strip entry in front.
+    ///   - focusedPaneContent: what the focused pane of that tab is showing, which for a tab
+    ///     nobody has split is the tab itself.
+    public static func target(
+        selectedTab: PaneContent?, focusedPaneContent: PaneContent?
+    ) -> PaneContent? {
+        guard let selectedTab else { return nil }
+        return focusedPaneContent ?? selectedTab
+    }
+}

--- a/Sources/BloomCore/Presentation/TabCycle.swift
+++ b/Sources/BloomCore/Presentation/TabCycle.swift
@@ -30,4 +30,48 @@ public enum TabCycle {
         let moved = ((index + offset) % count + count) % count
         return moved == index ? nil : tabs[moved]
     }
+
+    /// The tab a number reaches: Cmd+1 to Cmd+8 are the first eight, and Cmd+9 is the last one
+    /// whatever the count.
+    ///
+    /// Safari, Terminal and Xcode all bind these and all give 9 to the last tab rather than to the
+    /// ninth, which is the half of the convention that is easy to miss and the half that makes it
+    /// worth having: the two ends of the strip are one keystroke away from anywhere in it. In a
+    /// strip of five tabs, reaching the fifth was four presses of Cmd+Shift+].
+    ///
+    /// Nil for a number past the end of a short strip, so the item greys rather than landing
+    /// somewhere arbitrary.
+    public static func tab<Tab>(at ordinal: Int, in tabs: [Tab]) -> Tab? {
+        guard (1...9).contains(ordinal), !tabs.isEmpty else { return nil }
+        if ordinal == lastOrdinal { return tabs.last }
+        return ordinal <= tabs.count ? tabs[ordinal - 1] : nil
+    }
+
+    /// The strip with the number each tab answers to, for the menu that draws them.
+    ///
+    /// Every tab is listed, because a menu that hid the tenth would be lying about what is open.
+    /// Only the ones a key can reach carry a number: the first eight, and the last, which takes 9
+    /// away from a ninth tab whenever there are more than nine.
+    public static func numbered<Tab: Hashable>(_ tabs: [Tab]) -> [Numbered<Tab>] {
+        tabs.enumerated().map { index, tab in
+            if index == tabs.count - 1, tabs.count >= lastOrdinal {
+                return Numbered(tab: tab, ordinal: lastOrdinal)
+            }
+            return Numbered(tab: tab, ordinal: index < lastOrdinal - 1 ? index + 1 : nil)
+        }
+    }
+
+    /// A tab and the number that reaches it, if any.
+    ///
+    /// A type rather than a tuple because the menu draws these in a `ForEach` and Swift has no key
+    /// path to a tuple element. It is identified by the tab, which is a strip entry and therefore
+    /// already unique in the list it came from.
+    public struct Numbered<Tab: Hashable>: Hashable, Identifiable, Sendable where Tab: Sendable {
+        public let tab: Tab
+        public let ordinal: Int?
+
+        public var id: Tab { tab }
+    }
+
+    private static let lastOrdinal = 9
 }

--- a/Sources/BloomCore/Presentation/WorkspaceMenuSubject.swift
+++ b/Sources/BloomCore/Presentation/WorkspaceMenuSubject.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// The workspace the Workspace menu acts on, which is not always the one the sidebar is pointing
+/// at.
+///
+/// **The bug this is written from.** Every item in that menu was gated on
+/// `AppModel.selectedWorkspace`, which is derived from `SidebarSelection.workspaceID`. On Home the
+/// selection is `.home` and in the Archive it is `.archive`, so a row highlighted in either of
+/// those lists left Archive, Open in Editor, Reveal in Finder and Copy Branch Name all greyed out
+/// while the user was looking straight at the thing they name. Mail and Finder key their menus to
+/// whichever list holds the keyboard: select a message in the search results and Delete, Move To
+/// and Get Info all act on it.
+///
+/// **The rule, and why the selection is asked first.** A sidebar selection that names a workspace
+/// wins, because when the window is on a workspace the window is about that workspace. Only when
+/// it names something that is not a workspace (Home, Search, the Archive) does the highlighted row
+/// in the list on screen answer. In practice the two never both apply, because Home and the
+/// Archive fill the centre column and so cannot be on screen while a workspace is selected. The
+/// order is what makes that a guarantee rather than a coincidence: a focused value that lingered a
+/// frame too long after a screen was left can never redirect the menu at a row nobody can see.
+public enum WorkspaceMenuSubject: Hashable, Sendable {
+    /// A live workspace, with a worktree on disk.
+    case live(WorkspaceID)
+    /// One that has been archived: readable, restorable, and with nothing left on disk.
+    case archived(WorkspaceID)
+
+    /// The row a list has highlighted, published by whichever list is on screen.
+    ///
+    /// It carries `isArchived` rather than leaving the menu to look the id up, because Home lists
+    /// both kinds in one table and the row itself is the only place that already knows which it
+    /// is.
+    public struct FocusedRow: Hashable, Sendable {
+        public var id: WorkspaceID
+        public var isArchived: Bool
+
+        public init(id: WorkspaceID, isArchived: Bool) {
+            self.id = id
+            self.isArchived = isArchived
+        }
+    }
+
+    public static func resolve(
+        selection: SidebarSelection, focusedRow: FocusedRow?
+    ) -> WorkspaceMenuSubject? {
+        if let id = selection.workspaceID { return .live(id) }
+        if let id = selection.archivedWorkspaceID { return .archived(id) }
+        guard let focusedRow else { return nil }
+        return focusedRow.isArchived ? .archived(focusedRow.id) : .live(focusedRow.id)
+    }
+
+    /// The workspace this names, whether or not it still has a worktree.
+    public var id: WorkspaceID {
+        switch self {
+        case .live(let id), .archived(let id): id
+        }
+    }
+
+    /// Set only when the worktree is still there, which is what the four items that touch the disk
+    /// need to know.
+    public var liveID: WorkspaceID? {
+        if case .live(let id) = self { return id }
+        return nil
+    }
+
+    public var archivedID: WorkspaceID? {
+        if case .archived(let id) = self { return id }
+        return nil
+    }
+
+    /// Whether an item may be pressed against this subject.
+    ///
+    /// One table rather than a condition per item, because the two lists that publish a row and the
+    /// menu that reads one must not disagree about what an archived workspace can be asked to do.
+    /// The archived answers are `HomeRowMenu`'s, which has drawn exactly this menu for archived
+    /// rows since before the menu bar could reach them.
+    public func allows(_ action: WorkspaceMenuAction) -> Bool {
+        switch self {
+        case .live:
+            action != .restore
+        case .archived:
+            // Reading a branch name is the one thing that still means something once the worktree
+            // is gone. Opening an editor or a Finder window on a path that is not there is not,
+            // and neither is archiving what is already archived. Renaming is left out because
+            // Home's own menu leaves it out: an archived row is a record rather than a workspace.
+            action == .restore || action == .copyBranchName
+        }
+    }
+}
+
+/// The items in the Workspace menu that act on one workspace.
+///
+/// Setup, the run scripts and Stop Agent are not here: each needs a live `WorkspaceModel` rather
+/// than a row, and what they can do is decided by that model rather than by which list is focused.
+public enum WorkspaceMenuAction: String, Hashable, Sendable, CaseIterable {
+    case archive
+    case restore
+    case openInEditor
+    case revealInFinder
+    case copyBranchName
+    case rename
+}

--- a/Tests/BloomCoreTests/TabClosureTests.swift
+++ b/Tests/BloomCoreTests/TabClosureTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import BloomCore
+
+/// Cmd+W closing something other than what is in front.
+///
+/// It was Close Session, gated on the workspace having a conversation rather than on which tab was
+/// selected, so pressing it over a browser, a review or the notes closed a chat in another pane.
+@Suite("What Cmd+W closes")
+struct TabClosureTests {
+    private let chat = PaneContent.chat(SessionID("session-1"))
+    private let terminal = PaneContent.tool("tool-1")
+
+    @Test("a tab nobody has split closes itself")
+    func unsplitTab() {
+        #expect(TabClosure.target(selectedTab: terminal, focusedPaneContent: terminal) == terminal)
+    }
+
+    /// The bug, stated: a browser tab in front does not close a conversation.
+    @Test("the tab in front is what closes, not the workspace's conversation")
+    func theTabInFront() {
+        #expect(TabClosure.target(selectedTab: terminal, focusedPaneContent: nil) == terminal)
+        #expect(TabClosure.target(selectedTab: terminal, focusedPaneContent: terminal) != chat)
+    }
+
+    /// A tab's panes each hold a whole conversation or a whole shell, so the one with the keyboard
+    /// is what closing means. Cmd+Ctrl+W is the item that takes a pane out of the arrangement.
+    @Test("a split tab closes the pane the keyboard is in")
+    func splitTab() {
+        #expect(TabClosure.target(selectedTab: chat, focusedPaneContent: terminal) == terminal)
+        #expect(TabClosure.target(selectedTab: chat, focusedPaneContent: chat) == chat)
+    }
+
+    @Test("a workspace with no tabs has nothing to close")
+    func nothingOpen() {
+        #expect(TabClosure.target(selectedTab: nil, focusedPaneContent: nil) == nil)
+        #expect(TabClosure.target(selectedTab: nil, focusedPaneContent: chat) == nil)
+    }
+}

--- a/Tests/BloomCoreTests/TabCycleTests.swift
+++ b/Tests/BloomCoreTests/TabCycleTests.swift
@@ -49,4 +49,45 @@ struct TabCycleTests {
         #expect(TabCycle.next(from: "gone", in: tabs, offset: 1) == "chat")
         #expect(TabCycle.next(from: nil, in: tabs, offset: -1) == "chat")
     }
+
+    // MARK: - Cmd+1 to Cmd+9
+
+    /// Safari, Terminal and Xcode all give 9 to the LAST tab rather than to the ninth, which is
+    /// the half of the convention that makes the two ends of a long strip one keystroke apart.
+    @Test("a number reaches its tab, and nine reaches the last one")
+    func numbersReachTabs() {
+        let strip = (1...12).map { "tab\($0)" }
+        #expect(TabCycle.tab(at: 1, in: strip) == "tab1")
+        #expect(TabCycle.tab(at: 8, in: strip) == "tab8")
+        #expect(TabCycle.tab(at: 9, in: strip) == "tab12")
+        #expect(TabCycle.tab(at: 3, in: tabs) == "terminal")
+        #expect(TabCycle.tab(at: 9, in: tabs) == "terminal")
+    }
+
+    @Test("a number past the end of a short strip reaches nothing")
+    func numbersPastTheEnd() {
+        #expect(TabCycle.tab(at: 4, in: tabs) == nil)
+        #expect(TabCycle.tab(at: 1, in: [String]()) == nil)
+        #expect(TabCycle.tab(at: 0, in: tabs) == nil)
+        #expect(TabCycle.tab(at: 10, in: tabs) == nil)
+    }
+
+    /// The menu lists every tab, because one that hid the tenth would be lying about what is open.
+    /// Only the ones a key can reach carry a number.
+    @Test("the menu numbers the first eight and the last")
+    func numberingForTheMenu() {
+        let numbered = TabCycle.numbered((1...12).map { "tab\($0)" })
+        #expect(numbered.count == 12)
+        #expect(numbered.map(\.ordinal) == [1, 2, 3, 4, 5, 6, 7, 8, nil, nil, nil, 9])
+
+        #expect(TabCycle.numbered(tabs).map(\.ordinal) == [1, 2, 3])
+        #expect(TabCycle.numbered([String]()).isEmpty)
+    }
+
+    /// Nine tabs exactly: the ninth is the last, so it takes nine and nothing is unreachable.
+    @Test("a strip of nine has no unreachable tab")
+    func nineExactly() {
+        #expect(TabCycle.numbered((1...9).map { "tab\($0)" }).map(\.ordinal)
+            == [1, 2, 3, 4, 5, 6, 7, 8, 9])
+    }
 }

--- a/Tests/BloomCoreTests/WorkspaceMenuSubjectTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceMenuSubjectTests.swift
@@ -1,0 +1,100 @@
+import Testing
+@testable import BloomCore
+
+/// The menu bar going dead against a row that is visibly highlighted.
+///
+/// Home's selection is `.home` and the Archive's is `.archive`, so every item in the Workspace menu
+/// greyed out on both screens while the user was pointing at the workspace it names.
+@Suite("What the Workspace menu acts on")
+struct WorkspaceMenuSubjectTests {
+    private let live = WorkspaceID("workspace-1")
+    private let other = WorkspaceID("workspace-2")
+
+    @Test("a selected workspace answers, with no list focused")
+    func selectionAnswers() {
+        #expect(
+            WorkspaceMenuSubject.resolve(selection: .workspace(live), focusedRow: nil)
+                == .live(live)
+        )
+        #expect(
+            WorkspaceMenuSubject.resolve(selection: .archived(live), focusedRow: nil)
+                == .archived(live)
+        )
+    }
+
+    /// The whole point: on Home and in the Archive the highlighted row is what the menu means.
+    @Test("a highlighted row answers on the screens that have no workspace selected")
+    func focusedRowAnswers() {
+        for selection in [SidebarSelection.home, .search, .archive] {
+            #expect(
+                WorkspaceMenuSubject.resolve(
+                    selection: selection,
+                    focusedRow: .init(id: live, isArchived: false)
+                ) == .live(live)
+            )
+        }
+    }
+
+    @Test("an archived row is not offered as a live one")
+    func archivedRow() {
+        #expect(
+            WorkspaceMenuSubject.resolve(
+                selection: .home, focusedRow: .init(id: live, isArchived: true)
+            ) == .archived(live)
+        )
+    }
+
+    /// A subagent selection is a workspace selection, which is what keeps the menu pointed at the
+    /// parent while a child's transcript is being read.
+    @Test("reading a subagent still acts on its workspace")
+    func subagent() {
+        let subagent = SubagentID("subagent-1")
+        #expect(
+            WorkspaceMenuSubject.resolve(selection: .subagent(live, subagent), focusedRow: nil)
+                == .live(live)
+        )
+    }
+
+    /// The precedence, which exists so that a focused value published a frame after its screen was
+    /// left cannot aim the menu at a row nobody can see.
+    @Test("a selected workspace wins over a row left behind by another screen")
+    func selectionWins() {
+        #expect(
+            WorkspaceMenuSubject.resolve(
+                selection: .workspace(live), focusedRow: .init(id: other, isArchived: false)
+            ) == .live(live)
+        )
+    }
+
+    @Test("nothing selected and nothing highlighted is nothing to act on")
+    func nothing() {
+        #expect(WorkspaceMenuSubject.resolve(selection: .home, focusedRow: nil) == nil)
+    }
+
+    @Test("a live workspace answers to everything but Restore")
+    func liveActions() {
+        let subject = WorkspaceMenuSubject.live(live)
+        for action in WorkspaceMenuAction.allCases where action != .restore {
+            #expect(subject.allows(action), "\(action)")
+        }
+        #expect(!subject.allows(.restore))
+        #expect(subject.liveID == live)
+        #expect(subject.archivedID == nil)
+    }
+
+    /// An archived workspace has no worktree, so the four items that touch the disk are refused
+    /// and the two that read the database are not.
+    @Test("an archived workspace answers only to Restore and Copy Branch Name")
+    func archivedActions() {
+        let subject = WorkspaceMenuSubject.archived(live)
+        #expect(subject.allows(.restore))
+        #expect(subject.allows(.copyBranchName))
+        #expect(!subject.allows(.archive))
+        #expect(!subject.allows(.openInEditor))
+        #expect(!subject.allows(.revealInFinder))
+        #expect(!subject.allows(.rename))
+        #expect(subject.liveID == nil)
+        #expect(subject.archivedID == live)
+        #expect(subject.id == live)
+    }
+}


### PR DESCRIPTION
The Workspace menu keyed off the sidebar's selection alone, so a row visibly highlighted on Home or in the Archive greyed out every item that names it. What an item acts on is now `WorkspaceMenuSubject` in the core: the selection when it names a workspace, otherwise the row the list on screen published through `@FocusedValue`. Archived rows answer Restore and Copy Branch Name and refuse the four that touch a worktree that is gone.

Cmd+W was Close Session, gated on the workspace having a chat rather than on what was in front, so on a browser, review or notes tab it closed a conversation in another pane. It is Close Tab now, resolving the tab (or the focused pane of a split tab) through `TabClosure`. A chat still goes through `CloseSessionAlert`, so nothing closes more quietly than before. Close Session does not move to Shift+Cmd+W because that is the window's own Close, per `WindowDismissal`.

The rest of the same finding:

- Cmd+1 to Cmd+9 through a Go to Tab submenu that lists the strip by name. Nine is the last tab, as Safari, Terminal and Xcode have it (`TabCycle.numbered`).
- A Rename item, which existed only in the row context menus.
- A Save item under `.saveItem`, published by the focused window through `@FocusedValue`. The project settings bar publishes it; the inspector's file editor is another agent's file this session and needs the same one line.
- `onDeleteCommand` in the sidebar, on Home and in the Archive, each aimed at the action that screen already offers.
- Next and Previous Changed File moved off their hidden buttons into the View menu, and the duplicate Opt+Cmd+A came off the sidebar's add button, since File already advertises that command as Shift+Cmd+O.

Tests: `WorkspaceMenuSubjectTests`, `TabClosureTests`, and the new cases in `TabCycleTests`.