### PR TITLE
Give Cmd+F to the pane in front, and the app a Find group

### DIFF
--- a/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
+++ b/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
@@ -171,6 +171,27 @@ struct BloomCommands: Commands {
             // undivided run of eight items. Every Mac Edit menu keeps find in a group of its own.
             Divider()
 
+            // The find group every Mac Edit menu has, which this one did not: Cmd+F opened a
+            // screen, there was no Cmd+G anywhere in the app, and the terminal's own find bar had
+            // never been asked for. A submenu called Find, because that is where Mail, Safari,
+            // Preview and Xcode all keep these three.
+            Menu("Find") {
+                Button("Find…", action: find)
+                    .keyboardShortcut("f", modifiers: .command)
+                    // Never disabled. Whatever is in front either finds in place or falls through
+                    // to the search, and which of those it is cannot be read from here anyway:
+                    // this body is rebuilt when an `@Observable` moves, and first responder is not
+                    // one. See `FindCommand`, which is the rule, and `FindInPlace`, which asks the
+                    // responder chain at the moment the key is pressed.
+                    .disabled(model.repos.isEmpty && !FindInPlace.isAvailable)
+
+                Button("Find Next") { step(.nextMatch) }
+                    .keyboardShortcut("g", modifiers: .command)
+
+                Button("Find Previous") { step(.previousMatch) }
+                    .keyboardShortcut("g", modifiers: [.command, .shift])
+            }
+
             // "Search", not "Find Workspace". This opens the sidebar's own Search, which reads
             // the full text of every transcript as well as workspace names, so the old title
             // named the smaller half of what it does and nobody would have guessed the rest was
@@ -178,10 +199,15 @@ struct BloomCommands: Commands {
             //
             // No ellipsis: it puts a screen up in the window rather than raising anything to fill
             // in, which is what the ellipsis promises.
+            //
+            // Shift+Cmd+F rather than Cmd+F. Cmd+F is the most reflexive keystroke on the platform
+            // and it belongs to the pane in front; this is the one that always means the screen,
+            // which is what somebody in a terminal needs it to mean. Cmd+F still lands here
+            // whenever nothing in front can find, so the key that used to open this still does.
             Button("Search") {
                 model.selection = .search
             }
-            .keyboardShortcut("f", modifiers: .command)
+            .keyboardShortcut("f", modifiers: [.command, .shift])
             // Keyed on projects rather than on live workspaces, because search now also finds
             // archived ones and a machine whose every workspace is archived still has something
             // to find. See `AppModel.search`.
@@ -380,7 +406,8 @@ struct BloomCommands: Commands {
             // the same gesture aimed at two different answers: one asks for something to be
             // fixed, the other asks for something to be built.
             //
-            // Option+Command+F rather than Command+F, which is Search and stays that way.
+            // Option+Command+F rather than Command+F, which belongs to finding in the pane in
+            // front. Feedback keeps this key: it is the one somebody already knows.
             // The sheets themselves are raised from `RootView`, through `FeedbackPresenter`, for
             // the reason the create sheet is: a menu item cannot present anything, and the draft
             // has to outlive the sheet it was typed into.
@@ -531,6 +558,30 @@ struct BloomCommands: Commands {
                 WorkspaceTabsStore.shared.select($0, in: workspace)
             }
         }
+    }
+
+    // MARK: - Finding
+
+    /// Cmd+F. The pane in front gets first refusal, and the workspace search is what is left when
+    /// nothing there can find. See `FindCommand`, which is the rule and holds the tests.
+    private func find() {
+        switch FindCommand.find(
+            canFindInPlace: FindInPlace.isAvailable, hasProjects: !model.repos.isEmpty
+        ) {
+        case .findInPlace:
+            FindInPlace.perform(.showFindInterface)
+        case .workspaceSearch:
+            model.selection = .search
+        case nil:
+            break
+        }
+    }
+
+    private func step(_ action: NSTextFinder.Action) {
+        guard FindCommand.step(canFindInPlace: FindInPlace.isAvailable) == .findInPlace else {
+            return
+        }
+        FindInPlace.perform(action)
     }
 
     private func addProjectFolder() {

--- a/Sources/Bloom/Views/Chrome/App/FindInPlace.swift
+++ b/Sources/Bloom/Views/Chrome/App/FindInPlace.swift
@@ -1,0 +1,56 @@
+import AppKit
+import SwiftTerm
+
+/// The find bar of whatever is in front, reached the way AppKit reaches one.
+///
+/// **Why it walks the chain rather than sending to nil.** `NSApp.sendAction(to: nil)` finds the
+/// first responder that merely implements the selector, and in this window that is not always the
+/// one that can act on it. The transcript's text views set `usesFindBar = false` deliberately,
+/// because each holds a single paragraph, and an `NSTextView` in that state still answers
+/// `performTextFinderAction(_:)` by doing nothing at all. Sending blind would therefore swallow
+/// Cmd+F over a conversation instead of letting it fall through to the workspace search. The find
+/// bar SwiftTerm draws is the other half of the same problem: while its field has the keyboard the
+/// first responder is a field editor, so the terminal that owns the search is several steps up.
+///
+/// So the target is resolved rather than assumed: the nearest thing up the chain that genuinely
+/// has a find interface, which today is a terminal or an editable `SourceEditor`. Anything else is
+/// no answer, and `FindCommand` in the core decides what happens then.
+///
+/// **A menu item is the argument.** Both implementations read the action off the sender's tag,
+/// which is how AppKit has always carried it, so the item exists to hold the tag rather than to be
+/// drawn anywhere.
+@MainActor
+enum FindInPlace {
+    /// Whether anything in front can find, which is the boolean `FindCommand` is asked with.
+    static var isAvailable: Bool { target() != nil }
+
+    /// Runs one of the find actions against the pane in front. False when nothing there can find,
+    /// which is the caller's cue to do whatever the rule says instead.
+    @discardableResult
+    static func perform(_ action: NSTextFinder.Action) -> Bool {
+        guard let target = target() else { return false }
+        let item = NSMenuItem()
+        item.tag = action.rawValue
+        target.performTextFinderAction(item)
+        return true
+    }
+
+    /// The nearest responder above the keyboard that has a find bar of its own.
+    ///
+    /// `keyWindow` rather than `mainWindow`: a sheet or a panel in front is where the keystroke
+    /// was aimed, and a find sent past it to the window behind is a find nobody asked for.
+    private static func target() -> NSResponder? {
+        var responder = NSApp.keyWindow?.firstResponder
+        while let current = responder {
+            // SwiftTerm 1.19 implements `performTextFinderAction(_:)` and ships `MacFindBarView`,
+            // and nothing in Bloom had ever asked for either, so Cmd+F in a shell threw the reader
+            // out to the sidebar.
+            if current is SwiftTerm.TerminalView { return current }
+            // `usesFindBar` is exactly the question: `SourceEditor` turns it on for an editable
+            // file and the transcript turns it off, and those are the two right answers.
+            if let text = current as? NSTextView, text.usesFindBar { return text }
+            responder = current.nextResponder
+        }
+        return nil
+    }
+}

--- a/Sources/BloomCore/Presentation/FindCommand.swift
+++ b/Sources/BloomCore/Presentation/FindCommand.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// What Cmd+F does, which on this platform is always "find in the thing I am looking at".
+///
+/// **What Bloom did.** Cmd+F navigated the sidebar to a separate Search screen, replacing the whole
+/// centre column: the most reflexive keystroke there is took the reader away from what they were
+/// reading. There was no Cmd+G anywhere in the app, and the terminal shipped a working find bar
+/// that nothing ever asked for. Mail, Safari, Terminal, Preview, Notes and Xcode all open a find
+/// interface over the content in front and step it with Cmd+G, without exception.
+///
+/// **The rule, and why Search is still on the end of it.** The pane in front gets first refusal:
+/// a shell and a source editor both have a real find bar and answer for themselves. Where nothing
+/// in front can find, the workspace Search is what Cmd+F has always opened, and it reads the full
+/// text of every transcript, so falling through to it means the key keeps everything it could do
+/// before and gains what it should have done all along. It is also on Shift+Cmd+F of its own, so
+/// somebody who wants the search screen from inside a terminal has a key that always means it.
+public enum FindCommand {
+    public enum Target: Equatable, Sendable {
+        /// The pane in front answers, through its own find bar.
+        case findInPlace
+        /// The sidebar's Search screen, which reads every transcript on the machine.
+        case workspaceSearch
+    }
+
+    /// Cmd+F.
+    ///
+    /// - Parameters:
+    ///   - canFindInPlace: whether anything in the responder chain has a find interface.
+    ///   - hasProjects: whether the Search screen has anything to search. Keyed on projects rather
+    ///     than on live workspaces, because search finds archived ones too.
+    public static func find(canFindInPlace: Bool, hasProjects: Bool) -> Target? {
+        if canFindInPlace { return .findInPlace }
+        return hasProjects ? .workspaceSearch : nil
+    }
+
+    /// Cmd+G and Shift+Cmd+G, which only ever mean the find already running in front of you.
+    ///
+    /// Stepping the matches has no meaning on the Search screen: that is a list of results with its
+    /// own keyboard, and moving the sidebar's selection would not be finding a next anything.
+    public static func step(canFindInPlace: Bool) -> Target? {
+        canFindInPlace ? .findInPlace : nil
+    }
+}

--- a/Tests/BloomCoreTests/FindCommandTests.swift
+++ b/Tests/BloomCoreTests/FindCommandTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import BloomCore
+
+/// Cmd+F never finding what you are looking at.
+///
+/// It navigated to a separate Search screen, replacing the centre column, while the terminal in
+/// front of the reader had a find bar nothing ever asked for.
+@Suite("What Cmd+F finds")
+struct FindCommandTests {
+    /// The whole point: a shell or a source editor in front answers for itself and the reader is
+    /// not thrown out to another screen.
+    @Test("a pane that can find keeps the keystroke")
+    func findsInPlace() {
+        #expect(FindCommand.find(canFindInPlace: true, hasProjects: true) == .findInPlace)
+        #expect(FindCommand.find(canFindInPlace: true, hasProjects: false) == .findInPlace)
+    }
+
+    /// And what Cmd+F has always done is still on the end of it, so nothing that worked stops
+    /// working.
+    @Test("a pane that cannot find falls through to the workspace search")
+    func fallsThroughToSearch() {
+        #expect(FindCommand.find(canFindInPlace: false, hasProjects: true) == .workspaceSearch)
+    }
+
+    @Test("with no projects there is nothing to find anywhere")
+    func nothingToFind() {
+        #expect(FindCommand.find(canFindInPlace: false, hasProjects: false) == nil)
+    }
+
+    /// Stepping the matches is the find in front and nothing else. Moving the sidebar's selection
+    /// would not be finding a next anything.
+    @Test("Cmd+G only ever means the find in front")
+    func stepping() {
+        #expect(FindCommand.step(canFindInPlace: true) == .findInPlace)
+        #expect(FindCommand.step(canFindInPlace: false) == nil)
+    }
+}


### PR DESCRIPTION
Cmd+F navigated to the Search screen, replacing the centre column. There was no Cmd+G anywhere in the app, and SwiftTerm ships a working find bar that nothing ever asked for, so Cmd+F in a shell threw the reader out to the sidebar.

Edit now carries the find group every Mac Edit menu has: a Find submenu with Find… (Cmd+F), Find Next (Cmd+G) and Find Previous (Shift+Cmd+G), aimed at whatever in the responder chain actually has a find interface, which today is a terminal pane and an editable `SourceEditor`.

Search keeps its screen and its name and moves to Shift+Cmd+F, so there is a key that always means it. Cmd+F still opens it whenever nothing in front can find, which is the conversation, so the old key loses nothing it could do.

`FindCommand` in the core is the rule, with tests. `FindInPlace` resolves the target by walking up from first responder rather than sending blind: the transcript's text views set `usesFindBar = false` on purpose and would swallow the action by doing nothing, and while SwiftTerm's own find field has the keyboard the terminal that owns the search is several responders up.

Not in this change, and deliberately: find in page for the browser (another agent's file this session), a find bar for the transcript, which is a feature rather than a binding, and Use Selection for Find on Cmd+E, which the inspector's diff pane currently binds to something else.