### PR TITLE
Use one accent colour rather than two

### DIFF
--- a/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x93",
+          "green" : "0x75",
+          "red" : "0x19"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "bloom",
+    "version" : 1
+  }
+}

--- a/Resources/Assets.xcassets/Contents.json
+++ b/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "bloom",
+    "version" : 1
+  }
+}

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -18,6 +18,24 @@
 	<string>1</string>
 	<key>CFBundleIconName</key>
 	<string>Bloom</string>
+	<!--
+	    The one accent, rather than two.
+
+	    `Palette.accent` overrides `controlAccentColor` for everything Bloom draws itself, and that
+	    reached nothing AppKit draws: 37 toggles, every focus ring and every text selection stayed
+	    the user's blue, so one Settings pane held a Bloom-blue selected row and a system-blue
+	    switch. This key points AppKit at the `AccentColor` set in Assets.car, which
+	    `Tools/build.sh` compiles from Resources/Assets.xcassets, and `NSColor.controlAccentColor`
+	    then answers Spatie Blue for this process. Everything derived from it follows:
+	    `keyboardFocusIndicatorColor`, `selectedTextBackgroundColor` and
+	    `selectedContentBackgroundColor` were measured moving with it.
+
+	    It only wins where the user has not chosen an accent, which is the Multicolour default. A
+	    Mac set to Pink or to Graphite keeps that choice and this key is ignored, measured with a
+	    probe rather than assumed. See `Palette.accent` for the whole of it.
+	-->
+	<key>NSAccentColorName</key>
+	<string>AccentColor</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>NSHighResolutionCapable</key>

--- a/Sources/Bloom/Design/Gallery.swift
+++ b/Sources/Bloom/Design/Gallery.swift
@@ -77,6 +77,7 @@ extension Snapshot {
         .hoverCard,
         .panelTabs,
         .browserToolbar,
+        .systemAccent,
     ]
 
     /// The page `--gallery` names, falling back to the first rather than failing: a capture run

--- a/Sources/Bloom/Design/SystemAccentGallery.swift
+++ b/Sources/Bloom/Design/SystemAccentGallery.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+import BloomCore
+
+/// The controls Bloom does not draw, drawn.
+///
+///     Bloom --snapshot-gallery <dir> --gallery system-accent
+///
+/// Every other page in this folder photographs something in `Sources/Bloom`. This one photographs
+/// AppKit, on purpose, because the thing under review is a colour the app hands over and never
+/// touches again. `Palette.accent` overrode `controlAccentColor` for everything Bloom drew itself,
+/// and a `.tint` reaches none of these: a switch, a tick box, a radio dot, a slider's track, a
+/// stepper, a focus ring and the ground under selected text are all drawn by the system off the
+/// accent it resolves for the process. So the window held Bloom's blue and the user's at once, and
+/// no test in this repository could see it, because the pixels are AppKit's.
+///
+/// `NSAccentColorName` in `Resources/Info.plist` is what changed that, and the only honest way to
+/// review it is a picture: the ratio tests can hold a floor over the two colours AppKit DERIVES
+/// (see `PaletteInk.accentTextSelection`) and can say nothing at all about whether a switch came
+/// out teal.
+///
+/// **Two things this page cannot show, said here rather than left to be wondered about.** The focus
+/// ring is drawn round the first responder in a key window, and this page is captured with
+/// `needsFocus` false because taking the keyboard off whoever is at the machine is not worth a
+/// picture, so the ring is shown as its colour on a plate rather than round a real field. And the
+/// selection is `selectedTextBackgroundColor` with the ink AppKit really puts on it, painted rather
+/// than dragged over, for the same reason: an unfocused text view draws the unemphasised grey
+/// instead and the page would be photographing the wrong colour.
+///
+/// The last row is the control that deliberately does not follow, and it is here so the next person
+/// does not read its absence as a bug. See `InspectorToolbar` and `SettingsView`: a segmented
+/// control's selected cell is a neutral capsule on this SDK, and it stays one.
+struct SystemAccentGallery: View {
+    var app: AppModel
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Metrics.pane) {
+            VStack(alignment: .leading, spacing: Metrics.pane) {
+                captioned("What AppKit draws off the accent, and no .tint can reach") {
+                    SystemAccentControls()
+                }
+                Spacer(minLength: 0)
+            }
+            .frame(width: 300)
+
+            VStack(alignment: .leading, spacing: Metrics.pane) {
+                captioned("What AppKit derives from it") {
+                    VStack(alignment: .leading, spacing: Metrics.spacingWide) {
+                        swatch("controlAccentColor", Color(nsColor: .controlAccentColor), ink: .white)
+                        swatch(
+                            "keyboardFocusIndicatorColor",
+                            Palette.focusRing,
+                            ink: Color(nsColor: .labelColor)
+                        )
+                        swatch(
+                            "selectedTextBackgroundColor",
+                            Palette.textSelection,
+                            ink: Color(nsColor: .selectedTextColor)
+                        )
+                        swatch(
+                            "selectedContentBackgroundColor",
+                            Color(nsColor: .selectedContentBackgroundColor),
+                            ink: Color(nsColor: .alternateSelectedControlTextColor)
+                        )
+                    }
+                }
+
+                captioned("What Bloom draws itself, for comparison") {
+                    VStack(alignment: .leading, spacing: Metrics.spacingWide) {
+                        swatch("Palette.accentFill", Palette.accentFill, ink: Palette.textInverted)
+                        swatch("Palette.selected", Palette.selected, ink: Palette.textPrimary)
+                        HStack(spacing: Metrics.spacingWide) {
+                            Image(systemName: "checkmark.seal.fill")
+                                .foregroundStyle(Palette.accent)
+                            Text("Palette.accent, the ink half of the ramp")
+                                .font(Typo.caption)
+                                .foregroundStyle(Palette.accent)
+                        }
+                    }
+                }
+
+                captioned("The one that stays neutral, and is meant to") {
+                    SystemAccentSegments()
+                }
+
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(Metrics.pane)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(Palette.surface)
+        .environment(app)
+    }
+
+    /// A band of the colour with the ink AppKit really puts on it, so the page answers "can this be
+    /// read" rather than only "what hue is it". The name is drawn on the band for the same reason.
+    private func swatch(_ name: String, _ fill: Color, ink: Color) -> some View {
+        Text(name)
+            .font(Typo.caption)
+            .foregroundStyle(ink)
+            .padding(.horizontal, Metrics.gutter)
+            .padding(.vertical, Metrics.spacingWide)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(fill, in: .rect(cornerRadius: Metrics.cornerSmall))
+    }
+
+    private func captioned(_ caption: String, @ViewBuilder content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingWide) {
+            Text(caption)
+                .font(Typo.caption)
+                .foregroundStyle(Palette.textTertiary)
+            content()
+        }
+    }
+}
+
+/// The controls themselves, in their own type because each needs somewhere for its binding to
+/// point and a `body` full of `@State` reads worse than a harness does.
+///
+/// Both states of everything that has two, because "on" is the only state that carries the accent
+/// and an off switch beside it is what says the on one is coloured rather than simply dark.
+private struct SystemAccentControls: View {
+    @State private var switchOn = true
+    @State private var switchOff = false
+    @State private var boxOn = true
+    @State private var boxOff = false
+    @State private var choice = 1
+    @State private var slider = 0.65
+    @State private var steps = 3
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.gutter) {
+            Toggle("A switch, on", isOn: $switchOn)
+                .toggleStyle(.switch)
+            Toggle("A switch, off", isOn: $switchOff)
+                .toggleStyle(.switch)
+
+            Toggle("A tick box, ticked", isOn: $boxOn)
+                .toggleStyle(.checkbox)
+            Toggle("A tick box, clear", isOn: $boxOff)
+                .toggleStyle(.checkbox)
+
+            Picker("", selection: $choice) {
+                Text("A radio, unchosen").tag(0)
+                Text("A radio, chosen").tag(1)
+            }
+            .pickerStyle(.radioGroup)
+            .labelsHidden()
+
+            Slider(value: $slider)
+
+            ProgressView(value: slider)
+
+            Stepper("A stepper at \(steps)", value: $steps, in: 0...9)
+
+            HStack(spacing: Metrics.spacingWide) {
+                Button("Prominent") {}
+                    .buttonStyle(.borderedProminent)
+                Button("Bordered") {}
+                    .buttonStyle(.bordered)
+            }
+        }
+    }
+}
+
+/// The segmented control, alone, because the answer about it is "unchanged" and that is worth
+/// photographing next to everything that did change.
+private struct SystemAccentSegments: View {
+    @State private var segment = 0
+
+    var body: some View {
+        Picker("", selection: $segment) {
+            Text("Diff").tag(0)
+            Text("Files").tag(1)
+            Text("Checks").tag(2)
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .frame(width: 260)
+    }
+}
+
+extension Gallery {
+    /// The registry entry for this page. See `Gallery`.
+    ///
+    /// `needsFocus` is false, and the focus ring is the price. Taking the keys off the person at
+    /// the machine to photograph a two point outline is the wrong trade, so the ring is on this
+    /// page as its colour rather than round a field, and the head of `SystemAccentGallery` says so.
+    static let systemAccent = Gallery(
+        name: "system-accent",
+        title: "System accent",
+        size: CGSize(width: 820, height: 620),
+        needsFocus: false,
+        view: { app in AnyView(SystemAccentGallery(app: app)) }
+    )
+}

--- a/Sources/Bloom/Design/SystemAccentGallery.swift
+++ b/Sources/Bloom/Design/SystemAccentGallery.swift
@@ -37,6 +37,16 @@ struct SystemAccentGallery: View {
             VStack(alignment: .leading, spacing: Metrics.pane) {
                 captioned("What AppKit draws off the accent, and no .tint can reach") {
                     SystemAccentControls()
+                        // Every accented control drops to a neutral grey when its window is not
+                        // key, which is exactly what this page is captured in: `needsFocus` is
+                        // false, so the window is ordered front without the app being activated
+                        // and the first capture came back with an "on" switch identical to the
+                        // "off" one. `controlActiveState` is the environment value SwiftUI's own
+                        // controls read to decide that, so the page states the answer rather than
+                        // taking the keys off whoever is at the machine to earn it. The window is
+                        // still inactive; only these controls are told to draw as though it were
+                        // not.
+                        .environment(\.controlActiveState, .key)
                 }
                 Spacer(minLength: 0)
             }

--- a/Sources/Bloom/Design/SystemAccentGallery.swift
+++ b/Sources/Bloom/Design/SystemAccentGallery.swift
@@ -18,13 +18,15 @@ import BloomCore
 /// (see `PaletteInk.accentTextSelection`) and can say nothing at all about whether a switch came
 /// out teal.
 ///
-/// **Two things this page cannot show, said here rather than left to be wondered about.** The focus
-/// ring is drawn round the first responder in a key window, and this page is captured with
-/// `needsFocus` false because taking the keyboard off whoever is at the machine is not worth a
-/// picture, so the ring is shown as its colour on a plate rather than round a real field. And the
-/// selection is `selectedTextBackgroundColor` with the ink AppKit really puts on it, painted rather
-/// than dragged over, for the same reason: an unfocused text view draws the unemphasised grey
-/// instead and the page would be photographing the wrong colour.
+/// **What this page cannot show, said here rather than left to be wondered about.** All three
+/// have the same cause: an accented control, a focus ring and a text selection are all drawn in a
+/// neutral grey while their window is not key, and this page is captured with `needsFocus` false
+/// because taking the keyboard off whoever is at the machine is not worth a picture. So the ring
+/// and the selection are shown as their colours on a plate rather than round a real field and under
+/// a real drag, and the on switch is drawn grey, because `.switch` is an `NSSwitch` that reads its
+/// window where the tick box, the radio and the slider read the environment this page sets. The
+/// four swatches on the right are what those three would be drawn in, which is the same question
+/// answered one step indirectly.
 ///
 /// The last row is the control that deliberately does not follow, and it is here so the next person
 /// does not read its absence as a bug. See `InspectorToolbar` and `SettingsView`: a segmented
@@ -46,6 +48,14 @@ struct SystemAccentGallery: View {
                         // taking the keys off whoever is at the machine to earn it. The window is
                         // still inactive; only these controls are told to draw as though it were
                         // not.
+                        //
+                        // It moves the tick box, the radio, the slider and the prominent button,
+                        // and it does NOT move the switch, which is the one control this page most
+                        // wants to show: `.switch` is an `NSSwitch` under there and it reads its
+                        // real window rather than the environment, so the on switch on this page is
+                        // grey and is the only thing here that is lying. What it draws when the
+                        // window is key is `controlAccentColor`, which is the top swatch on the
+                        // right, so the page still answers the question, one step indirectly.
                         .environment(\.controlActiveState, .key)
                 }
                 Spacer(minLength: 0)

--- a/Sources/Bloom/Design/Theme.swift
+++ b/Sources/Bloom/Design/Theme.swift
@@ -179,6 +179,15 @@ enum Palette {
     // colour alone does not: the focus ring follows the Full Keyboard Access setting, the caret
     // follows the text colour on high contrast, and the selection is the paler fill a text run
     // gets rather than the solid one a list row gets.
+    //
+    // All three are still semantic and none of them is a hex here, which is right for the same
+    // three reasons. What changed is what they are derived FROM. They are computed off
+    // `controlAccentColor`, and until `NSAccentColorName` went into the bundle that was the user's
+    // accent while every fill Bloom drew was Bloom's, so a focus ring round a field was the system
+    // blue an inch under a selected row that was Spatie Blue. Now the accent AppKit derives them
+    // from is `accentFill`, and the three follow it: measured `#006282` and `#37A3C7` for the ring
+    // at half alpha, and `PaletteInk.accentTextSelection` for the selection, which
+    // `PaletteContrastTests` holds a floor over because it is a fill with a paragraph on it.
 
     /// The focus ring around the control that has keyboard focus.
     static let focusRing = Color(nsColor: .keyboardFocusIndicatorColor)
@@ -205,6 +214,29 @@ enum Palette {
     ///
     /// This is for ink and for strokes. A filled control that has to carry white text uses
     /// `accentFill`, which is a different member of the ramp for exactly that reason.
+    ///
+    /// **The override used to reach only what Bloom draws itself, and that was the whole bug.**
+    /// Thirty-seven toggles, three steppers, every focus ring and every text selection are drawn by
+    /// AppKit off `controlAccentColor`, which no `.tint` can reach, so one Settings pane held a
+    /// switch in the user's blue, a focus ring in the user's blue and a selected sidebar row in
+    /// Bloom's. Two accents in one window, structurally rather than by slip. `NSAccentColorName` in
+    /// `Resources/Info.plist` names the `AccentColor` set in Assets.car, which carries `accentFill`,
+    /// and `controlAccentColor` then answers that for the whole process: measured `#197593` in both
+    /// appearances, with the ring, the text selection and the list selection all derived from it.
+    ///
+    /// **What it does not reach, and this was measured rather than repeated from the docs.** The
+    /// key wins only where the user has left the accent on Multicolour, which is the default and so
+    /// most machines. A probe bundle carrying this exact key and catalogue, handed a chosen accent,
+    /// answered `#F74F9E` for `controlAccentColor` and derived its ring and its selection from that:
+    /// the user's choice beats the app's every time. So a Mac set to Pink or to Graphite has the
+    /// two accents it had before, and this fixes the default case and nothing else. The other
+    /// coherent answer, giving the sidebar selection back to `controlAccentColor`, is the one to
+    /// reach for if the brand argument ever gives.
+    ///
+    /// Increase Contrast is the system's business either way now, because the colour it is lifting
+    /// is `controlAccentColor` and that is this. A colour set can carry a High Contrast variant of
+    /// its own the day `PaletteInk` grows a high-contrast tier; it has none, so it declares one
+    /// colour and the system does what it does to it.
     static let accent = dynamic(PaletteInk.accent)
 
     /// The same pair as an `NSColor`, for the layers that hold a `CGColor` and therefore have to be
@@ -217,6 +249,14 @@ enum Palette {
     /// on it measures 5.2 to 1, which is where macOS's own selection fill sits (4.9 to 1), so a
     /// selected row reads exactly as firmly as it did. Bloom itself cannot do this job: white on
     /// `#4FD8C4` is 1.6 to 1, an unreadable row.
+    ///
+    /// **This is also the colour AppKit is handed**, through `NSAccentColorName` and the
+    /// `AccentColor` set in Assets.car, and it is this member of the ramp rather than `accent` for
+    /// the reason above: `controlAccentColor` is a FILL everywhere the system reaches for it, the
+    /// track of a switch, the box of a ticked checkbox, the dot of a radio button, all of them with
+    /// white on top. `accent` in dark is `#4FD8C4` and would leave every tick in the app at 1.6 to
+    /// 1. One value in both appearances is what a colour set wants anyway, and this pair already is
+    /// one, which is why `Tools/build.sh` refuses a build where the two halves have come apart.
     static let accentFill = dynamic(PaletteInk.accentFill)
 
     /// An address in running text: underlined, and this colour.

--- a/Sources/BloomCore/Presentation/PaletteInk.swift
+++ b/Sources/BloomCore/Presentation/PaletteInk.swift
@@ -56,4 +56,33 @@ public enum PaletteInk {
     public static let synVariable = Pair(light: 0x6A3FB5, dark: 0xB49BF0)
     public static let synAttribute = Pair(light: 0x8A6A00, dark: 0xD9B65C)
     public static let synOperator = Pair(light: 0x5A5A60, dark: 0xA8A8B0)
+
+    /// What AppKit derives from `accentFill` for the ground under selected text, measured rather
+    /// than chosen.
+    ///
+    /// This is the one pair here Bloom does not draw. `Palette.textSelection` is
+    /// `selectedTextBackgroundColor` and stays semantic, because the selection has to follow Full
+    /// Keyboard Access and the key window the way the system's does. What changed is what the
+    /// system derives it FROM: `NSAccentColorName` in the bundle's Info.plist points
+    /// `controlAccentColor` at the `AccentColor` set in Assets.car, which carries `accentFill`, and
+    /// every colour AppKit computes off the accent moves with it. Before that the selection was
+    /// `#B3D7FF` and `#3F638B`, the system blue's, while the row selection two hundred points away
+    /// was Bloom's, which is the two-blues complaint at its most visible.
+    ///
+    /// A derived colour is exactly the kind of claim that used to go in a doc comment and never be
+    /// checked again, so it is a number here instead: read off `NSColor.selectedTextBackgroundColor`
+    /// in a bundle carrying this accent, in both appearances, and asserted by
+    /// `PaletteContrastTests`. It sits BEHIND text, so the day somebody retunes `accentFill` up the
+    /// ramp, the test says whether the selection still carries a label rather than leaving it to be
+    /// noticed while dragging over a paragraph.
+    ///
+    /// It only describes a Mac left on the Multicolour default. A user who has chosen an accent in
+    /// System Settings gets their own derivation and this pair is not what is on screen, which is
+    /// the same caveat `Palette.accent` carries about the whole mechanism.
+    public static let accentTextSelection = Pair(light: 0xBAD6DF, dark: 0x46626B)
+
+    /// The ink AppKit puts on that ground: `selectedTextColor`, which resolves to plain black and
+    /// plain white rather than to `labelColor`. Stated so the assertion measures the pair that is
+    /// really on screen instead of assuming the text colour.
+    public static let selectedTextInk = Pair(light: 0x000000, dark: 0xFFFFFF)
 }

--- a/Tests/BloomCoreTests/PaletteContrastTests.swift
+++ b/Tests/BloomCoreTests/PaletteContrastTests.swift
@@ -129,6 +129,51 @@ struct PaletteContrastTests {
         }
     }
 
+    /// The accent stopped being only Bloom's business the day `NSAccentColorName` went into the
+    /// bundle, and this is the floor that came with it.
+    ///
+    /// Before that the accent reached only what Bloom drew, so a wrong one was a wrong chip. Now
+    /// AppKit derives the ground under selected text from it, and that ground sits behind a
+    /// paragraph somebody is reading while they drag over it: `selectedTextBackgroundColor` is a
+    /// fill with a label on it, in the one state where the reader cannot move the label out of the
+    /// way. `PaletteInk.accentTextSelection` is what the system derived from `accentFill`, measured
+    /// in both appearances, and this asks the question that matters about it.
+    ///
+    /// The floor is the text one rather than the non-text one, deliberately. The whole point of a
+    /// selection is that the words under it stay words.
+    @Test("selected text is still readable on the ground the accent derives")
+    func selectedTextClearsItsFloor() {
+        for (appearance, isDark) in Self.appearances {
+            let ratio = Contrast.ratio(
+                PaletteInk.selectedTextInk.member(dark: isDark),
+                PaletteInk.accentTextSelection.member(dark: isDark)
+            )
+            #expect(
+                ratio >= Contrast.textFloor,
+                "selected text on the accent's selection fill, \(appearance): \(ratio.rounded(to: 2)) to 1"
+            )
+        }
+    }
+
+    /// The other half of the same question, and the one a retune is likelier to break. A selection
+    /// nobody can see is a selection that has to be guessed at, and the fill is a pale wash on the
+    /// light ramp: `#BAD6DF` on white is a step of 1.4, which is under any text floor and is not
+    /// meant to clear one, but it has to be findable.
+    @Test("a selection can be seen against the page it is on")
+    func aSelectionIsFindable() {
+        for (appearance, isDark) in Self.appearances {
+            for (groundName, ground) in Self.grounds {
+                let ratio = Contrast.ratio(
+                    PaletteInk.accentTextSelection.member(dark: isDark), ground.member(dark: isDark)
+                )
+                #expect(
+                    ratio >= 1.2,
+                    "the selection fill on \(groundName), \(appearance): \(ratio.rounded(to: 2)) to 1"
+                )
+            }
+        }
+    }
+
     /// The tab strip's own two colours, which is the one control in the window whose fill and ink
     /// were chosen together rather than inherited from a list row.
     ///

--- a/Tools/build.sh
+++ b/Tools/build.sh
@@ -170,6 +170,41 @@ embed_sparkle() {
 
 embed_sparkle
 
+# The accent Bloom hands to AppKit, checked against the one Bloom draws with itself.
+#
+# Resources/Assets.xcassets/AccentColor.colorset is a colour set and nothing more, and a colour set
+# cannot reference a Swift constant. So the hex is stated twice, once in `PaletteInk.accentFill` and
+# once in the JSON, and this reads both and refuses a build where they have drifted. Without the
+# check the failure is silent and permanent: every AppKit control would go on drawing the colour the
+# ramp used to be, and the window would be back to two accents with nothing saying so.
+verify_accent_matches_palette() {
+  local colourset=Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+  local ink=Sources/BloomCore/Presentation/PaletteInk.swift
+  [[ -f "$colourset" && -f "$ink" ]] || return 0
+
+  local declared asset
+  # Pair(light: 0x197593, dark: 0x197593). Both members, because a pair whose halves differ cannot
+  # be one colour set and this should say so rather than silently taking the light one.
+  declared="$(sed -n 's/.*accentFill = Pair(light: 0x\([0-9A-Fa-f]*\), dark: 0x\([0-9A-Fa-f]*\)).*/\1 \2/p' "$ink")"
+  if [[ "${declared%% *}" != "${declared##* }" ]]; then
+    echo "==> accent: PaletteInk.accentFill is a pair ($declared), which one colour set cannot be" >&2
+    return 1
+  fi
+
+  asset="$(/usr/bin/python3 -c '
+import json, sys
+c = json.load(open(sys.argv[1]))["colors"][0]["color"]["components"]
+print("".join(c[k][2:].upper() for k in ("red", "green", "blue")))
+' "$colourset")"
+
+  if [[ "$asset" != "$(echo "${declared%% *}" | tr "[:lower:]" "[:upper:]")" ]]; then
+    echo "==> accent: $colourset says #$asset, PaletteInk.accentFill says #${declared%% *}" >&2
+    return 1
+  fi
+}
+
+verify_accent_matches_palette
+
 # macOS 26 draws an app icon from a layered Icon Composer document rather than from a flat bitmap:
 # the glass, the shadow and the specular pass belong to the system and are applied live to the
 # layers. Resources/Bloom.icon is that document. actool compiles it into an Assets.car, which the
@@ -177,14 +212,25 @@ embed_sparkle
 # floor is macOS 26 and there is no system left that would draw a flat one. Tools/icon/make.py's
 # docstring carries the measurement that settled that.
 #
+# Resources/Assets.xcassets goes into the same catalogue and the same invocation, because a second
+# actool run compiling to the same directory writes a second Assets.car over the first and the app
+# loses whichever went in first. One run, two inputs, one file with both in it. What is in the
+# catalogue besides the icon is the AccentColor set NSAccentColorName names, which is what makes
+# every AppKit control in the window draw in Bloom's accent rather than the user's.
+#
 # Command line tools on their own carry no actool, so a machine with only those produces a bundle
-# with no icon at all. That is loud enough to notice and cheaper than failing the build.
-compile_layered_icon() {
+# with no icon at all, and no accent either: the app then falls back to the system accent, which is
+# what it drew before this existed. That is loud enough to notice and cheaper than failing the
+# build.
+compile_asset_catalogue() {
   local iconName=Bloom deployment
-  [[ -d "Resources/$iconName.icon" ]] || return 0
+  local -a inputs
+  [[ -d "Resources/$iconName.icon" ]] && inputs+=("$PWD/Resources/$iconName.icon")
+  [[ -d "Resources/Assets.xcassets" ]] && inputs+=("$PWD/Resources/Assets.xcassets")
+  (( ${#inputs} )) || return 0
 
   if ! xcrun --find actool >/dev/null 2>&1; then
-    echo "==> skipping layered icon: actool not found"
+    echo "==> skipping asset catalogue: actool not found"
     return 0
   fi
 
@@ -192,7 +238,7 @@ compile_layered_icon() {
 
   # Absolute, because actool hands a relative input path to ibtoold, which resolves it against a
   # working directory of its own and crashes rather than reporting a missing file.
-  xcrun actool "$PWD/Resources/$iconName.icon" \
+  xcrun actool "${inputs[@]}" \
     --compile "$APP/Contents/Resources" \
     --app-icon "$iconName" \
     --output-partial-info-plist "$BIN_DIR/$iconName.icon.plist" \
@@ -210,12 +256,12 @@ compile_layered_icon() {
   # Nothing above proves the catalogue arrived: actool reports a failure in the plist it prints and
   # is not reliably non-zero about it. The bundle either has the file or the build is wrong.
   if [[ ! -f "$APP/Contents/Resources/Assets.car" ]]; then
-    echo "==> layered icon: actool produced no Assets.car" >&2
+    echo "==> asset catalogue: actool produced no Assets.car" >&2
     return 1
   fi
 }
 
-compile_layered_icon
+compile_asset_catalogue
 
 # What the app looks up in its own bundle by name: the Spatie logos the About pane draws, the
 # menu bar mark, and the product marks the About window's makers section shows. The logos and the


### PR DESCRIPTION
`Palette.accent` overrode `controlAccentColor` for everything Bloom draws itself and reached nothing AppKit draws. 37 toggles, every focus ring and every text selection stayed the user's blue, so one Settings pane held a system-blue switch above a Bloom-blue selected row.

`NSAccentColorName` now names an `AccentColor` set in the `Assets.car` the build already compiles, carrying `PaletteInk.accentFill`. The fill member rather than the ink one, because `controlAccentColor` is a fill wherever the system reaches for it, and `accent` in dark is `#4FD8C4`, which would leave every tick at 1.6 to 1.

`Tools/build.sh` gained a second input to the one `actool` run (a second run to the same directory overwrites the first `Assets.car`) and a check that the colour set and `PaletteInk` still agree, since a colour set cannot reference a Swift constant. Every path ships through that script, `dev`, `master` and `release` alike.

**The caveat is true, measured with a probe bundle rather than taken from the docs.** The key wins only where the accent is left on Multicolour. Handed a chosen accent, the same bundle answered `#F74F9E` for `controlAccentColor` and derived its own ring and selection from it. So this fixes the default case, which is most machines, and leaves Graphite where it was.

`PaletteInk.accentTextSelection` is what AppKit derives for the ground under selected text, `#BAD6DF` and `#46626B`, and `PaletteContrastTests` holds a floor over it now that the accent decides a fill with a paragraph on it: 13.8 to 1 in light, 6.5 in dark, against 6.2 for the system blue it replaces.

Two places that deliberately wanted the system's accent now get Bloom's, both in files this branch does not touch: `MenuInk.calm` in `QuotaPanel`, whose comment argues a menu does not belong to Bloom, and the Settings tab bar, whose comment calls itself the last system-accent control in the window.

`--gallery system-accent` photographs the controls no test here can see.