### PR TITLE
Give the probes one harness, and a report a type it cannot lie in

### DIFF
--- a/Sources/Bloom/Design/FrameProbe.swift
+++ b/Sources/Bloom/Design/FrameProbe.swift
@@ -1,7 +1,6 @@
 import AppKit
 import SwiftUI
 import QuartzCore
-import Synchronization
 import BloomCore
 
 /// Measures how many frames the window actually produces while the sidebar divider is dragged.
@@ -28,33 +27,24 @@ import BloomCore
 ///
 ///     Bloom --frame-probe /tmp/probe.json [--probe-driver mouse|programmatic]
 ///           [--probe-select <workspaceID>] [--window-size 1440x900] [--probe-sweeps 6]
+///
+/// Everything that is not the drag itself is `ProbeHarness`: the flags, the window, the failure,
+/// the report.
 @MainActor
 enum FrameProbe {
-    static var isRequested: Bool {
-        CommandLine.arguments.contains("--frame-probe")
-    }
+    private static let harness = ProbeHarness(subject: "frame")
+
+    static var isRequested: Bool { harness.isRequested }
 
     // MARK: - Arguments
 
-    private static func value(for flag: String) -> String? {
-        let arguments = CommandLine.arguments
-        guard let index = arguments.firstIndex(of: flag), index + 1 < arguments.count else {
-            return nil
-        }
-        return arguments[index + 1]
-    }
-
-    private static var outputPath: String {
-        value(for: "--frame-probe") ?? (NSTemporaryDirectory() + "bloom-frame-probe.json")
-    }
-
-    private static var driver: String { value(for: "--probe-driver") ?? "mouse" }
+    private static var driver: String { ProbeHarness.text("--probe-driver", or: "mouse") }
 
     /// Window state a run wants to start in, so the inspector can be taken out of the picture and
     /// the centre column measured on its own. Read by `AppModel`, which owns the switch.
-    static var wantsInspector: Bool { !CommandLine.arguments.contains("--probe-no-inspector") }
-    private static var sweeps: Int { Int(value(for: "--probe-sweeps") ?? "") ?? 6 }
-    private static var selection: String? { value(for: "--probe-select") }
+    static var wantsInspector: Bool { !ProbeHarness.isPresent("--probe-no-inspector") }
+    private static var sweeps: Int { ProbeHarness.count("--probe-sweeps", or: 6) }
+    private static var selection: String? { ProbeHarness.value(for: "--probe-select") }
 
     /// What the run drags. The sidebar divider, which is what this probe was written for, or the
     /// window's own bottom right corner, which is the gesture the owner called janky.
@@ -62,25 +52,17 @@ enum FrameProbe {
     /// A separate flag rather than a fourth driver, because the two gestures cross with the same
     /// three drivers: a window can be resized by a synthetic hand, at a hand's pace from code, or
     /// as fast as the run loop will take it.
-    private static var gesture: String { value(for: "--probe-gesture") ?? "sidebar" }
+    private static var gesture: String { ProbeHarness.text("--probe-gesture", or: "sidebar") }
 
     /// A pane to open on the selected workspace before anything is measured, so a run can name
     /// what is on screen instead of inheriting whatever the last one left there.
     private static var requestedPane: PaneKind? {
-        value(for: "--probe-pane").flatMap(PaneKind.init(rawValue:))
+        ProbeHarness.value(for: "--probe-pane").flatMap(PaneKind.init(rawValue:))
     }
 
     /// Where a browser pane opened by `--probe-pane browser` should go. A file URL by preference:
     /// a run that has to reach the network measures the network.
-    private static var paneURL: String { value(for: "--probe-url") ?? "" }
-
-    private static var windowSize: CGSize? {
-        guard let raw = value(for: "--window-size") else { return nil }
-        let parts = raw.split(separator: "x")
-        guard parts.count == 2, let width = Double(parts[0]), let height = Double(parts[1])
-        else { return nil }
-        return CGSize(width: width, height: height)
-    }
+    private static var paneURL: String { ProbeHarness.text("--probe-url", or: "") }
 
     // MARK: - Entry
 
@@ -90,27 +72,9 @@ enum FrameProbe {
 
     private static func run() async {
         // The app is deliberately not brought to the front. A probe run happens while the owner is
-        // using their own copy, and an activation would steal their keyboard.
-        try? await Task.sleep(for: .seconds(3))
-
-        var window: NSWindow?
-        for _ in 0..<60 {
-            window = NSApp.windows.first {
-                $0.isVisible && $0.contentView != nil && $0.parent == nil
-                    && $0.styleMask.contains(.titled)
-            }
-            if window != nil { break }
-            try? await Task.sleep(for: .milliseconds(250))
-        }
-        guard let window, let contentView = window.contentView else {
-            return fail("no window to probe")
-        }
-
-        if let size = windowSize {
-            window.setContentSize(size)
-            window.layoutIfNeeded()
-            try? await Task.sleep(for: .seconds(1))
-        }
+        // using their own copy, and an activation would steal their keyboard. See `ProbeHarness`,
+        // which waits out the launch and applies `--window-size`.
+        let (window, contentView) = await harness.window()
 
         if let selection {
             OpenWorkspaceNotification.post(WorkspaceID(selection))
@@ -127,10 +91,10 @@ enum FrameProbe {
         var split: NSSplitView?
         if gesture != "window" {
             guard let found = sidebarSplitView(in: contentView) else {
-                return fail("no sidebar NSSplitView found")
+                harness.fail("no sidebar NSSplitView found")
             }
             guard found.arrangedSubviews.count >= 2 else {
-                return fail("sidebar split view has \(found.arrangedSubviews.count) panes")
+                harness.fail("sidebar split view has \(found.arrangedSubviews.count) panes")
             }
             split = found
         }
@@ -148,24 +112,20 @@ enum FrameProbe {
         await drag(split: split, window: window, sweeps: 1, recorder: nil)
         try? await Task.sleep(for: .seconds(1))
 
-        // A marker on disk rather than a line on stderr, so a shell watching for it can start
-        // `sample` against this pid at the moment the measured drag begins instead of profiling
-        // ten seconds of a window doing nothing.
-        try? Data("\(ProcessInfo.processInfo.processIdentifier)".utf8)
-            .write(to: URL(fileURLWithPath: outputPath + ".started"))
+        harness.markStarted()
 
         PaneLayoutTiming.reset()
         PaneLayoutTiming.isEnabled = true
         recorder.start()
-        let cpuBefore = mainThreadCPUSeconds()
+        let cpuBefore = ProbeHarness.mainThreadCPUSeconds()
         let wallBefore = CACurrentMediaTime()
         await drag(split: split, window: window, sweeps: sweeps, recorder: recorder)
-        mainThreadCPU = mainThreadCPUSeconds() - cpuBefore
+        mainThreadCPU = ProbeHarness.mainThreadCPUSeconds() - cpuBefore
         wallClock = CACurrentMediaTime() - wallBefore
         recorder.stop()
         PaneLayoutTiming.isEnabled = false
 
-        write(report(recorder: recorder, window: window, split: split))
+        harness.write(report(recorder: recorder, window: window, split: split))
         exit(0)
     }
 
@@ -258,23 +218,18 @@ enum FrameProbe {
         window.makeKeyAndOrderFront(nil)
         try? await Task.sleep(for: .milliseconds(400))
 
-        let done = Mutex(false)
         let pid = ProcessInfo.processInfo.processIdentifier
         let sequence = sweepOffsets(sweeps: sweeps)
-        Thread.detachNewThread {
-            post(.leftMouseDown, at: flipped, pid: pid)
+        await harness.onEventThread(polling: .milliseconds(4)) {
+            ProbeHarness.post(.leftMouseDown, at: flipped, pid: pid)
             Thread.sleep(forTimeInterval: 0.05)
             for offset in sequence {
-                post(.leftMouseDragged, at: CGPoint(x: flipped.x + offset, y: flipped.y), pid: pid)
+                ProbeHarness.post(
+                    .leftMouseDragged, at: CGPoint(x: flipped.x + offset, y: flipped.y), pid: pid
+                )
                 Thread.sleep(forTimeInterval: 1.0 / 120.0)
             }
-            post(.leftMouseUp, at: flipped, pid: pid)
-            done.withLock { $0 = true }
-        }
-
-        while !done.withLock({ $0 }) {
-            await Task.yield()
-            try? await Task.sleep(for: .milliseconds(4))
+            ProbeHarness.post(.leftMouseUp, at: flipped, pid: pid)
         }
         try? await Task.sleep(for: .milliseconds(300))
     }
@@ -321,37 +276,20 @@ enum FrameProbe {
         window.makeKeyAndOrderFront(nil)
         try? await Task.sleep(for: .milliseconds(400))
 
-        // Posted from a thread of its own at a steady 120Hz, which is what a trackpad on this
-        // machine delivers. Pacing from the main thread would mean the drag slowed down exactly
-        // when the main thread got busy, which is the thing being measured.
-        let done = Mutex(false)
+        // Posted at a steady 120Hz, which is what a trackpad on this machine delivers. See
+        // `ProbeHarness.onEventThread` for why the posting is not done from here.
         let pid = ProcessInfo.processInfo.processIdentifier
-        Thread.detachNewThread {
-            post(.leftMouseDown, at: flipped, pid: pid)
+        await harness.onEventThread(polling: .milliseconds(4)) {
+            ProbeHarness.post(.leftMouseDown, at: flipped, pid: pid)
             Thread.sleep(forTimeInterval: 0.05)
             for offset in sequence {
                 let point = CGPoint(x: flipped.x + offset, y: flipped.y)
-                post(.leftMouseDragged, at: point, pid: pid)
+                ProbeHarness.post(.leftMouseDragged, at: point, pid: pid)
                 Thread.sleep(forTimeInterval: 1.0 / 120.0)
             }
-            post(.leftMouseUp, at: CGPoint(x: flipped.x, y: flipped.y), pid: pid)
-            done.withLock { $0 = true }
-        }
-
-        // Waited on by yielding the main thread rather than blocking it: the tracking loop that
-        // consumes these events IS the main thread.
-        while !done.withLock({ $0 }) {
-            await Task.yield()
-            try? await Task.sleep(for: .milliseconds(4))
+            ProbeHarness.post(.leftMouseUp, at: CGPoint(x: flipped.x, y: flipped.y), pid: pid)
         }
         try? await Task.sleep(for: .milliseconds(300))
-    }
-
-    private nonisolated static func post(_ type: CGEventType, at point: CGPoint, pid: pid_t) {
-        guard let event = CGEvent(
-            mouseEventSource: nil, mouseType: type, mouseCursorPosition: point, mouseButton: .left
-        ) else { return }
-        event.postToPid(pid)
     }
 
     /// Two modes, because they answer two different questions and neither answers both.
@@ -408,61 +346,64 @@ enum FrameProbe {
 
     // MARK: - Reporting
 
+    /// The one report in the family that counts frames against a fixed deadline.
+    ///
+    /// `framesOver16ms` and `framesOver33ms` are 60Hz and 30Hz, and they stay literals here where
+    /// `ScrollProbe` and `ResizeProbe` measure against their own median. This probe's question is
+    /// whether a drag holds a frame budget; theirs is whether a run stuttered against whatever
+    /// this panel is doing. See `ProbeHarness.frameTimings`.
     private static func report(
         recorder: FrameRecorder, window: NSWindow, split: NSSplitView?
-    ) -> [String: Any] {
+    ) -> JSONValue {
         let intervals = recorder.intervals.map { $0 * 1000 }
         let sorted = intervals.sorted()
-        func percentile(_ p: Double) -> Double {
-            guard !sorted.isEmpty else { return 0 }
-            let index = min(sorted.count - 1, max(0, Int((Double(sorted.count - 1) * p).rounded())))
-            return sorted[index]
+        func percentile(_ fraction: Double) -> Double {
+            ProbeStats.percentile(fraction, of: sorted)
         }
         let total = intervals.reduce(0, +)
         let mean = intervals.isEmpty ? 0 : total / Double(intervals.count)
-        let refresh = Double(window.screen?.maximumFramesPerSecond ?? 60)
+        let steps = sweepOffsets(sweeps: sweeps).count
 
-        return [
-            "driver": driver,
-            "gesture": gesture,
-            "pane": requestedPane?.rawValue ?? "whatever was open",
-            "selection": selection ?? "home",
+        let own: [String: JSONValue] = [
+            "driver": .string(driver),
+            "gesture": .string(gesture),
+            "pane": .string(requestedPane?.rawValue ?? "whatever was open"),
+            "selection": .string(selection ?? "home"),
             // What the window is ACTUALLY showing, rather than what was asked for. `AppModel`
             // reselects the last workspace on launch, so a run that meant to measure Home
             // silently measured a workspace as soon as any earlier run had opened one, and the
             // two configurations converged on the same number for a reason that had nothing to do
             // with either of them.
-            "inspector": wantsInspector,
-            "restoredWorkspace":
-                UserDefaults.standard.string(forKey: "sidebar.lastWorkspaceID") ?? "none",
-            "configuration": buildConfiguration,
-            "displayHz": refresh,
-            "frames": intervals.count,
-            "durationMs": total,
-            "meanMs": mean,
-            "meanFps": mean > 0 ? 1000 / mean : 0,
-            "medianMs": percentile(0.5),
-            "medianFps": percentile(0.5) > 0 ? 1000 / percentile(0.5) : 0,
-            "p95Ms": percentile(0.95),
-            "p99Ms": percentile(0.99),
-            "maxMs": sorted.last ?? 0,
-            "framesOver16ms": intervals.filter { $0 > 16.7 }.count,
-            "framesOver33ms": intervals.filter { $0 > 33.4 }.count,
-            "sidebarWidth": split?.arrangedSubviews[0].frame.width ?? 0,
+            "inspector": .bool(wantsInspector),
+            "restoredWorkspace": .string(
+                UserDefaults.standard.string(forKey: "sidebar.lastWorkspaceID") ?? "none"
+            ),
+            "frames": .integer(intervals.count),
+            "durationMs": .number(total),
+            "meanMs": .number(mean),
+            "meanFps": .number(mean > 0 ? 1000 / mean : 0),
+            "medianMs": .number(percentile(0.5)),
+            "medianFps": .number(percentile(0.5) > 0 ? 1000 / percentile(0.5) : 0),
+            "p95Ms": .number(percentile(0.95)),
+            "p99Ms": .number(percentile(0.99)),
+            "maxMs": .number(sorted.last ?? 0),
+            "framesOver16ms": .integer(intervals.filter { $0 > 16.7 }.count),
+            "framesOver33ms": .integer(intervals.filter { $0 > 33.4 }.count),
+            "sidebarWidth": .number(Double(split?.arrangedSubviews[0].frame.width ?? 0)),
             // Proof the drag landed. A run whose min and max are the same measured nothing.
-            "widthMin": recorder.widths.min() ?? 0,
-            "widthMax": recorder.widths.max() ?? 0,
-            "widthSteps": Set(recorder.widths).count,
-            "windowSize": ["w": window.frame.width, "h": window.frame.height],
-            "dragSteps": sweepOffsets(sweeps: sweeps).count,
-            "mainThreadCpuMs": mainThreadCPU * 1000,
-            "wallMs": wallClock * 1000,
-            "mainThreadBusyFraction": wallClock > 0 ? mainThreadCPU / wallClock : 0,
-            "cpuMsPerStep": mainThreadCPU * 1000 / Double(max(1, sweepOffsets(sweeps: sweeps).count)),
-            "loadAverage": systemLoadAverage(),
-            "paneLayout": PaneLayoutTiming.summary(),
-            "histogramMs": intervals,
+            "widthMin": .number(Double(recorder.widths.min() ?? 0)),
+            "widthMax": .number(Double(recorder.widths.max() ?? 0)),
+            "widthSteps": .integer(Set(recorder.widths).count),
+            "dragSteps": .integer(steps),
+            "mainThreadCpuMs": .number(mainThreadCPU * 1000),
+            "wallMs": .number(wallClock * 1000),
+            "mainThreadBusyFraction": .number(wallClock > 0 ? mainThreadCPU / wallClock : 0),
+            "cpuMsPerStep": .number(mainThreadCPU * 1000 / Double(max(1, steps))),
+            "paneLayout": .map(PaneLayoutTiming.summary()),
+            "histogramMs": .numbers(intervals),
         ]
+        // The probe's own keys win, so a report that has an opinion about the window keeps it.
+        return .object(own.merging(harness.conditions(window: window)) { mine, _ in mine })
     }
 
     /// How much CPU the main thread actually burned, and over how long.
@@ -473,36 +414,4 @@ enum FrameProbe {
     /// the frame interval is the number that says what the drag feels like.
     private static var mainThreadCPU: Double = 0
     private static var wallClock: Double = 0
-
-    private static func mainThreadCPUSeconds() -> Double {
-        Double(clock_gettime_nsec_np(CLOCK_THREAD_CPUTIME_ID)) / 1_000_000_000
-    }
-
-    private static var buildConfiguration: String {
-        #if DEBUG
-        "debug"
-        #else
-        "release"
-        #endif
-    }
-
-    /// Recorded with every run, so a number taken while three other builds were running can be
-    /// recognised as one rather than believed.
-    private static func systemLoadAverage() -> Double {
-        var loads = [Double](repeating: 0, count: 3)
-        guard getloadavg(&loads, 3) > 0 else { return 0 }
-        return loads[0]
-    }
-
-    private static func write(_ report: [String: Any]) {
-        let data = (try? JSONSerialization.data(withJSONObject: report, options: [.prettyPrinted]))
-            ?? Data()
-        try? data.write(to: URL(fileURLWithPath: outputPath))
-        FileHandle.standardError.write(Data("frame probe wrote \(outputPath)\n".utf8))
-    }
-
-    private static func fail(_ message: String) {
-        FileHandle.standardError.write(Data("frame probe: \(message)\n".utf8))
-        exit(1)
-    }
 }

--- a/Sources/Bloom/Design/ProbeHarness.swift
+++ b/Sources/Bloom/Design/ProbeHarness.swift
@@ -1,0 +1,364 @@
+import AppKit
+import Foundation
+import Synchronization
+import BloomCore
+
+/// The machinery six probes were each written with their own copy of.
+///
+/// `FrameProbe`, `SwitchProbe`, `TabProbe`, `ScrollProbe`, `IdleProbe` and `ResizeProbe` measure
+/// six different gestures and shared almost everything else. Counted before this existed:
+/// `value(for:)` in seven copies byte for byte, the `WxH` parse in five, the sixty iteration
+/// window wait in four, `systemLoadAverage` and `buildConfiguration` in three each, and `fail` six
+/// times in two different signatures. That was the largest duplicate mass in the tree, ahead of
+/// `AgentRunner` and `CodexRunner`.
+///
+/// # Why it was worth a file rather than a shrug
+///
+/// Because it had already drifted, and the drift cost measurements rather than tidiness.
+/// `SwitchProbe`, `TabProbe` and, because it was copied from one of them, `ResizeProbe` checked a
+/// report before serialising it. `FrameProbe`, `ScrollProbe` and `IdleProbe` did not, so half the
+/// family could still die on the last line of a run. The lesson was written down three times, in
+/// the three files that could not teach it to the other three, and the seventh probe would have
+/// inherited whichever half it was written from.
+///
+/// **The bug that lesson came from, and why nothing here can have it again.** A report used to be
+/// a `[String: Any]`, so a typed id went in without complaint and arrived at `JSONSerialization`
+/// as `__SwiftValue`. `JSONSerialization` raises on a value it cannot carry rather than throwing
+/// one, an Objective-C exception is not something `try?` catches, and the probe died at the very
+/// end of a twenty minute run, after every measurement had been taken and before any of it was on
+/// disk. A report is a `JSONValue` now (`BloomCore`, `Sendable`, `Codable`, and with no case that
+/// can hold a `WorkspaceID`), so the same mistake is a compile error at the line that makes it.
+/// The runtime guard the two probes carried is gone because there is nothing left for it to
+/// catch, which is the only kind of check worth deleting.
+///
+/// # What is NOT here
+///
+/// Every probe's driver and subject: a divider drag, a workspace selection, a tab pick, a scroll,
+/// an idle pass, a window resize. Those are what the six files are actually about, they are all
+/// different, and the arguments in their heads for why each is shaped as it is are the value in
+/// them. `FrameProbe` has two drivers because each answers a different objection; `TabProbe` has
+/// one and will never have a second. A harness that flattened either would have made the tree
+/// worse.
+@MainActor
+struct ProbeHarness {
+    /// The probe's own word: `frame`, `switch`, `tab`, `scroll`, `idle`, `resize`.
+    ///
+    /// The flag, the default report path and the name in front of every line on stderr all follow
+    /// from it, because all six spelled all three the same way and a seventh should not have to be
+    /// told how.
+    let subject: String
+
+    /// `--frame-probe`, whose value names the report to write.
+    var flag: String { "--\(subject)-probe" }
+
+    /// "frame probe", which is how a line on stderr introduces itself.
+    var name: String { "\(subject) probe" }
+
+    var isRequested: Bool { CommandLine.arguments.contains(flag) }
+
+    var outputPath: String {
+        Self.value(for: flag) ?? (NSTemporaryDirectory() + "bloom-\(subject)-probe.json")
+    }
+
+    // MARK: - Arguments
+
+    /// The value after a flag, or nil if the flag is absent or last.
+    ///
+    /// A hand-rolled scan rather than anything cleverer, because these flags are read before any
+    /// scene exists and half of them are read by a probe that is about to refuse the run.
+    static func value(for flag: String) -> String? {
+        let arguments = CommandLine.arguments
+        guard let index = arguments.firstIndex(of: flag), index + 1 < arguments.count else {
+            return nil
+        }
+        return arguments[index + 1]
+    }
+
+    static func text(_ flag: String, or fallback: String) -> String {
+        value(for: flag) ?? fallback
+    }
+
+    static func count(_ flag: String, or fallback: Int) -> Int {
+        Int(value(for: flag) ?? "") ?? fallback
+    }
+
+    static func points(_ flag: String, or fallback: CGFloat) -> CGFloat {
+        CGFloat(Double(value(for: flag) ?? "") ?? Double(fallback))
+    }
+
+    static func isPresent(_ flag: String) -> Bool {
+        CommandLine.arguments.contains(flag)
+    }
+
+    // MARK: - The window
+
+    /// The seconds a run gives a launch before it touches anything.
+    ///
+    /// Its own method because `IdleProbe` waits and has no window to wait for: what it measures is
+    /// the work the six second diff loop does, and a launch's own git reads landing inside the
+    /// first pass would be counted as the loop's.
+    func settle() async {
+        try? await Task.sleep(for: .seconds(3))
+    }
+
+    /// The window a run measures, once there is one and once it is the size the run asked for.
+    ///
+    /// **The app is deliberately never brought to the front here.** A probe run happens while the
+    /// owner is using his own copy of Bloom, and an activation would take his keyboard. The two
+    /// drivers that cannot work without the front, `FrameProbe`'s mouse and `SwitchProbe`'s click,
+    /// activate for themselves and each says why beside the call.
+    ///
+    /// The wait loop is a loop because there is no window for the first moments of a launch, and
+    /// a probe that asked once got nil and reported nothing at all.
+    func window() async -> (window: NSWindow, content: NSView) {
+        await settle()
+        for _ in 0..<60 {
+            let candidate = NSApp.windows.first {
+                $0.isVisible && $0.contentView != nil && $0.parent == nil
+                    && $0.styleMask.contains(.titled)
+            }
+            if let candidate, let content = candidate.contentView {
+                await resize(candidate)
+                return (candidate, content)
+            }
+            try? await Task.sleep(for: .milliseconds(250))
+        }
+        fail("no window to probe")
+    }
+
+    /// `--window-size 1440x900`, applied and given a second to settle.
+    ///
+    /// A size that cannot be read ends the run rather than being ignored, which is a change from
+    /// the five copies this replaces. A run that silently measured whatever size the window was
+    /// last left at, while its report named the size that was asked for, is a run whose number
+    /// means something other than what it says.
+    private func resize(_ window: NSWindow) async {
+        guard let raw = Self.value(for: "--window-size") else { return }
+        guard let size = ProbeStats.windowSize(raw) else {
+            fail("--window-size wants WxH, as in 1440x900, and was given \(raw)")
+        }
+        window.setContentSize(size)
+        window.layoutIfNeeded()
+        try? await Task.sleep(for: .seconds(1))
+    }
+
+    // MARK: - Reaching the model
+
+    /// The app's state, weakly, because a probe has no business keeping the app alive.
+    ///
+    /// Handed over from two places on purpose. `AppModel.bootstrap` sets `probeInstance` and
+    /// `BloomAppDelegate` calls `attach`, and the two moments are not ordered against each other,
+    /// so a probe takes whichever of them has landed.
+    private static weak var attached: AppModel?
+
+    static func attach(_ model: AppModel) {
+        attached = model
+    }
+
+    static var appModel: AppModel? { attached ?? AppModel.probeInstance }
+
+    // MARK: - Synthetic events
+
+    /// One mouse event, delivered to THIS process and to nothing else.
+    ///
+    /// `postToPid` takes a pid, so a probe driving a drag or a click never goes near another
+    /// application whatever is under the pointer.
+    nonisolated static func post(_ type: CGEventType, at point: CGPoint, pid: pid_t) {
+        guard let event = CGEvent(
+            mouseEventSource: nil, mouseType: type, mouseCursorPosition: point, mouseButton: .left
+        ) else { return }
+        event.postToPid(pid)
+    }
+
+    /// Runs a burst of synthetic events on a thread of its own and waits for it from here.
+    ///
+    /// Posted from a thread rather than from the main actor because pacing from the main thread
+    /// would mean the drag slowed down exactly when the main thread got busy, which is the thing
+    /// being measured. Waited on by yielding rather than by blocking, because the tracking loop
+    /// that consumes these events IS the main thread, and a blocked main thread consumes nothing.
+    ///
+    /// `polling` is the caller's, not a constant, because it is main actor time spent inside the
+    /// measurement and each driver chose its own.
+    func onEventThread(polling: Duration, _ work: @escaping @Sendable () -> Void) async {
+        let done = Mutex(false)
+        Thread.detachNewThread {
+            work()
+            done.withLock { $0 = true }
+        }
+        while !done.withLock({ $0 }) {
+            await Task.yield()
+            try? await Task.sleep(for: polling)
+        }
+    }
+
+    // MARK: - What a report says about the run
+
+    /// Which build, how loaded the machine was, and what the window was.
+    ///
+    /// All three on every report, where three of the six carried only some of them. A wall clock
+    /// frame interval is a measurement of this Mac as well as of this app, and this Mac has other
+    /// agents building on it, so a number taken at a load average of thirty has to be
+    /// recognisable as one rather than believed. `ScrollProbe` could not say which build it had
+    /// measured at all.
+    func conditions(window: NSWindow?) -> [String: JSONValue] {
+        var conditions: [String: JSONValue] = [
+            "configuration": .string(Self.buildConfiguration),
+            "loadAverage": .number(Self.systemLoadAverage()),
+        ]
+        guard let window else { return conditions }
+        conditions["windowSize"] = .object([
+            "w": .number(window.frame.width), "h": .number(window.frame.height),
+        ])
+        conditions["displayHz"] = .number(Double(window.screen?.maximumFramesPerSecond ?? 60))
+        return conditions
+    }
+
+    /// The frame timings `ScrollProbe` and `ResizeProbe` both report, from a list of frame
+    /// intervals in milliseconds.
+    ///
+    /// Sorted here rather than by the caller. Every number below is a rank or the top of the list,
+    /// so a caller that handed this an unsorted list would get a plausible report full of wrong
+    /// numbers, and no probe would notice.
+    ///
+    /// The dropped frame threshold is this run's own median rather than a fixed 16.7, because this
+    /// Mac may be running at 120Hz and calling every 10ms frame a stutter on a 60Hz panel would
+    /// report a problem nobody can see. `FrameProbe` counts against 16.7 and 33.4 instead, and
+    /// that is not an oversight in this one: its question is how many frames missed a 60Hz
+    /// deadline, which is a claim about the deadline rather than about the run.
+    static func frameTimings(_ intervals: [Double]) -> [String: JSONValue] {
+        let ms = intervals.sorted()
+        let median = ProbeStats.percentile(0.5, of: ms)
+        let dropped = ms.filter { $0 > (ms.isEmpty ? 8.3 : median) * 1.8 }.count
+        return [
+            "frames": .integer(ms.count),
+            "medianMs": .number(median),
+            "medianFps": .number(median > 0 ? 1000 / median : 0),
+            "p95Ms": .number(ProbeStats.percentile(0.95, of: ms)),
+            "p99Ms": .number(ProbeStats.percentile(0.99, of: ms)),
+            "worstMs": .number(ms.last ?? 0),
+            "droppedFrames": .integer(dropped),
+            "droppedShare": .number(ms.isEmpty ? 0 : Double(dropped) / Double(ms.count)),
+        ]
+    }
+
+    static var buildConfiguration: String {
+        #if DEBUG
+        "debug"
+        #else
+        "release"
+        #endif
+    }
+
+    static func systemLoadAverage() -> Double {
+        var loads = [Double](repeating: 0, count: 3)
+        guard getloadavg(&loads, 3) > 0 else { return 0 }
+        return loads[0]
+    }
+
+    /// How much CPU the main thread has burned since this process started.
+    ///
+    /// Read either side of a measured pass, because a wall clock frame interval says what a
+    /// gesture feels like on the machine it was taken on, and CPU per step of the same gesture
+    /// barely moves when the load average does. The second is the number two builds can be
+    /// compared with while three other agents are building.
+    static func mainThreadCPUSeconds() -> Double {
+        Double(clock_gettime_nsec_np(CLOCK_THREAD_CPUTIME_ID)) / 1_000_000_000
+    }
+
+    // MARK: - Writing it down
+
+    /// A marker on disk saying the measured pass has begun.
+    ///
+    /// On disk rather than on stderr so a shell watching for it can start `sample` against this
+    /// pid at the moment the measurement starts, instead of profiling twenty seconds of a window
+    /// loading a transcript.
+    func markStarted() {
+        try? Data("\(ProcessInfo.processInfo.processIdentifier)".utf8)
+            .write(to: URL(fileURLWithPath: outputPath + ".started"))
+    }
+
+    /// The report, on disk and named on stderr.
+    ///
+    /// `.sortedKeys` on every report rather than on two of the five, so any two runs can be
+    /// diffed against each other. `echo` puts the whole report on stderr as well, which is how
+    /// `IdleProbe` is read: its runs are short and are driven from a shell that never opens the
+    /// file.
+    func write(_ report: JSONValue, echo: Bool = false) {
+        guard let data = Self.encoded(report) else {
+            fail("the report could not be encoded")
+        }
+        try? data.write(to: URL(fileURLWithPath: outputPath))
+        if echo {
+            FileHandle.standardError.write(data)
+            FileHandle.standardError.write(Data("\n".utf8))
+        }
+        FileHandle.standardError.write(Data("\(name) wrote \(outputPath)\n".utf8))
+    }
+
+    /// One signature for all six, where there used to be two.
+    ///
+    /// `Never`, so a caller can end a run with it from inside a `guard`. Three of the six returned
+    /// `Void` and were written `return fail(...)`, which reads the same and works only where the
+    /// caller happens to be able to return, so those three could not refuse a run from a `guard`
+    /// at all.
+    ///
+    /// **A failed run leaves a report saying so**, which none of the six except `IdleProbe` did.
+    /// The report path is reused between runs, so a run that failed and left the last one's file
+    /// on disk is a run somebody reads as this one's answer, at a glance, with every number in it
+    /// looking exactly as plausible as it did an hour ago.
+    func fail(_ message: String) -> Never {
+        FileHandle.standardError.write(Data("\(name): \(message)\n".utf8))
+        let report = JSONValue.object([
+            "probe": .string(name),
+            "error": .string(message),
+            "configuration": .string(Self.buildConfiguration),
+        ])
+        if let data = Self.encoded(report) {
+            try? data.write(to: URL(fileURLWithPath: outputPath))
+        }
+        exit(1)
+    }
+
+    /// Deliberately not `write`'s body: `write` ends a hopeless encode with `fail`, and `fail`
+    /// writes a report of its own, so one of the two has to be the one that cannot recurse.
+    private static func encoded(_ report: JSONValue) -> Data? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return try? encoder.encode(report)
+    }
+}
+
+/// The shapes a probe's own instruments hand back, as JSON.
+///
+/// Written out here rather than at each call site, because the alternative to six of these is a
+/// `[String: Any]` and a dynamic cast, which is the hole the whole family fell down. Everything
+/// below is typed: nothing in a report can be a value JSON cannot carry.
+extension JSONValue {
+    static func numbers(_ values: [Double]) -> JSONValue {
+        .array(values.map { .number($0) })
+    }
+
+    static func numbers(_ values: [CGFloat]) -> JSONValue {
+        .array(values.map { .number(Double($0)) })
+    }
+
+    static func numbers(_ rows: [[Double]]) -> JSONValue {
+        .array(rows.map { numbers($0) })
+    }
+
+    static func strings(_ values: [String]) -> JSONValue {
+        .array(values.map { .string($0) })
+    }
+
+    static func map(_ values: [String: Double]) -> JSONValue {
+        .object(values.mapValues { .number($0) })
+    }
+
+    static func map(_ values: [String: [String: Double]]) -> JSONValue {
+        .object(values.mapValues { map($0) })
+    }
+
+    static func map(_ values: [String: [[Double]]]) -> JSONValue {
+        .object(values.mapValues { numbers($0) })
+    }
+}

--- a/Sources/Bloom/Design/ScrollProbe.swift
+++ b/Sources/Bloom/Design/ScrollProbe.swift
@@ -28,37 +28,20 @@ import BloomCore
 /// A sweep is one trip from the bottom of the transcript to the top and back. `--scroll-step` is
 /// how far the origin moves per frame: 24 points at 120Hz is about 2,900 points a second, which is
 /// a brisk flick rather than a drag, and is the speed at which a row that lays out slowly shows.
+///
+/// Everything that is not the scroll itself is `ProbeHarness`: the flags, the window, the failure,
+/// the frame timings, the report.
 @MainActor
 enum ScrollProbe {
-    static var isRequested: Bool {
-        CommandLine.arguments.contains("--scroll-probe")
-    }
+    private static let harness = ProbeHarness(subject: "scroll")
+
+    static var isRequested: Bool { harness.isRequested }
 
     // MARK: - Arguments
 
-    private static func value(for flag: String) -> String? {
-        let arguments = CommandLine.arguments
-        guard let index = arguments.firstIndex(of: flag), index + 1 < arguments.count else {
-            return nil
-        }
-        return arguments[index + 1]
-    }
-
-    private static var outputPath: String {
-        value(for: "--scroll-probe") ?? (NSTemporaryDirectory() + "bloom-scroll-probe.json")
-    }
-
-    private static var workspace: String? { value(for: "--scroll-workspace") }
-    private static var sweeps: Int { Int(value(for: "--scroll-sweeps") ?? "") ?? 4 }
-    private static var step: CGFloat { CGFloat(Double(value(for: "--scroll-step") ?? "") ?? 24) }
-
-    private static var windowSize: CGSize? {
-        guard let raw = value(for: "--window-size") else { return nil }
-        let parts = raw.split(separator: "x")
-        guard parts.count == 2, let width = Double(parts[0]), let height = Double(parts[1])
-        else { return nil }
-        return CGSize(width: width, height: height)
-    }
+    private static var workspace: String? { ProbeHarness.value(for: "--scroll-workspace") }
+    private static var sweeps: Int { ProbeHarness.count("--scroll-sweeps", or: 4) }
+    private static var step: CGFloat { ProbeHarness.points("--scroll-step", or: 24) }
 
     // MARK: - Entry
 
@@ -67,18 +50,8 @@ enum ScrollProbe {
     }
 
     private static func run() async {
-        // Not brought to the front, for the reason at the head of `FrameProbe`.
-        try? await Task.sleep(for: .seconds(3))
-
-        guard let window = await firstWindow(), let contentView = window.contentView else {
-            return fail("no window to probe")
-        }
-
-        if let size = windowSize {
-            window.setContentSize(size)
-            window.layoutIfNeeded()
-            try? await Task.sleep(for: .seconds(1))
-        }
+        // Not brought to the front, for the reason at the head of `ProbeHarness.window`.
+        let (window, contentView) = await harness.window()
 
         if let workspace {
             OpenWorkspaceNotification.post(WorkspaceID(workspace))
@@ -87,7 +60,7 @@ enum ScrollProbe {
         }
 
         guard let scroll = transcriptScrollView(in: contentView) else {
-            return fail("no transcript NSScrollView found")
+            harness.fail("no transcript NSScrollView found")
         }
 
         // Sampled before the sweep and again in the report, because these two disagreeing is
@@ -97,7 +70,7 @@ enum ScrollProbe {
         let heightBefore = scroll.documentView?.frame.height ?? 0
         let travel = scrollableHeight(scroll)
         guard travel > 1 else {
-            return fail("the transcript is shorter than its viewport, so there is nothing to scroll")
+            harness.fail("the transcript is shorter than its viewport, so there is nothing to scroll")
         }
 
         // The offset, sampled once a frame. A run whose min and max agree scrolled nothing, which
@@ -112,12 +85,7 @@ enum ScrollProbe {
         await sweep(scroll, travel: travel, sweeps: 1)
         try? await Task.sleep(for: .seconds(1))
 
-        // A marker on disk rather than a line on stderr, so a shell watching for it can start
-        // `sample` against this pid at the moment the measured sweep begins instead of profiling
-        // twenty seconds of a window loading a transcript. Copied from `FrameProbe`, which needed
-        // it for the same reason.
-        try? Data("\(ProcessInfo.processInfo.processIdentifier)".utf8)
-            .write(to: URL(fileURLWithPath: outputPath + ".started"))
+        harness.markStarted()
 
         recorder.start()
         let wallBefore = CACurrentMediaTime()
@@ -125,22 +93,11 @@ enum ScrollProbe {
         let wall = CACurrentMediaTime() - wallBefore
         recorder.stop()
 
-        write(report(
-            recorder: recorder, travel: travel, wall: wall, scroll: scroll, heightBefore: heightBefore
+        harness.write(report(
+            recorder: recorder, travel: travel, wall: wall, window: window, scroll: scroll,
+            heightBefore: heightBefore
         ))
         exit(0)
-    }
-
-    private static func firstWindow() async -> NSWindow? {
-        for _ in 0..<60 {
-            let window = NSApp.windows.first {
-                $0.isVisible && $0.contentView != nil && $0.parent == nil
-                    && $0.styleMask.contains(.titled)
-            }
-            if let window { return window }
-            try? await Task.sleep(for: .milliseconds(250))
-        }
-        return nil
     }
 
     // MARK: - Finding the transcript
@@ -204,56 +161,28 @@ enum ScrollProbe {
     // MARK: - Reporting
 
     private static func report(
-        recorder: FrameRecorder, travel: CGFloat, wall: Double, scroll: NSScrollView,
-        heightBefore: CGFloat
-    ) -> [String: Any] {
-        let ms = recorder.intervals.map { $0 * 1000 }.sorted()
-        func percentile(_ p: Double) -> Double {
-            guard !ms.isEmpty else { return 0 }
-            let index = Int((Double(ms.count - 1) * p).rounded())
-            return ms[min(max(index, 0), ms.count - 1)]
-        }
+        recorder: FrameRecorder, travel: CGFloat, wall: Double, window: NSWindow,
+        scroll: NSScrollView, heightBefore: CGFloat
+    ) -> JSONValue {
         let offsets = recorder.widths
-        // A frame that took longer than two vsyncs at 120Hz. Not a fixed 16.7, because this Mac
-        // may be running at 120Hz, and calling every 10ms frame a stutter on a 60Hz panel would
-        // report a problem that nobody can see.
-        let refresh = ms.isEmpty ? 8.3 : percentile(0.5)
-        let dropped = ms.filter { $0 > refresh * 1.8 }.count
-
-        return [
-            "frames": ms.count,
-            "wallSeconds": wall,
-            "travelPoints": travel,
-            "documentHeightBefore": heightBefore,
-            "documentHeightAfter": scroll.documentView?.frame.height ?? 0,
-            "viewportHeight": scroll.contentView.bounds.height,
-            "offsetMin": offsets.min() ?? 0,
-            "offsetMax": offsets.max() ?? 0,
+        let own: [String: JSONValue] = [
+            "wallSeconds": .number(wall),
+            "travelPoints": .number(Double(travel)),
+            "documentHeightBefore": .number(Double(heightBefore)),
+            "documentHeightAfter": .number(Double(scroll.documentView?.frame.height ?? 0)),
+            "viewportHeight": .number(Double(scroll.contentView.bounds.height)),
+            "offsetMin": .number(Double(offsets.min() ?? 0)),
+            "offsetMax": .number(Double(offsets.max() ?? 0)),
             // The check that a run actually moved. See the note on the recorder above.
-            "didScroll": (offsets.max() ?? 0) - (offsets.min() ?? 0) > 1,
-            "medianMs": percentile(0.5),
-            "medianFps": percentile(0.5) > 0 ? 1000 / percentile(0.5) : 0,
-            "p95Ms": percentile(0.95),
-            "p99Ms": percentile(0.99),
-            "worstMs": ms.last ?? 0,
-            "droppedFrames": dropped,
-            "droppedShare": ms.isEmpty ? 0 : Double(dropped) / Double(ms.count),
-            "step": step,
-            "sweeps": sweeps,
+            "didScroll": .bool((offsets.max() ?? 0) - (offsets.min() ?? 0) > 1),
+            "step": .number(Double(step)),
+            "sweeps": .integer(sweeps),
         ]
-    }
-
-    private static func write(_ report: [String: Any]) {
-        guard let data = try? JSONSerialization.data(
-            withJSONObject: report, options: [.prettyPrinted, .sortedKeys]
-        ) else { return fail("could not serialise the report") }
-        try? data.write(to: URL(fileURLWithPath: outputPath))
-    }
-
-    /// Typed as returning nothing rather than `Never`, so `return fail(...)` reads the same in
-    /// a guard as it does in the other three probes. It exits either way.
-    private static func fail(_ message: String) {
-        FileHandle.standardError.write(Data("scroll probe: \(message)\n".utf8))
-        exit(1)
+        // The probe's own keys win over both, so a report that has an opinion keeps it.
+        return .object(
+            own
+                .merging(ProbeHarness.frameTimings(recorder.intervals.map { $0 * 1000 })) { mine, _ in mine }
+                .merging(harness.conditions(window: window)) { mine, _ in mine }
+        )
     }
 }

--- a/Sources/BloomCore/Presentation/ProbeStats.swift
+++ b/Sources/BloomCore/Presentation/ProbeStats.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// The two pieces of arithmetic the window probes do, in the target that can test them.
+///
+/// Both were written more than once and neither was tested. `FrameProbe` clamped the index and
+/// then read it, `ScrollProbe` read it and then clamped, and `IdleProbe` took a median by halving
+/// the count: three spellings of one answer whose agreement was something a reader had to work
+/// out rather than something the suite says. That matters more here than the duplication does. A
+/// probe that computes a percentile a hair differently from its sibling makes two runs
+/// incomparable, and two runs being comparable is the whole of what a measuring instrument is
+/// for.
+///
+/// Here rather than beside the probes because a decision taken inside the app target is a
+/// decision nothing can test, and neither of these needs a window to answer.
+public enum ProbeStats {
+    /// The value `fraction` of the way through `sorted`, which has to be sorted already.
+    ///
+    /// Nearest rank, rounding halves away from zero, clamped at both ends, so a fraction outside
+    /// `0...1` returns an end rather than trapping. An empty list is nought rather than nil:
+    /// every caller is writing a number into a report and has nothing better to write.
+    public static func percentile(_ fraction: Double, of sorted: [Double]) -> Double {
+        guard !sorted.isEmpty else { return 0 }
+        let last = Double(sorted.count - 1)
+        // Clamped as a `Double` before the conversion rather than after it. `Int(_:)` traps on a
+        // value `Int` cannot hold and on a NaN, and both probes that take a step or a sweep count
+        // off the command line are one arithmetic mistake away from handing this one.
+        let rank = min(last, max(0, (last * fraction).rounded()))
+        return sorted[Int(rank)]
+    }
+
+    /// A window size as `--window-size` spells it: `1440x900`.
+    ///
+    /// Nil for anything else, a zero included, because the caller's answer to nil is to refuse
+    /// the run rather than to carry on. A probe that quietly measured a window of some other size
+    /// than the one its report names is a probe whose number means something else.
+    public static func windowSize(_ raw: String) -> CGSize? {
+        let parts = raw.split(separator: "x")
+        guard parts.count == 2,
+              let width = Double(parts[0]), let height = Double(parts[1]),
+              width > 0, height > 0
+        else { return nil }
+        return CGSize(width: width, height: height)
+    }
+}

--- a/Tests/BloomCoreTests/ProbeStatsTests.swift
+++ b/Tests/BloomCoreTests/ProbeStatsTests.swift
@@ -1,0 +1,78 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+@Suite("What a probe's report is made of")
+struct ProbeStatsTests {
+    @Test("a percentile of nothing is nought rather than a trap")
+    func empty() {
+        #expect(ProbeStats.percentile(0.5, of: []) == 0)
+        #expect(ProbeStats.percentile(0.99, of: []) == 0)
+    }
+
+    @Test("the ends and the middle")
+    func ends() {
+        let sorted = [1.0, 2, 3, 4, 5]
+        #expect(ProbeStats.percentile(0, of: sorted) == 1)
+        #expect(ProbeStats.percentile(0.5, of: sorted) == 3)
+        #expect(ProbeStats.percentile(1, of: sorted) == 5)
+    }
+
+    /// A fraction is a literal at every call site today. It is clamped anyway, because the day one
+    /// of them is worked out from a count instead is the day this traps in the last line of a
+    /// twenty minute run, which is a failure this family has had once already.
+    @Test("a fraction outside 0...1 lands on an end")
+    func outsideTheRange() {
+        let sorted = [1.0, 2, 3]
+        #expect(ProbeStats.percentile(-1, of: sorted) == 1)
+        #expect(ProbeStats.percentile(2, of: sorted) == 3)
+        #expect(ProbeStats.percentile(.nan, of: sorted) == 1)
+    }
+
+    /// The claim the review made about the two copies and could not check: `FrameProbe` clamped
+    /// the index and then read it, `ScrollProbe` read it and then clamped. They agree, on every
+    /// length from one to fifty and on the four fractions the reports actually ask for, and that
+    /// is now something the suite says rather than something a reader works out.
+    @Test("both spellings the probes used agree with this one")
+    func theTwoOldSpellingsAgree() {
+        for count in 1...50 {
+            let sorted = (0..<count).map(Double.init)
+            for fraction in [0.5, 0.95, 0.99, 1.0] {
+                let clampedThenRead = sorted[
+                    min(sorted.count - 1, max(0, Int((Double(sorted.count - 1) * fraction).rounded())))
+                ]
+                let readThenClamped = sorted[
+                    min(max(Int((Double(sorted.count - 1) * fraction).rounded()), 0), sorted.count - 1)
+                ]
+                let now = ProbeStats.percentile(fraction, of: sorted)
+                #expect(now == clampedThenRead)
+                #expect(now == readThenClamped)
+            }
+        }
+    }
+
+    /// And the third spelling. `IdleProbe` took its median as `sorted[count / 2]`, which is a
+    /// different formula and the same answer: the two disagree on no length, because rounding
+    /// half away from zero at the halfway mark is what integer division does going up.
+    @Test("the median by halving the count is the same number")
+    func theHalvedMedianAgrees() {
+        for count in 1...50 {
+            let sorted = (0..<count).map(Double.init)
+            #expect(ProbeStats.percentile(0.5, of: sorted) == sorted[sorted.count / 2])
+        }
+    }
+
+    @Test("a window size is WxH and nothing else")
+    func windowSize() {
+        #expect(ProbeStats.windowSize("1440x900") == CGSize(width: 1440, height: 900))
+        #expect(ProbeStats.windowSize("1440.5x900.25") == CGSize(width: 1440.5, height: 900.25))
+        #expect(ProbeStats.windowSize("1440") == nil)
+        #expect(ProbeStats.windowSize("1440x") == nil)
+        #expect(ProbeStats.windowSize("axb") == nil)
+        #expect(ProbeStats.windowSize("1440x900x600") == nil)
+        // A zero is refused rather than applied, because a window cannot be measured at nought
+        // and a run that tried would report frame times for nothing at all.
+        #expect(ProbeStats.windowSize("0x900") == nil)
+        #expect(ProbeStats.windowSize("1440x0") == nil)
+    }
+}


### PR DESCRIPTION
The six window probes are one harness written six times: `value(for:)` in seven copies byte for byte, the `WxH` parse in five, the window wait loop in four, `systemLoadAverage` and `buildConfiguration` in three each, `fail` six times in two signatures.

It had drifted where it mattered. Three of the six checked a report with `JSONSerialization.isValidJSONObject` before writing it, because a `WorkspaceID` in a `[String: Any]` once killed a twenty minute run on its last line. Three never learned it.

`ProbeHarness` holds the flags, the window and its wait, `--window-size`, one `Never`-returning `fail`, the mouse event thread, the load average, the build configuration, the main thread CPU clock, the `.started` marker and the report. A report is a `JSONValue`, so that bug is a compile error now and the runtime guard is gone. Every report is sorted, carries the build and the load average, and a failed run leaves a report saying so rather than the previous run's file.

`ProbeStats` (percentile, `WxH`) is in the core with tests, because the three spellings of a percentile agreed and nothing said so.

Not shared: each probe's driver and subject, and the arguments in their heads. `FrameProbe` keeps both its drivers and the reason each exists.

This one converts `FrameProbe` and `ScrollProbe`. The other four follow in #60.

Measured before and after, release build, three runs each, 1440x900 against a 1,104 row conversation:

| | before | after |
|---|---|---|
| sidebar drag, ms a frame | 9.99, 10.11 | 10.00, 10.13 |
| sidebar drag, main thread CPU per step | 5.93, 5.93 | 5.91, 6.01 |
| window edge, main thread busy | 0.961, 0.961 | 0.963, 0.962 |
| scroll, ms a frame | 8.336, 8.337 | 8.337, 8.336 |
| scroll, frames dropped | 15.9%, 15.7% | 15.6%, 15.5% |
