### PR TITLE
Stop a turn Bloom never started from ending the one it did

### DIFF
--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -601,12 +601,11 @@ final class TranscriptModel {
 
     /// The one place a turn starts, reached only from `drain`.
     private func deliver(_ delivery: Delivery) async {
-        guard let store else { return }
-        // A `return` used to stand here, and the sentence went nowhere: `drain` has already
+        // A bare `return` used to stand here, and the sentence went nowhere: `drain` has already
         // retired this delivery from the queue and drawn it as sent, so a quiet return leaves a
-        // bubble claiming to have been said to an agent that was never built. It needs the
-        // database open, so it is close to impossible, and a message of the owner's disappearing
-        // without a word is not a thing to leave resting on that.
+        // bubble claiming to have been said to an agent that was never built. It takes a database
+        // that never opened, so it is close to impossible, and a message of the owner's
+        // disappearing without a word is not a thing to leave resting on that.
         guard let runner = ensureRunner() else {
             await abandon(delivery, saying: "Bloom could not open an agent for this chat.")
             return
@@ -653,20 +652,24 @@ final class TranscriptModel {
     /// lost its place in the order. An unsent prompt is often minutes of thought and this app
     /// holds the only copy of it; it stays where it can be read, cancelled and sent again.
     private func abandon(_ delivery: Delivery, saying complaint: String) async {
-        guard let store else { return }
-
         // Nothing was said after all, so the bubble that said it was going stops claiming so.
         sending = nil
-        try? await store.restoreDelivery(id: delivery.id)
-        await refreshQueue()
 
         Log.composer.error(
             "the agent would not start, so the prompt stayed in the queue: \(complaint, privacy: .public)"
         )
 
-        let row = AgentError.notStarted(message: complaint)
-        _ = try? await store.appendNext(sessionID: session.id, kind: .error, payload: row.raw)
-        await appendLatestMessages()
+        // Everything durable needs the database, and one of the two ways in here is the database
+        // never having opened. The alert below is outside this on purpose: it is the half that
+        // still works when there is nowhere to write, and the half nobody can be left without.
+        if let store {
+            try? await store.restoreDelivery(id: delivery.id)
+            await refreshQueue()
+
+            let row = AgentError.notStarted(message: complaint)
+            _ = try? await store.appendNext(sessionID: session.id, kind: .error, payload: row.raw)
+            await appendLatestMessages()
+        }
 
         app.alert = BloomAlert(title: "Could not start the agent", message: complaint)
     }

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -601,7 +601,16 @@ final class TranscriptModel {
 
     /// The one place a turn starts, reached only from `drain`.
     private func deliver(_ delivery: Delivery) async {
-        guard let store, let runner = ensureRunner() else { return }
+        guard let store else { return }
+        // A `return` used to stand here, and the sentence went nowhere: `drain` has already
+        // retired this delivery from the queue and drawn it as sent, so a quiet return leaves a
+        // bubble claiming to have been said to an agent that was never built. It needs the
+        // database open, so it is close to impossible, and a message of the owner's disappearing
+        // without a word is not a thing to leave resting on that.
+        guard let runner = ensureRunner() else {
+            await abandon(delivery, saying: "Bloom could not open an agent for this chat.")
+            return
+        }
         turnStartedAt = Date()
         wasStoppedByHand = false
         // **The clearing rule.** The last turn's subagents go here, at the one place a turn
@@ -625,23 +634,41 @@ final class TranscriptModel {
         } catch {
             setRunning(false)
             statusLabel = nil
-            // Nothing was said after all, so the bubble that said it was going stops claiming so.
-            // The restore below puts it back in the queue, where it is drawn as pending again.
-            sending = nil
-            // Nothing was said, so the delivery goes back to being pending rather than reading as
-            // sent. It used to go back into the composer, which was right when the composer was
-            // the only place an unsent prompt could live and is wrong now that there is a queue:
-            // a failed start with three messages behind it would have pasted one of them over the
-            // top of whatever the user was typing, and lost its place in the order. An unsent
-            // prompt is often minutes of thought and this app holds the only copy of it; it stays
-            // where it can be read, edited by cancelling it, and sent again.
-            try? await store.restoreDelivery(id: delivery.id)
-            await refreshQueue()
-            Log.composer.error(
-                "the agent would not start, so the prompt stayed in the queue: \(error.readableMessage, privacy: .public)"
-            )
-            app.alert = BloomAlert(title: "Could not start the agent", message: error.readableMessage)
+            await abandon(delivery, saying: error.readableMessage)
         }
+    }
+
+    /// A turn that could not start, said out loud and put back in the queue.
+    ///
+    /// **The row is the part that was missing, and silence is what this bug cost.** An alert says
+    /// it once, to whoever is looking at that moment, and then it is gone; the transcript is where
+    /// somebody goes a minute later to work out what happened, and it held nothing at all. So the
+    /// account of it goes in as an `.error` row, drawn by `AgentErrorRowView` beside every other
+    /// way a turn can fail, and the alert stays for the person who is watching now.
+    ///
+    /// The delivery goes back to being pending rather than reading as sent. It used to go back
+    /// into the composer, which was right when the composer was the only place an unsent prompt
+    /// could live and is wrong now that there is a queue: a failed start with three messages
+    /// behind it would have pasted one of them over the top of whatever the user was typing, and
+    /// lost its place in the order. An unsent prompt is often minutes of thought and this app
+    /// holds the only copy of it; it stays where it can be read, cancelled and sent again.
+    private func abandon(_ delivery: Delivery, saying complaint: String) async {
+        guard let store else { return }
+
+        // Nothing was said after all, so the bubble that said it was going stops claiming so.
+        sending = nil
+        try? await store.restoreDelivery(id: delivery.id)
+        await refreshQueue()
+
+        Log.composer.error(
+            "the agent would not start, so the prompt stayed in the queue: \(complaint, privacy: .public)"
+        )
+
+        let row = AgentError.notStarted(message: complaint)
+        _ = try? await store.appendNext(sessionID: session.id, kind: .error, payload: row.raw)
+        await appendLatestMessages()
+
+        app.alert = BloomAlert(title: "Could not start the agent", message: complaint)
     }
 
     func saveDraft() async {

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -1326,14 +1326,18 @@ final class WorkspaceModel {
     /// it down exactly the path the composer uses, which is also why the request appears in the
     /// transcript and streams back like anything else the user typed.
     ///
+    /// **A press lands whatever the chat is doing**, and this is where all four of the strip's
+    /// buttons state that. Each of them used to open with `guard !isRunning else { return "…is
+    /// still working. Wait for the turn to finish, then ask again." }`, written when the composer
+    /// was the only way into a chat and a second message really would have interleaved with the
+    /// first. There is a queue now. Everything a person types goes into it and waits its turn, so
+    /// a button that refuses is the one route into a conversation that behaves differently from
+    /// every other, and what it produced was a press that looked like it had done nothing. The
+    /// request joins the queue like a typed message, is drawn as a pending bubble that says when
+    /// it goes, and can be cancelled there. See `Delivery` and `DeliveryHold`.
+    ///
     /// Returns nil on success, or the sentence to put in front of the user.
     func requestPullRequest(overrides: PromptOverrides = PromptOverrides()) async -> String? {
-        // One agent, one turn. Sending into a running turn would interleave with whatever the user
-        // asked for a moment ago, and the runner writes both into the same transcript.
-        guard !isRunning else {
-            return "\(workspace.name) is still working. Wait for the turn to finish, then ask again."
-        }
-
         let template = overrides.template(for: .createPullRequest)
         let wanted = Set(PromptTemplate.variableNames(in: template))
 
@@ -1374,16 +1378,12 @@ final class WorkspaceModel {
     /// agent knows what it changed, how this project words a commit and what to do when the push
     /// is rejected. A message this app invented would be in the repository's history forever.
     ///
-    /// The same guard and the same route as `requestPullRequest`, so both buttons in the strip
-    /// behave identically: one agent, one turn, and the session comes forward so the reader is
-    /// looking at the answer to the button they pressed.
+    /// The same route as `requestPullRequest`, so both buttons in the strip behave identically:
+    /// the request joins the chat's queue whatever the chat is doing, and the session comes
+    /// forward so the reader is looking at the answer to the button they pressed.
     ///
     /// Returns nil on success, or the sentence to put in front of the user.
     func requestPush(overrides: PromptOverrides = PromptOverrides()) async -> String? {
-        guard !isRunning else {
-            return "\(workspace.name) is still working. Wait for the turn to finish, then ask again."
-        }
-
         let template = overrides.template(for: .pushLocalWork)
         let wanted = Set(PromptTemplate.variableNames(in: template))
 
@@ -1423,8 +1423,8 @@ final class WorkspaceModel {
     /// It also puts the merge behind the permission mode the person already chose. A button
     /// running `gh pr merge` is outside all of that by construction; a turn is not.
     ///
-    /// The same guard and the same route as `requestPullRequest` and `requestPush`, so all three
-    /// buttons in the strip behave identically.
+    /// The same route as `requestPullRequest` and `requestPush`, so all three buttons in the
+    /// strip behave identically, queue included.
     ///
     /// Returns nil on success, or the sentence to put in front of the user.
     func requestMerge(
@@ -1432,11 +1432,6 @@ final class WorkspaceModel {
         method: GitHub.MergeMethod,
         overrides: PromptOverrides = PromptOverrides()
     ) async -> String? {
-        guard !isRunning else {
-            return "\(workspace.name) is still working. Wait for the turn to finish, then press "
-                + "Merge again."
-        }
-
         guard let session = await sessionForPullRequest(titledIfNew: "Merge") else {
             return "Could not open a session in \(workspace.name) to send the request to."
         }
@@ -1478,7 +1473,7 @@ final class WorkspaceModel {
     /// already said the branch does not apply to its base, so the only thing that press could
     /// produce was the agent running `gh pr merge` and reading the refusal back out.
     ///
-    /// The same guard and the same route as the other three buttons in the strip, with two
+    /// The same route as the other three buttons in the strip, with two
     /// differences that are both about what this turn does NOT do. There is no instructions file,
     /// because nothing here acts on a server and the project's conventions for resolving a
     /// conflict are already in front of the agent; and there is no confirmation in front of it,
@@ -1489,11 +1484,6 @@ final class WorkspaceModel {
         _ pullRequest: PullRequest,
         overrides: PromptOverrides = PromptOverrides()
     ) async -> String? {
-        guard !isRunning else {
-            return "\(workspace.name) is still working. Wait for the turn to finish, then press "
-                + "Fix merge conflicts again."
-        }
-
         guard let session = await sessionForPullRequest(titledIfNew: "Fix merge conflicts") else {
             return "Could not open a session in \(workspace.name) to send the request to."
         }

--- a/Sources/Bloom/Views/Inspector/PullRequestCreator.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestCreator.swift
@@ -182,9 +182,9 @@ struct PullRequestCreator: View {
             .buttonStyle(.borderedProminent)
             .tint(Palette.accentFill)
             .controlSize(.regular)
-            // Only for a turn that is already running, which ends on its own. A branch with
-            // nothing on it does not draw this button at all: see `body`.
-            .disabled(isAgentBusy)
+            // Never disabled for a turn that is already running: the request queues behind it.
+            // See `PullRequestStatus.agentBusyReason`. A branch with nothing on it does not draw
+            // this button at all: see `body`.
             .help(helpText)
     }
 

--- a/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
@@ -26,10 +26,11 @@ struct PullRequestSummary: View {
     /// still running, which is not the same as "nothing", and is drawn as nothing extra.
     var localWork: LocalWork?
     var isWorking: Bool
-    /// The workspace's agent is mid turn. Every button in this strip works by composing a turn and
-    /// sending it, and an agent runs one turn at a time, so none of them can do anything until
-    /// this one is over. `PullRequestCreator` takes the same fact for the same reason, and both
-    /// say it in the same words: `PullRequestStatus.agentBusyReason`.
+    /// The workspace's agent is mid turn. Every button in this strip works by composing a turn
+    /// and sending it, and an agent runs one turn at a time, so a press made now joins the chat's
+    /// queue and goes when this turn ends. That is what the buttons say while it is true;
+    /// `PullRequestCreator` takes the same fact for the same reason, and both say it in the same
+    /// words: `PullRequestStatus.agentBusyReason`.
     var isAgentBusy: Bool
     var onMerge: (GitHub.MergeMethod) -> Void
     /// Hands the outstanding work to the workspace's agent to commit and push.
@@ -372,7 +373,7 @@ struct PullRequestSummary: View {
             .buttonStyle(.borderedProminent)
             .tint(status.tone.fill)
             .controlSize(.regular)
-            .disabled(isAgentBusy)
+            // Not disabled mid turn. See `PullRequestStatus.agentBusyReason`.
             .help(
                 isAgentBusy
                     ? PullRequestStatus.agentBusyReason
@@ -432,7 +433,7 @@ struct PullRequestSummary: View {
             .buttonStyle(.borderedProminent)
             .tint(status.tone.fill)
             .controlSize(.regular)
-            .disabled(isAgentBusy)
+            // Not disabled mid turn. See `PullRequestStatus.agentBusyReason`.
             .help(
                 isAgentBusy
                     ? PullRequestStatus.agentBusyReason
@@ -492,7 +493,9 @@ struct PullRequestSummary: View {
             .buttonStyle(.borderedProminent)
             .tint(status.tone.fill)
             .controlSize(.regular)
-            .disabled(!status.canMerge || isAgentBusy)
+            // A busy agent is not in here any more, only a pull request GitHub will not merge.
+            // See `PullRequestStatus.agentBusyReason`.
+            .disabled(!status.canMerge)
             // Disabled controls do not explain themselves, and "why is this greyed out" is the
             // whole question a blocked pull request raises.
             .help(blockedReason ?? "Squash and merge, or choose another method")
@@ -500,11 +503,11 @@ struct PullRequestSummary: View {
 
     // MARK: - Text
 
-    /// Why nothing here can be pressed, or nil when something can.
+    /// What the Merge button has to say for itself, or nil when there is nothing.
     ///
     /// The busy turn comes first. It is true of every button in this strip rather than of one of
-    /// them, and it is the reason that goes away on its own, so a reader who hovers a grey button
-    /// while their agent is working is told to wait rather than told about a draft.
+    /// them, and it is the reason that goes away on its own, so a reader hovering while their
+    /// agent is working is told where their press will land rather than told about a draft.
     private var blockedReason: String? {
         isAgentBusy ? PullRequestStatus.agentBusyReason : status.blockedReason
     }

--- a/Sources/BloomCore/Agent/AgentEvent.swift
+++ b/Sources/BloomCore/Agent/AgentEvent.swift
@@ -376,6 +376,11 @@ public struct AgentResult: Sendable, Hashable {
     public let permissionDenials: Int
     public let uuid: String?
     public let sessionID: String?
+    /// `origin.kind`, and empty when the line named none.
+    ///
+    /// Which is every result an owner's prompt has produced: the CLI states an origin only for a
+    /// turn it started for a reason of its own. See `StrayResult`, which is the one reader.
+    public let origin: String
 
     public init(
         usage: AgentUsage = .zero,
@@ -390,7 +395,8 @@ public struct AgentResult: Sendable, Hashable {
         terminalReason: String? = nil,
         permissionDenials: Int = 0,
         uuid: String? = nil,
-        sessionID: String? = nil
+        sessionID: String? = nil,
+        origin: String = ""
     ) {
         self.usage = usage
         self.summary = summary
@@ -405,6 +411,7 @@ public struct AgentResult: Sendable, Hashable {
         self.permissionDenials = permissionDenials
         self.uuid = uuid
         self.sessionID = sessionID
+        self.origin = origin
     }
 
     public var succeeded: Bool { !isError && subtype == "success" }
@@ -437,6 +444,28 @@ extension AgentError {
         }
         let payload = (try? JSONEncoder().encode(StorageFailure(message: message)))
             ?? Data(#"{"type":"error","subtype":"storage"}"#.utf8)
+        return AgentError(message: message, raw: payload)
+    }
+
+    /// The `.error` row Bloom writes when a turn never reached a process at all.
+    ///
+    /// **Silence is the worst thing this app can do to a prompt.** A message that was queued,
+    /// retired from the queue and then handed to nothing left the transcript showing a sentence
+    /// that had apparently been sent, with nothing behind it and nothing to read. The alert that
+    /// went up said so once and was gone; the transcript, which is where somebody looks a minute
+    /// later to work out what happened, said nothing at all.
+    ///
+    /// So the account of it is a row, in the transcript, in the same place every other failure of
+    /// a turn is drawn. `AgentExit` reads this subtype back and carries the words. Nothing was
+    /// launched here, so there is no exit status and no stderr to put in it.
+    public static func notStarted(message: String) -> AgentError {
+        struct StartFailure: Encodable {
+            let type = "error"
+            let subtype = "notStarted"
+            let message: String
+        }
+        let payload = (try? JSONEncoder().encode(StartFailure(message: message)))
+            ?? Data(#"{"type":"error","subtype":"notStarted"}"#.utf8)
         return AgentError(message: message, raw: payload)
     }
 }
@@ -884,7 +913,8 @@ public enum AgentEvent: Sendable {
             terminalReason: json["terminal_reason"]?.stringValue,
             permissionDenials: json["permission_denials"]?.arrayValue?.count ?? 0,
             uuid: json["uuid"]?.stringValue,
-            sessionID: json["session_id"]?.stringValue
+            sessionID: json["session_id"]?.stringValue,
+            origin: json["origin"]?["kind"]?.stringValue ?? ""
         ))
     }
 }

--- a/Sources/BloomCore/Agent/AgentExit.swift
+++ b/Sources/BloomCore/Agent/AgentExit.swift
@@ -19,6 +19,9 @@ public enum AgentExitCause: Sendable, Hashable {
     case silent
     /// Bloom could not write the row. The agent is not what failed.
     case storage(String)
+    /// The turn never reached a process. Nothing was launched and nothing was said to the agent,
+    /// so there is no exit status and no output: the string is Bloom's own account of why.
+    case notStarted(String)
 }
 
 /// What an `.error` row says, in words a person can act on.
@@ -57,6 +60,7 @@ public struct AgentExit: Sendable, Hashable {
     /// The label in the row's first column.
     public var title: String {
         if case .storage = cause { return "Not saved" }
+        if case .notStarted = cause { return "Not sent" }
         return status.map { "Agent exited (\($0))" } ?? "Agent error"
     }
 
@@ -72,6 +76,8 @@ public struct AgentExit: Sendable, Hashable {
         case .silent:
             "It stopped without printing anything."
         case .storage(let message):
+            Self.oneLine(message)
+        case .notStarted(let message):
             Self.oneLine(message)
         }
     }
@@ -108,6 +114,12 @@ public struct AgentExit: Sendable, Hashable {
             """
             The agent itself kept running. It is Bloom's copy of the conversation that is missing \
             a row, so check that the disk is not full, then reopen the workspace.
+            """
+        case .notStarted:
+            """
+            Nothing was said to the agent and nothing in this worktree was touched. Your message \
+            is back in the queue above the composer, so it goes with your next one, and you can \
+            cancel it there if you would rather send something else.
             """
         }
     }
@@ -147,6 +159,15 @@ public struct AgentExit: Sendable, Hashable {
         if json?["subtype"]?.stringValue == "storage" {
             let message = json?["message"]?.stringValue ?? ""
             let cause: AgentExitCause = message.isEmpty ? .silent : .storage(message)
+            return AgentExit(status: status, cause: cause, detail: message)
+        }
+
+        // Same bargain as storage above, and for the same reason: a turn that never started
+        // carries a sentence of Bloom's and no stderr, so reading it as a process exit would draw
+        // an empty row about a process that was never launched.
+        if json?["subtype"]?.stringValue == "notStarted" {
+            let message = json?["message"]?.stringValue ?? ""
+            let cause: AgentExitCause = message.isEmpty ? .silent : .notStarted(message)
             return AgentExit(status: status, cause: cause, detail: message)
         }
 

--- a/Sources/BloomCore/Agent/AgentRunner.swift
+++ b/Sources/BloomCore/Agent/AgentRunner.swift
@@ -449,7 +449,10 @@ public actor AgentRunner {
         do {
             for try await line in lines {
                 guard let event = AgentEvent.decode(line: line) else { continue }
-                if case .result = event { sawResult = true }
+                // A stray result does not count as the turn having reported itself. Letting it
+                // would mean a process that printed one and then died on a non-zero status
+                // exited without `finish` ever drawing the error row that says so.
+                if case .result(let result) = event, !StrayResult.isStray(result) { sawResult = true }
                 await ingest(event)
             }
         } catch {
@@ -472,6 +475,18 @@ public actor AgentRunner {
     /// Persist one event, apply whatever it says about the session, then hand it to the UI.
     /// Internal rather than private so tests can exercise persistence without a process.
     func ingest(_ event: AgentEvent) async {
+        // A result for a turn Bloom never asked for closes nothing, and it is dropped here rather
+        // than further down because every reader of a result treats one as a turn boundary: the
+        // footer, the token counts, `SessionLifecycle`, and the drain that starts the next queued
+        // message. The line is still written, as a `system` row, so the record of what the CLI
+        // said stays whole and nothing in the transcript draws a turn that never happened. See
+        // `StrayResult` for the tenth of a second this cost.
+        if case .result(let result) = event, StrayResult.isStray(result) {
+            Self.log.info("ignored a result for a turn Bloom did not start: \(result.origin, privacy: .public)")
+            await persist(kind: .system, payload: event.raw)
+            return
+        }
+
         if event.isTranscriptRow || persistsStreamDeltas {
             var durationMS: Int?
             if case .result(let result) = event { durationMS = result.durationMS }

--- a/Sources/BloomCore/Agent/StrayResult.swift
+++ b/Sources/BloomCore/Agent/StrayResult.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// A `result` line that closes a turn nobody in Bloom asked for.
+///
+/// **The bug: a turn that started and ended in a tenth of a second having done nothing.** The
+/// owner pressed Commit and push. The transcript drew his prompt, then "Session started", then
+/// "0,1s", and after that no tool call, no prose and no error. He pressed the button again. The
+/// second press landed in a turn that was, by then, genuinely working, so his prompt was injected
+/// into the middle of a turn: the one thing the delivery queue exists to prevent.
+///
+/// His database holds the whole explanation. One process launch, and then two `init` lines five
+/// milliseconds apart with a `result` wedged between them:
+///
+///     {"type":"system","subtype":"init",...}
+///     {"type":"result","subtype":"success","num_turns":0,"duration_api_ms":0,"result":"",
+///      "origin":{"kind":"task-notification"},"duration_ms":60,...}
+///     {"type":"system","subtype":"init",...}
+///
+/// The CLI had a background task notification waiting for it from hours earlier. `--resume`
+/// brought the session back, the CLI ran that notification as a turn of its own before it read
+/// anything from stdin, decided there was nothing to do, and said so in sixty milliseconds. Then
+/// it started the owner's turn, which is the second `init`.
+///
+/// Bloom read that `result` because every `result` used to end whatever turn was open. It wrote
+/// the footer, put sixty milliseconds under it, cleared `isRunning`, told the sidebar the
+/// workspace was idle and drained the queue, all while the owner's turn was still starting. The
+/// same pair of lines is in the database twice, from two different workspaces on the same day, so
+/// it is a shape rather than a one-off.
+///
+/// Here rather than in the runner because it is a decision about whose turn a line belongs to,
+/// and the test target cannot see a view or launch a CLI.
+public enum StrayResult {
+    /// Whether this line closes a turn Bloom never started.
+    ///
+    /// **Two facts have to agree, and needing both is the point.** The origin is the CLI saying
+    /// where the turn came from, and every result an owner's prompt has ever produced in this
+    /// database names none at all, so a stated origin is somebody else's turn by construction.
+    /// Testing for the absence rather than for the literal `task-notification` is what keeps this
+    /// working when the CLI invents a second kind, or renames this one.
+    ///
+    /// The emptiness is the net under that reading. No turn Bloom sent comes back with no API
+    /// time, no iterations, nothing said and no error, so nothing this ignores was ever an answer
+    /// to a prompt. Ignoring a real result would leave the composer reading "Working" until the
+    /// process exited, and trading this bug for that one is not a fix.
+    public static func isStray(_ result: AgentResult) -> Bool {
+        !result.origin.isEmpty && didNothing(result)
+    }
+
+    /// A turn that reached no model, ran no tool, said nothing and did not fail.
+    private static func didNothing(_ result: AgentResult) -> Bool {
+        !result.isError
+            && result.numTurns == 0
+            && result.durationAPIMS == 0
+            && result.summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}

--- a/Sources/BloomCore/GitHub/PullRequestStatus.swift
+++ b/Sources/BloomCore/GitHub/PullRequestStatus.swift
@@ -60,14 +60,21 @@ public struct PullRequestStatus: Sendable, Hashable {
         case fixConflicts
     }
 
-    /// Why the strip's buttons are dead while the workspace's agent is mid turn.
+    /// What the strip's buttons say about themselves while the workspace's agent is mid turn.
     ///
     /// Here rather than in the two views that say it, because it is one fact about how every one
     /// of these buttons works: none of them does anything itself, they all compose a turn, and an
     /// agent runs one turn at a time. `PullRequestCreator` and `PullRequestSummary` both show it,
     /// and a sentence written out twice is a sentence that gets improved once.
+    ///
+    /// **They used to be dead while it said this, and are not any more.** A disabled button and a
+    /// press that quietly refused were two ways of saying the same thing, and both of them left
+    /// somebody pressing again to find out whether the first press had counted. The turn goes into
+    /// the chat's queue instead, drawn above the composer as a pending message that says when it
+    /// goes and can be cancelled there. See `WorkspaceModel.requestPullRequest`.
     public static let agentBusyReason =
-        "The agent is working. The request is sent as a turn, so it has to wait for this one."
+        "The agent is working. The request is sent as a turn, so it waits in the queue for this "
+            + "one to finish."
 
     public init(
         tone: Tone,

--- a/Tests/BloomCoreTests/AgentExitTests.swift
+++ b/Tests/BloomCoreTests/AgentExitTests.swift
@@ -258,6 +258,7 @@ struct AgentExitTests {
             .reported("Error: x"),
             .silent,
             .storage("storing an event: disk full"),
+            .notStarted("Bloom could not open an agent for this chat."),
         ]
 
         for cause in causes {

--- a/Tests/BloomCoreTests/AgentRunnerTests.swift
+++ b/Tests/BloomCoreTests/AgentRunnerTests.swift
@@ -575,6 +575,55 @@ struct AgentRunnerPersistenceTests {
         #expect(try await store.session(id: session.id)?.state == .failed)
     }
 
+    @Test("a result for a turn Bloom never started closes nothing")
+    func ignoresAStrayResult() async throws {
+        let store = try makeTestStore("agent")
+        let session = try await makeSession(store)
+        // Mid turn, because that is the whole of the bug: the owner's prompt had just gone and the
+        // CLI answered a background task notification of its own before it read it.
+        let runner = AgentRunner(
+            workspacePath: "/tmp/w", session: session.with { $0.apply(.turnStarted) }, store: store
+        )
+
+        let line = #"""
+        {"type":"result","subtype":"success","is_error":false,"duration_api_ms":0,"num_turns":0,\
+        "session_id":"s1","total_cost_usd":0,"result":"","origin":{"kind":"task-notification"},\
+        "duration_ms":60,"uuid":"u"}
+        """#.replacingOccurrences(of: "\\\n", with: "")
+        await runner.ingest(try #require(AgentEvent.decode(line: line)))
+
+        // Still running, so the transcript does not draw a footer, the sidebar does not call the
+        // workspace idle, and the queue does not hand the next message to a turn already in flight.
+        #expect(await runner.currentSession.state == .running)
+
+        // The line is kept, because the record of what the CLI said stays whole. As a system row,
+        // which nothing renders as a turn: a `.result` row is a turn boundary by definition.
+        let stored = try await store.messages(sessionID: session.id)
+        #expect(stored.map(\.kind) == [.system])
+        #expect(stored.first?.durationMS == nil)
+    }
+
+    @Test("the real result behind a stray one still ends the turn")
+    func stillEndsOnTheRealResult() async throws {
+        let store = try makeTestStore("agent")
+        let session = try await makeSession(store)
+        let runner = AgentRunner(
+            workspacePath: "/tmp/w", session: session.with { $0.apply(.turnStarted) }, store: store
+        )
+
+        let stray = #"""
+        {"type":"result","subtype":"success","is_error":false,"duration_api_ms":0,"num_turns":0,\
+        "result":"","origin":{"kind":"task-notification"},"duration_ms":60,"uuid":"u1"}
+        """#.replacingOccurrences(of: "\\\n", with: "")
+        await runner.ingest(try #require(AgentEvent.decode(line: stray)))
+
+        let real = try #require(try fixtureSessionLines().last { $0.contains("\"type\":\"result\"") })
+        await runner.ingest(try #require(AgentEvent.decode(line: real)))
+
+        #expect(try await store.session(id: session.id)?.state == .idle)
+        #expect(try await store.messages(sessionID: session.id).map(\.kind) == [.system, .result])
+    }
+
     @Test("continues the sequence of an already stored transcript")
     func continuesSeq() async throws {
         let store = try makeTestStore("agent")

--- a/Tests/BloomCoreTests/StrayResultTests.swift
+++ b/Tests/BloomCoreTests/StrayResultTests.swift
@@ -1,0 +1,65 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+/// The 0.1 second turn, written down. See `StrayResult` for the database rows this came from.
+@Suite("Stray results", .tags(.agentProtocol))
+struct StrayResultTests {
+    /// The line the CLI actually printed, between the two `init`s, on the press that did nothing.
+    /// Trimmed of the accounting that has no bearing on the decision, and otherwise as measured.
+    private static let asMeasured = #"""
+    {"type":"result","subtype":"success","is_error":false,"duration_api_ms":0,"num_turns":0,\
+    "stop_reason":null,"session_id":"b5261ad0","total_cost_usd":0,"result":"",\
+    "origin":{"kind":"task-notification"},"duration_ms":60,"uuid":"db9d3351"}
+    """#.replacingOccurrences(of: "\\\n", with: "")
+
+    private func result(in line: String) -> AgentResult? {
+        guard case .result(let result)? = AgentEvent.decode(line: line) else { return nil }
+        return result
+    }
+
+    @Test("the origin the CLI names is read off the line")
+    func readsOrigin() throws {
+        #expect(try #require(result(in: Self.asMeasured)).origin == "task-notification")
+    }
+
+    @Test("the turn that ended in a tenth of a second closes nothing")
+    func theBug() throws {
+        #expect(StrayResult.isStray(try #require(result(in: Self.asMeasured))))
+    }
+
+    @Test("a result naming no origin is the owner's, whatever else it says")
+    func unstatedIsOwners() {
+        // The empty turn's own shape, with only the origin taken off. Every result an owner's
+        // prompt has produced in the real database names none, so this must stay the owner's or
+        // the composer locks on a turn nothing will ever close.
+        #expect(!StrayResult.isStray(AgentResult(numTurns: 0, durationAPIMS: 0)))
+    }
+
+    @Test("an origin on a turn that did real work is still the owner's")
+    func workIsNeverStray() {
+        #expect(!StrayResult.isStray(
+            AgentResult(summary: "Pushed.", numTurns: 3, durationAPIMS: 4_200, origin: "whatever")
+        ))
+        // One iteration is work, even with nothing said and no API time recorded.
+        #expect(!StrayResult.isStray(AgentResult(numTurns: 1, origin: "whatever")))
+        // So is a sentence, even with no iterations counted.
+        #expect(!StrayResult.isStray(AgentResult(summary: "Nothing to commit.", origin: "whatever")))
+    }
+
+    @Test("a failure is never stray, however empty it is")
+    func failuresAreNeverStray() {
+        #expect(!StrayResult.isStray(
+            AgentResult(isError: true, subtype: "error_during_execution", origin: "whatever")
+        ))
+    }
+
+    @Test("a kind nobody has seen yet is caught by the same rule")
+    func anyStatedOrigin() {
+        // Deliberately not a test for the literal `task-notification`. What makes this somebody
+        // else's turn is that the CLI named an origin at all, so a renamed kind, or a second one,
+        // does not bring the bug back.
+        #expect(StrayResult.isStray(AgentResult(origin: "hook")))
+        #expect(StrayResult.isStray(AgentResult(origin: "task-notification")))
+    }
+}

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -157,6 +157,20 @@ Last line of a turn.
 `modelUsage.<model>.contextWindow` is where the context-window size comes from, so a
 "how full is the context" gauge can be drawn.
 
+**It is the last line of a turn, and not always of the turn you sent.** The CLI starts turns of
+its own, and when it does the result carries an `origin` object naming why:
+
+```json
+{"type":"result","subtype":"success","is_error":false,"duration_ms":60,
+ "duration_api_ms":0,"num_turns":0,"result":"","origin":{"kind":"task-notification"},...}
+```
+
+Measured on 25 August 2026, twice, in two workspaces. Both times a `--resume` brought back a
+session that had a background task notification waiting for it, and the CLI ran that as a turn
+before it read anything from stdin: `init`, this line, then a second `init` for the turn the user
+had actually sent. A result answering a prompt names no origin at all. See `StrayResult`, which is
+the bug that cost.
+
 ### `rate_limit_event`
 
 One per turn, and it carries **one window**, never a set:


### PR DESCRIPTION
A press of Commit and push composed the prompt, opened a session, and the turn was over in a tenth of a second with nothing in it. The transcript rows say why.

One process launch, and then two `init` lines five milliseconds apart with a `result` between them:

```
{"type":"system","subtype":"init",...}
{"type":"result","subtype":"success","num_turns":0,"duration_api_ms":0,"result":"",
 "origin":{"kind":"task-notification"},"duration_ms":60,...}
{"type":"system","subtype":"init",...}
```

The CLI had a background task notification waiting from hours earlier, ran it as a turn of its own the moment `--resume` brought the session back, decided there was nothing to do, and said so. Bloom ended the owner's turn on it, because every `result` used to end whatever turn was open: footer drawn, 60ms under it, `isRunning` cleared, workspace called idle, queue drained. His turn was still starting. The second press then went into the middle of it. The same pair of lines is in the database twice, from two workspaces on the same day.

`StrayResult` reads the origin the CLI names. A result that names one and did nothing at all is filed as a `system` row and ignored, so the record stays whole and nothing draws a turn that never happened. Both facts have to agree: a stated origin rather than the literal `task-notification`, so a renamed kind does not bring it back, and the emptiness so a real answer can never be swallowed.

Two smaller things behind it. A turn that could not start now writes an error row instead of only raising an alert, including the path where the delivery had already left the queue and went nowhere at all. And the four buttons in the pull request strip queue rather than refusing while the agent is mid turn, which is what the composer has done since the queue existed.
