### PR TITLE
Commit an in-place rename when the field is left

### DIFF
--- a/Sources/Bloom/Views/Home/HomeListRow.swift
+++ b/Sources/Bloom/Views/Home/HomeListRow.swift
@@ -43,6 +43,9 @@ struct HomeListRow: View {
     var onCancelRename: () -> Void
 
     @State private var draft = ""
+    /// Whether this rename has already been finished, so the ways of leaving the field cannot ask
+    /// for the same rename twice. Reset when the field opens. See `end(_:)`.
+    @State private var hasEnded = false
     @FocusState private var fieldFocused: Bool
 
     private var workspace: Workspace { row.workspace }
@@ -74,10 +77,18 @@ struct HomeListRow: View {
                 TextField("Workspace name", text: $draft)
                     .textFieldStyle(.plain)
                     .focused($fieldFocused)
-                    .onSubmit { onCommitRename(draft) }
-                    .onExitCommand(perform: onCancelRename)
+                    .onSubmit { end(.submitted) }
+                    .onExitCommand { end(.escaped) }
+                    // Clicking away commits, as it does in Finder, rather than leaving the field
+                    // open on the row holding text nobody ever asked to keep. Guarded on having
+                    // had the focus, so the false the field starts at is not read as losing it.
+                    .onChange(of: fieldFocused) { had, has in
+                        guard had, !has else { return }
+                        end(.focusLost)
+                    }
                     .task {
                         draft = workspace.name
+                        hasEnded = false
                         // A beat, so the field exists before focus moves to it.
                         try? await Task.sleep(for: .milliseconds(30))
                         fieldFocused = true
@@ -291,6 +302,24 @@ struct HomeListRow: View {
             )
         )
         return parts.joined(separator: ", ")
+    }
+
+    // MARK: - Renaming
+
+    /// One door out of the field, for each of the ways of leaving it. Which of them writes the
+    /// name is `InPlaceRename` in the core, so this row, the sidebar's and the project header's
+    /// cannot answer the same gesture three different ways.
+    ///
+    /// `hasEnded` is what stops one rename being asked for twice: committing closes the field,
+    /// which is itself a focus change, and the write is asynchronous so the second caller would
+    /// still see the old name.
+    private func end(_ ending: InPlaceRename.Ending) {
+        guard !hasEnded else { return }
+        hasEnded = true
+        guard case .commit(let name) = InPlaceRename.outcome(
+            ending, draft: draft, current: workspace.name
+        ) else { return onCancelRename() }
+        onCommitRename(name)
     }
 }
 

--- a/Sources/Bloom/Views/Home/HomeView.swift
+++ b/Sources/Bloom/Views/Home/HomeView.swift
@@ -130,7 +130,7 @@ struct HomeView: View {
                             now: now,
                             isRenaming: renaming == row.id,
                             onCommitRename: { commitRename(row, to: $0) },
-                            onCancelRename: { renaming = nil }
+                            onCancelRename: { closeField(of: row) }
                         )
                         // Innermost, on the drawing alone. Everything below this line is what the
                         // list is told about the row, and a row that is fading in is still
@@ -359,10 +359,18 @@ struct HomeView: View {
         Task { await app.addProjectByAsking() }
     }
 
+    /// The name has already been through `InPlaceRename` in the row, which is what decided there
+    /// was anything to write at all: it is trimmed, not empty, and different from the one the
+    /// workspace has. All that is left here is closing the field and writing it.
     private func commitRename(_ row: HomeRow, to newName: String) {
-        let name = newName.trimmingCharacters(in: .whitespacesAndNewlines)
-        renaming = nil
-        guard !name.isEmpty, name != row.workspace.name else { return }
-        Task { await app.rename(row.workspace, to: name) }
+        closeField(of: row)
+        Task { await app.rename(row.workspace, to: newName) }
+    }
+
+    /// Only if the open field is still this row's. A rename started on another row is what ends
+    /// this one, and clearing the shared id unconditionally would close the field that had just
+    /// been opened over there.
+    private func closeField(of row: HomeRow) {
+        if renaming == row.id { renaming = nil }
     }
 }

--- a/Sources/Bloom/Views/Sidebar/RepoHeaderRow.swift
+++ b/Sources/Bloom/Views/Sidebar/RepoHeaderRow.swift
@@ -106,8 +106,14 @@ struct RepoHeaderRow: View {
                     .textFieldStyle(.plain)
                     .font(Typo.title)
                     .focused($repoFieldFocused)
-                    .onSubmit(commitRepoRename)
-                    .onExitCommand { isRenamingRepo = false }
+                    .onSubmit { endRepoRename(.submitted) }
+                    .onExitCommand { endRepoRename(.escaped) }
+                    // Clicking away commits, as it does in Finder. Guarded on having had the
+                    // focus, so the false the field starts at is not read as having lost it.
+                    .onChange(of: repoFieldFocused) { had, has in
+                        guard had, !has else { return }
+                        endRepoRename(.focusLost)
+                    }
             } else {
                 name
             }
@@ -399,10 +405,14 @@ struct RepoHeaderRow: View {
         }
     }
 
-    private func commitRepoRename() {
-        let name = repoDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+    /// One door out of the field, for each of the ways of leaving it. Escape is the only one that
+    /// throws the draft away. See `InPlaceRename`.
+    private func endRepoRename(_ ending: InPlaceRename.Ending) {
+        guard isRenamingRepo else { return }
         isRenamingRepo = false
-        guard !name.isEmpty, name != repo.name else { return }
+        guard case .commit(let name) = InPlaceRename.outcome(
+            ending, draft: repoDraft, current: repo.name
+        ) else { return }
         Task { await app.rename(repo, to: name) }
     }
 }

--- a/Sources/Bloom/Views/Sidebar/SidebarView.swift
+++ b/Sources/Bloom/Views/Sidebar/SidebarView.swift
@@ -296,6 +296,11 @@ struct SidebarView: View {
         .onChange(of: listSelection) { _, _ in commitSelection() }
         // Moving off a row has to close whatever field was open on it, or the rename would carry
         // on editing a workspace that is no longer on screen.
+        //
+        // Closing it no longer throws away what was typed. This line used to be the second half of
+        // an edit being eaten: the field went and the draft went with it, so selecting another
+        // workspace mid rename silently lost the name. The row watches `renaming` and commits when
+        // it is taken away, which is `InPlaceRename`'s `dismissed` ending. See `WorkspaceRow.end`.
         .onChange(of: app.selection, initial: true) { _, target in
             renaming = nil
             listSelection = target

--- a/Sources/Bloom/Views/Sidebar/WorkspaceRow.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspaceRow.swift
@@ -61,6 +61,9 @@ struct WorkspaceRow: View {
     /// crossing the pane lights one row at a time.
     @State private var isHovered = false
     @State private var draft = ""
+    /// Whether this rename has already been finished, so the four ways of leaving the field cannot
+    /// write the name twice. Reset when the field opens. See `end(_:)`.
+    @State private var hasEnded = false
     @FocusState private var fieldFocused: Bool
 
     private var isRenaming: Bool { renaming == workspace.id }
@@ -82,10 +85,19 @@ struct WorkspaceRow: View {
                         // background in both appearances and owes nothing to what is behind it.
                         .foregroundStyle(Palette.textPrimary)
                         .focused($fieldFocused)
-                        .onSubmit { commit() }
-                        .onExitCommand { renaming = nil }
+                        .onSubmit { end(.submitted) }
+                        .onExitCommand { end(.escaped) }
+                        // Clicking away commits, which is what Finder, Xcode and Mail do and what
+                        // this field did not: it stayed open on the row holding uncommitted text
+                        // for as long as the window was left alone. Guarded on having had the
+                        // focus, so the false this starts at is not read as having lost it.
+                        .onChange(of: fieldFocused) { had, has in
+                            guard had, !has else { return }
+                            end(.focusLost)
+                        }
                         .task {
                             draft = workspace.name
+                            hasEnded = false
                             // A beat, so the field exists before focus moves to it.
                             try? await Task.sleep(for: .milliseconds(30))
                             fieldFocused = true
@@ -170,6 +182,14 @@ struct WorkspaceRow: View {
         // The list inverts the row's text for us, but a label that carries its own colour, such as
         // the green plus count, has to be told. This is the same signal the inspector's lists send.
         .environment(\.isOnEmphasizedSelection, isEmphasized)
+        // On the ROW rather than on the field, because this is the ending the field is not around
+        // to see: `SidebarView` closes it whenever the selection moves, and what was typed used to
+        // go with it. The row is still in the list when that happens, so this fires and the name is
+        // written. See `InPlaceRename`.
+        .onChange(of: isRenaming) { was, now in
+            guard was, !now else { return }
+            end(.dismissed)
+        }
     }
 
     // MARK: - Trailing
@@ -373,10 +393,22 @@ struct WorkspaceRow: View {
 
     // MARK: - Renaming
 
-    private func commit() {
-        let name = draft.trimmingCharacters(in: .whitespacesAndNewlines)
-        renaming = nil
-        guard !name.isEmpty, name != workspace.name else { return }
+    /// One door out of the field, for all four ways of leaving it.
+    ///
+    /// `hasEnded` is what stops the name being written twice. Ending the rename clears `renaming`,
+    /// which both removes the field (so the focus change fires) and flips `isRenaming` (so the
+    /// row's own watcher fires), and the write is asynchronous, so the second caller would still
+    /// see the old name and ask for the same rename again.
+    private func end(_ ending: InPlaceRename.Ending) {
+        guard !hasEnded else { return }
+        hasEnded = true
+        // Only if the field is still this row's. Starting a rename on another row is what ends
+        // this one, and clearing the shared id unconditionally would close the field that had just
+        // been opened over there.
+        if renaming == workspace.id { renaming = nil }
+        guard case .commit(let name) = InPlaceRename.outcome(
+            ending, draft: draft, current: workspace.name
+        ) else { return }
         Task { await app.rename(workspace, to: name) }
     }
 }

--- a/Sources/BloomCore/Presentation/InPlaceRename.swift
+++ b/Sources/BloomCore/Presentation/InPlaceRename.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// What happens to a name being typed on a row when the field stops being edited.
+///
+/// **The bug this is written from.** The three rows with an in-place rename (a workspace in the
+/// sidebar, a project header, a workspace on Home) each wired Return and Escape and nothing else.
+/// Click anywhere else in the window and the field stayed open on the row, holding uncommitted
+/// text, indefinitely; and the sidebar cleared the field whenever the selection moved, so
+/// selecting another workspace silently threw away what had been typed. Finder, Xcode and Mail all
+/// commit an in-place rename when the field resigns first responder, and a Mac user reads an
+/// abandoned edit as the app having eaten it.
+///
+/// **Why one rule rather than three.** The three rows had three copies of the same four lines, and
+/// what they must agree on is not the typing but the endings: Escape is the only one that throws
+/// the draft away, and everything else keeps it. A rule with the endings named is also the only way
+/// to test it, since a decision taken inside a view is a decision nothing can hold still.
+public enum InPlaceRename {
+    /// How the field stopped being edited.
+    public enum Ending: String, Sendable, CaseIterable {
+        /// Return.
+        case submitted
+        /// The field lost first responder: a click elsewhere in the window, or the keyboard moving
+        /// to another control.
+        case focusLost
+        /// Escape.
+        case escaped
+        /// The list closed the field from underneath, which is what moving the selection does.
+        case dismissed
+    }
+
+    public enum Outcome: Equatable, Sendable {
+        case commit(String)
+        /// Nothing to write: the edit was cancelled, or the name came back the same or empty.
+        case discard
+    }
+
+    /// - Parameters:
+    ///   - draft: what is in the field, untrimmed.
+    ///   - current: the name the thing already has.
+    public static func outcome(_ ending: Ending, draft: String, current: String) -> Outcome {
+        // Escape is the one ending that means "forget it", and it has to stay that way: it is the
+        // only way out of a rename that does not write, and a Mac user who has typed the wrong
+        // thing reaches for it before they reach for the old name.
+        guard ending != .escaped else { return .discard }
+
+        let name = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        // An empty field is not a request to have no name, and a name that came back unchanged is
+        // not a rename: writing either would spend a database round trip and a sidebar reflow on
+        // nothing.
+        guard !name.isEmpty, name != current else { return .discard }
+        return .commit(name)
+    }
+}

--- a/Tests/BloomCoreTests/InPlaceRenameTests.swift
+++ b/Tests/BloomCoreTests/InPlaceRenameTests.swift
@@ -1,0 +1,53 @@
+import Testing
+@testable import BloomCore
+
+/// The in-place rename that never committed when you clicked away, and that the sidebar threw away
+/// whenever the selection moved.
+@Suite("Ending an in-place rename")
+struct InPlaceRenameTests {
+    /// The fix, stated: everything but Escape keeps what was typed. Finder, Xcode and Mail all
+    /// commit on losing first responder.
+    @Test("every ending but Escape writes the name")
+    func endingsThatCommit() {
+        for ending in InPlaceRename.Ending.allCases where ending != .escaped {
+            #expect(
+                InPlaceRename.outcome(ending, draft: "new name", current: "old name")
+                    == .commit("new name"),
+                "\(ending)"
+            )
+        }
+    }
+
+    /// Including the one the sidebar used to lose: the list closing the field because the
+    /// selection moved to another workspace.
+    @Test("a field closed from underneath still writes")
+    func dismissed() {
+        #expect(
+            InPlaceRename.outcome(.dismissed, draft: "renamed", current: "old")
+                == .commit("renamed")
+        )
+    }
+
+    @Test("Escape throws the draft away")
+    func escape() {
+        #expect(InPlaceRename.outcome(.escaped, draft: "typed", current: "old") == .discard)
+    }
+
+    @Test("surrounding space is not part of the name")
+    func trimming() {
+        #expect(
+            InPlaceRename.outcome(.submitted, draft: "  spaced  ", current: "old")
+                == .commit("spaced")
+        )
+        #expect(InPlaceRename.outcome(.focusLost, draft: "   ", current: "old") == .discard)
+        #expect(InPlaceRename.outcome(.submitted, draft: "", current: "old") == .discard)
+    }
+
+    /// A name that came back unchanged is not a rename, so it costs no write and no reflow. The
+    /// trim runs first, which is what makes "old " unchanged rather than new.
+    @Test("an unchanged name writes nothing")
+    func unchanged() {
+        #expect(InPlaceRename.outcome(.submitted, draft: "old", current: "old") == .discard)
+        #expect(InPlaceRename.outcome(.focusLost, draft: " old ", current: "old") == .discard)
+    }
+}


### PR DESCRIPTION
The three rows with an in-place rename (a workspace in the sidebar, a project header, a workspace on Home) wired `onSubmit` and `onExitCommand` and nothing else. Click anywhere else and the field stayed open on the row holding uncommitted text; and `SidebarView` clears the field whenever `app.selection` moves, so selecting another workspace mid rename threw the name away without a word.

Which ending writes is `InPlaceRename` in the core, with the four ways of leaving a field named and tested. Escape discards. Submitting, losing first responder, and having the field closed from underneath all commit a trimmed name that is neither empty nor the one it already had. The sidebar row watches the shared `renaming` id for that last case, so the teardown that used to lose the draft now commits it.

Two details worth reading in the diff: each row ends once, guarded, because committing closes the field and that is itself a focus change while the write is asynchronous; and no row clears the shared id unless the open field is still its own, since starting a rename on another row is one of the ways this one ends.