### PR TITLE
Answer a page's questions, let it download, and find in it

### DIFF
--- a/Sources/Bloom/Views/Center/Browser/BrowserDialogPresenter.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserDialogPresenter.swift
@@ -1,0 +1,112 @@
+import AppKit
+import BloomCore
+
+/// What came back from a question a page asked.
+struct BrowserDialogAnswer {
+    /// Whether the reader pressed the affirmative button. `confirm` returns this straight to the
+    /// page; `alert` has nothing to return and ignores it.
+    var isConfirmed: Bool
+    /// What a `prompt` was answered with, or nothing for a cancel and for the other two.
+    var text: String?
+    /// The reader ticked the box asking this page to stop.
+    var isSilenced = false
+
+    /// Nobody was asked, or the question went away before it was answered. It is the answer a
+    /// browser gives for a cancel, which is the one a page must always be ready for.
+    static let dismissed = BrowserDialogAnswer(isConfirmed: false, text: nil)
+}
+
+/// Puts one of a page's questions on screen and waits for it to be answered.
+///
+/// **A sheet on the window the page is in, and never `runModal`.** That is the rule the rest of
+/// this app already follows and the reason is in `PanelPresentation`: `runModal` is not "this
+/// window is busy", it is "this process is busy", and a page that asked a question would stop
+/// every other workspace's transcript streaming until somebody answered it. A sheet is also what
+/// the platform does with a question a document raises, so it hangs off the window the page is in
+/// rather than floating in the middle of the screen with no idea which pane it came from.
+///
+/// **The completion handler is the whole hazard here, and the design is about calling it exactly
+/// once.** WebKit gives a page's JavaScript back its answer through a handler that Bloom has to
+/// call: never calling it hangs that page for ever with no way back short of closing the tab, and
+/// calling it twice raises. Two things hold that here. The delegate methods are written in their
+/// `async` spelling, so the compiler resumes the caller exactly once whatever path this returns
+/// by, and `dismiss` ends the sheet through AppKit, which runs the same single completion. There
+/// is no path that answers a page by hand.
+///
+/// **If the pane goes away while a question is up**, `BrowserSession.stop` calls `dismiss`, the
+/// sheet is ended, and the page is answered as though the reader had pressed Cancel. That is the
+/// answer a page is already obliged to handle, and it happens before the web view is let go, so
+/// the closing tab never leaves a sheet standing on the window.
+@MainActor
+final class BrowserDialogPresenter {
+    /// The question on screen, if there is one. Held so it can be taken down from outside.
+    private var live: (alert: NSAlert, host: NSWindow)?
+
+    /// A field, kept for as long as the prompt it belongs to, because `NSAlert.accessoryView` is
+    /// the only reference to it and reading it after the sheet has ended is the whole point.
+    private var field: NSTextField?
+
+    func ask(
+        _ kind: BrowserDialogs.Kind,
+        _ presentation: BrowserDialogs.Presentation,
+        over window: NSWindow?
+    ) async -> BrowserDialogAnswer {
+        // A page in a tab the reader has switched away from has no window to hang a sheet on, and
+        // must not get one: a background page that could put a modal sheet over whatever pane is
+        // in front would be the loop this whole type is guarding against, with the reader unable
+        // to see which page was doing it. Answered as a cancel, which is what every browser does
+        // with a dialog from a tab you are not looking at.
+        guard let window else { return .dismissed }
+
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = presentation.title
+        alert.informativeText = presentation.message
+        alert.addButton(withTitle: "OK")
+        if kind != .alert { alert.addButton(withTitle: "Cancel") }
+
+        if kind == .prompt {
+            let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 280, height: 22))
+            field.stringValue = presentation.defaultText
+            field.isEditable = true
+            field.isSelectable = true
+            alert.accessoryView = field
+            alert.window.initialFirstResponder = field
+            self.field = field
+        }
+
+        if presentation.offersSuppression {
+            alert.showsSuppressionButton = true
+            // Not "Don't show more dialogs from this page", which is the phrasing two other
+            // browsers use, because the reader is not being offered a way to hide something: they
+            // are being offered a way to make the page stop, and every question after this one is
+            // answered as a cancel rather than swallowed.
+            alert.suppressionButton?.title = "Stop this page asking"
+        }
+
+        live = (alert, window)
+        let response = await alert.beginSheetModal(for: window)
+        // Only if it is still ours. `dismiss` clears it, and a later question may have claimed it.
+        if live?.alert === alert { live = nil }
+
+        let isConfirmed = response == .alertFirstButtonReturn
+        let text = (kind == .prompt && isConfirmed) ? (field?.stringValue ?? "") : nil
+        field = nil
+        return BrowserDialogAnswer(
+            isConfirmed: isConfirmed,
+            text: text,
+            isSilenced: alert.suppressionButton?.state == .on
+        )
+    }
+
+    /// Takes the question down and lets the page have its answer, which is what closing the pane
+    /// under an open dialog has to do.
+    ///
+    /// Through `endSheet` rather than by resuming anything of ours, so the one completion AppKit
+    /// owns is the one that runs. Calling this with nothing on screen does nothing.
+    func dismiss() {
+        guard let live else { return }
+        self.live = nil
+        live.host.endSheet(live.alert.window, returnCode: .cancel)
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserDownloadItem.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserDownloadItem.swift
@@ -1,0 +1,202 @@
+import AppKit
+import CoreServices
+import Foundation
+import Observation
+import WebKit
+import BloomCore
+
+/// One file a page is handing over, and the delegate WebKit reports it through.
+///
+/// **Where it lands, and why there is no save panel.** Every download goes to the reader's own
+/// Downloads folder, under a name `BrowserDownloadFile` decides. The two other answers were both
+/// considered and both are worse. A modal `NSSavePanel` for every file turns a one click download
+/// into two clicks and a decision, and it is the wrong dialog besides: nobody chooses a folder for
+/// a zip they are about to unpack. Writing into the workspace's worktree, which the review that
+/// asked for this suggested, is worse still: a download would show up in `git status`, land in the
+/// diff the reader is reviewing, and could be committed by an agent that never knew where it came
+/// from. Downloads is where the platform puts these, it is outside every worktree, and it is the
+/// one folder a reader already knows to look in.
+///
+/// **And he is told.** A file arriving in silence is the poor half of that answer, so the pane
+/// grows a strip under its toolbar naming what came, how far it has got and where it went, with
+/// Show in Finder on it. See `BrowserDownloadsBar`.
+///
+/// The delegate is this object rather than one beside it because `WKDownload.delegate` is weak:
+/// something has to hold it for the life of the download, and the list the strip is drawn from is
+/// exactly that. One per download, so two at once cannot be confused for each other.
+@MainActor
+@Observable
+final class BrowserDownloadItem: NSObject, WKDownloadDelegate, Identifiable {
+    enum State: Equatable {
+        case running
+        case finished
+        case failed(String)
+    }
+
+    let id = UUID()
+
+    /// What the file is called on disk, which is not always what the page called it. Empty until
+    /// WebKit has asked where to put it, which is one round trip after the download starts.
+    private(set) var name = ""
+    private(set) var destination: URL?
+    private(set) var state: State = .running
+    private(set) var received: Int64 = 0
+    private(set) var expected: Int64 = 0
+
+    /// KVO on the download's own `Progress`, because `WKDownloadDelegate` has no callback that
+    /// reports how far it has got. Read on whatever thread `Progress` posts from, which is why the
+    /// two counts are taken out of it there and only the numbers cross back.
+    @ObservationIgnored private var progress: NSKeyValueObservation?
+
+    /// The last fraction that was published, so a hundred megabyte file redraws the strip a
+    /// hundred times rather than once per packet. `fractionCompleted` fires far faster than
+    /// anything anybody can read.
+    @ObservationIgnored private var lastFraction = 0.0
+
+    /// Where the file came from, kept for the quarantine record rather than for the strip.
+    @ObservationIgnored private let source: URL?
+
+    init(_ download: WKDownload) {
+        source = download.originalRequest?.url
+        super.init()
+        watch(download.progress)
+    }
+
+    /// What the strip says under the name.
+    var status: String {
+        switch state {
+        case .running: BrowserDownloadFile.progress(received: received, expected: expected)
+        case .finished: BrowserDownloadFile.size(received)
+        case .failed(let reason): reason
+        }
+    }
+
+    /// How far along, for a bar, or nothing when the server sent no length and there is no
+    /// fraction to draw.
+    var fraction: Double? {
+        guard state == .running, expected > 0 else { return nil }
+        return min(Double(received) / Double(expected), 1)
+    }
+
+    // MARK: - WKDownloadDelegate
+
+    /// Where the file goes.
+    ///
+    /// **The `async` spelling, so the destination is decided exactly once.** WebKit fails the
+    /// download if the handler is never called and raises if it is called twice, and this is the
+    /// one delegate method with a filesystem question in the middle of it.
+    ///
+    /// Nil cancels, which is what a Downloads folder that cannot be made deserves: better a
+    /// download that visibly does not happen than one written somewhere nobody will look.
+    func download(
+        _ download: WKDownload,
+        decideDestinationUsing response: URLResponse,
+        suggestedFilename: String
+    ) async -> URL? {
+        let manager = FileManager.default
+        guard let folder = Self.folder(manager) else {
+            state = .failed("Bloom could not reach your Downloads folder.")
+            return nil
+        }
+
+        // The name the page chose is never trusted. `BrowserDownloadFile` takes the path out of
+        // it, unhides it, cuts it to something a file system will take, and numbers around
+        // anything already in the folder, so a page cannot write over the reader's own files.
+        let filename = BrowserDownloadFile.filename(for: suggestedFilename) {
+            manager.fileExists(atPath: folder.appendingPathComponent($0).path)
+        }
+        let url = folder.appendingPathComponent(filename)
+
+        name = filename
+        destination = url
+        expected = max(response.expectedContentLength, 0)
+        return url
+    }
+
+    func downloadDidFinish(_ download: WKDownload) {
+        progress = nil
+        if expected > 0 { received = expected }
+        quarantine()
+        state = .finished
+    }
+
+    func download(_ download: WKDownload, didFailWithError error: any Error, resumeData: Data?) {
+        progress = nil
+        state = .failed(error.readableMessage)
+    }
+
+    // A redirect during a download is deliberately not answered here, and WebKit's own default of
+    // following it is what a file behind a signed URL needs anyway. It is worth writing down why
+    // rather than leaving the gap to look like an oversight: the four delegate methods above are
+    // written in their `async` spelling and every one of them produces an `@objc` thunk under the
+    // completion handler selector WebKit calls, which was measured rather than assumed by dumping
+    // the class's method list. `willPerformHTTPRedirection` is the one that does not. Written the
+    // same way it compiles, satisfies the protocol, and emits no thunk at all, so WebKit's
+    // `respondsToSelector:` says no and the method is never called. A method that looks like a
+    // policy and is not one is worse than no method.
+
+    // MARK: - The parts that are not WebKit's
+
+    private func watch(_ progress: Progress) {
+        self.progress = progress.observe(\.fractionCompleted) { [weak self] progress, _ in
+            // Out of `Progress` here, because it is not `Sendable` and only these two numbers may
+            // cross. `Progress` posts from whatever thread the download is running on.
+            let fraction = progress.fractionCompleted
+            let received = progress.completedUnitCount
+            let total = progress.totalUnitCount
+            Task { @MainActor [weak self] in
+                self?.advance(fraction: fraction, received: received, expected: total)
+            }
+        }
+    }
+
+    private func advance(fraction: Double, received: Int64, expected: Int64) {
+        guard state == .running else { return }
+        // A hundredth of the file at a time. Every write here redraws the pane's strip, and
+        // `fractionCompleted` fires per packet, which for a fast local server is thousands a
+        // second for a line nobody can read changing that quickly.
+        guard fraction - lastFraction >= 0.01 || received == expected else { return }
+        lastFraction = fraction
+        self.received = received
+        if expected > 0 { self.expected = expected }
+    }
+
+    /// Marks the file as having come off the web, which is what makes Gatekeeper ask before it is
+    /// opened and what puts "downloaded today from ..." in the dialog.
+    ///
+    /// Set here rather than trusted to WebKit, which does apply it in Safari and makes no promise
+    /// about a `WKWebView` embedded in somebody else's app. Two mechanisms agreeing is the point,
+    /// and a file the owner did not ask for is exactly the one that should be asked about.
+    private func quarantine() {
+        guard var url = destination else { return }
+        var values = URLResourceValues()
+        values.quarantineProperties = [
+            kLSQuarantineTypeKey as String: kLSQuarantineTypeWebDownload,
+            kLSQuarantineAgentNameKey as String: "Bloom",
+            kLSQuarantineDataURLKey as String: source?.absoluteString ?? "",
+        ]
+        do {
+            try url.setResourceValues(values)
+        } catch {
+            // Nothing to do and nothing to say to the reader: the file is downloaded either way,
+            // and a volume that does not carry the attribute (a network share, an old format) is
+            // not a failure of the download. It is left unquarantined rather than deleted.
+        }
+    }
+
+    /// The reader's own Downloads folder, made if it is not there.
+    private static func folder(_ manager: FileManager) -> URL? {
+        guard let url = manager.urls(for: .downloadsDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+        guard !manager.fileExists(atPath: url.path) else { return url }
+        do {
+            try manager.createDirectory(at: url, withIntermediateDirectories: true)
+        } catch {
+            // Somebody has deleted their Downloads folder and it cannot be put back. Answered with
+            // nil, which cancels the download rather than writing the file somewhere else.
+            return nil
+        }
+        return url
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserDownloadsBar.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserDownloadsBar.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+import BloomCore
+
+/// The strip under a browser pane's toolbar saying what the page has handed over.
+///
+/// **A file that lands in silence is a poor answer**, and it is the half of "no save panel" that
+/// has to be paid for: if the reader is not asked where a download goes, the pane has to say where
+/// it went. So this appears the moment a download starts, names the file, counts it in, and offers
+/// Show in Finder when it is there.
+///
+/// **Under the toolbar rather than over the page**, so it never covers what the reader was looking
+/// at, and it pushes the page down by one row rather than floating: a browser pane is already one
+/// pane of a split column and a floating panel inside one is a second window nobody asked for.
+///
+/// It goes away when the reader closes it, and only then. A strip that removed itself on a timer
+/// would be a strip that told somebody about a file after they had looked away, which is the same
+/// silence with extra steps.
+struct BrowserDownloadsBar: View {
+    var downloads: [BrowserDownloadItem]
+    var clear: @MainActor () -> Void
+
+    /// The most recent few. A page that has handed over twenty files has said everything it has to
+    /// say with the last three, and the rest are in the folder the strip names.
+    private static let shown = 3
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(downloads.suffix(Self.shown)) { download in
+                row(download)
+            }
+        }
+        .background(Palette.surfaceSunken)
+        .overlay(alignment: .top) { Hairline() }
+    }
+
+    private func row(_ download: BrowserDownloadItem) -> some View {
+        HStack(spacing: Metrics.spacingWide) {
+            Image(systemName: glyph(download))
+                .foregroundStyle(tint(download))
+                .frame(width: Metrics.glyph)
+
+            VStack(alignment: .leading, spacing: 0) {
+                Text(download.name.isEmpty ? "Starting" : download.name)
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(download.status)
+                    .font(Typo.micro)
+                    .foregroundStyle(Palette.textTertiary)
+                    .lineLimit(1)
+            }
+
+            if let fraction = download.fraction {
+                ProgressView(value: fraction)
+                    .progressViewStyle(.linear)
+                    .frame(width: 80)
+            }
+
+            Spacer(minLength: 0)
+
+            if download.state == .finished, let destination = download.destination {
+                Button("Show in Finder") { Reveal.inFinder(destination.path) }
+                    .buttonStyle(.accessoryBar)
+                    .font(Typo.micro)
+            }
+
+            // One button for the whole strip rather than one per row: what it closes is the
+            // report, and a row that could be dismissed on its own would invite reading it as
+            // cancelling the download.
+            Button {
+                clear()
+            } label: {
+                Label("Close", systemImage: "xmark")
+                    .labelStyle(.iconOnly)
+                    .foregroundStyle(Palette.textSecondary)
+            }
+            .buttonStyle(.accessoryBar)
+            .help("Stop showing what this page has downloaded")
+        }
+        .padding(.horizontal, Metrics.spacingWide)
+        .frame(height: Metrics.barHeight)
+    }
+
+    private func glyph(_ download: BrowserDownloadItem) -> String {
+        switch download.state {
+        case .running: "arrow.down.circle"
+        case .finished: "checkmark.circle"
+        case .failed: "exclamationmark.triangle"
+        }
+    }
+
+    private func tint(_ download: BrowserDownloadItem) -> Color {
+        switch download.state {
+        case .running: Palette.textSecondary
+        case .finished: Palette.positive
+        case .failed: Palette.negative
+        }
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserFindBar.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserFindBar.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import BloomCore
+
+/// Find in Page, drawn where a browser puts it: a banner between the toolbar and the page.
+///
+/// **A banner rather than a floating panel**, for the reason the rest of this pane gives: a
+/// browser tab is already one pane of a split centre column, and a panel hovering inside one is a
+/// second window nobody asked for. It pushes the page down by a row while it is up, which is what
+/// Safari's does.
+///
+/// **`Cmd G` and `Shift Cmd G` are on the two arrows** rather than only on the menu bar, because
+/// the bar being on screen is exactly the state in which those keys mean stepping this search. A
+/// key equivalent on a button reaches only as far as the view hierarchy holding it, so they are
+/// claimed while the bar is up and given back the moment it closes. `BrowserPageWebView` claims
+/// the same two while the page holds the keyboard, and `BrowserFindCommand` is the one mapping
+/// both routes read, so the two cannot come to disagree.
+struct BrowserFindBar: View {
+    var find: BrowserFind
+    var focus: FocusState<Bool>.Binding
+    var type: @MainActor (String) -> Void
+    var step: @MainActor (BrowserFindCommand) -> Void
+    var done: @MainActor () -> Void
+
+    /// The field's own text. Local, so a keystroke draws immediately rather than waiting on the
+    /// search behind it, in the same shape and for the same reason as the address field above.
+    @State private var query = ""
+
+    var body: some View {
+        HStack(spacing: Metrics.spacingWide) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(Palette.textTertiary)
+                .frame(width: Metrics.glyph)
+
+            field
+
+            if !find.status.isEmpty {
+                Text(find.status)
+                    .font(Typo.micro)
+                    .foregroundStyle(Palette.textTertiary)
+            }
+
+            BrowserToolbarButton(
+                control: BrowserFindBar.previous(find), action: { step(.previous) }
+            )
+            .keyboardShortcut("g", modifiers: [.command, .shift])
+
+            BrowserToolbarButton(control: BrowserFindBar.next(find), action: { step(.next) })
+                .keyboardShortcut("g", modifiers: .command)
+
+            Button("Done", action: done)
+                .buttonStyle(.accessoryBar)
+                .font(Typo.caption)
+        }
+        .padding(.horizontal, Metrics.spacingSmall)
+        .frame(height: Metrics.barHeight)
+        .background(Palette.surfaceSunken)
+        .overlay(alignment: .bottom) { Hairline() }
+        .task(id: find.opens) {
+            // On every open rather than on the first, so a second Cmd F puts the caret back in the
+            // field and selects what is there, which is what the key does everywhere else.
+            query = find.query
+            focus.wrappedValue = true
+        }
+    }
+
+    private var field: some View {
+        TextField("Find on page", text: $query)
+            .textFieldStyle(.plain)
+            .font(Typo.label)
+            .focused(focus)
+            .autocorrectionDisabled()
+            .frame(maxWidth: 220)
+            .onChange(of: query) { type(query) }
+            .onSubmit { step(.next) }
+            // Escape closes the banner, which is what it does in every find bar on the platform.
+            .onExitCommand(perform: done)
+    }
+
+    /// The two arrows, described the way the toolbar above describes its own, so a disabled one
+    /// here and a disabled Back up there are the same grey and the same shape.
+    private static func previous(_ find: BrowserFind) -> BrowserToolbar.Control {
+        BrowserToolbar.Control(
+            symbol: "chevron.up",
+            name: "Find Previous",
+            help: "Go to the previous match",
+            isEnabled: find.canStep
+        )
+    }
+
+    private static func next(_ find: BrowserFind) -> BrowserToolbar.Control {
+        BrowserToolbar.Control(
+            symbol: "chevron.down",
+            name: "Find Next",
+            help: "Go to the next match",
+            isEnabled: find.canStep
+        )
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
@@ -75,6 +75,10 @@ final class BrowserSession {
     /// what holds each download's delegate alive, since `WKDownload.delegate` is weak.
     private(set) var downloads: [BrowserDownloadItem] = []
 
+    /// Find in Page: whether the bar is up, what is in it and how the last search went. The rules
+    /// are `BrowserFind` in the core.
+    private(set) var find = BrowserFind()
+
     /// KVO on everything the toolbar reads, because the navigation delegate does not see every
     /// navigation.
     ///
@@ -116,6 +120,9 @@ final class BrowserSession {
         webView.navigationDelegate = navigation
         ui.owner = self
         webView.uiDelegate = ui
+        // Weak, because the web view is owned by this session: a strong capture here would be the
+        // session holding itself through its own subview.
+        webView.findCommand = { [weak self] command in self?.perform(command) }
         observations = [
             webView.observe(\.title, options: [.initial, .new]) { [weak self] view, _ in
                 // On the main thread, measured rather than assumed: WebKit posts every one of
@@ -331,6 +338,58 @@ final class BrowserSession {
     /// must not count as one: the reader silenced a page, not an address.
     fileprivate func pageCommitted() {
         dialogs.pageCommitted()
+    }
+
+    // MARK: - Find in page
+
+    /// One of the four things the keyboard asks of Find in Page, from the Edit menu or from the
+    /// key equivalents `BrowserPageWebView` claims while the page holds the keyboard.
+    func perform(_ command: BrowserFindCommand) {
+        switch command {
+        case .show: find.show()
+        case .next: step(backwards: false)
+        case .previous: step(backwards: true)
+        case .hide: find.hide()
+        }
+    }
+
+    /// The field changed. Searched on every keystroke, which is what find does on this platform:
+    /// the reader watches the page move under the words they are typing.
+    func typeInFind(_ text: String) {
+        find.type(text)
+        step(backwards: false)
+    }
+
+    /// Looks for what is in the field, and records whether it was there.
+    ///
+    /// **The bar can say "Not found" and nothing else, and that is WebKit's limit rather than a
+    /// decision.** `WKFindResult` carries one property, `matchFound`. There is no count and no
+    /// index, and the only way to get one would be to run a script of Bloom's own over somebody
+    /// else's logged-in page, which is what the head of `BrowserPaneCommand` argues at length that
+    /// this pane does not do.
+    ///
+    /// The answer is dropped if the field has moved on while WebKit was looking, so a fast typist
+    /// never sees "Not found" from two keystrokes ago.
+    private func step(backwards: Bool) {
+        guard find.canStep else { return find.settle(matched: false) }
+
+        let query = find.query
+        let configuration = WKFindConfiguration()
+        configuration.backwards = backwards
+        configuration.caseSensitive = find.isCaseSensitive
+        // Round the end and on, because a find bar that stopped at the bottom of the page with no
+        // count to explain why would read as having lost the match it just had.
+        configuration.wraps = true
+
+        Task { [weak self] in
+            guard let self else { return }
+            // A throw here is a page that went away under the search, which is a navigation
+            // committing between the call and the answer. That is not a match, and it is not
+            // worth a sentence either: the bar will be searched again on the next keystroke.
+            let result = try? await webView.find(query, configuration: configuration)
+            guard find.query == query else { return }
+            find.settle(matched: result?.matchFound ?? false)
+        }
     }
 
     // MARK: - Downloads

--- a/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
@@ -68,6 +68,13 @@ final class BrowserSession {
     @ObservationIgnored private var dialogs = BrowserDialogs()
     @ObservationIgnored private let dialogPresenter = BrowserDialogPresenter()
 
+    /// How many files a page may hand over, which is `BrowserDownloads` in the core.
+    @ObservationIgnored private var downloadLimit = BrowserDownloads()
+
+    /// What this page has handed over, newest last, for the strip under the toolbar. It is also
+    /// what holds each download's delegate alive, since `WKDownload.delegate` is weak.
+    private(set) var downloads: [BrowserDownloadItem] = []
+
     /// KVO on everything the toolbar reads, because the navigation delegate does not see every
     /// navigation.
     ///
@@ -326,6 +333,36 @@ final class BrowserSession {
         dialogs.pageCommitted()
     }
 
+    // MARK: - Downloads
+
+    /// A response became a file rather than a page. Where it goes is `BrowserDownloadItem`; how
+    /// many a page may send is `BrowserDownloads` in the core.
+    func begin(_ download: WKDownload) {
+        switch downloadLimit.request(from: pageName) {
+        case .save:
+            let item = BrowserDownloadItem(download)
+            downloads.append(item)
+            download.delegate = item
+        case .refuse:
+            download.cancel { _ in }
+        case .refuseAndSay(let notice):
+            download.cancel { _ in }
+            host.report(notice)
+        }
+    }
+
+    /// Forgets the downloads the strip is drawn from. The files stay where they are: this is
+    /// closing the strip, not undoing anything.
+    func clearDownloads() {
+        downloads.removeAll { $0.state != .running }
+    }
+
+    /// The page as `BrowserPageOrigin` names it, for the sentence a refusal carries.
+    private var pageName: String? {
+        guard let url = webView.url ?? currentURL, let host = url.host() else { return nil }
+        return BrowserPageOrigin.name(scheme: url.scheme ?? "", host: host, port: url.port ?? 0)
+    }
+
     func stop() {
         observations = []
         // Before the web view is let go, so a page waiting on an answer gets one. Never calling
@@ -480,6 +517,48 @@ private final class NavigationObserver: NSObject, WKNavigationDelegate {
         withError error: any Error
     ) {
         owner?.refresh()
+    }
+
+    // MARK: - Turning a navigation into a file
+
+    /// A link carrying the `download` attribute, which is a click that says "save this" rather
+    /// than "show me this".
+    ///
+    /// **This method not existing is half of why downloads never started.** WebKit's default
+    /// policy is `.allow`, and allowing a navigation that was meant to be a download leaves the
+    /// page where it was with nothing said. Everything else is allowed exactly as before, so no
+    /// navigation that used to happen stops happening.
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction
+    ) async -> WKNavigationActionPolicy {
+        navigationAction.shouldPerformDownload ? .download : .allow
+    }
+
+    /// A response a web view cannot draw, which is the other half: a zip, a tarball, a PDF served
+    /// as an attachment. Without this the response is allowed, WebKit finds it cannot render it,
+    /// and the navigation quietly stops.
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationResponse: WKNavigationResponse
+    ) async -> WKNavigationResponsePolicy {
+        navigationResponse.canShowMIMEType ? .allow : .download
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        navigationAction: WKNavigationAction,
+        didBecome download: WKDownload
+    ) {
+        owner?.begin(download)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        navigationResponse: WKNavigationResponse,
+        didBecome download: WKDownload
+    ) {
+        owner?.begin(download)
     }
 }
 

--- a/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
@@ -63,6 +63,11 @@ final class BrowserSession {
     /// The rule is in the core; this is the count for this one page.
     @ObservationIgnored private var popups = BrowserPopups()
 
+    /// How the page's own questions are put up, and how many it may ask. The rule is in the core;
+    /// this is the count for this one page, and it is reset by a document committing.
+    @ObservationIgnored private var dialogs = BrowserDialogs()
+    @ObservationIgnored private let dialogPresenter = BrowserDialogPresenter()
+
     /// KVO on everything the toolbar reads, because the navigation delegate does not see every
     /// navigation.
     ///
@@ -291,8 +296,42 @@ final class BrowserSession {
         }
     }
 
+    /// One of `alert`, `confirm` or `prompt`, asked by the page.
+    ///
+    /// Whether it goes up at all, what Bloom's own line above it says and how much of the page's
+    /// words are drawn is `BrowserDialogs` in the core. Putting it on the window is
+    /// `BrowserDialogPresenter`. What is here is the wiring, and one fact neither of those can
+    /// hold: the reader ticking the box silences THIS session's page, so the answer comes back
+    /// through the same call that asked.
+    func ask(
+        _ kind: BrowserDialogs.Kind,
+        message: String,
+        defaultText: String = "",
+        from name: String?
+    ) async -> BrowserDialogAnswer {
+        switch dialogs.request(kind, message: message, defaultText: defaultText, from: name) {
+        case .suppress:
+            return .dismissed
+        case .show(let presentation):
+            let answer = await dialogPresenter.ask(kind, presentation, over: webView.window)
+            if answer.isSilenced { dialogs.silence() }
+            return answer
+        }
+    }
+
+    /// A document committed in this pane, which is what gives a page that was silenced its voice
+    /// back. Called from the navigation delegate, because a `pushState` is not one of these and
+    /// must not count as one: the reader silenced a page, not an address.
+    fileprivate func pageCommitted() {
+        dialogs.pageCommitted()
+    }
+
     func stop() {
         observations = []
+        // Before the web view is let go, so a page waiting on an answer gets one. Never calling
+        // WebKit's completion handler hangs that page for ever, and a closing tab must not leave a
+        // sheet standing on the window either. See `BrowserDialogPresenter`.
+        dialogPresenter.dismiss()
         webView.stopLoading()
         webView.navigationDelegate = nil
         // With the navigation delegate, and for the same reason: a page whose pane has gone must
@@ -421,6 +460,10 @@ private final class NavigationObserver: NSObject, WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
         owner?.refresh()
+        // A new document, so a page the reader had told to stop asking may ask again. This is the
+        // one callback that means it: `didStartProvisionalNavigation` fires for a load that may
+        // yet fail, and a failed load leaves the old document in place.
+        owner?.pageCommitted()
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
@@ -20,6 +20,10 @@ struct BrowserTabView: View {
     /// on submit.
     @State private var address = ""
     @FocusState private var isAddressFocused: Bool
+    /// The find banner's field, held here rather than in the banner because a `FocusState` belongs
+    /// to the view that stays on screen: the banner is added and removed, and a focus binding torn
+    /// down with it would never settle.
+    @FocusState private var isFindFocused: Bool
 
     /// True from the press until the picture is in the composer. It is normally a tenth of a
     /// second, and it is not always: `takeSnapshot` waits for the page to finish laying out, and
@@ -44,6 +48,15 @@ struct BrowserTabView: View {
         VStack(spacing: 0) {
             toolbar(session)
             Hairline()
+            if session.find.isShowing {
+                BrowserFindBar(
+                    find: session.find,
+                    focus: $isFindFocused,
+                    type: session.typeInFind,
+                    step: session.perform,
+                    done: { session.perform(.hide) }
+                )
+            }
             if !session.downloads.isEmpty {
                 BrowserDownloadsBar(
                     downloads: session.downloads, clear: session.clearDownloads

--- a/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
@@ -44,6 +44,11 @@ struct BrowserTabView: View {
         VStack(spacing: 0) {
             toolbar(session)
             Hairline()
+            if !session.downloads.isEmpty {
+                BrowserDownloadsBar(
+                    downloads: session.downloads, clear: session.clearDownloads
+                )
+            }
             BrowserWebView(session: session, paneMenu: pageMenu, host: host)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }

--- a/Sources/Bloom/Views/Center/Browser/BrowserUIDelegate.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserUIDelegate.swift
@@ -2,14 +2,16 @@ import AppKit
 import WebKit
 import BloomCore
 
-/// The things a page asks the application for, rather than the network: a window of its own, and
-/// a file off this Mac.
+/// The things a page asks the application for, rather than the network: a window of its own, a
+/// question put to the reader, and a file off this Mac.
 ///
 /// **A browser pane had no `WKUIDelegate` at all**, and WebKit's answer to a missing one is to do
 /// nothing without saying so. Every `target="_blank"` link and every `window.open` returned null
-/// and left the reader looking at a page where a click had visibly failed; every
-/// `<input type="file">` opened no panel. For a pane whose whole job is the dev server running in
-/// the worktree next door, those are the everyday cases rather than the exotic ones.
+/// and left the reader looking at a page where a click had visibly failed; `alert` drew nothing,
+/// `confirm` was always false and `prompt` was always null, so a page that waited for the reader
+/// to agree to something waited for ever; every `<input type="file">` opened no panel. For a pane
+/// whose whole job is the dev server running in the worktree next door, those are the everyday
+/// cases rather than the exotic ones.
 ///
 /// Kept off `BrowserSession` for the reason `NavigationObserver` is: `uiDelegate` is the sort of
 /// reference that outlives what it points at, and a separate object makes the weak link back
@@ -62,6 +64,62 @@ final class BrowserUIObserver: NSObject, WKUIDelegate {
     ) -> WKWebView? {
         owner?.openWindow(navigationAction.request.url)
         return nil
+    }
+
+    // MARK: - The page's own questions
+
+    /// `alert`.
+    ///
+    /// **The `async` spelling of all three, and that is the safety property rather than a
+    /// nicety.** WebKit hands each of these a completion handler that gives the page's JavaScript
+    /// its answer back: never calling it hangs the page for ever, and calling it twice raises.
+    /// Written this way the compiler resumes the caller exactly once whatever path the method
+    /// returns by, including the one where the pane is closed while the sheet is up, which
+    /// `BrowserDialogPresenter.dismiss` turns into an ordinary cancel.
+    ///
+    /// Nothing is returned to the page by `alert`, so the answer is dropped. It is still awaited,
+    /// because the page is entitled to be blocked until the reader has read it: that is what
+    /// `alert` means, and a page that carried on regardless would put its next dialog up over this
+    /// one.
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptAlertPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo
+    ) async {
+        _ = await owner?.ask(.alert, message: message, from: Self.name(of: frame.securityOrigin))
+    }
+
+    /// `confirm`. False for a cancel, and false for a page that has been silenced or has no window
+    /// to ask in, which is the answer a page must already be ready for.
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptConfirmPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo
+    ) async -> Bool {
+        let answer = await owner?.ask(
+            .confirm, message: message, from: Self.name(of: frame.securityOrigin)
+        )
+        return answer?.isConfirmed ?? false
+    }
+
+    /// `prompt`. Nil for a cancel, which is what a browser returns and what a page tests for.
+    ///
+    /// An empty string is a different answer from nil and is preserved: a reader who clears the
+    /// field and presses OK has said "nothing", and a page that treats that as a cancel is a page
+    /// making its own mistake.
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptTextInputPanelWithPrompt prompt: String,
+        defaultText: String?,
+        initiatedByFrame frame: WKFrameInfo
+    ) async -> String? {
+        let answer = await owner?.ask(
+            .prompt,
+            message: prompt,
+            defaultText: defaultText ?? "",
+            from: Self.name(of: frame.securityOrigin)
+        )
+        return answer?.text
     }
 
     // MARK: - A file off this Mac

--- a/Sources/Bloom/Views/Center/Browser/BrowserWebView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserWebView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import AppKit
 import WebKit
+import BloomCore
 
 /// A plain container so SwiftUI can attach and detach a long-lived view without that view ever
 /// being deallocated, and so the page follows the pane size on every layout pass.
@@ -60,6 +61,10 @@ final class BrowserPageWebView: WKWebView {
     /// split at the moment of the click.
     var paneMenu: (@MainActor () -> NSMenu)?
 
+    /// Where a find key press goes. Set by `BrowserSession`, which owns both this view and the
+    /// state the bar is drawn from.
+    var findCommand: (@MainActor (BrowserFindCommand) -> Void)?
+
     /// `NSMenuItem` does not own what answers it, so the menu the items came out of is kept until
     /// the next right click replaces it. Letting it go at the end of `willOpenMenu` leaves a menu
     /// of rows that draw and do nothing.
@@ -79,6 +84,76 @@ final class BrowserPageWebView: WKWebView {
         for item in hosted.items {
             hosted.removeItem(item)
             menu.addItem(item)
+        }
+    }
+
+    // MARK: - Find in page
+
+    /// The Edit menu's Find items, which arrive here down the responder chain when the page holds
+    /// the keyboard.
+    ///
+    /// **This is the route that costs nothing and survives.** The conventional Find submenu sends
+    /// `performFindPanelAction:` to the first responder, which is what `NSTextView` and SwiftTerm
+    /// both already answer, so a browser pane that answers it too is found by that menu the day it
+    /// is added without either half knowing about the other. `performKeyEquivalent` below is the
+    /// same thing for today, for as long as there is no such menu.
+    ///
+    /// Not an `override`: `performFindPanelAction` is declared on `NSTextView` rather than on
+    /// `NSResponder`, so there is nothing here to override and the selector is reached by the
+    /// responder chain's own dispatch.
+    @objc func performFindPanelAction(_ sender: Any?) {
+        guard let tag = (sender as? NSMenuItem)?.tag,
+              let action = NSTextFinder.Action(rawValue: tag),
+              let command = Self.command(for: action) else { return }
+        findCommand?(command)
+    }
+
+    /// `Cmd F`, `Cmd G` and `Shift Cmd G`, and only while this page holds the keyboard.
+    ///
+    /// **The focus test is the whole of what makes this safe to add.** A key equivalent claimed by
+    /// a view claims it for the window: a browser pane merely being on screen while the reader
+    /// types in the composer must not take `Cmd F` off the transcript, which is exactly the bug
+    /// the review records `Cmd W` having (it closes a chat session in some other pane from a
+    /// browser tab). So the event is only read when the first responder is this view or something
+    /// inside it, which for a page with focus is WebKit's own content view.
+    ///
+    /// Everything else falls straight through to `super`, and from there to the menu bar, which is
+    /// entitled to it.
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        guard let command = findKey(event) else { return super.performKeyEquivalent(with: event) }
+        findCommand?(command)
+        return true
+    }
+
+    private func findKey(_ event: NSEvent) -> BrowserFindCommand? {
+        guard findCommand != nil, holdsKeyboard else { return nil }
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        // Option and Control are somebody else's business, and a pane that read past them would
+        // answer `Ctrl Cmd G` as Find Previous.
+        guard !flags.contains(.option), !flags.contains(.control) else { return nil }
+        return BrowserFindCommand.forKey(
+            event.charactersIgnoringModifiers ?? "",
+            hasCommand: flags.contains(.command),
+            hasShift: flags.contains(.shift)
+        )
+    }
+
+    /// Whether the keys are coming to this page. WebKit's first responder is a content view of its
+    /// own inside this one rather than this one, so the test is descent and not identity.
+    private var holdsKeyboard: Bool {
+        guard let responder = window?.firstResponder as? NSView else { return false }
+        return responder === self || responder.isDescendant(of: self)
+    }
+
+    /// Which of the standard find actions a browser pane has an answer for. Replace and its
+    /// friends are not among them: there is nothing here to write into.
+    private static func command(for action: NSTextFinder.Action) -> BrowserFindCommand? {
+        switch action {
+        case .showFindInterface: .show
+        case .nextMatch: .next
+        case .previousMatch: .previous
+        case .hideFindInterface: .hide
+        default: nil
         }
     }
 }

--- a/Sources/BloomCore/System/BrowserBurst.swift
+++ b/Sources/BloomCore/System/BrowserBurst.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Something Bloom decided on the reader's behalf, in words they can read.
+///
+/// Its own type rather than a pair of strings because two things in a browser pane raise one now,
+/// a page refused more windows and a page refused more downloads, and the app presents both the
+/// same way. See `BrowserPaneHost.report`.
+public struct BrowserNotice: Sendable, Equatable {
+    public var title: String
+    public var message: String
+
+    public init(title: String, message: String) {
+        self.title = title
+        self.message = message
+    }
+}
+
+/// How often a page may make something happen outside itself, counted over a rolling window.
+///
+/// **A rate limit rather than a permission, and the difference is the point.** A reader clicking
+/// links that open in a new tab, or pressing a download button twice, is doing the ordinary thing
+/// and must not be asked about it. A page in a loop calling `window.open` or pointing an iframe at
+/// an attachment a thousand times must not be able to fill the strip or the disk. There is no
+/// signal in WebKit's delegate callbacks that says a human pressed the mouse, so those two are
+/// told apart by how fast they arrive and by nothing else, and a handful in a few seconds is above
+/// anything a hand does and far below what a loop does in one frame.
+///
+/// **The first refusal in a run says so and the rest are silent.** A loop refused a thousand times
+/// would otherwise put up a thousand dialogs, which is the same denial of service by another door.
+/// Something being allowed again arms the notice, which is what a reader clicking a link a minute
+/// later does.
+///
+/// The clock is passed in rather than read here, so the suite can drive it. Every caller in the
+/// app passes `Date()`.
+public struct BrowserBurst: Sendable, Equatable {
+    public enum Verdict: Sendable, Equatable {
+        case allowed
+        /// Over the limit, and the reader has already been told about this run.
+        case refused
+        /// Over the limit, and this is the first refusal since anything was last allowed, so this
+        /// is the one that carries a sentence.
+        case refusedAndUnsaid
+    }
+
+    public let limit: Int
+    public let window: TimeInterval
+
+    /// When each of the recent allowances was given, oldest first. Pruned on every call, so it
+    /// never holds more than `limit` entries.
+    private var moments: [Date] = []
+    private var hasSaidSo = false
+
+    public init(limit: Int, window: TimeInterval) {
+        self.limit = limit
+        self.window = window
+    }
+
+    public mutating func take(at now: Date) -> Verdict {
+        moments.removeAll { now.timeIntervalSince($0) >= window }
+        guard moments.count < limit else {
+            guard !hasSaidSo else { return .refused }
+            hasSaidSo = true
+            return .refusedAndUnsaid
+        }
+        moments.append(now)
+        hasSaidSo = false
+        return .allowed
+    }
+}

--- a/Sources/BloomCore/System/BrowserDialogs.swift
+++ b/Sources/BloomCore/System/BrowserDialogs.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+/// The three questions a page can ask the person reading it: `alert`, `confirm` and `prompt`.
+///
+/// A browser pane answered none of them, because there was no `WKUIDelegate`, and WebKit's answer
+/// to a missing one is to return the default and say nothing. So `confirm` was always false,
+/// `prompt` was always null, and a page that waited for the reader to agree to something waited
+/// for ever. This is what decides how each one is put up.
+///
+/// ## Two things a page controls, and what is done about each
+///
+/// **The words.** Every character of the message is written by the page, and the panel it lands on
+/// is chrome the reader trusts. A page that writes "Bloom needs your GitHub token" into an alert
+/// is doing the oldest trick there is, and the answer every browser reached is the same: Bloom's
+/// own line at the top saying which site is speaking, and the page's words underneath it as an
+/// informative paragraph. `BrowserPageOrigin` is what names the site, and it is host and port
+/// rather than anything a page can write.
+///
+/// The words are also cut down. A page can pass a megabyte to `alert`, and `NSAlert` has no
+/// scroller: it lays the whole string out and grows, so an alert taller than the display has an OK
+/// button nobody can reach, and that is a window nobody can get out of. Control characters go for
+/// the same reason, because a run of them draws as nothing at all and a dialog that appears empty
+/// is a dialog that reads as broken.
+///
+/// **How many.** `while (true) alert()` is a loop that puts up a window-modal sheet, waits for it
+/// to be answered, and puts up the next one, which locks the reader out of the whole window for as
+/// long as the page cares to keep going. Every browser answers this the same way too, with a tick
+/// box on the second dialog offering to stop the page raising any more, so this counts them: from
+/// the second dialog since the page last committed a document, the box is offered, and ticking it
+/// makes every later question answer itself with the safe answer until the page navigates.
+///
+/// The reset is a navigation and not a timer, because "this page" is what the reader was told they
+/// were silencing, and a page they have since left is a different promise.
+public struct BrowserDialogs: Sendable, Equatable {
+    /// Which of the three was asked. The safe answer differs, which is why the caller switches on
+    /// it rather than being handed one value.
+    public enum Kind: Sendable, Equatable {
+        case alert
+        case confirm
+        case prompt
+    }
+
+    /// What to put on screen, once the page's words have been made safe to draw.
+    public struct Presentation: Sendable, Equatable {
+        /// Bloom's own line, naming who is speaking.
+        public var title: String
+        /// The page's words, trimmed of anything that cannot be drawn and cut to a length a panel
+        /// can hold.
+        public var message: String
+        /// What a `prompt` starts with in its field, cut the same way and to one line.
+        public var defaultText: String
+        /// Whether to offer the reader a way to stop this page asking anything else.
+        public var offersSuppression: Bool
+
+        public init(
+            title: String,
+            message: String,
+            defaultText: String = "",
+            offersSuppression: Bool = false
+        ) {
+            self.title = title
+            self.message = message
+            self.defaultText = defaultText
+            self.offersSuppression = offersSuppression
+        }
+    }
+
+    public enum Decision: Sendable, Equatable {
+        case show(Presentation)
+        /// The reader has already said this page may not ask anything else. Answer it with the
+        /// safe answer and put nothing on screen.
+        case suppress
+    }
+
+    /// How many dialogs this document may put up before the tick box is offered. The second one
+    /// carries it, which is where Safari and Chrome both put it.
+    public static let suppressionOffered = 2
+    /// The most of a page's message that is drawn. Long enough for any sentence anybody means to
+    /// write, short enough that the panel keeps its buttons on the display.
+    public static let messageLimit = 900
+    /// And the most lines of it, for the same reason: 900 characters of newlines is 900 lines.
+    public static let lineLimit = 12
+
+    /// How many this document has put up since it committed.
+    private var shown = 0
+    /// Whether the reader has told this document to stop.
+    private var isSilenced = false
+
+    public init() {}
+
+    /// Asks how a dialog should be put up, and counts it.
+    ///
+    /// `name` is what `BrowserPageOrigin.name` made of the frame's origin, or nothing for a
+    /// document with no host, which is one loaded from a string or a file.
+    public mutating func request(
+        _ kind: Kind,
+        message: String,
+        defaultText: String = "",
+        from name: String? = nil
+    ) -> Decision {
+        guard !isSilenced else { return .suppress }
+        shown += 1
+        return .show(
+            Presentation(
+                title: Self.title(from: name),
+                message: Self.readable(message),
+                defaultText: kind == .prompt ? Self.oneLine(defaultText) : "",
+                offersSuppression: shown >= Self.suppressionOffered
+            )
+        )
+    }
+
+    /// The reader ticked the box. Everything this document asks from here answers itself.
+    public mutating func silence() {
+        isSilenced = true
+    }
+
+    /// A document committed in this pane, which is the one thing that undoes a silencing and
+    /// starts the count again. A `pushState` is not one of these, and should not be: it is the
+    /// same document, and the reader silenced a page rather than an address.
+    public mutating func pageCommitted() {
+        shown = 0
+        isSilenced = false
+    }
+
+    /// Whether the reader has silenced the page currently loaded.
+    public var isSilent: Bool { isSilenced }
+
+    // MARK: - Making a page's words drawable
+
+    /// Bloom's own line above the page's words.
+    ///
+    /// "says" rather than a colon or an exclamation, because it is the sentence every browser on
+    /// every platform puts there and the reader has read it a thousand times.
+    static func title(from name: String?) -> String {
+        guard let name else { return "This page says" }
+        return "\(name) says"
+    }
+
+    /// The page's message, made into something a panel can hold.
+    ///
+    /// Control characters out, because a run of them draws as nothing and an empty-looking dialog
+    /// reads as a broken app rather than as a page misbehaving. Tabs and newlines stay, because a
+    /// real message is laid out with them. Then the lines are capped and the whole thing is capped,
+    /// and either cut is said with an ellipsis rather than done silently.
+    static func readable(_ message: String) -> String {
+        var text = String(message.unicodeScalars.filter { scalar in
+            scalar == "\n" || scalar == "\t" || !CharacterSet.controlCharacters.contains(scalar)
+        })
+
+        var lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        if lines.count > lineLimit {
+            lines = Array(lines.prefix(lineLimit))
+            text = lines.joined(separator: "\n") + "\n..."
+        } else {
+            text = lines.joined(separator: "\n")
+        }
+
+        if text.count > messageLimit {
+            text = String(text.prefix(messageLimit)) + "..."
+        }
+        return text
+    }
+
+    /// A `prompt`'s starting text, which goes into a field rather than a paragraph, so it is one
+    /// line and a short one.
+    static func oneLine(_ text: String) -> String {
+        let flattened = readable(text)
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\t", with: " ")
+        return String(flattened.prefix(messageLimit))
+    }
+}

--- a/Sources/BloomCore/System/BrowserDownloadFile.swift
+++ b/Sources/BloomCore/System/BrowserDownloadFile.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// What a file a page hands over is called on disk, and how far it has got.
+///
+/// **The suggested name is written by the page and is the whole reason this exists.** It arrives
+/// from `Content-Disposition` or from a `download` attribute, which is to say from whoever wrote
+/// the server, and it lands in a call that creates a file on the owner's Mac. A name of
+/// `../../.zshrc` is a path and not a name; a name beginning with a dot is a file Finder will not
+/// show him; a name with a control character in it draws as something other than what it is; and a
+/// name that already exists is somebody else's file about to be written over. Every one of those
+/// is answered here rather than trusted, and the answers are tested.
+public enum BrowserDownloadFile {
+    /// The longest a name may be. HFS+ and APFS both stop at 255 bytes, and a name near that in
+    /// UTF-8 is a name that fails to write for reasons nobody can read, so this leaves room.
+    public static let nameLimit = 200
+
+    /// What Bloom is willing to call a file a page offered.
+    ///
+    /// The last path component and nothing else, so a name that is really a path can only ever
+    /// name a file in the folder downloads go to. Leading dots go, because a page that names its
+    /// file `.zshrc` has chosen a name the reader will not see in Finder, and a download he cannot
+    /// see is a download he cannot check. Control characters go for the same reason: a name is
+    /// something to be read.
+    ///
+    /// **The extension is kept, deliberately.** Taking it off would make every download open in
+    /// whatever Launch Services guesses, and a `.zip` that has stopped saying `.zip` is worse than
+    /// one that says it. What protects the reader is that the file lands in Downloads with the
+    /// quarantine flag on it, which is Gatekeeper's business rather than this function's.
+    public static func name(from suggested: String) -> String {
+        // Characters first and the path afterwards, because a NUL between two slashes would
+        // otherwise become part of a component. Not `URL(fileURLWithPath:)`, which was tried and
+        // is the wrong tool twice over: it resolves a relative path against the working directory,
+        // so ".." came back as the name of the folder the process happened to be in, and it
+        // percent encodes what it cannot hold, so a NUL came back as the four characters "%00".
+        var name = String(suggested.unicodeScalars.filter { scalar in
+            !CharacterSet.controlCharacters.contains(scalar) && scalar != ":"
+        })
+
+        name = name.split(separator: "/").last.map(String.init) ?? ""
+        name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        while name.hasPrefix(".") { name.removeFirst() }
+        name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !name.isEmpty else { return "download" }
+        return shortened(name)
+    }
+
+    /// A name a page offered, cut to something a file system will take, with its extension left on
+    /// the end where it belongs.
+    private static func shortened(_ name: String) -> String {
+        guard name.count > nameLimit else { return name }
+        let parts = parted(name)
+        // An "extension" of forty characters is not one, it is the tail of a long name, and
+        // keeping it would leave nothing of the part a reader recognises.
+        guard !parts.ext.isEmpty, parts.ext.count <= 20 else {
+            return String(name.prefix(nameLimit))
+        }
+        return String(parts.stem.prefix(nameLimit - parts.ext.count - 1)) + "." + parts.ext
+    }
+
+    /// A name split at its last full stop, or the whole of it and nothing when there is no
+    /// extension to speak of. A leading dot is already gone by the time anything asks.
+    static func parted(_ name: String) -> (stem: String, ext: String) {
+        guard let dot = name.lastIndex(of: "."), dot != name.startIndex else { return (name, "") }
+        let ext = String(name[name.index(after: dot)...])
+        guard !ext.isEmpty else { return (name, "") }
+        return (String(name[..<dot]), ext)
+    }
+
+    /// The name to write, given what is already in the folder.
+    ///
+    /// **A download never writes over a file that is already there.** The folder is the reader's
+    /// own Downloads, which has his things in it, and a page choosing the name means a page could
+    /// choose one of them. Numbered like Safari does it, `report-2.pdf` after `report.pdf`, so the
+    /// second copy of a thing is recognisably the second copy.
+    ///
+    /// `isTaken` is asked rather than a listing being taken, because the folder can hold thousands
+    /// of files and because the only question is about the handful of names this one could use.
+    public static func filename(for suggested: String, isTaken: (String) -> Bool) -> String {
+        let name = name(from: suggested)
+        guard isTaken(name) else { return name }
+
+        for number in 2...1_000 {
+            let candidate = numbered(name, number)
+            if !isTaken(candidate) { return candidate }
+        }
+        // A thousand files of the same name is not a case worth a nicer answer, and returning a
+        // name that is taken would be a write over somebody's file.
+        return numbered(name, Int(Date().timeIntervalSince1970))
+    }
+
+    static func numbered(_ name: String, _ number: Int) -> String {
+        let parts = parted(name)
+        guard !parts.ext.isEmpty else { return "\(name)-\(number)" }
+        return "\(parts.stem)-\(number).\(parts.ext)"
+    }
+
+    // MARK: - How far it has got
+
+    /// A count of bytes, in the units the platform writes them in: decimal, because that is what
+    /// Finder and every browser show, rather than the binary ones a terminal shows.
+    ///
+    /// Its own arithmetic rather than `ByteCountFormatter`, because that formatter is localised
+    /// and its output has changed between releases, and this is a line the suite pins.
+    public static func size(_ bytes: Int64) -> String {
+        guard bytes >= 1_000 else { return "\(max(bytes, 0)) bytes" }
+
+        var value = Double(bytes)
+        var units = ["kB", "MB", "GB", "TB"].makeIterator()
+        var unit = "kB"
+        while value >= 1_000, let next = units.next() {
+            value /= 1_000
+            unit = next
+        }
+        // `String(format:)` with no locale is not localised, so the separator is a full stop
+        // wherever this runs, which is what the suite asserts against.
+        return String(format: "%.1f %@", value, unit)
+    }
+
+    /// The line under a download that is still arriving.
+    ///
+    /// A server that sends no `Content-Length` is common enough on a dev server to be worth
+    /// handling rather than showing "of 0 bytes": what is known is how much has arrived, so that
+    /// is all it says.
+    public static func progress(received: Int64, expected: Int64) -> String {
+        guard expected > 0 else { return size(received) }
+        return "\(size(received)) of \(size(expected))"
+    }
+}

--- a/Sources/BloomCore/System/BrowserDownloads.swift
+++ b/Sources/BloomCore/System/BrowserDownloads.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Whether a page may put a file on this Mac, and how many.
+///
+/// **A download is a file arriving on the owner's disk, and a page can start one without a
+/// click.** A link with a `download` attribute needs a press, but a response carrying
+/// `Content-Disposition: attachment` does not: one line of script pointing an iframe at one is
+/// enough, and a loop around that line is a folder full of rubbish or a disk with nothing left on
+/// it. Safari answers this by asking the reader the first time a site wants to download anything;
+/// Chrome answers it by blocking a page that starts several without a gesture.
+///
+/// Bloom answers it with `BrowserBurst`, the same counter that holds `window.open`, because it is
+/// the same shape of problem and the same reasoning: a reader pressing a download button twice is
+/// not to be asked about it, and a loop is to be stopped inside a second. Three in five seconds,
+/// which is lower than the window limit because a person starts far fewer downloads than they
+/// click links.
+///
+/// What that leaves is stated rather than glossed: a page can still put three files in the
+/// reader's Downloads folder with no click at all. What stops those being dangerous is the rest of
+/// the design and not this counter: they land in Downloads and never in a worktree, so a download
+/// cannot dirty a diff or be committed; they never write over a file that is already there,
+/// because `BrowserDownloadFile.filename` numbers around it; they carry the quarantine flag, so
+/// Gatekeeper treats them as what they are; and the pane says what arrived rather than letting it
+/// land in silence.
+public struct BrowserDownloads: Sendable, Equatable {
+    public enum Decision: Sendable, Equatable {
+        case save
+        /// Refused, and the reader has already been told about this run.
+        case refuse
+        /// Refused, and this is the one that says why.
+        case refuseAndSay(BrowserNotice)
+    }
+
+    private var burst: BrowserBurst
+
+    public init(limit: Int = 3, window: TimeInterval = 5) {
+        burst = BrowserBurst(limit: limit, window: window)
+    }
+
+    /// `name` is the page, as `BrowserPageOrigin.name` gives it, and is only used in the sentence.
+    public mutating func request(from name: String?, at now: Date = Date()) -> Decision {
+        switch burst.take(at: now) {
+        case .allowed: return .save
+        case .refused: return .refuse
+        case .refusedAndUnsaid: return .refuseAndSay(Self.notice(from: name))
+        }
+    }
+
+    private static func notice(from name: String?) -> BrowserNotice {
+        let who = name ?? "That page"
+        return BrowserNotice(
+            title: "Bloom stopped \(who) downloading more files",
+            message: """
+                This page started several downloads at once, which is what a page in a loop does. \
+                Bloom kept the first few and refused the rest. What did arrive is in your \
+                Downloads folder.
+                """
+        )
+    }
+}

--- a/Sources/BloomCore/System/BrowserFind.swift
+++ b/Sources/BloomCore/System/BrowserFind.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// What Find in Page is doing in a browser pane, and what its bar says.
+///
+/// `Cmd F` is the most reflexive keystroke on this platform and the browser pane answered it with
+/// nothing at all. The review that asked for this puts it first: a Mac app finds the thing in
+/// front of you, in Mail, Safari, Terminal, Preview, Notes and Xcode without exception.
+///
+/// ## What WebKit will and will not tell us
+///
+/// `WKWebView.find(_:configuration:)` answers with a `WKFindResult`, and that type has exactly one
+/// property on it: `matchFound`. There is no match count and no index, so the bar cannot say
+/// "3 of 17" however much it would like to, and pretending otherwise would mean running a script
+/// of our own over the page to count, which is the thing `BrowserPaneCommand` argues at length
+/// that this pane does not do. So the bar says nothing when there is a match and "Not found" when
+/// there is not, which is the honest half of Safari's banner.
+///
+/// ## Smart case, and why it is not Safari's rule
+///
+/// Safari's find is always case insensitive. This is not, and the reason is what a browser pane in
+/// this window is for: it is pointed at a dev server, and the thing being looked for is as often
+/// an identifier as a word. A reader who types `userId` means `userId` and not `userid`, and a
+/// reader who types `submit` means any of them. Typing a capital is the only signal available and
+/// it is the one Xcode and every editor in this repository's world already reads.
+public struct BrowserFind: Sendable, Equatable {
+    public enum Outcome: Sendable, Equatable {
+        /// Nothing has been looked for yet, or the field has been emptied.
+        case idle
+        case found
+        case notFound
+    }
+
+    /// Whether the bar is on screen. The query survives it being closed, so reopening find and
+    /// pressing Return steps the same search rather than starting from an empty field.
+    public var isShowing = false
+    public var query = ""
+    public var outcome: Outcome = .idle
+
+    public init() {}
+
+    /// Whether there is anything to step through. An empty field is not a search, and the arrows
+    /// beside it should say so rather than doing nothing when pressed.
+    public var canStep: Bool { !query.isEmpty }
+
+    /// What the bar says to the right of the field.
+    ///
+    /// Empty for a match, because WebKit gives no count and "Found" under a highlighted word is a
+    /// line that says less than the highlight does.
+    public var status: String {
+        switch outcome {
+        case .idle, .found: ""
+        case .notFound: "Not found"
+        }
+    }
+
+    /// Whether the search should respect capitals, which is decided by whether the reader typed
+    /// any. See the note above about why this is not Safari's rule.
+    public var isCaseSensitive: Bool {
+        query.contains { $0.isUppercase }
+    }
+
+    /// How many times the bar has been asked for.
+    ///
+    /// The bar takes the keyboard when this moves rather than when `isShowing` does, because a
+    /// second `Cmd F` while the bar is already up has to put the caret back in the field: that is
+    /// what the key does in every other application, and watching `isShowing` alone would make it
+    /// do nothing at all.
+    public private(set) var opens = 0
+
+    /// Opens the bar. The query is kept, so `Cmd F` twice in a row does not lose what was typed.
+    public mutating func show() {
+        isShowing = true
+        opens += 1
+    }
+
+    public mutating func hide() {
+        isShowing = false
+        outcome = .idle
+    }
+
+    /// The field changed. A field emptied is not a search that failed, so the "Not found" goes
+    /// with the text rather than sitting under an empty box.
+    public mutating func type(_ text: String) {
+        query = text
+        if text.isEmpty { outcome = .idle }
+    }
+
+    public mutating func settle(matched: Bool) {
+        guard canStep else { return outcome = .idle }
+        outcome = matched ? .found : .notFound
+    }
+}
+
+/// The four things the keyboard asks of Find in Page.
+///
+/// Its own type in the core so that both routes into it agree: the Edit menu's Find items, which
+/// arrive as `performFindPanelAction` down the responder chain, and the key equivalents a browser
+/// pane claims for itself while its page holds the keyboard. Two mappings written separately are
+/// two mappings that eventually disagree about `Shift Cmd G`.
+public enum BrowserFindCommand: Sendable, Equatable {
+    case show
+    case next
+    case previous
+    case hide
+
+    /// What a key press means to a browser page, or nothing when it means nothing.
+    ///
+    /// Only the presses this pane should take. Everything else must fall through, because a
+    /// browser pane claiming a key while it merely exists is how `Cmd W` came to close a chat
+    /// session in a different pane, and because the menu bar is entitled to the rest.
+    ///
+    /// `characters` is the unmodified string off the event, lowercased by the caller or not: both
+    /// spellings are read here, since `Shift Cmd G` delivers "G" and `Cmd G` delivers "g".
+    public static func forKey(
+        _ characters: String,
+        hasCommand: Bool,
+        hasShift: Bool
+    ) -> BrowserFindCommand? {
+        guard hasCommand else { return nil }
+        switch characters.lowercased() {
+        case "f": return hasShift ? nil : .show
+        case "g": return hasShift ? .previous : .next
+        default: return nil
+        }
+    }
+}

--- a/Sources/BloomCore/System/BrowserPopups.swift
+++ b/Sources/BloomCore/System/BrowserPopups.swift
@@ -7,18 +7,9 @@ import Foundation
 /// took the default answer of nil and the click looked broken. Bloom's answer is a second browser
 /// tab in the same workspace, and this is the rule that decides whether the page gets one.
 ///
-/// **It is a rate limit rather than a permission**, and the difference is the point. A reader
-/// clicking links that open in a new tab is doing the ordinary thing and must not be asked about
-/// it; a page in a loop calling `window.open` a thousand times must not be able to fill the strip
-/// with a thousand tabs. Those two are told apart by how fast they arrive and by nothing else,
-/// because there is no signal in `WKNavigationAction` that says a human pressed the mouse. Five in
-/// five seconds is above anything a hand does and far below what a loop does in one frame.
-///
-/// **The first refusal says so and the rest are silent.** A loop that is refused a thousand times
-/// would otherwise put up a thousand alerts, which is the same denial of service by another door.
-/// So the notice is carried on the first refusal after a run of allowed openings and on no other,
-/// and the count is reset by an opening being allowed again, which is what a reader clicking a
-/// link a minute later does.
+/// **How many is `BrowserBurst`**, which is where the argument for a rate limit rather than a
+/// permission is written down, and which counts a page's downloads the same way. Five in five
+/// seconds is above anything a hand does and far below what a loop does in one frame.
 ///
 /// **A scheme a browser pane cannot show is refused quietly.** `window.open("mailto:...")` and
 /// anything with a custom scheme are not addresses this pane can hold, and handing one to
@@ -27,15 +18,7 @@ import Foundation
 /// The test is `BrowserAddress.shows`, which is the same one the transcript's link menu asks.
 public struct BrowserPopups: Sendable, Equatable {
     /// What to tell the reader, when there is anything to tell them.
-    public struct Notice: Sendable, Equatable {
-        public var title: String
-        public var message: String
-
-        public init(title: String, message: String) {
-            self.title = title
-            self.message = message
-        }
-    }
+    public typealias Notice = BrowserNotice
 
     public enum Decision: Sendable, Equatable {
         /// Open a browser tab on this address, in front.
@@ -46,42 +29,27 @@ public struct BrowserPopups: Sendable, Equatable {
         case refuseAndSay(Notice)
     }
 
-    /// How many windows a page may open in `window` seconds.
-    public var limit: Int
-    /// The length of the rolling window the limit is counted over, in seconds.
-    public var window: TimeInterval
-
-    /// When each of the recent openings was allowed, oldest first. Pruned on every request, so it
-    /// never holds more than `limit` entries.
-    private var openings: [Date] = []
-    /// Whether the reader has already been told about this run of refusals.
-    private var hasSaidSo = false
+    private var burst: BrowserBurst
 
     public init(limit: Int = 5, window: TimeInterval = 5) {
-        self.limit = limit
-        self.window = window
+        burst = BrowserBurst(limit: limit, window: window)
     }
 
     /// Asks whether a page may open `url` in a tab of its own, and records the answer.
-    ///
-    /// `now` is passed in rather than read here so the suite can drive the clock. Every caller in
-    /// the app passes `Date()`.
     public mutating func request(_ url: URL?, at now: Date = Date()) -> Decision {
         // A page that calls `window.open()` with no address gets an empty window in a browser, and
         // an empty window is not a thing this pane can be: a browser tab pointed nowhere shows an
         // address field the page cannot then reach. Nothing to show, so nothing happens.
+        //
+        // Asked before the burst is counted, so a page firing `mailto:` at the delegate cannot
+        // spend the allowance the reader's next real link needs.
         guard let url, BrowserAddress.shows(url) else { return .refuse }
 
-        openings.removeAll { now.timeIntervalSince($0) >= window }
-        guard openings.count < limit else {
-            guard !hasSaidSo else { return .refuse }
-            hasSaidSo = true
-            return .refuseAndSay(Self.notice(for: url))
+        switch burst.take(at: now) {
+        case .allowed: return .open(url)
+        case .refused: return .refuse
+        case .refusedAndUnsaid: return .refuseAndSay(Self.notice(for: url))
         }
-
-        openings.append(now)
-        hasSaidSo = false
-        return .open(url)
     }
 
     /// The sentence the first refusal carries.

--- a/Tests/BloomCoreTests/BrowserDialogsTests.swift
+++ b/Tests/BloomCoreTests/BrowserDialogsTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// How the three questions a page can ask are put up, and what stops a page asking for ever.
+@Suite("Browser dialogs")
+struct BrowserDialogsTests {
+    private static func shown(_ decision: BrowserDialogs.Decision) -> BrowserDialogs.Presentation? {
+        guard case .show(let presentation) = decision else { return nil }
+        return presentation
+    }
+
+    // MARK: - Whose words are whose
+
+    @Test("Bloom's own line names the site, above whatever the page wrote")
+    func theTitleNamesTheSite() {
+        var dialogs = BrowserDialogs()
+        let first = Self.shown(dialogs.request(.alert, message: "Saved", from: "localhost:3100"))
+        #expect(first?.title == "localhost:3100 says")
+        #expect(first?.message == "Saved")
+    }
+
+    @Test("A document with no host still gets a line")
+    func anUnnamedPageStillHasATitle() {
+        var dialogs = BrowserDialogs()
+        #expect(Self.shown(dialogs.request(.alert, message: "Hello"))?.title == "This page says")
+    }
+
+    @Test("A message longer than a panel can hold is cut and says so")
+    func aLongMessageIsCut() {
+        var dialogs = BrowserDialogs()
+        let huge = String(repeating: "a", count: 100_000)
+        let presentation = Self.shown(dialogs.request(.alert, message: huge))
+        #expect(presentation?.message.count == BrowserDialogs.messageLimit + 3)
+        #expect(presentation?.message.hasSuffix("...") == true)
+    }
+
+    @Test("A message of nothing but newlines cannot grow the panel off the display")
+    func aTallMessageIsCut() {
+        var dialogs = BrowserDialogs()
+        let tall = String(repeating: "line\n", count: 500)
+        let message = Self.shown(dialogs.request(.alert, message: tall))?.message ?? ""
+        #expect(message.split(separator: "\n").count == BrowserDialogs.lineLimit + 1)
+    }
+
+    @Test("Control characters go, so a dialog never draws as empty")
+    func controlCharactersGo() {
+        var dialogs = BrowserDialogs()
+        let message = Self.shown(dialogs.request(.alert, message: "a\u{0}\u{7}\u{1B}b\nc\td"))?.message
+        #expect(message == "ab\nc\td")
+    }
+
+    @Test("A prompt's starting text is one line, and only a prompt has one")
+    func promptTextIsOneLine() {
+        var dialogs = BrowserDialogs()
+        let prompt = Self.shown(dialogs.request(.prompt, message: "Name?", defaultText: "a\nb\tc"))
+        #expect(prompt?.defaultText == "a b c")
+
+        let confirm = Self.shown(dialogs.request(.confirm, message: "Sure?", defaultText: "ignored"))
+        #expect(confirm?.defaultText == "")
+    }
+
+    // MARK: - How many
+
+    @Test("The first dialog is asked plainly, and the second offers a way out")
+    func theSecondOffersAWayOut() {
+        var dialogs = BrowserDialogs()
+        #expect(Self.shown(dialogs.request(.alert, message: "one"))?.offersSuppression == false)
+        #expect(Self.shown(dialogs.request(.alert, message: "two"))?.offersSuppression == true)
+        #expect(Self.shown(dialogs.request(.alert, message: "three"))?.offersSuppression == true)
+    }
+
+    @Test("A silenced page puts nothing on screen, however many times it asks")
+    func silencingHolds() {
+        var dialogs = BrowserDialogs()
+        _ = dialogs.request(.alert, message: "one")
+        _ = dialogs.request(.alert, message: "two")
+        dialogs.silence()
+        #expect(dialogs.isSilent)
+        for _ in 0..<1_000 {
+            #expect(dialogs.request(.confirm, message: "again") == .suppress)
+        }
+    }
+
+    @Test("A navigation undoes the silencing and starts the count again")
+    func aNavigationResetsIt() {
+        var dialogs = BrowserDialogs()
+        _ = dialogs.request(.alert, message: "one")
+        _ = dialogs.request(.alert, message: "two")
+        dialogs.silence()
+
+        dialogs.pageCommitted()
+        #expect(!dialogs.isSilent)
+        #expect(Self.shown(dialogs.request(.alert, message: "one again"))?.offersSuppression == false)
+    }
+}

--- a/Tests/BloomCoreTests/BrowserDownloadTests.swift
+++ b/Tests/BloomCoreTests/BrowserDownloadTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// What a file a page hands over is called, how far it has got, and how many of them it may send.
+@Suite("Browser downloads")
+struct BrowserDownloadTests {
+    private static let start = Date(timeIntervalSince1970: 1_700_000_000)
+
+    // MARK: - The name a page chose
+
+    @Test("A name that is really a path can only ever name a file in the download folder")
+    func aPathIsNotAName() {
+        #expect(BrowserDownloadFile.name(from: "../../../etc/passwd") == "passwd")
+        #expect(BrowserDownloadFile.name(from: "/Users/freek/.ssh/id_ed25519") == "id_ed25519")
+        #expect(BrowserDownloadFile.name(from: "a/b/report.pdf") == "report.pdf")
+    }
+
+    @Test("A leading dot goes, because a download the reader cannot see is one he cannot check")
+    func aHiddenNameIsUnhidden() {
+        #expect(BrowserDownloadFile.name(from: ".zshrc") == "zshrc")
+        #expect(BrowserDownloadFile.name(from: "...hidden.sh") == "hidden.sh")
+    }
+
+    @Test("A name with nothing left in it is still a name")
+    func anEmptyNameGetsOne() {
+        #expect(BrowserDownloadFile.name(from: "") == "download")
+        #expect(BrowserDownloadFile.name(from: "..") == "download")
+        #expect(BrowserDownloadFile.name(from: "   ") == "download")
+        #expect(BrowserDownloadFile.name(from: "/") == "download")
+    }
+
+    @Test("Control characters and separators go, so a name draws as what it is")
+    func aNameIsReadable() {
+        #expect(BrowserDownloadFile.name(from: "in\u{0}voi\u{7}ce.pdf") == "invoice.pdf")
+        #expect(BrowserDownloadFile.name(from: "a:b.txt") == "ab.txt")
+    }
+
+    @Test("A very long name is cut and keeps its extension")
+    func aLongNameKeepsItsExtension() {
+        let long = String(repeating: "a", count: 500) + ".zip"
+        let name = BrowserDownloadFile.name(from: long)
+        #expect(name.count == BrowserDownloadFile.nameLimit)
+        #expect(name.hasSuffix(".zip"))
+    }
+
+    // MARK: - Not writing over somebody's file
+
+    @Test("A free name is used as it is")
+    func aFreeNameIsKept() {
+        #expect(BrowserDownloadFile.filename(for: "report.pdf", isTaken: { _ in false })
+            == "report.pdf")
+    }
+
+    @Test("A taken name is numbered around rather than written over")
+    func aTakenNameIsNumbered() {
+        let taken: Set<String> = ["report.pdf", "report-2.pdf"]
+        let name = BrowserDownloadFile.filename(for: "report.pdf") { taken.contains($0) }
+        #expect(name == "report-3.pdf")
+    }
+
+    @Test("A name with no extension is numbered too")
+    func anExtensionlessNameIsNumbered() {
+        let taken: Set<String> = ["Makefile"]
+        let name = BrowserDownloadFile.filename(for: "Makefile") { taken.contains($0) }
+        #expect(name == "Makefile-2")
+    }
+
+    @Test("A folder that is full of that name still never returns one that is taken")
+    func aFullFolderStillAnswers() {
+        let name = BrowserDownloadFile.filename(for: "x.txt") { $0 != "x-1001.txt" }
+        #expect(name != "x.txt")
+        #expect(name.hasSuffix(".txt"))
+    }
+
+    // MARK: - How far it has got
+
+    @Test("Bytes are counted in the units the platform writes them in")
+    func sizesReadLikeFinder() {
+        #expect(BrowserDownloadFile.size(0) == "0 bytes")
+        #expect(BrowserDownloadFile.size(999) == "999 bytes")
+        #expect(BrowserDownloadFile.size(1_000) == "1.0 kB")
+        #expect(BrowserDownloadFile.size(1_500_000) == "1.5 MB")
+        #expect(BrowserDownloadFile.size(2_400_000_000) == "2.4 GB")
+    }
+
+    @Test("A server that sends no length says only what has arrived")
+    func anUnknownLengthSaysWhatItKnows() {
+        #expect(BrowserDownloadFile.progress(received: 2_000, expected: 0) == "2.0 kB")
+        #expect(BrowserDownloadFile.progress(received: 2_000, expected: 8_000)
+            == "2.0 kB of 8.0 kB")
+    }
+
+    // MARK: - How many
+
+    @Test("A reader pressing a download button is never asked about it")
+    func anOrdinaryDownloadIsSaved() {
+        var downloads = BrowserDownloads()
+        #expect(downloads.request(from: "localhost:3100", at: Self.start) == .save)
+    }
+
+    @Test("A page in a loop is stopped, and says so once")
+    func aLoopIsStopped() {
+        var downloads = BrowserDownloads(limit: 2, window: 5)
+        #expect(downloads.request(from: "localhost:3100", at: Self.start) == .save)
+        #expect(downloads.request(from: "localhost:3100", at: Self.start) == .save)
+
+        let third = downloads.request(from: "localhost:3100", at: Self.start)
+        guard case .refuseAndSay(let notice) = third else {
+            Issue.record("the third download in a burst should be refused, got \(third)")
+            return
+        }
+        #expect(notice.title.contains("localhost:3100"))
+
+        for _ in 0..<100 {
+            #expect(downloads.request(from: "localhost:3100", at: Self.start) == .refuse)
+        }
+    }
+}

--- a/Tests/BloomCoreTests/BrowserFindTests.swift
+++ b/Tests/BloomCoreTests/BrowserFindTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// Find in Page: what the bar says, and what the keyboard means to it.
+@Suite("Browser find")
+struct BrowserFindTests {
+    @Test("A pane that has never been searched says nothing and can step nowhere")
+    func anIdleFindIsQuiet() {
+        let find = BrowserFind()
+        #expect(!find.isShowing)
+        #expect(!find.canStep)
+        #expect(find.status == "")
+    }
+
+    @Test("A search that found nothing says so, and one that found something does not")
+    func onlyAFailureSpeaks() {
+        var find = BrowserFind()
+        find.type("widget")
+        find.settle(matched: false)
+        #expect(find.status == "Not found")
+
+        find.settle(matched: true)
+        #expect(find.status == "")
+    }
+
+    @Test("Emptying the field is not a search that failed")
+    func anEmptyFieldClearsTheFailure() {
+        var find = BrowserFind()
+        find.type("widget")
+        find.settle(matched: false)
+        find.type("")
+        #expect(find.status == "")
+        #expect(!find.canStep)
+    }
+
+    @Test("An answer for a field that has since been emptied is not shown")
+    func aLateAnswerIsIgnored() {
+        var find = BrowserFind()
+        find.type("")
+        find.settle(matched: false)
+        #expect(find.status == "")
+    }
+
+    @Test("Capitals in the query are what makes the search respect them")
+    func smartCase() {
+        var find = BrowserFind()
+        find.type("submit")
+        #expect(!find.isCaseSensitive)
+
+        find.type("userId")
+        #expect(find.isCaseSensitive)
+    }
+
+    @Test("Closing the bar keeps the query, so reopening steps the same search")
+    func theQuerySurvivesClosing() {
+        var find = BrowserFind()
+        find.show()
+        find.type("widget")
+        find.hide()
+        #expect(!find.isShowing)
+        #expect(find.query == "widget")
+
+        find.show()
+        #expect(find.canStep)
+    }
+
+    // MARK: - What the keyboard means
+
+    @Test("The three find keys, and only those three")
+    func theFindKeys() {
+        #expect(BrowserFindCommand.forKey("f", hasCommand: true, hasShift: false) == .show)
+        #expect(BrowserFindCommand.forKey("g", hasCommand: true, hasShift: false) == .next)
+        #expect(BrowserFindCommand.forKey("G", hasCommand: true, hasShift: true) == .previous)
+    }
+
+    @Test("A press with no command key is not ours, whatever the letter")
+    func plainLettersFallThrough() {
+        #expect(BrowserFindCommand.forKey("f", hasCommand: false, hasShift: false) == nil)
+        #expect(BrowserFindCommand.forKey("g", hasCommand: false, hasShift: false) == nil)
+    }
+
+    @Test("Every other command key falls through to whatever else wants it")
+    func otherKeysFallThrough() {
+        for key in ["w", "r", "l", "s", "1", "["] {
+            #expect(BrowserFindCommand.forKey(key, hasCommand: true, hasShift: false) == nil)
+            #expect(BrowserFindCommand.forKey(key, hasCommand: true, hasShift: true) == nil)
+        }
+        // Shift Cmd F is the cross-transcript search screen's, not this pane's.
+        #expect(BrowserFindCommand.forKey("f", hasCommand: true, hasShift: true) == nil)
+    }
+}


### PR DESCRIPTION
Three changes to the browser pane, rebased onto main after the UI delegate landed.

A page can ask three questions, alert, confirm and prompt, and each is an NSAlert sheet on the web view's own window, never runModal. All three use the async spelling so the compiler resumes them exactly once. Closing a pane under an open question answers the page with a cancel rather than leaving it waiting forever, and a background tab has no window so it is cancelled without a sheet. The second dialog since the page committed carries Stop this page asking.

Downloads land in ~/Downloads, never in a worktree, because a file there would show up in git status and could be committed by accident. The page's suggested name is stripped of its path, unhidden, cut and numbered around what is already there, and the finished file gets the quarantine flag by hand. A strip under the toolbar names each one with Show in Finder. Capped at three in five seconds.

Find binds Cmd+F, Cmd+G and Shift+Cmd+G while the page holds the keyboard, and answers performFindPanelAction: so the Edit menu's Find group reaches it.