### PR TITLE
Find in page, on the key a Mac reader presses without thinking

### DIFF
--- a/Sources/Bloom/Views/Center/Browser/BrowserFindBar.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserFindBar.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import BloomCore
+
+/// Find in Page, drawn where a browser puts it: a banner between the toolbar and the page.
+///
+/// **A banner rather than a floating panel**, for the reason the rest of this pane gives: a
+/// browser tab is already one pane of a split centre column, and a panel hovering inside one is a
+/// second window nobody asked for. It pushes the page down by a row while it is up, which is what
+/// Safari's does.
+///
+/// **`Cmd G` and `Shift Cmd G` are on the two arrows** rather than only on the menu bar, because
+/// the bar being on screen is exactly the state in which those keys mean stepping this search. A
+/// key equivalent on a button reaches only as far as the view hierarchy holding it, so they are
+/// claimed while the bar is up and given back the moment it closes. `BrowserPageWebView` claims
+/// the same two while the page holds the keyboard, and `BrowserFindCommand` is the one mapping
+/// both routes read, so the two cannot come to disagree.
+struct BrowserFindBar: View {
+    var find: BrowserFind
+    var focus: FocusState<Bool>.Binding
+    var type: @MainActor (String) -> Void
+    var step: @MainActor (BrowserFindCommand) -> Void
+    var done: @MainActor () -> Void
+
+    /// The field's own text. Local, so a keystroke draws immediately rather than waiting on the
+    /// search behind it, in the same shape and for the same reason as the address field above.
+    @State private var query = ""
+
+    var body: some View {
+        HStack(spacing: Metrics.spacingWide) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(Palette.textTertiary)
+                .frame(width: Metrics.glyph)
+
+            field
+
+            if !find.status.isEmpty {
+                Text(find.status)
+                    .font(Typo.micro)
+                    .foregroundStyle(Palette.textTertiary)
+            }
+
+            BrowserToolbarButton(
+                control: BrowserFindBar.previous(find), action: { step(.previous) }
+            )
+            .keyboardShortcut("g", modifiers: [.command, .shift])
+
+            BrowserToolbarButton(control: BrowserFindBar.next(find), action: { step(.next) })
+                .keyboardShortcut("g", modifiers: .command)
+
+            Button("Done", action: done)
+                .buttonStyle(.accessoryBar)
+                .font(Typo.caption)
+        }
+        .padding(.horizontal, Metrics.spacingSmall)
+        .frame(height: Metrics.barHeight)
+        .background(Palette.surfaceSunken)
+        .overlay(alignment: .bottom) { Hairline() }
+        .task(id: find.opens) {
+            // On every open rather than on the first, so a second Cmd F puts the caret back in the
+            // field and selects what is there, which is what the key does everywhere else.
+            query = find.query
+            focus.wrappedValue = true
+        }
+    }
+
+    private var field: some View {
+        TextField("Find on page", text: $query)
+            .textFieldStyle(.plain)
+            .font(Typo.label)
+            .focused(focus)
+            .autocorrectionDisabled()
+            .frame(maxWidth: 220)
+            .onChange(of: query) { type(query) }
+            .onSubmit { step(.next) }
+            // Escape closes the banner, which is what it does in every find bar on the platform.
+            .onExitCommand(perform: done)
+    }
+
+    /// The two arrows, described the way the toolbar above describes its own, so a disabled one
+    /// here and a disabled Back up there are the same grey and the same shape.
+    private static func previous(_ find: BrowserFind) -> BrowserToolbar.Control {
+        BrowserToolbar.Control(
+            symbol: "chevron.up",
+            name: "Find Previous",
+            help: "Go to the previous match",
+            isEnabled: find.canStep
+        )
+    }
+
+    private static func next(_ find: BrowserFind) -> BrowserToolbar.Control {
+        BrowserToolbar.Control(
+            symbol: "chevron.down",
+            name: "Find Next",
+            help: "Go to the next match",
+            isEnabled: find.canStep
+        )
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
@@ -75,6 +75,10 @@ final class BrowserSession {
     /// what holds each download's delegate alive, since `WKDownload.delegate` is weak.
     private(set) var downloads: [BrowserDownloadItem] = []
 
+    /// Find in Page: whether the bar is up, what is in it and how the last search went. The rules
+    /// are `BrowserFind` in the core.
+    private(set) var find = BrowserFind()
+
     /// KVO on everything the toolbar reads, because the navigation delegate does not see every
     /// navigation.
     ///
@@ -116,6 +120,9 @@ final class BrowserSession {
         webView.navigationDelegate = navigation
         ui.owner = self
         webView.uiDelegate = ui
+        // Weak, because the web view is owned by this session: a strong capture here would be the
+        // session holding itself through its own subview.
+        webView.findCommand = { [weak self] command in self?.perform(command) }
         observations = [
             webView.observe(\.title, options: [.initial, .new]) { [weak self] view, _ in
                 // On the main thread, measured rather than assumed: WebKit posts every one of
@@ -331,6 +338,58 @@ final class BrowserSession {
     /// must not count as one: the reader silenced a page, not an address.
     fileprivate func pageCommitted() {
         dialogs.pageCommitted()
+    }
+
+    // MARK: - Find in page
+
+    /// One of the four things the keyboard asks of Find in Page, from the Edit menu or from the
+    /// key equivalents `BrowserPageWebView` claims while the page holds the keyboard.
+    func perform(_ command: BrowserFindCommand) {
+        switch command {
+        case .show: find.show()
+        case .next: step(backwards: false)
+        case .previous: step(backwards: true)
+        case .hide: find.hide()
+        }
+    }
+
+    /// The field changed. Searched on every keystroke, which is what find does on this platform:
+    /// the reader watches the page move under the words they are typing.
+    func typeInFind(_ text: String) {
+        find.type(text)
+        step(backwards: false)
+    }
+
+    /// Looks for what is in the field, and records whether it was there.
+    ///
+    /// **The bar can say "Not found" and nothing else, and that is WebKit's limit rather than a
+    /// decision.** `WKFindResult` carries one property, `matchFound`. There is no count and no
+    /// index, and the only way to get one would be to run a script of Bloom's own over somebody
+    /// else's logged-in page, which is what the head of `BrowserPaneCommand` argues at length that
+    /// this pane does not do.
+    ///
+    /// The answer is dropped if the field has moved on while WebKit was looking, so a fast typist
+    /// never sees "Not found" from two keystrokes ago.
+    private func step(backwards: Bool) {
+        guard find.canStep else { return find.settle(matched: false) }
+
+        let query = find.query
+        let configuration = WKFindConfiguration()
+        configuration.backwards = backwards
+        configuration.caseSensitive = find.isCaseSensitive
+        // Round the end and on, because a find bar that stopped at the bottom of the page with no
+        // count to explain why would read as having lost the match it just had.
+        configuration.wraps = true
+
+        Task { [weak self] in
+            guard let self else { return }
+            // A throw here is a page that went away under the search, which is a navigation
+            // committing between the call and the answer. That is not a match, and it is not
+            // worth a sentence either: the bar will be searched again on the next keystroke.
+            let result = try? await webView.find(query, configuration: configuration)
+            guard find.query == query else { return }
+            find.settle(matched: result?.matchFound ?? false)
+        }
     }
 
     // MARK: - Downloads

--- a/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
@@ -20,6 +20,10 @@ struct BrowserTabView: View {
     /// on submit.
     @State private var address = ""
     @FocusState private var isAddressFocused: Bool
+    /// The find banner's field, held here rather than in the banner because a `FocusState` belongs
+    /// to the view that stays on screen: the banner is added and removed, and a focus binding torn
+    /// down with it would never settle.
+    @FocusState private var isFindFocused: Bool
 
     /// True from the press until the picture is in the composer. It is normally a tenth of a
     /// second, and it is not always: `takeSnapshot` waits for the page to finish laying out, and
@@ -44,6 +48,15 @@ struct BrowserTabView: View {
         VStack(spacing: 0) {
             toolbar(session)
             Hairline()
+            if session.find.isShowing {
+                BrowserFindBar(
+                    find: session.find,
+                    focus: $isFindFocused,
+                    type: session.typeInFind,
+                    step: session.perform,
+                    done: { session.perform(.hide) }
+                )
+            }
             if !session.downloads.isEmpty {
                 BrowserDownloadsBar(
                     downloads: session.downloads, clear: session.clearDownloads

--- a/Sources/Bloom/Views/Center/Browser/BrowserWebView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserWebView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import AppKit
 import WebKit
+import BloomCore
 
 /// A plain container so SwiftUI can attach and detach a long-lived view without that view ever
 /// being deallocated, and so the page follows the pane size on every layout pass.
@@ -60,6 +61,10 @@ final class BrowserPageWebView: WKWebView {
     /// split at the moment of the click.
     var paneMenu: (@MainActor () -> NSMenu)?
 
+    /// Where a find key press goes. Set by `BrowserSession`, which owns both this view and the
+    /// state the bar is drawn from.
+    var findCommand: (@MainActor (BrowserFindCommand) -> Void)?
+
     /// `NSMenuItem` does not own what answers it, so the menu the items came out of is kept until
     /// the next right click replaces it. Letting it go at the end of `willOpenMenu` leaves a menu
     /// of rows that draw and do nothing.
@@ -79,6 +84,76 @@ final class BrowserPageWebView: WKWebView {
         for item in hosted.items {
             hosted.removeItem(item)
             menu.addItem(item)
+        }
+    }
+
+    // MARK: - Find in page
+
+    /// The Edit menu's Find items, which arrive here down the responder chain when the page holds
+    /// the keyboard.
+    ///
+    /// **This is the route that costs nothing and survives.** The conventional Find submenu sends
+    /// `performFindPanelAction:` to the first responder, which is what `NSTextView` and SwiftTerm
+    /// both already answer, so a browser pane that answers it too is found by that menu the day it
+    /// is added without either half knowing about the other. `performKeyEquivalent` below is the
+    /// same thing for today, for as long as there is no such menu.
+    ///
+    /// Not an `override`: `performFindPanelAction` is declared on `NSTextView` rather than on
+    /// `NSResponder`, so there is nothing here to override and the selector is reached by the
+    /// responder chain's own dispatch.
+    @objc func performFindPanelAction(_ sender: Any?) {
+        guard let tag = (sender as? NSMenuItem)?.tag,
+              let action = NSTextFinder.Action(rawValue: tag),
+              let command = Self.command(for: action) else { return }
+        findCommand?(command)
+    }
+
+    /// `Cmd F`, `Cmd G` and `Shift Cmd G`, and only while this page holds the keyboard.
+    ///
+    /// **The focus test is the whole of what makes this safe to add.** A key equivalent claimed by
+    /// a view claims it for the window: a browser pane merely being on screen while the reader
+    /// types in the composer must not take `Cmd F` off the transcript, which is exactly the bug
+    /// the review records `Cmd W` having (it closes a chat session in some other pane from a
+    /// browser tab). So the event is only read when the first responder is this view or something
+    /// inside it, which for a page with focus is WebKit's own content view.
+    ///
+    /// Everything else falls straight through to `super`, and from there to the menu bar, which is
+    /// entitled to it.
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        guard let command = findKey(event) else { return super.performKeyEquivalent(with: event) }
+        findCommand?(command)
+        return true
+    }
+
+    private func findKey(_ event: NSEvent) -> BrowserFindCommand? {
+        guard findCommand != nil, holdsKeyboard else { return nil }
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        // Option and Control are somebody else's business, and a pane that read past them would
+        // answer `Ctrl Cmd G` as Find Previous.
+        guard !flags.contains(.option), !flags.contains(.control) else { return nil }
+        return BrowserFindCommand.forKey(
+            event.charactersIgnoringModifiers ?? "",
+            hasCommand: flags.contains(.command),
+            hasShift: flags.contains(.shift)
+        )
+    }
+
+    /// Whether the keys are coming to this page. WebKit's first responder is a content view of its
+    /// own inside this one rather than this one, so the test is descent and not identity.
+    private var holdsKeyboard: Bool {
+        guard let responder = window?.firstResponder as? NSView else { return false }
+        return responder === self || responder.isDescendant(of: self)
+    }
+
+    /// Which of the standard find actions a browser pane has an answer for. Replace and its
+    /// friends are not among them: there is nothing here to write into.
+    private static func command(for action: NSTextFinder.Action) -> BrowserFindCommand? {
+        switch action {
+        case .showFindInterface: .show
+        case .nextMatch: .next
+        case .previousMatch: .previous
+        case .hideFindInterface: .hide
+        default: nil
         }
     }
 }

--- a/Sources/BloomCore/System/BrowserFind.swift
+++ b/Sources/BloomCore/System/BrowserFind.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// What Find in Page is doing in a browser pane, and what its bar says.
+///
+/// `Cmd F` is the most reflexive keystroke on this platform and the browser pane answered it with
+/// nothing at all. The review that asked for this puts it first: a Mac app finds the thing in
+/// front of you, in Mail, Safari, Terminal, Preview, Notes and Xcode without exception.
+///
+/// ## What WebKit will and will not tell us
+///
+/// `WKWebView.find(_:configuration:)` answers with a `WKFindResult`, and that type has exactly one
+/// property on it: `matchFound`. There is no match count and no index, so the bar cannot say
+/// "3 of 17" however much it would like to, and pretending otherwise would mean running a script
+/// of our own over the page to count, which is the thing `BrowserPaneCommand` argues at length
+/// that this pane does not do. So the bar says nothing when there is a match and "Not found" when
+/// there is not, which is the honest half of Safari's banner.
+///
+/// ## Smart case, and why it is not Safari's rule
+///
+/// Safari's find is always case insensitive. This is not, and the reason is what a browser pane in
+/// this window is for: it is pointed at a dev server, and the thing being looked for is as often
+/// an identifier as a word. A reader who types `userId` means `userId` and not `userid`, and a
+/// reader who types `submit` means any of them. Typing a capital is the only signal available and
+/// it is the one Xcode and every editor in this repository's world already reads.
+public struct BrowserFind: Sendable, Equatable {
+    public enum Outcome: Sendable, Equatable {
+        /// Nothing has been looked for yet, or the field has been emptied.
+        case idle
+        case found
+        case notFound
+    }
+
+    /// Whether the bar is on screen. The query survives it being closed, so reopening find and
+    /// pressing Return steps the same search rather than starting from an empty field.
+    public var isShowing = false
+    public var query = ""
+    public var outcome: Outcome = .idle
+
+    public init() {}
+
+    /// Whether there is anything to step through. An empty field is not a search, and the arrows
+    /// beside it should say so rather than doing nothing when pressed.
+    public var canStep: Bool { !query.isEmpty }
+
+    /// What the bar says to the right of the field.
+    ///
+    /// Empty for a match, because WebKit gives no count and "Found" under a highlighted word is a
+    /// line that says less than the highlight does.
+    public var status: String {
+        switch outcome {
+        case .idle, .found: ""
+        case .notFound: "Not found"
+        }
+    }
+
+    /// Whether the search should respect capitals, which is decided by whether the reader typed
+    /// any. See the note above about why this is not Safari's rule.
+    public var isCaseSensitive: Bool {
+        query.contains { $0.isUppercase }
+    }
+
+    /// How many times the bar has been asked for.
+    ///
+    /// The bar takes the keyboard when this moves rather than when `isShowing` does, because a
+    /// second `Cmd F` while the bar is already up has to put the caret back in the field: that is
+    /// what the key does in every other application, and watching `isShowing` alone would make it
+    /// do nothing at all.
+    public private(set) var opens = 0
+
+    /// Opens the bar. The query is kept, so `Cmd F` twice in a row does not lose what was typed.
+    public mutating func show() {
+        isShowing = true
+        opens += 1
+    }
+
+    public mutating func hide() {
+        isShowing = false
+        outcome = .idle
+    }
+
+    /// The field changed. A field emptied is not a search that failed, so the "Not found" goes
+    /// with the text rather than sitting under an empty box.
+    public mutating func type(_ text: String) {
+        query = text
+        if text.isEmpty { outcome = .idle }
+    }
+
+    public mutating func settle(matched: Bool) {
+        guard canStep else { return outcome = .idle }
+        outcome = matched ? .found : .notFound
+    }
+}
+
+/// The four things the keyboard asks of Find in Page.
+///
+/// Its own type in the core so that both routes into it agree: the Edit menu's Find items, which
+/// arrive as `performFindPanelAction` down the responder chain, and the key equivalents a browser
+/// pane claims for itself while its page holds the keyboard. Two mappings written separately are
+/// two mappings that eventually disagree about `Shift Cmd G`.
+public enum BrowserFindCommand: Sendable, Equatable {
+    case show
+    case next
+    case previous
+    case hide
+
+    /// What a key press means to a browser page, or nothing when it means nothing.
+    ///
+    /// Only the presses this pane should take. Everything else must fall through, because a
+    /// browser pane claiming a key while it merely exists is how `Cmd W` came to close a chat
+    /// session in a different pane, and because the menu bar is entitled to the rest.
+    ///
+    /// `characters` is the unmodified string off the event, lowercased by the caller or not: both
+    /// spellings are read here, since `Shift Cmd G` delivers "G" and `Cmd G` delivers "g".
+    public static func forKey(
+        _ characters: String,
+        hasCommand: Bool,
+        hasShift: Bool
+    ) -> BrowserFindCommand? {
+        guard hasCommand else { return nil }
+        switch characters.lowercased() {
+        case "f": return hasShift ? nil : .show
+        case "g": return hasShift ? .previous : .next
+        default: return nil
+        }
+    }
+}

--- a/Tests/BloomCoreTests/BrowserFindTests.swift
+++ b/Tests/BloomCoreTests/BrowserFindTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// Find in Page: what the bar says, and what the keyboard means to it.
+@Suite("Browser find")
+struct BrowserFindTests {
+    @Test("A pane that has never been searched says nothing and can step nowhere")
+    func anIdleFindIsQuiet() {
+        let find = BrowserFind()
+        #expect(!find.isShowing)
+        #expect(!find.canStep)
+        #expect(find.status == "")
+    }
+
+    @Test("A search that found nothing says so, and one that found something does not")
+    func onlyAFailureSpeaks() {
+        var find = BrowserFind()
+        find.type("widget")
+        find.settle(matched: false)
+        #expect(find.status == "Not found")
+
+        find.settle(matched: true)
+        #expect(find.status == "")
+    }
+
+    @Test("Emptying the field is not a search that failed")
+    func anEmptyFieldClearsTheFailure() {
+        var find = BrowserFind()
+        find.type("widget")
+        find.settle(matched: false)
+        find.type("")
+        #expect(find.status == "")
+        #expect(!find.canStep)
+    }
+
+    @Test("An answer for a field that has since been emptied is not shown")
+    func aLateAnswerIsIgnored() {
+        var find = BrowserFind()
+        find.type("")
+        find.settle(matched: false)
+        #expect(find.status == "")
+    }
+
+    @Test("Capitals in the query are what makes the search respect them")
+    func smartCase() {
+        var find = BrowserFind()
+        find.type("submit")
+        #expect(!find.isCaseSensitive)
+
+        find.type("userId")
+        #expect(find.isCaseSensitive)
+    }
+
+    @Test("Closing the bar keeps the query, so reopening steps the same search")
+    func theQuerySurvivesClosing() {
+        var find = BrowserFind()
+        find.show()
+        find.type("widget")
+        find.hide()
+        #expect(!find.isShowing)
+        #expect(find.query == "widget")
+
+        find.show()
+        #expect(find.canStep)
+    }
+
+    // MARK: - What the keyboard means
+
+    @Test("The three find keys, and only those three")
+    func theFindKeys() {
+        #expect(BrowserFindCommand.forKey("f", hasCommand: true, hasShift: false) == .show)
+        #expect(BrowserFindCommand.forKey("g", hasCommand: true, hasShift: false) == .next)
+        #expect(BrowserFindCommand.forKey("G", hasCommand: true, hasShift: true) == .previous)
+    }
+
+    @Test("A press with no command key is not ours, whatever the letter")
+    func plainLettersFallThrough() {
+        #expect(BrowserFindCommand.forKey("f", hasCommand: false, hasShift: false) == nil)
+        #expect(BrowserFindCommand.forKey("g", hasCommand: false, hasShift: false) == nil)
+    }
+
+    @Test("Every other command key falls through to whatever else wants it")
+    func otherKeysFallThrough() {
+        for key in ["w", "r", "l", "s", "1", "["] {
+            #expect(BrowserFindCommand.forKey(key, hasCommand: true, hasShift: false) == nil)
+            #expect(BrowserFindCommand.forKey(key, hasCommand: true, hasShift: true) == nil)
+        }
+        // Shift Cmd F is the cross-transcript search screen's, not this pane's.
+        #expect(BrowserFindCommand.forKey("f", hasCommand: true, hasShift: true) == nil)
+    }
+}


### PR DESCRIPTION
Stacked on #56.

`Cmd F` in a browser pane did nothing to the browser pane.

Two routes in, one mapping. `BrowserPageWebView` answers `performFindPanelAction:` down the responder chain, which is what a conventional Find submenu sends and what `NSTextView` and SwiftTerm already answer, so this pane is found by that menu the day it is added. It also claims `Cmd F`, `Cmd G` and `Shift Cmd G` directly for now, and only while the page holds the keyboard: a browser pane merely being on screen while the reader types in the composer must not take the key off the transcript. Both routes read `BrowserFindCommand`.

The banner sits between the toolbar and the page, where Safari puts it. Escape closes it, Return steps it, the arrows carry the two step keys while it is up, and the query survives closing.

Two honest limits: `WKFindResult` carries only `matchFound`, so the banner says "Not found" and cannot say "3 of 17" (counting would mean running a script of ours over a logged-in page, which `BrowserPaneCommand` argues against at length); and the search is smart case rather than Safari's always insensitive, because what is looked for in a dev server is as often an identifier as a word.

Coordination note: this stays out of `BloomCommands.swift` and the transcript and terminal find work entirely.