### PR TITLE
Make the window keep up: a transcript window, a file system watcher, and a coalesced live tail

### DIFF
--- a/Sources/Bloom/BloomApp.swift
+++ b/Sources/Bloom/BloomApp.swift
@@ -55,6 +55,12 @@ struct BloomApp: App {
         // complaint is about. See `ResizeProbe`.
         if ResizeProbe.isRequested { ResizeProbe.schedule() }
 
+        // And the one that measures the app being USED rather than a gesture somebody made to it:
+        // `Bloom --stream-probe <out.json>` types into the composer and then streams a turn into
+        // the transcript, and reports what each keystroke and each delta cost the window. See
+        // `StreamProbe`.
+        if StreamProbe.isRequested { StreamProbe.schedule() }
+
         // And the one that answers "the battery menu says Bloom is using significant energy":
         // `Bloom --idle-probe <out.json> --idle-worktrees <list>` runs the diff stat pass the six
         // second loop runs and reports what it cost in process time and in subprocesses. It is the

--- a/Sources/Bloom/Design/FrameProbe.swift
+++ b/Sources/Bloom/Design/FrameProbe.swift
@@ -369,6 +369,7 @@ enum FrameProbe {
             "gesture": .string(gesture),
             "pane": .string(requestedPane?.rawValue ?? "whatever was open"),
             "selection": .string(selection ?? "home"),
+            "drawnRows": .integer(TranscriptDrawn.rows),
             // What the window is ACTUALLY showing, rather than what was asked for. `AppModel`
             // reselects the last workspace on launch, so a run that meant to measure Home
             // silently measured a workspace as soon as any earlier run had opened one, and the

--- a/Sources/Bloom/Design/ProbeHarness.swift
+++ b/Sources/Bloom/Design/ProbeHarness.swift
@@ -191,6 +191,55 @@ struct ProbeHarness {
         }
     }
 
+    // MARK: - The transcript's scroll view
+
+    /// The transcript's scroll view, picked as the one with the most to scroll.
+    ///
+    /// By document height rather than by position or by class name. The window holds several
+    /// scroll views (the sidebar, the inspector's file list, the transcript, sometimes a diff),
+    /// and a private SwiftUI class name would be a guess a future release breaks silently. A
+    /// transcript with a few hundred messages in it is an order of magnitude taller than any of
+    /// the others.
+    ///
+    /// Here rather than in `ScrollProbe`, which is where it was written, because `SwitchProbe`
+    /// needs the same view to answer a different question: where a workspace switch left the
+    /// reader.
+    static func transcriptScrollView(in root: NSView) -> NSScrollView? {
+        var found: [NSScrollView] = []
+        func walk(_ view: NSView) {
+            if let scroll = view as? NSScrollView { found.append(scroll) }
+            for subview in view.subviews { walk(subview) }
+        }
+        walk(root)
+        return found.max { scrollableHeight(of: $0) < scrollableHeight(of: $1) }
+    }
+
+    static func scrollableHeight(of scroll: NSScrollView) -> CGFloat {
+        let document = scroll.documentView?.frame.height ?? 0
+        return max(0, document - scroll.contentView.bounds.height)
+    }
+
+    /// Where a transcript is standing, as a report says it.
+    ///
+    /// `atEnd` is the one that matters to a reader: "I was at the bottom, I went away, I came
+    /// back". A tolerance rather than an exact equality, because the live end of a list whose
+    /// last row has just been measured is a point or two away from the bottom of the content.
+    static func scrollPlace(_ scroll: NSScrollView?) -> [String: JSONValue] {
+        guard let scroll else { return ["found": .bool(false)] }
+        let offset = Double(scroll.contentView.bounds.origin.y)
+        let content = Double(scroll.documentView?.frame.height ?? 0)
+        let viewport = Double(scroll.contentView.bounds.height)
+        let reach = max(0, content - viewport - offset)
+        return [
+            "found": .bool(true),
+            "offset": .number(offset),
+            "contentHeight": .number(content),
+            "viewportHeight": .number(viewport),
+            "reachToEnd": .number(reach),
+            "atEnd": .bool(reach <= 4),
+        ]
+    }
+
     // MARK: - What a report says about the run
 
     /// Which build, how loaded the machine was, and what the window was.

--- a/Sources/Bloom/Design/ResizeProbe.swift
+++ b/Sources/Bloom/Design/ResizeProbe.swift
@@ -218,6 +218,7 @@ enum ResizeProbe {
             "arrangement": .string(arrangement),
             "workspace": .string(workspace.workspace.id.rawValue),
             "workspaceName": .string(workspace.workspace.name),
+            "drawnRows": .integer(TranscriptDrawn.rows),
             "sessionRows": .integer(workspace.activeTranscript?.rows.count ?? 0),
             // The three claims the timings below are worthless without. See the head of this file.
             "panes": .integer(panes),

--- a/Sources/Bloom/Design/ScrollProbe.swift
+++ b/Sources/Bloom/Design/ScrollProbe.swift
@@ -59,7 +59,7 @@ enum ScrollProbe {
             try? await Task.sleep(for: .seconds(8))
         }
 
-        guard let scroll = transcriptScrollView(in: contentView) else {
+        guard let scroll = ProbeHarness.transcriptScrollView(in: contentView) else {
             harness.fail("no transcript NSScrollView found")
         }
 
@@ -68,7 +68,7 @@ enum ScrollProbe {
         // is one whose rows are still being measured, and every one of those measurements lands
         // on the main thread inside a frame somebody is waiting for.
         let heightBefore = scroll.documentView?.frame.height ?? 0
-        let travel = scrollableHeight(scroll)
+        let travel = ProbeHarness.scrollableHeight(of: scroll)
         guard travel > 1 else {
             harness.fail("the transcript is shorter than its viewport, so there is nothing to scroll")
         }
@@ -98,32 +98,6 @@ enum ScrollProbe {
             heightBefore: heightBefore
         ))
         exit(0)
-    }
-
-    // MARK: - Finding the transcript
-
-    /// The transcript's scroll view, picked as the one with the most to scroll.
-    ///
-    /// By document height rather than by position or by class name. The window holds several
-    /// scroll views (the sidebar, the inspector's file list, the transcript, sometimes a diff),
-    /// and a private SwiftUI class name would be a guess a future release breaks silently. A
-    /// transcript with a few thousand messages in it is an order of magnitude taller than any of
-    /// the others, so "the tallest" is not a tie worth worrying about. A run against a workspace
-    /// with three messages in it would be measuring the wrong view, and would also be measuring
-    /// nothing, which is why an unscrollable answer is a failure rather than a zero.
-    private static func transcriptScrollView(in root: NSView) -> NSScrollView? {
-        var found: [NSScrollView] = []
-        func walk(_ view: NSView) {
-            if let scroll = view as? NSScrollView { found.append(scroll) }
-            for subview in view.subviews { walk(subview) }
-        }
-        walk(root)
-        return found.max { scrollableHeight($0) < scrollableHeight($1) }
-    }
-
-    private static func scrollableHeight(_ scroll: NSScrollView) -> CGFloat {
-        let document = scroll.documentView?.frame.height ?? 0
-        return max(0, document - scroll.contentView.bounds.height)
     }
 
     // MARK: - Driving

--- a/Sources/Bloom/Design/StreamProbe.swift
+++ b/Sources/Bloom/Design/StreamProbe.swift
@@ -1,0 +1,200 @@
+import AppKit
+import SwiftUI
+import QuartzCore
+import BloomCore
+
+/// Measures the two states Bloom actually spends its day in: somebody typing, and an agent
+/// writing.
+///
+/// The seventh of the family, and the first that does not measure a gesture. `FrameProbe`,
+/// `SwitchProbe`, `TabProbe`, `ScrollProbe` and `ResizeProbe` all drive something a hand does to a
+/// window and then let go; `IdleProbe` measures the app with nobody in it. **None of them measures
+/// the app being used**, and the two ways it is used all day are a prompt being written and a turn
+/// arriving. Both were argued about from the mechanism and neither had a number.
+///
+/// # What each half drives, and why it is driven this way
+///
+/// **Typing** goes through `NSTextView.insertText`, on the real composer, one character at a time.
+/// Not synthetic key events: the owner may be at this Mac, and a probe that posted keys would need
+/// the window in front and would take his keyboard. `TabProbe` makes the same trade and says so.
+/// What is lost is AppKit's own key handling, which is the same in every application; what is kept
+/// is the whole of what a keystroke costs this app, because `insertText` runs the delegate, the
+/// draft binding, the chip scan, the height report and every body they invalidate.
+///
+/// **Streaming** pushes real `AgentEvent.streamDelta` values into the transcript's own event
+/// handler, at a fixed rate. Not a real agent: `BLOOM_LIVE` costs money, a model's pace is not
+/// repeatable, and what is being measured is what Bloom does with a delta rather than how fast one
+/// arrives. Every delta travels the path a real one does, which is why `TranscriptModel` has one
+/// door for this and it is named after this file.
+///
+///     Bloom --stream-probe /tmp/stream.json --stream-workspace <id>
+///           [--stream-typed 120] [--stream-deltas 200] [--stream-chunk 14]
+///           [--stream-rate 25] [--window-size 1440x900]
+///
+/// `--stream-rate` is deltas per second, which is roughly what Claude Code emits at full tilt.
+/// `--stream-chunk` is characters per delta. The two together are the shape of a real turn; what
+/// the report says is what each one cost the window.
+///
+/// Everything that is not the typing and the streaming is `ProbeHarness`: the flags, the window,
+/// the model, the failure, the frame timings, the report.
+@MainActor
+enum StreamProbe {
+    private static let harness = ProbeHarness(subject: "stream")
+
+    static var isRequested: Bool { harness.isRequested }
+
+    // MARK: - Arguments
+
+    private static var workspaceID: WorkspaceID? {
+        ProbeHarness.value(for: "--stream-workspace").map(WorkspaceID.init)
+    }
+
+    private static var typed: Int { ProbeHarness.count("--stream-typed", or: 120) }
+    private static var deltas: Int { ProbeHarness.count("--stream-deltas", or: 200) }
+    private static var chunk: Int { ProbeHarness.count("--stream-chunk", or: 14) }
+    private static var rate: Int { max(1, ProbeHarness.count("--stream-rate", or: 25)) }
+
+    // MARK: - Entry
+
+    static func schedule() {
+        Task { @MainActor in await run() }
+    }
+
+    static func attach(_ model: AppModel) {
+        guard isRequested else { return }
+        ProbeHarness.attach(model)
+    }
+
+    private static func run() async {
+        // Not brought to the front, for the reason at the head of `ProbeHarness.window`.
+        let (window, contentView) = await harness.window()
+
+        guard let workspaceID else { harness.fail("--stream-workspace names no workspace") }
+        OpenWorkspaceNotification.post(workspaceID)
+        // Long enough for the transcript to load every row and for the inspector to settle.
+        try? await Task.sleep(for: .seconds(8))
+
+        guard let app = ProbeHarness.appModel else { harness.fail("no app model") }
+        guard let model = app.existingModel(for: workspaceID) else {
+            harness.fail("workspace \(workspaceID.rawValue) is not open")
+        }
+        guard let session = model.activeSession,
+              let transcript = model.existingTranscript(for: session.id) else {
+            harness.fail("workspace \(workspaceID.rawValue) has no conversation open")
+        }
+        guard let editor = composer(in: contentView) else {
+            harness.fail("no composer text view found")
+        }
+
+        let recorder = FrameRecorder(view: contentView) { CGFloat(transcript.rows.count) }
+
+        harness.markStarted()
+
+        // Typing first, and into an empty draft, so the two halves cannot be measuring each
+        // other: a live tail on screen would be under every keystroke of the second half.
+        let typing = await measureTyping(editor: editor, transcript: transcript, recorder: recorder)
+        let streaming = await measureStreaming(transcript: transcript, recorder: recorder)
+
+        harness.write(.object([
+            "workspace": .string(workspaceID.rawValue),
+            "workspaceName": .string(model.workspace.name),
+            // What the pane was holding, because a run against a short conversation is a run whose
+            // numbers mean something else. Every probe here has learned that the hard way.
+            "sessionRows": .integer(transcript.rows.count),
+            "typing": .object(typing),
+            "streaming": .object(streaming),
+        ].merging(harness.conditions(window: window)) { mine, _ in mine }))
+        exit(0)
+    }
+
+    // MARK: - Typing
+
+    /// One character at a time into the real composer, with the frame timings either side.
+    ///
+    /// The pace is one character per frame at most, which is faster than anybody types and is the
+    /// point: a keystroke that costs more than a frame shows up as a frame interval longer than a
+    /// frame, and a probe that typed slowly would leave room for the cost to hide in.
+    private static func measureTyping(
+        editor: ComposerTextView, transcript: TranscriptModel, recorder: FrameRecorder
+    ) async -> [String: JSONValue] {
+        editor.window?.makeFirstResponder(editor)
+        let sentence = Array("the quick brown fox jumps over the lazy dog. ")
+        var typedCharacters = 0
+
+        recorder.start()
+        let cpuBefore = ProbeHarness.mainThreadCPUSeconds()
+        let wallBefore = CACurrentMediaTime()
+        for index in 0..<typed {
+            editor.insertText(String(sentence[index % sentence.count]), replacementRange: NSRange(location: NSNotFound, length: 0))
+            typedCharacters += 1
+            // One vsync, so each keystroke is measured against a frame rather than against the
+            // one before it.
+            try? await Task.sleep(for: .milliseconds(8))
+        }
+        let wall = CACurrentMediaTime() - wallBefore
+        let cpu = ProbeHarness.mainThreadCPUSeconds() - cpuBefore
+        recorder.stop()
+
+        // The draft goes, so the streaming half is measured over the composer the reader would
+        // actually be looking at and so the dev database is not left holding a page of foxes.
+        transcript.draft = ""
+
+        var report = ProbeHarness.frameTimings(recorder.intervals.map { $0 * 1000 })
+        report["characters"] = .integer(typedCharacters)
+        report["wallSeconds"] = .number(wall)
+        report["mainThreadCpuMsPerKeystroke"] = .number(
+            typedCharacters > 0 ? cpu * 1000 / Double(typedCharacters) : 0
+        )
+        // A run whose keystrokes never reached the draft measured an empty composer.
+        report["didType"] = .bool(typedCharacters > 0)
+        return report
+    }
+
+    // MARK: - Streaming
+
+    /// Real deltas through the transcript's own handler, at a fixed rate.
+    private static func measureStreaming(
+        transcript: TranscriptModel, recorder: FrameRecorder
+    ) async -> [String: JSONValue] {
+        let text = String(repeating: "x", count: max(1, chunk))
+        let gap = Duration.milliseconds(1000 / rate)
+
+        recorder.start()
+        let cpuBefore = ProbeHarness.mainThreadCPUSeconds()
+        let wallBefore = CACurrentMediaTime()
+        for _ in 0..<deltas {
+            await transcript.acceptForProbe(.streamDelta(.text(text + " ")))
+            try? await Task.sleep(for: gap)
+        }
+        let wall = CACurrentMediaTime() - wallBefore
+        let cpu = ProbeHarness.mainThreadCPUSeconds() - cpuBefore
+        recorder.stop()
+
+        var report = ProbeHarness.frameTimings(recorder.intervals.map { $0 * 1000 })
+        report["deltas"] = .integer(deltas)
+        report["chunkCharacters"] = .integer(chunk)
+        report["ratePerSecond"] = .integer(rate)
+        report["wallSeconds"] = .number(wall)
+        report["mainThreadCpuMsPerDelta"] = .number(
+            deltas > 0 ? cpu * 1000 / Double(deltas) : 0
+        )
+        // The tail really did grow, which is the check every probe here owes its own numbers.
+        report["tailCharacters"] = .integer(transcript.streamingText.count)
+        return report
+    }
+
+    // MARK: - Finding the composer
+
+    /// The composer's own text view, by type rather than by position.
+    ///
+    /// A window can hold several text views: every prose row of the transcript is one, and so is
+    /// the review comment field. Only the composer is a `ComposerTextView`, and it is the deepest
+    /// one this walk finds first because the composer sits at the foot of the centre column.
+    private static func composer(in root: NSView) -> ComposerTextView? {
+        if let editor = root as? ComposerTextView { return editor }
+        for subview in root.subviews {
+            if let found = composer(in: subview) { return found }
+        }
+        return nil
+    }
+}

--- a/Sources/Bloom/Design/SwitchProbe.swift
+++ b/Sources/Bloom/Design/SwitchProbe.swift
@@ -150,6 +150,11 @@ enum SwitchProbe {
         return [
             "workspace": .string(id.rawValue),
             "name": .string(name),
+            // Where the switch left the reader, which is the whole of what "it did not keep my
+            // place" means. See `ProbeHarness.scrollPlace`.
+            "place": .object(ProbeHarness.scrollPlace(
+                ProbeHarness.transcriptScrollView(in: contentView)
+            )),
             "marks": SwitchTrace.timeline(),
             "frameCount": .integer(ticker.intervalsMs.count),
             "blocks": .numbers(ticker.blocksMs),

--- a/Sources/Bloom/Design/SwitchProbe.swift
+++ b/Sources/Bloom/Design/SwitchProbe.swift
@@ -208,6 +208,20 @@ enum SwitchProbe {
         if case .number(let before)? = left["offset"], case .number(let after)? = returned["offset"] {
             report["movedPoints"] = .number(abs(after - before))
         }
+        // **Whether the run tested anything at all**, and it often does not.
+        //
+        // Writing the clip view's origin is not a hand on the wheel: SwiftUI never sees it, so the
+        // list's own `ScrollPosition` goes on standing at `.bottom`, and the next layout pass that
+        // grows the content reapplies that edge and puts the view back at the end. Measured: this
+        // probe asked for two thousand points off the end and reported `atEnd` on both samples.
+        //
+        // So the report says whether the reader was actually moved, and a run that could not move
+        // them is a run whose numbers say nothing about the anchor. Driving it faithfully needs
+        // real scroll wheel events, which need the window in front, which is the owner's keyboard.
+        // See the head of `ProbeHarness.window`.
+        if case .bool(let wasAtEnd)? = left["atEnd"] {
+            report["drove"] = .bool(!wasAtEnd)
+        }
         return report
     }
 

--- a/Sources/Bloom/Design/SwitchProbe.swift
+++ b/Sources/Bloom/Design/SwitchProbe.swift
@@ -97,6 +97,11 @@ enum SwitchProbe {
             }
         }
 
+        // Whether a reader who was NOT at the live end is put back where they were, which is the
+        // half of `TranscriptResume` the runs above cannot reach: a probe that only ever sits at
+        // the end measures the flag, never the anchor.
+        let kept = await keepsItsPlace(contentView: contentView, ticker: ticker)
+
         // The case that breaks first: away before the asynchronous work has landed. Nothing from
         // the workspace being left may appear in the one being arrived at.
         let rapid = await rapidSwitches(contentView: contentView, ticker: ticker)
@@ -111,6 +116,7 @@ enum SwitchProbe {
             "settleMs": .integer(settle),
             "runs": .array(runs),
             "rapid": .object(rapid),
+            "keepsItsPlace": .object(kept),
         ]
         harness.write(.object(own.merging(harness.conditions(window: window)) { mine, _ in mine }))
         exit(0)
@@ -162,6 +168,47 @@ enum SwitchProbe {
             "panePasses": .map(PaneLayoutTiming.timeline()),
             "worstFrameMs": .number(ticker.intervalsMs.max() ?? 0),
         ]
+    }
+
+    /// Leaves a reader part way up a conversation, goes somewhere else, and comes back.
+    ///
+    /// The offsets either side are the whole report. They are not required to be equal to the
+    /// point: the rows above the viewport are re-measured on the way back, so an anchor that lands
+    /// the same ROW at the top can legitimately land a few points from where it was. What would
+    /// fail is landing at the live end (the flag was written when it should not have been), at the
+    /// top (nothing was restored), or at the first unread row, which is what a refused restore
+    /// used to do and is halfway up a long conversation.
+    private static func keepsItsPlace(
+        contentView: NSView, ticker: Ticker
+    ) async -> [String: JSONValue] {
+        guard let app = ProbeHarness.appModel, order.count >= 2 else { return [:] }
+        let subject = order[0]
+
+        app.selection = .workspace(subject)
+        try? await Task.sleep(for: .milliseconds(settle))
+        guard let scroll = ProbeHarness.transcriptScrollView(in: contentView) else { return [:] }
+
+        // A long way up, so the answer cannot be confused with a reader who never left the end.
+        let travel = ProbeHarness.scrollableHeight(of: scroll)
+        let target = max(0, travel - 2_000)
+        scroll.contentView.setBoundsOrigin(CGPoint(x: 0, y: target))
+        scroll.reflectScrolledClipView(scroll.contentView)
+        // Long enough for the scroll to settle and for the pane to write down where it is: the
+        // record is made when a scroll ENDS, which is a phase change rather than a frame.
+        try? await Task.sleep(for: .seconds(2))
+        let left = ProbeHarness.scrollPlace(scroll)
+
+        await switchTo(order[order.count - 1], contentView: contentView, ticker: ticker)
+        await switchTo(subject, contentView: contentView, ticker: ticker)
+
+        let returned = ProbeHarness.scrollPlace(
+            ProbeHarness.transcriptScrollView(in: contentView)
+        )
+        var report: [String: JSONValue] = ["left": .object(left), "returned": .object(returned)]
+        if case .number(let before)? = left["offset"], case .number(let after)? = returned["offset"] {
+            report["movedPoints"] = .number(abs(after - before))
+        }
+        return report
     }
 
     /// Switches back and forth without waiting, then reports what is on screen at the end.

--- a/Sources/Bloom/Design/TranscriptDrawn.swift
+++ b/Sources/Bloom/Design/TranscriptDrawn.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// How many rows the transcript is currently handing its lazy stack, for a probe to read.
+///
+/// A number a run has to be able to see, because the whole of `TranscriptWindow` is a claim about
+/// it and a report that says "1,582 rows in the session" says nothing about how many of them are
+/// in the stack. Written where the window is set and nowhere else, and read by nothing but a
+/// probe's report, so a build nobody is measuring pays for one integer store per workspace switch.
+@MainActor
+enum TranscriptDrawn {
+    private(set) static var rows = 0
+
+    static func note(_ count: Int) { rows = count }
+}

--- a/Sources/Bloom/State/AppModel.swift
+++ b/Sources/Bloom/State/AppModel.swift
@@ -257,6 +257,24 @@ final class AppModel {
     /// `DiffRefreshSchedule` to decide which of them this tick is for. Outside observation because
     /// nothing draws from it and it is written every six seconds.
     @ObservationIgnored private var lastDiffRefresh: [WorkspaceID: Date] = [:]
+
+    /// The worktrees the file system says have actually changed since they were last asked about.
+    ///
+    /// This is what turns the refresh loop from a poll into a backstop. Every `git` process the
+    /// loop used to run existed to find out whether anything had happened, and on an idle machine
+    /// the answer is always no; a worktree in here is one where the answer is provably yes. See
+    /// `WorktreeWatcher`, which carries the measurement, and `DiffRefreshSchedule`, whose backstop
+    /// age could be lengthened because of it.
+    ///
+    /// Outside observation for the same reason `lastDiffRefresh` is: nothing draws from it, and it
+    /// is written by a background queue's hop onto this actor whenever an agent touches a file.
+    @ObservationIgnored private var changedWorkspaceIDs: Set<WorkspaceID> = []
+
+    /// The one watcher, over every active worktree. Built lazily so that a model made by a test or
+    /// a probe with no workspaces at all never subscribes to anything.
+    @ObservationIgnored private lazy var worktreeWatcher = WorktreeWatcher { [weak self] paths in
+        Task { @MainActor in self?.noteWorktreesChanged(paths) }
+    }
     private var storeObservationTask: Task<Void, Never>?
     private var sessionObservationTask: Task<Void, Never>?
     private var quotaObservationTask: Task<Void, Never>?
@@ -415,6 +433,7 @@ final class AppModel {
     func shutdownEverything() async {
         refreshTask?.cancel()
         refreshTask = nil
+        worktreeWatcher.stop()
         storeObservationTask?.cancel()
         storeObservationTask = nil
         sessionObservationTask?.cancel()
@@ -483,6 +502,11 @@ final class AppModel {
                 let landed = Set(reconciled.map(\.id))
                 pendingWorkspaces.removeAll { landed.contains($0.id) }
             }
+            // And the file system watcher, from the same place and for the same reason: this is
+            // the one line the workspace list is published from, so a worktree created, archived
+            // or restored anywhere in the app is watched or forgotten without anybody remembering
+            // to say so. Watching a list it is already watching does nothing at all.
+            worktreeWatcher.watch(roots: workspaces.map(\.path))
             // The models hold a copy of their `Workspace`, and this is where those copies go
             // stale. Refreshing here keeps `model(for:)` out of every view body.
             for workspace in workspaces {
@@ -665,8 +689,15 @@ final class AppModel {
                 // agent editing the worktree is exactly when this loop is most likely to collide
                 // with a lock it has no business waiting for.
                 guard NSApp?.isActive ?? true else { continue }
-                await self.refreshDiffStats()
-                await self.refreshSelectedChangedFiles()
+                let refreshed = await self.refreshDiffStats()
+                // Only when the workspace on screen was one of them. This used to run on every
+                // tick, which is a second set of `git` processes every six seconds against a
+                // worktree nothing had written to, and the answer was the file list it already
+                // had. What decides is now the same decision as above: an agent writing, the file
+                // system reporting a change, or the backstop age coming round.
+                if let selected = self.selection.workspaceID, refreshed.contains(selected) {
+                    await self.refreshSelectedChangedFiles()
+                }
             }
         }
     }
@@ -691,17 +722,39 @@ final class AppModel {
         await model.refreshChanges(.quiet)
     }
 
-    func refreshDiffStats() async {
-        guard let manager else { return }
+    /// What the file system watcher saw, turned into workspaces the next tick has to ask git about.
+    ///
+    /// Paths rather than ids come back, because a watcher has no idea what a workspace is. A path
+    /// that matches nothing is dropped, which is what happens for the moment between a worktree
+    /// being removed and the watcher being pointed at the shorter list.
+    private func noteWorktreesChanged(_ paths: Set<String>) {
+        let changed = workspaces.filter { paths.contains($0.path) }.map(\.id)
+        guard !changed.isEmpty else { return }
+        changedWorkspaceIDs.formUnion(changed)
+    }
+
+    /// - Returns: the workspaces this pass actually asked git about.
+    @discardableResult
+    func refreshDiffStats() async -> Set<WorkspaceID> {
+        guard let manager else { return [] }
 
         // Not every workspace on every tick. `DiffRefreshSchedule` carries the measurement: one
         // pass over one worktree is seven git processes, and running twenty of them every six
         // seconds on an idle machine is what put Bloom under "Using Significant Energy".
+        //
+        // A worktree the file system says has changed is due now rather than whenever its turn in
+        // the backstop rotation comes round, which is what lets that rotation be slow. See
+        // `WorktreeWatcher`.
         var busy = runningWorkspaceIDs
-        if let selected = selection.workspaceID { busy.insert(selected) }
+        busy.formUnion(changedWorkspaceIDs)
         let due = Set(DiffRefreshSchedule.due(
             workspaces: workspaces.map(\.id),
             busy: busy,
+            // No longer folded into `busy`. The workspace on screen used to be refreshed on every
+            // tick, which is six or seven `git` processes every six seconds for as long as a
+            // window sits open on an idle worktree; it now has an age of its own, and the watcher
+            // is what makes a real change arrive before that age is reached.
+            selected: selection.workspaceID,
             lastRefreshed: lastDiffRefresh,
             now: Date()
         ))
@@ -711,8 +764,9 @@ final class AppModel {
         let present = Set(workspaces.map(\.id))
         lastDiffRefresh = lastDiffRefresh.filter { present.contains($0.key) }
 
+        var refreshed: Set<WorkspaceID> = []
         for workspace in workspaces where due.contains(workspace.id) {
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled else { return refreshed }
             // A worktree that has been removed outside Bloom would make git walk up to the parent
             // repository and answer about the wrong tree.
             guard FileManager.default.fileExists(atPath: workspace.path) else { continue }
@@ -722,12 +776,18 @@ final class AppModel {
             // After the pass rather than before it, so a workspace whose git call took four
             // seconds is not immediately due again on the next tick.
             lastDiffRefresh[workspace.id] = Date()
+            // And it has now been asked about, so the watcher's report is spent. Anything that
+            // happened WHILE the pass ran is a fresh event and lands back in here behind us, which
+            // is the right answer: the numbers this pass read are already a moment old.
+            changedWorkspaceIDs.remove(workspace.id)
+            refreshed.insert(workspace.id)
         }
         // Nothing is read back here. `Store.updateDiffStat` only writes when one of the three
         // numbers has actually moved, and a write that happens publishes itself, so the sidebar is
         // refreshed by the same feed as every other change to a row. On an idle machine this whole
         // pass now writes nothing, publishes nothing and costs the window nothing, where it used
         // to re-read every workspace every six seconds whether or not anything had changed.
+        return refreshed
     }
 
     /// Runs work with a deadline. One `git` blocked on an `index.lock`, which is routine while an

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -877,12 +877,16 @@ final class TranscriptModel {
 
         case .streamDelta(let delta):
             switch delta {
-            case .text(let chunk): streamingText += chunk
-            case .thinking(let chunk): streamingThinking += chunk
+            case .text(let chunk): buffer.text += chunk
+            case .thinking(let chunk): buffer.thinking += chunk
+            // Not buffered. It arrives once per tool call rather than per token, and it is what
+            // the status line under the tail says, so a delay on it would be visible where a
+            // delay on a few characters of prose is not.
             case .toolName(let name): streamingToolName = name
             case .toolInput: break
             case .blockFinished: break
             }
+            scheduleStreamFlush()
 
         case .assistantText, .thinking, .toolUse, .toolResult:
             // Anything at all arriving from the model means the request that was being retried got
@@ -1079,7 +1083,55 @@ final class TranscriptModel {
         if usage != contextUsage { contextUsage = usage }
     }
 
+    /// Text and thinking that has arrived and is not on screen yet. See `scheduleStreamFlush`.
+    private var buffer = (text: "", thinking: "")
+    private var streamFlush: Task<Void, Never>?
+
+    /// How often the live tail is allowed to redraw while an answer arrives.
+    ///
+    /// **Fifty milliseconds, because the cost of drawing the tail is per REDRAW and the rate the
+    /// deltas arrive at is not ours to choose.** Measured with `--stream-probe` on a release
+    /// build over a 1,582 row chat: 6.6ms of main thread per delta at sixty deltas a second, which
+    /// is 40% of a core burned continuously for as long as an agent is writing, and thirty per
+    /// cent of frames late. Most of that is the same work over and over: the whole answer so far
+    /// is re-parsed as markdown and re-measured by TextKit on every delta, so a turn that streams
+    /// n chunks does O(n²) work to draw one paragraph.
+    ///
+    /// Coalescing bounds it. Twenty redraws a second is faster than anybody reads and is the same
+    /// number whether the backend sends twenty five chunks a second or two hundred, which is the
+    /// property that matters: what the app costs while a turn runs stops depending on how chatty
+    /// the CLI happens to be.
+    ///
+    /// Nothing is lost by waiting. Every path that ENDS a stream flushes first, so the last few
+    /// characters are on screen before the stored row replaces them.
+    private static let streamFlushInterval = Duration.milliseconds(50)
+
+    private func scheduleStreamFlush() {
+        guard streamFlush == nil else { return }
+        streamFlush = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: Self.streamFlushInterval)
+            guard let self else { return }
+            streamFlush = nil
+            flushStream()
+        }
+    }
+
+    /// Puts what has arrived on screen, in one write per property rather than one per delta.
+    private func flushStream() {
+        if !buffer.text.isEmpty {
+            streamingText += buffer.text
+            buffer.text = ""
+        }
+        if !buffer.thinking.isEmpty {
+            streamingThinking += buffer.thinking
+            buffer.thinking = ""
+        }
+    }
+
     private func clearStreaming() {
+        streamFlush?.cancel()
+        streamFlush = nil
+        buffer = ("", "")
         streamingText = ""
         streamingThinking = ""
         streamingToolName = nil
@@ -1087,6 +1139,7 @@ final class TranscriptModel {
 
     var isStreaming: Bool {
         !streamingText.isEmpty || !streamingThinking.isEmpty || streamingToolName != nil
+            || !buffer.text.isEmpty || !buffer.thinking.isEmpty
     }
 
     private func notifyFinished(result: AgentResult) async {

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -845,6 +845,19 @@ final class TranscriptModel {
 
     // MARK: - Event handling
 
+    /// The event pump's door, opened for one caller: `StreamProbe`.
+    ///
+    /// **A probe hook in a production type, deliberately, and this is the argument for it.** What
+    /// the probe has to measure is what Bloom does with a delta, and the only faithful way to
+    /// measure that is to hand this the events a runner hands it. The alternative was a probe that
+    /// wrote `streamingText` directly, which measures a property being assigned rather than a turn
+    /// arriving, and would go on measuring it after the pump around it had changed. Nothing else
+    /// may call this: a runner reaches `handle` through its own pump, and anything else pushing
+    /// events into a transcript would be a second writer on state that has exactly one.
+    func acceptForProbe(_ event: AgentEvent) async {
+        await handle(event)
+    }
+
     private func handle(_ event: AgentEvent) async {
         switch event {
         case .initialized:

--- a/Sources/Bloom/Views/Center/Composer/ComposerRoom.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerRoom.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import Observation
+
+/// How much room the composer has been given, held where changing it costs the composer rather
+/// than everything beside it.
+///
+/// The number itself is not new and neither is what it is for: the divider between a conversation
+/// and the box under it can only be dragged so far, and what stops it is how tall the pane is. It
+/// used to be `@State` in `ChatPaneView`, passed down as a parameter, and that is the part this
+/// type exists to change. A parameter is read by the view that PASSES it, so every change to it
+/// re-ran the pane's body and rebuilt the whole transcript subtree beside the composer, to move a
+/// clamp on a box the transcript knows nothing about.
+///
+/// It moves whenever the composer's own text rewraps, which during a window resize is most frames:
+/// the editor grows a line, the chrome under it is measured again, the pane publishes a new height
+/// and the transcript is rebuilt. Measured on a release build at 1440 by 900 over a 1,582 row
+/// chat, a centre column layout pass is 11.1ms, and a resize asks for two or three of them a
+/// frame.
+///
+/// So the value is handed down as an object instead. The identity never changes, so a pane holding
+/// one takes no dependency on the height at all; only `ComposerView`, which reads `height` inside
+/// its own body, is invalidated when the room changes. This is the same bargain `TranscriptBubbleWidth`
+/// and `TranscriptHoverHost` make next door, and for the same reason: observation is recorded
+/// where a property is READ.
+@MainActor
+@Observable
+final class ComposerRoom {
+    /// The height the transcript and the composer share, already quantised by `PaneMeasure.room`.
+    /// Nought until the pane has been laid out, which `ComposerView` reads as "no cap yet".
+    var height: CGFloat = 0
+}

--- a/Sources/Bloom/Views/Center/Composer/ComposerView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerView.swift
@@ -14,8 +14,12 @@ struct ComposerView: View {
     /// the session list is kept in step with edits made here.
     var model: WorkspaceModel?
     /// How tall the region the transcript and the composer share is, so a drag can be stopped
-    /// before the transcript is squeezed out of it. Zero reads as "not laid out yet, no cap".
-    var availableHeight: CGFloat = 0
+    /// before the transcript is squeezed out of it.
+    ///
+    /// An object rather than a number, and `ComposerRoom` carries the measurement for why: a
+    /// number is read by the view that passes it, so the pane publishing a new height rebuilt the
+    /// transcript beside this box on every frame that rewrapped a line of the draft.
+    var room: ComposerRoom = ComposerRoom()
 
     @Environment(AppModel.self) private var app
 
@@ -135,9 +139,10 @@ struct ComposerView: View {
     /// every render and not only while dragging, so shrinking the window shrinks the composer back
     /// rather than pushing the transcript off the top.
     private var maxEditorHeight: CGFloat {
-        guard availableHeight > 0 else { return .greatestFiniteMagnitude }
-        let room = availableHeight - chromeHeight - Self.minTranscriptHeight
-        return max(room, ComposerTextEditor.lineHeight)
+        let available = room.height
+        guard available > 0 else { return .greatestFiniteMagnitude }
+        let left = available - chromeHeight - Self.minTranscriptHeight
+        return max(left, ComposerTextEditor.lineHeight)
     }
 
     /// The drag begins from whatever is on screen, so switching out of automatic sizing never jumps.

--- a/Sources/Bloom/Views/Center/Panes/ChatPaneView.swift
+++ b/Sources/Bloom/Views/Center/Panes/ChatPaneView.swift
@@ -29,11 +29,14 @@ struct ChatPaneView: View {
     /// the divider between the two can be dragged.
     ///
     /// Rounded, and that is a performance decision rather than a tidiness one. Raw, it changed on
-    /// every pixel of a window or sidebar drag, which is once a frame, and every one of those
-    /// changes re-ran this body: the whole transcript subtree and the composer under it, rebuilt to
-    /// move a clamp by one point. See `PaneMeasure`, and `TranscriptGeometry` for the same decision
-    /// taken for the same reason one view down.
-    @State private var conversationHeight: CGFloat = 0
+    /// every pixel of a window or sidebar drag, which is once a frame. See `PaneMeasure`, and
+    /// `TranscriptGeometry` for the same decision taken for the same reason one view down.
+    ///
+    /// An object rather than `@State`, which is the other half of the same fix: rounding cut how
+    /// OFTEN this body was re-run, and holding the number where only the composer reads it cuts
+    /// what a re-run costs to nothing at all. The transcript is rebuilt by neither now. See
+    /// `ComposerRoom`.
+    @State private var room = ComposerRoom()
 
     /// The conversation's text size, applied here because this pane is exactly what the setting is
     /// scoped to: what was said and what you are about to say. The sidebar, the inspector and the
@@ -71,17 +74,13 @@ struct ChatPaneView: View {
                 }
             }
 
-            ComposerView(
-                transcript: transcript,
-                model: model,
-                availableHeight: conversationHeight
-            )
+            ComposerView(transcript: transcript, model: model, room: room)
         }
         // Rounded inside the probe rather than after it, because `onGeometryChange` only calls
         // the action when the value it is given has changed. Rounding here is what stops the
         // action running at all for the frames that do not cross a step.
         .onGeometryChange(for: CGFloat.self) { PaneMeasure.room($0.size.height) } action: {
-            conversationHeight = $0
+            room.height = $0
         }
         .background(Palette.windowBackground)
         .environment(\.fontScale, textSize.scale)

--- a/Sources/Bloom/Views/Center/Panes/ReviewPaneView.swift
+++ b/Sources/Bloom/Views/Center/Panes/ReviewPaneView.swift
@@ -43,7 +43,11 @@ struct ReviewPaneView: View {
     }
 
     /// How tall the whole pane is, which caps how far the composer's divider can be dragged.
-    @State private var paneHeight: CGFloat = 0
+    ///
+    /// In the composer's own object rather than in this view's state, and quantised on the way in,
+    /// for the reason `ComposerRoom` sets out: as state it re-ran this body, and with it the diff
+    /// beside the box, every time the draft rewrapped a line.
+    @State private var room = ComposerRoom()
 
     /// The conversation's text size and face, applied to the composer here exactly as
     /// `ChatPaneView` applies them to its whole subtree. Without this the same composer would
@@ -63,12 +67,14 @@ struct ReviewPaneView: View {
             // comments on this screen and then leaving it to send them. A second composer view
             // was considered and rejected: one draft, one send path, nothing to keep in step.
             if let transcript = composerTranscript {
-                ComposerView(transcript: transcript, model: model, availableHeight: paneHeight)
+                ComposerView(transcript: transcript, model: model, room: room)
                     .environment(\.fontScale, textSize.scale)
                     .environment(\.chatFont, chatFont)
             }
         }
-        .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { paneHeight = $0 }
+        .onGeometryChange(for: CGFloat.self) { PaneMeasure.room($0.size.height) } action: {
+            room.height = $0
+        }
         .background(Palette.surface)
         // A pane can be pointed at a session this launch has never opened, so the transcript is
         // built here rather than assumed, exactly as `CenterPaneView.prepare` does for a chat.

--- a/Sources/Bloom/Views/Chrome/App/BloomAppDelegate.swift
+++ b/Sources/Bloom/Views/Chrome/App/BloomAppDelegate.swift
@@ -37,6 +37,7 @@ final class BloomAppDelegate: NSObject, NSApplicationDelegate, UNUserNotificatio
         // The tab probe needs it for the same reason, and reaches one workspace's model through
         // it: what it drives is `WorkspaceTabsStore.select`, which takes one.
         TabProbe.attach(model)
+        StreamProbe.attach(model)
         servicesProvider.attach(model)
         // And a Shortcut needs it for the same reason the Services menu does: an intent runs in
         // this process and has to execute the same code a click in the create sheet does, rather

--- a/Sources/Bloom/Views/Transcript/TranscriptGeometry.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptGeometry.swift
@@ -38,15 +38,6 @@ struct TranscriptGeometry: Equatable {
     /// for a line and a half of scrolling is an offer to go where the reader already is. See
     /// `ScrollEnd.offerAfterScreens`.
     var isFarFromEnd = false
-    /// How far below the viewport the end of the conversation is, already rounded, and read for
-    /// one thing only: how long the jump pill's scroll back to the live end should run for.
-    ///
-    /// Rounded hard, and it can afford to be. `TranscriptMotion.liveEndMove` moves its answer by
-    /// a tenth of a second across the whole of its range and stops moving it at all past
-    /// `glideRamp`, so a step of a quarter of a pane is finer than the answer, and a reader
-    /// dragging the scroller crosses a handful of steps rather than writing this state once a
-    /// frame. See `bubbleCap` for the same decision made for the same reason.
-    var reachToEnd: Double = 0
 
     /// The quantum the cap is rounded to. Eight points is invisible on a bubble that is several
     /// hundred wide, and small enough that a pane resized by hand still ends up with a bubble that

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -154,6 +154,19 @@ struct TranscriptListView: View {
     /// so that a drag stops writing state, and a raw offset would undo that for all of them.
     @State private var contentOffset = GeometryBox(0.0)
 
+    /// How far below the viewport the end of the conversation is, read for one thing only: how
+    /// long the jump pill's scroll back to the live end should run for.
+    ///
+    /// In a box rather than in `TranscriptGeometry`, which is `@State`. It used to be a field of
+    /// it, quantised to a quarter of a pane so that a reader dragging the scroller crossed a
+    /// handful of steps rather than writing state once a frame. That is the right treatment for a
+    /// scroll and the wrong one for a window resize, where the CONTENT height moves on every frame
+    /// and crosses a step every few: each crossing re-ran this body and rebuilt every row the
+    /// stack had realised, to store a number that is only ever read inside a button's action. See
+    /// `TranscriptBubbleWidth`, which carries the same argument for the bubble cap, and
+    /// `GeometryBox` for why a box is not observed.
+    @State private var reachToEnd = GeometryBox(0.0)
+
     /// The text scale the rows are being drawn at, read for one thing: an offset written down at
     /// one size is a point into a document laid out at another. See `TranscriptPaneState.Measure`.
     @Environment(\.fontScale) private var fontScale
@@ -558,6 +571,12 @@ struct TranscriptListView: View {
             .onScrollGeometryChange(for: CGFloat.self, of: Self.bubbleCapOf) { _, new in
                 bubbleWidth.cap = new
             }
+            // And the reach, on a subscription of its own for the same reason: what it writes is a
+            // box rather than state, so a window resize moving the content height no longer runs
+            // this body. See `reachToEnd`.
+            .onScrollGeometryChange(for: Double.self, of: Self.reachOf) { _, new in
+                reachToEnd.value = new
+            }
             .onScrollGeometryChange(for: TranscriptGeometry.self, of: Self.measure) { _, new in
                 geometry = new
                 // The bottom half of the window, and it needs neither an anchor nor a flag: rows
@@ -933,6 +952,14 @@ struct TranscriptListView: View {
         scroll.contentOffset.y < scroll.containerSize.height
     }
 
+    private static func reachOf(_ scroll: ScrollGeometry) -> Double {
+        TranscriptGeometry.reach(
+            contentHeight: scroll.contentSize.height,
+            viewportHeight: scroll.containerSize.height,
+            offset: scroll.contentOffset.y
+        )
+    }
+
     private static func measure(_ scroll: ScrollGeometry) -> TranscriptGeometry {
         TranscriptGeometry(
             paneHeight: TranscriptGeometry.height(scroll.containerSize.height),
@@ -946,11 +973,6 @@ struct TranscriptListView: View {
                 viewportHeight: scroll.containerSize.height,
                 offset: scroll.contentOffset.y
             ),
-            reachToEnd: TranscriptGeometry.reach(
-                contentHeight: scroll.contentSize.height,
-                viewportHeight: scroll.containerSize.height,
-                offset: scroll.contentOffset.y
-            )
         )
     }
 
@@ -1020,7 +1042,9 @@ struct TranscriptListView: View {
             TranscriptDrawn.note(drawn.window.count)
         }
 
-        let move = TranscriptMotion.liveEndMove(distance: geometry.reachToEnd, reduceMotion: reduceMotion)
+        let move = TranscriptMotion.liveEndMove(
+            distance: reachToEnd.value, reduceMotion: reduceMotion
+        )
         switch move {
         case .jump:
             scrollPosition.scrollTo(edge: .bottom)

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -1116,8 +1116,7 @@ struct TranscriptListView: View {
         // pane was on another tab and those rows are rows the reader is now looking at.
         switch TranscriptResume.placement(
             for: memory?.remembered(session: transcript.session.id),
-            rowCount: transcript.rows.count,
-            measure: currentMeasure
+            rowCount: transcript.rows.count
         ) {
         case .liveEnd:
             opening = .liveEnd
@@ -1147,21 +1146,6 @@ struct TranscriptListView: View {
 
     // MARK: Remembering where the reader was
 
-    /// What this pane is now, or nothing if it has not been laid out yet.
-    ///
-    /// The bubble cap rather than the container width, because that is the number this view
-    /// actually holds and it is a step function of the width: see `TranscriptGeometry`, which
-    /// explains why the raw width is deliberately not kept. `paneHeight` is nought until the first
-    /// layout, and that is what tells an unmeasured pane apart from a narrow one.
-    ///
-    /// Read off the object rather than out of `geometry` since the cap moved there. Both callers
-    /// are outside `body`, so this reads `cap` without subscribing this view to it, which is the
-    /// whole point of the object.
-    private var currentMeasure: TranscriptPaneState.Measure? {
-        guard geometry.paneHeight > 0 else { return nil }
-        return TranscriptPaneState.Measure(width: bubbleWidth.cap, fontScale: fontScale)
-    }
-
     /// Writes down where the reader is, for the pane to find when it is built again.
     ///
     /// Called when a scroll settles, when a row is folded or unfolded, and when the pane goes
@@ -1179,7 +1163,6 @@ struct TranscriptListView: View {
                 offset: contentOffset.value,
                 isAtLiveEnd: geometry.isNearBottom,
                 rowCount: transcript.rows.count,
-                measure: currentMeasure,
                 // The offset above is a number of points into content that starts at this row.
                 // Written down together because they are one measurement: see `TranscriptWindow`.
                 drawn: drawn.window

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -696,6 +696,7 @@ struct TranscriptListView: View {
                         rowCount: transcript.rows.count
                     )
                 )
+                TranscriptDrawn.note(transcript.rows.count - drawn.start)
                 // Whatever the session arrived with, taken in without a fade. This runs whether
                 // or not the row count changed, which matters: two sessions can hold the same
                 // number of rows, and then nothing else would have told the tracker it is
@@ -754,6 +755,7 @@ struct TranscriptListView: View {
                     from: drawn.start, rowCount: transcript.rows.count
                 )
                 drawn = Drawn(session: transcript.session.id, start: settled)
+                TranscriptDrawn.note(transcript.rows.count - settled)
                 // **The number the whole of this is about.** The work stamp is the instant the
                 // history was asked for; the vsync stamp is the first frame that could show it,
                 // and the display link cannot run while the main thread is laying rows out. The
@@ -1178,6 +1180,7 @@ struct TranscriptListView: View {
         else { return }
         isGrowing = true
         drawn.start = TranscriptWindow.grown(from: drawn.start)
+        TranscriptDrawn.note(transcript.rows.count - drawn.start)
         Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(120))
             isGrowing = false

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -1145,7 +1145,10 @@ struct TranscriptListView: View {
     /// dropped: a reader who arrives, reads what is on screen and switches tab has scrolled
     /// nothing and folded nothing, and is exactly the case this whole file is about.
     private func remember() {
-        guard let memory else { return }
+        // Nothing is written down about a pane that has not drawn anything yet. Its window is
+        // empty, its offset is nought, and both would be restored over a session that has since
+        // loaded. See `TranscriptResume.window`.
+        guard let memory, drawn.window.count > 0 else { return }
         memory.remember(
             TranscriptPaneState(
                 expanded: expanded,

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -680,6 +680,22 @@ struct TranscriptListView: View {
                 // offset the view is already at moves nothing. See `onStart`.
                 follower.onStart = { [box = _scrollPosition] y in box.wrappedValue.scrollTo(y: y) }
                 await transcript.load()
+                // The window, now that there are rows to work it out from.
+                //
+                // The initialiser and the session's `onChange` both ran before this: the first
+                // when the pane was built, which for a session this launch has never opened is
+                // before a single row exists, and the second while `transcript.rows` still held
+                // the conversation being left. Neither could name a tail, and a window of "from
+                // row zero" is the whole session. This is the first moment the answer can be
+                // right, and it is still before anything has been drawn from it.
+                drawn = Drawn(
+                    session: transcript.session.id,
+                    start: TranscriptResume.window(
+                        memory?.remembered(session: transcript.session.id),
+                        tailStart: TranscriptTail.start(in: transcript.rows.lazy.map(\.kind)),
+                        rowCount: transcript.rows.count
+                    )
+                )
                 // Whatever the session arrived with, taken in without a fade. This runs whether
                 // or not the row count changed, which matters: two sessions can hold the same
                 // number of rows, and then nothing else would have told the tracker it is

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -1174,7 +1174,20 @@ struct TranscriptListView: View {
     /// moves nothing: by then the content size is settled, and an anchor only does anything on a
     /// change of size.
     private func growWindow() {
-        guard drawn.session == transcript.session.id,
+        // **Only once the session has finished arriving, and this is the whole of why the first
+        // build of this measured worse than no window at all.** A list is at offset nought for the
+        // moments between being built and being put on its live end, and offset nought is "near
+        // the top" by any definition: measured with `--frame-probe`, the arrival alone grew the
+        // window four times and the stack ended up holding all 1,582 rows of the session, which is
+        // where it started. `arrivalSession` is set by the reveal, after the positioning, and is
+        // exactly the flag that says the list is where somebody meant it to be.
+        //
+        // The live end is checked as well, because a session whose window is shorter than the pane
+        // is at its top and its bottom at once, and growing it would add rows above a reader who
+        // is reading the newest one.
+        guard arrivalSession == transcript.session.id,
+              !geometry.isNearBottom,
+              drawn.session == transcript.session.id,
               TranscriptWindow.canGrow(from: drawn.start),
               !isGrowing
         else { return }

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -31,8 +31,17 @@ struct TranscriptListView: View {
         // that is `@ObservationIgnored`, so asking costs nothing and subscribes to nothing.
         let remembered = memory?.remembered(session: transcript.session.id)
         _expanded = State(initialValue: remembered?.expanded ?? [])
-        _drawnInFull = State(
-            initialValue: TranscriptResume.drawsInFull(remembered) ? transcript.session.id : nil
+        let rows = transcript.rows
+        _drawn = State(initialValue: Drawn(
+            session: transcript.session.id,
+            start: TranscriptResume.window(
+                remembered,
+                tailStart: TranscriptTail.start(in: rows.lazy.map(\.kind)),
+                rowCount: rows.count
+            )
+        ))
+        _resumed = State(
+            initialValue: TranscriptResume.isResuming(remembered) ? transcript.session.id : nil
         )
     }
 
@@ -149,12 +158,35 @@ struct TranscriptListView: View {
     /// one size is a point into a document laid out at another. See `TranscriptPaneState.Measure`.
     @Environment(\.fontScale) private var fontScale
 
-    /// The session whose history has been put back, if any. See `visibleRows`.
+    /// How much of the session the lazy stack is being handed, and which session that is about.
     ///
-    /// A session id rather than a flag, because this view is the same view in the same place for
-    /// every workspace the window visits, and a flag left standing from the last one would draw
-    /// the next one's whole history onto the frame that is trying to arrive.
-    @State private var drawnInFull: SessionID?
+    /// A session id rather than a bare index, because this view is the same view in the same place
+    /// for every workspace the window visits, and a window left standing from the last one would
+    /// name a row in a conversation nobody is looking at.
+    private struct Drawn: Equatable {
+        var session: SessionID
+        /// The first row drawn, as an index into `transcript.rows`. See `TranscriptWindow`.
+        var start: Int
+    }
+
+    @State private var drawn: Drawn
+
+    /// The session this pane was restored into, if it was restored rather than arrived at.
+    ///
+    /// A reader coming back is already where they left off, so the window is whatever they were
+    /// reading in and nothing grows under them a moment later. See `TranscriptResume.isResuming`.
+    @State private var resumed: SessionID?
+
+    /// Whether the window is being grown upward right now, which is the one moment the list wants
+    /// the bottom anchor whatever the reader's position says.
+    ///
+    /// Growing adds rows ABOVE the viewport. Left to the default, a scroll view keeps its offset
+    /// when its content grows, and an offset measured from the top of a document that has just
+    /// become several hundred rows taller names somewhere else entirely: the reader is thrown
+    /// backwards through the conversation by exactly the amount that was added. Anchored to the
+    /// bottom for that one update, the distance to the end is what is kept, which is the distance
+    /// nothing above the viewport can change. See `growWindow`.
+    @State private var isGrowing = false
 
     /// Sentinel id, negative so it can never collide with a row sequence number.
     private static let streamingID = -2
@@ -231,26 +263,43 @@ struct TranscriptListView: View {
     /// over a slice that starts in the middle.
     private var visibleRows: ArraySlice<TranscriptRow> {
         let rows = transcript.rows
-        guard drawnInFull != transcript.session.id else { return rows[...] }
+        return rows[min(windowStart, rows.count)...]
+    }
 
-        // Lazily, so the kinds are read through the rows rather than copied out of them. This is
-        // asked on every pass, inside the arrival window the tail exists to protect, and the walk
-        // reads at most twice the tail's length of them however long the session is.
-        let start = TranscriptTail.start(in: rows.lazy.map(\.kind))
-        guard start > 0 else { return rows[...] }
-        // A session opens on the first thing the user has not read, and a scroll can only find a
-        // row the list is drawing. Anything unread above the tail and there is no tail: opening in
-        // the right place matters more than arriving quickly.
-        if let unread = transcript.firstUnreadSeq, unread < rows[start].seq { return rows[...] }
-        // Same rule for a search result, and it is the case that needs it most: the row somebody
-        // searched for is nearly always old, and a scroll can only find a row the list is drawing.
-        // Read rather than taken here, because a view body must not mutate; `position` takes it.
+    /// The first row of the session this pass hands to the stack.
+    ///
+    /// The window itself is state, because it only ever grows and a window recomputed from scratch
+    /// on every pass would shrink back the moment the thing that widened it went away, taking the
+    /// rows out from under the reader. What is computed here is the one thing that cannot be
+    /// state: a row somebody has asked for by name has to be in the list on the very pass that
+    /// asks for it, and `position` pins the answer the moment it has used it.
+    private var windowStart: Int {
+        let rows = transcript.rows
+        let tailStart = drawn.session == transcript.session.id
+            ? min(drawn.start, rows.count)
+            : TranscriptTail.start(in: rows.lazy.map(\.kind))
+        return TranscriptWindow.opening(
+            rowCount: rows.count, tailStart: tailStart, mustReach: mustReachIndex
+        )
+    }
+
+    /// The row the reader has asked for by name, if there is one: a search result, or the unread
+    /// mark a session opens on. A scroll can only find a row the list is drawing, so the window is
+    /// opened wide enough to hold it whatever the tail said.
+    ///
+    /// Both are read here rather than taken, because a view body must not mutate. `position` takes
+    /// the search target, and `markAllRead` clears the unread mark, and both then pin the window
+    /// so that the answer surviving is not a matter of what is still outstanding.
+    private var mustReachIndex: Int? {
+        let seqs = transcript.rows.lazy.map(\.seq)
         if let target = app.pendingTranscriptTarget,
-           target.workspaceID == transcript.workspace.id,
-           target.seq < rows[start].seq {
-            return rows[...]
+           target.workspaceID == transcript.workspace.id {
+            return TranscriptWindow.index(ofSeqAtOrAfter: target.seq, in: seqs)
         }
-        return rows[start...]
+        if let unread = transcript.firstUnreadSeq {
+            return TranscriptWindow.index(ofSeqAtOrAfter: unread, in: seqs)
+        }
+        return nil
     }
 
     /// What a link in any row of this transcript does. Its own property rather than an expression
@@ -480,7 +529,18 @@ struct TranscriptListView: View {
             // scrolled away, which is the rule the per-row scroll used to enforce by hand. Yanking
             // someone back down as they read something further up is the single most irritating
             // thing a live log can do.
-            .defaultScrollAnchor(geometry.isNearBottom ? .bottom : nil, for: .sizeChanges)
+            .defaultScrollAnchor(geometry.isNearBottom || isGrowing ? .bottom : nil, for: .sizeChanges)
+            // More history, when the reader gets near the top of what is drawn.
+            //
+            // A Bool rather than the offset, and that is the whole reason it can be a subscription
+            // of its own: a projection that answers the same value re-runs nothing, so a scroll
+            // through the middle of a conversation writes no state at all and only crossing into
+            // the top of it does. `TranscriptGeometry` makes the same bargain by quantising, one
+            // step coarser.
+            .onScrollGeometryChange(for: Bool.self, of: Self.isNearTop) { _, isNearTop in
+                guard isNearTop else { return }
+                growWindow()
+            }
             // Its own subscription, for the reason the raw offset below has one: what this
             // writes is an object rather than state, so nothing in this body is invalidated by it
             // and the rows that draw a bubble are. Folded into the projection above it would put
@@ -581,14 +641,23 @@ struct TranscriptListView: View {
                 // nothing. Without this the composer keeps whatever the last session told it.
                 onScrolledUpChange?(false)
                 // Arriving somewhere means arriving on its tail, unless this pane has drawn the
-                // session before, in which case there is nothing to arrive at: see
-                // `TranscriptResume.drawsInFull`. Said here as well as in `task`, because leaving
-                // a session before its history had landed and coming straight back would
-                // otherwise find its own id still recorded and put four thousand rows on the
-                // frame that is trying to arrive.
-                drawnInFull = TranscriptResume.drawsInFull(remembered) ? transcript.session.id : nil
+                // session before, in which case it goes back to the window the reader was reading
+                // in: see `TranscriptResume.window`. Said here as well as in the initialiser,
+                // because a pane pointed at a second session is the same view with the same state,
+                // and a window left standing from the last one names rows in the wrong
+                // conversation.
+                drawn = Drawn(
+                    session: transcript.session.id,
+                    start: TranscriptResume.window(
+                        remembered,
+                        tailStart: TranscriptTail.start(in: transcript.rows.lazy.map(\.kind)),
+                        rowCount: transcript.rows.count
+                    )
+                )
+                resumed = TranscriptResume.isResuming(remembered) ? transcript.session.id : nil
+                isGrowing = false
                 // And nothing in the session being arrived at counts as having arrived. Cleared
-                // here as well as set in `task` for the same reason `drawnInFull` is: leaving a
+                // here as well as set in `task` for the same reason the window is: leaving a
                 // session before it had settled and coming straight back must not find its own
                 // id still recorded and fade its whole tail up.
                 arrivalSession = nil
@@ -622,30 +691,37 @@ struct TranscriptListView: View {
                 // and the unread badge stuck until the next row happened to land.
                 position(proxy)
 
-                // A pane coming back to a session it has drawn before has the whole of it on the
-                // frame it arrived on and is already where the reader left it, so none of the
-                // reveal below applies: there is no tail to grow into the history, nothing moves
-                // under the viewport, and the two-call dance that exists because something does
-                // has nothing to correct. Measured on a release build at 1440 by 900 against a
-                // 3,848 row session: the reveal cost a 163ms to 169ms main thread block on every
-                // return, on top of the 104ms to 125ms the tail before it cost, and this is the
-                // whole of what removing it removes.
+                // A pane coming back to a session it has drawn before is already in the window
+                // the reader was reading in and already where they left off, so none of the reveal
+                // below applies: nothing has to grow under the viewport, and the two-call dance
+                // that exists because something does has nothing to correct. Measured on a release
+                // build at 1440 by 900 against a 3,848 row session: the reveal cost a 163ms to
+                // 169ms main thread block on every return, on top of the 104ms to 125ms the tail
+                // before it cost, and this is the whole of what removing it removes.
                 //
                 // It is skipped rather than deleted. On a FIRST open the sequence is still right
                 // and `TranscriptTail` still carries the argument for it.
-                guard drawnInFull != transcript.session.id else {
+                guard resumed != transcript.session.id else {
                     arrivalSession = transcript.session.id
                     // The same mark pair the deferred path carries below, so that a run of
                     // `TabProbe` before and after this change is comparing the same span: the
                     // moment the whole session is on the list, and the first frame that can show
                     // it. Here the first half is already true when this line is reached, which is
                     // the entire change.
-                    SwitchTrace.mark("transcript.full", workspace: transcript.workspace.id)
-                    SwitchTrace.markOnScreen("transcript.full", workspace: transcript.workspace.id)
+                    SwitchTrace.mark("transcript.window", workspace: transcript.workspace.id)
+                    SwitchTrace.markOnScreen("transcript.window", workspace: transcript.workspace.id)
                     return
                 }
 
-                // The rest of the session, once the frame carrying the tail has been drawn.
+                // A few hundred rows of history behind the tail, once the frame carrying the tail
+                // has been drawn.
+                //
+                // It used to be the WHOLE session here, and the tail's saving therefore lasted
+                // exactly one frame: everything after it, every resize and every streamed token,
+                // was paid over a lazy stack holding four thousand children. `TranscriptWindow`
+                // carries what that costs. What the reader actually needs a moment after arriving
+                // is enough history to scroll back through without waiting, and the rest arrives
+                // when they go looking for it.
                 //
                 // A wait rather than a yield, because a yield is the same run loop pass and would
                 // put the layout this exists to defer back on the frame it was taken off. Long
@@ -658,14 +734,17 @@ struct TranscriptListView: View {
                 // before this lands never pays for the history of a workspace nobody is on.
                 try? await Task.sleep(for: .milliseconds(100))
                 guard !Task.isCancelled else { return }
-                drawnInFull = transcript.session.id
+                let settled = TranscriptWindow.settling(
+                    from: drawn.start, rowCount: transcript.rows.count
+                )
+                drawn = Drawn(session: transcript.session.id, start: settled)
                 // **The number the whole of this is about.** The work stamp is the instant the
                 // history was asked for; the vsync stamp is the first frame that could show it,
                 // and the display link cannot run while the main thread is laying rows out. The
                 // gap between the two IS the layout `TranscriptTail` exists to keep off the
                 // arrival frame, and on a return to a chat tab it is paid all over again.
-                SwitchTrace.mark("transcript.full", workspace: transcript.workspace.id)
-                SwitchTrace.markOnScreen("transcript.full", workspace: transcript.workspace.id)
+                SwitchTrace.mark("transcript.window", workspace: transcript.workspace.id)
+                SwitchTrace.markOnScreen("transcript.window", workspace: transcript.workspace.id)
                 // Not an arrival. See `TranscriptLiveEndFollower.forget`.
                 follower.forget()
                 // And the live end again, in two calls, in two passes.
@@ -812,6 +891,15 @@ struct TranscriptListView: View {
         )
     }
 
+    /// Whether the reader is within a screenful of the top of what is drawn.
+    ///
+    /// A screenful rather than the edge itself, because a growth is a layout and the reader is
+    /// still moving: asked at the edge, the window would be handed its next rows on the frame
+    /// after the scroll had already stopped against the top of the ones it has.
+    private static func isNearTop(_ scroll: ScrollGeometry) -> Bool {
+        scroll.contentOffset.y < scroll.containerSize.height
+    }
+
     private static func measure(_ scroll: ScrollGeometry) -> TranscriptGeometry {
         TranscriptGeometry(
             paneHeight: TranscriptGeometry.height(scroll.containerSize.height),
@@ -944,6 +1032,14 @@ struct TranscriptListView: View {
         guard !transcript.rows.isEmpty, !didPosition else { return }
         didPosition = true
 
+        // The window this opening is resolved against, pinned before anything below can take the
+        // reason for it away. `windowStart` widens to hold a search result or an unread mark, and
+        // both of those are gone moments from now: the target is taken a few lines down and the
+        // session is marked read at the foot of this function. Left computed, the window would
+        // narrow again on the next pass and take the rows the reader was just sent to out from
+        // under them. See `mustReachIndex`.
+        drawn = Drawn(session: transcript.session.id, start: windowStart)
+
         // A pane coming back to a session it has already drawn is put back where the reader left
         // it, and none of the three openings below applies: they are all answers to "where should
         // somebody arriving at this conversation start reading", and this reader is not arriving.
@@ -1013,7 +1109,10 @@ struct TranscriptListView: View {
                 offset: contentOffset.value,
                 isAtLiveEnd: geometry.isNearBottom,
                 rowCount: transcript.rows.count,
-                measure: currentMeasure
+                measure: currentMeasure,
+                // The offset above is a number of points into content that starts at this row.
+                // Written down together because they are one measurement: see `TranscriptWindow`.
+                drawnStart: drawn.start
             ),
             session: transcript.session.id
         )
@@ -1040,6 +1139,32 @@ struct TranscriptListView: View {
             scrollPosition.scrollTo(y: y)
         case nil:
             break
+        }
+    }
+
+    // MARK: Growing the window
+
+    /// Puts another chunk of the conversation into the list, above what is drawn.
+    ///
+    /// The reader is by definition scrolled away from the live end when this runs, so nothing here
+    /// is allowed to move what they are looking at: `isGrowing` hands the scroll view the bottom
+    /// anchor for the one update that grows it, which keeps the distance to the end, which is the
+    /// distance the rows arriving above cannot change.
+    ///
+    /// It is cleared a beat later rather than immediately, because the anchor has to survive the
+    /// layout pass the growth causes and not merely the state write that asks for it. Clearing it
+    /// moves nothing: by then the content size is settled, and an anchor only does anything on a
+    /// change of size.
+    private func growWindow() {
+        guard drawn.session == transcript.session.id,
+              TranscriptWindow.canGrow(from: drawn.start),
+              !isGrowing
+        else { return }
+        isGrowing = true
+        drawn.start = TranscriptWindow.grown(from: drawn.start)
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(120))
+            isGrowing = false
         }
     }
 

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -138,10 +138,21 @@ struct TranscriptListView: View {
         case liveEnd
         /// A row, and where in the pane it was put.
         case row(Int, UnitPoint)
-
+        /// A number of points down the content, which only a pane coming back to a session it has
+        /// already drawn ever has. See `TranscriptResume`.
+        case offset(Double)
     }
 
     @State private var opening: Opening?
+
+    /// Where the scroll view is now, so that leaving the pane can write it down.
+    ///
+    /// In a box rather than in `@State` for the reason `GeometryBox` sets out: this is written on
+    /// every frame of every scroll, and as `@State` every one of those frames would re-run this
+    /// body and with it every realised row, to store a number the body never reads. It is
+    /// deliberately not folded into `TranscriptGeometry` either: every value in there is quantised
+    /// so that a drag stops writing state, and a raw offset would undo that for all of them.
+    @State private var contentOffset = GeometryBox(0.0)
 
     /// How far below the viewport the end of the conversation is, read for one thing only: how
     /// long the jump pill's scroll back to the live end should run for.
@@ -328,28 +339,6 @@ struct TranscriptListView: View {
         )
     }
 
-    /// Everything typed and waiting to go, at the foot of the list.
-    ///
-    /// Lifted out of the stack because the stack's body is at the type checker's limit: adding
-    /// `scrollTargetLayout` to it was enough to push the whole expression past what it will solve
-    /// in reasonable time, and this is the piece with the most inference in it.
-    @ViewBuilder
-    private var queuedRows: some View {
-        ForEach(transcript.waitingDeliveries) { delivery in
-            PendingTurnRowView(
-                delivery: delivery,
-                // One sentence for the queue, at the foot of it. See the note on
-                // `PendingTurnRowView.caption`.
-                hold: delivery.id == transcript.waitingDeliveries.last?.id
-                    ? transcript.deliveryHold
-                    : nil,
-                onDelete: { transcript.askToDiscard(delivery) }
-            )
-            .padding(.horizontal, TranscriptLayout.inset)
-            .id(Self.pendingID(delivery.id))
-        }
-    }
-
     var body: some View {
         // The first pass of this body after a tab switch, which is where the rebuilt list starts.
         // Stamped once per timeline, so the passes that follow it cost nothing to ignore.
@@ -505,20 +494,20 @@ struct TranscriptListView: View {
                     // be said belongs. Drawn from the workspace's queue rather than from a row, so
                     // none of it can reach the agent before it is actually sent: see
                     // `PendingTurnRowView` and `WorkspaceEvent`, which is the same rule.
-                    //
-                    // Its own property rather than an expression in the stack, because the stack
-                    // is long enough that one more modifier on it tips the type checker over. See
-                    // `queuedRows`.
-                    queuedRows
+                    ForEach(transcript.waitingDeliveries) { delivery in
+                        PendingTurnRowView(
+                            delivery: delivery,
+                            // One sentence for the queue, at the foot of it. See the note on
+                            // `PendingTurnRowView.caption`.
+                            hold: delivery.id == transcript.waitingDeliveries.last?.id
+                                ? transcript.deliveryHold
+                                : nil,
+                            onDelete: { transcript.askToDiscard(delivery) }
+                        )
+                        .padding(.horizontal, TranscriptLayout.inset)
+                        .id(Self.pendingID(delivery.id))
+                    }
                 }
-                // What lets `ScrollPosition` say WHICH row is at the top of the pane, which is
-                // what a reader's place is written down as. Without a target layout the position
-                // can only speak in edges and points, and a point into a transcript is not a
-                // place: see `TranscriptPaneState.anchorSeq`.
-                //
-                // No `scrollTargetBehavior` with it, deliberately. That is the modifier that makes
-                // a scroll SNAP to a row, and a conversation is read continuously.
-                .scrollTargetLayout()
                 .padding(.vertical, TranscriptLayout.block)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 // Inside the content, so the scroll view behind the transcript can be found by
@@ -611,6 +600,14 @@ struct TranscriptListView: View {
                 // reader arrives at or leaves the end. So the extra reports are a handful per
                 // scroll, and each of them is a correction the transition form could not make.
                 onScrolledUpChange?(new.isFarFromEnd)
+            }
+            // A second subscription, on the raw offset, and deliberately not folded into the one
+            // above. Everything in `TranscriptGeometry` is quantised precisely so that a drag
+            // stops writing state; a raw offset in that value would undo the quantisation for all
+            // of it. This one writes a box, which SwiftUI cannot see, so a scroll costs one
+            // closure call per frame and no pass over this list. See `contentOffset`.
+            .onScrollGeometryChange(for: Double.self) { $0.contentOffset.y } action: { _, new in
+                contentOffset.value = new
             }
             // Where the reader ends up, written down for the pane that is built next. On the end
             // of a gesture rather than during one: see `remember`.
@@ -1119,16 +1116,13 @@ struct TranscriptListView: View {
         // pane was on another tab and those rows are rows the reader is now looking at.
         switch TranscriptResume.placement(
             for: memory?.remembered(session: transcript.session.id),
-            rowCount: transcript.rows.count
+            rowCount: transcript.rows.count,
+            measure: currentMeasure
         ) {
         case .liveEnd:
             opening = .liveEnd
-        case .row(let seq):
-            // At the top of the pane, which is where it was when it was written down: the anchor
-            // IS the row the reader had at the top. Not centred, which is what a search result
-            // gets, because a search result is a row somebody is being shown rather than a place
-            // somebody is being put back.
-            opening = .row(seq, .top)
+        case .offset(let y):
+            opening = .offset(y)
         case .first:
             // A search result outranks both of the others. Somebody who clicked a line of a
             // transcript in the search screen asked for that line, and taking them to their unread
@@ -1153,6 +1147,21 @@ struct TranscriptListView: View {
 
     // MARK: Remembering where the reader was
 
+    /// What this pane is now, or nothing if it has not been laid out yet.
+    ///
+    /// The bubble cap rather than the container width, because that is the number this view
+    /// actually holds and it is a step function of the width: see `TranscriptGeometry`, which
+    /// explains why the raw width is deliberately not kept. `paneHeight` is nought until the first
+    /// layout, and that is what tells an unmeasured pane apart from a narrow one.
+    ///
+    /// Read off the object rather than out of `geometry` since the cap moved there. Both callers
+    /// are outside `body`, so this reads `cap` without subscribing this view to it, which is the
+    /// whole point of the object.
+    private var currentMeasure: TranscriptPaneState.Measure? {
+        guard geometry.paneHeight > 0 else { return nil }
+        return TranscriptPaneState.Measure(width: bubbleWidth.cap, fontScale: fontScale)
+    }
+
     /// Writes down where the reader is, for the pane to find when it is built again.
     ///
     /// Called when a scroll settles, when a row is folded or unfolded, and when the pane goes
@@ -1167,13 +1176,10 @@ struct TranscriptListView: View {
         memory.remember(
             TranscriptPaneState(
                 expanded: expanded,
-                // The row at the top of the pane, which SwiftUI is already tracking for the list:
-                // see `scrollTargetLayout` on the stack. Nil while nothing has been laid out, and
-                // nil for a top row that is not one of the session's own (the setup log's, or a
-                // queued message's), which is the honest answer in both cases.
-                anchorSeq: scrollPosition.viewID(type: Int.self),
+                offset: contentOffset.value,
                 isAtLiveEnd: geometry.isNearBottom,
                 rowCount: transcript.rows.count,
+                measure: currentMeasure,
                 // The offset above is a number of points into content that starts at this row.
                 // Written down together because they are one measurement: see `TranscriptWindow`.
                 drawn: drawn.window
@@ -1194,6 +1200,13 @@ struct TranscriptListView: View {
             proxy.scrollTo(seq, anchor: anchor)
         case .liveEnd:
             scrollPosition.scrollTo(edge: .bottom)
+        case .offset(let y):
+            // A point rather than an edge or a row, and it needs neither of the two dances above.
+            // The content is already whole on the frame this runs on, so nothing grows underneath
+            // it and there is nothing for the reveal to put back; and the value it is being moved
+            // to is a value the state does not already hold, so one update is a change SwiftUI
+            // applies. See the reveal in `task` for why the LIVE END takes two.
+            scrollPosition.scrollTo(y: y)
         case nil:
             break
         }

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -34,7 +34,7 @@ struct TranscriptListView: View {
         let rows = transcript.rows
         _drawn = State(initialValue: Drawn(
             session: transcript.session.id,
-            start: TranscriptResume.window(
+            window: TranscriptResume.window(
                 remembered,
                 tailStart: TranscriptTail.start(in: rows.lazy.map(\.kind)),
                 rowCount: rows.count
@@ -165,8 +165,8 @@ struct TranscriptListView: View {
     /// name a row in a conversation nobody is looking at.
     private struct Drawn: Equatable {
         var session: SessionID
-        /// The first row drawn, as an index into `transcript.rows`. See `TranscriptWindow`.
-        var start: Int
+        /// The rows drawn, as indices into `transcript.rows`. See `TranscriptWindow`.
+        var window: TranscriptWindow
     }
 
     @State private var drawn: Drawn
@@ -262,8 +262,8 @@ struct TranscriptListView: View {
     /// `TurnFooterView` hands to `TurnScan` to walk backwards through, and neither could be right
     /// over a slice that starts in the middle.
     private var visibleRows: ArraySlice<TranscriptRow> {
-        let rows = transcript.rows
-        return rows[min(windowStart, rows.count)...]
+        let window = drawnWindow
+        return transcript.rows[window.start..<window.end]
     }
 
     /// The first row of the session this pass hands to the stack.
@@ -273,13 +273,23 @@ struct TranscriptListView: View {
     /// rows out from under the reader. What is computed here is the one thing that cannot be
     /// state: a row somebody has asked for by name has to be in the list on the very pass that
     /// asks for it, and `position` pins the answer the moment it has used it.
-    private var windowStart: Int {
+    private var drawnWindow: TranscriptWindow {
         let rows = transcript.rows
-        let tailStart = drawn.session == transcript.session.id
-            ? min(drawn.start, rows.count)
-            : TranscriptTail.start(in: rows.lazy.map(\.kind))
+        guard drawn.session == transcript.session.id else {
+            return TranscriptWindow.opening(
+                rowCount: rows.count,
+                tailStart: TranscriptTail.start(in: rows.lazy.map(\.kind)),
+                mustReach: mustReachIndex
+            )
+        }
+        let held = drawn.window.clamped(rowCount: rows.count)
+        // A row asked for by name that the held window does not reach moves the window to it.
+        // Everything else leaves it exactly where growth and the arrival put it.
+        guard let mustReach = mustReachIndex, mustReach < held.start || mustReach >= held.end else {
+            return held
+        }
         return TranscriptWindow.opening(
-            rowCount: rows.count, tailStart: tailStart, mustReach: mustReachIndex
+            rowCount: rows.count, tailStart: held.start, mustReach: mustReach
         )
     }
 
@@ -550,6 +560,11 @@ struct TranscriptListView: View {
             }
             .onScrollGeometryChange(for: TranscriptGeometry.self, of: Self.measure) { _, new in
                 geometry = new
+                // The bottom half of the window, and it needs neither an anchor nor a flag: rows
+                // added BELOW the viewport move nothing at all. A window with a bottom edge only
+                // exists after a session was opened on an old row, and reaching the end of it is
+                // the reader asking for what came next. See `TranscriptWindow`.
+                if new.isNearBottom { growWindowDown() }
                 // The state, every time, rather than only on a transition of it.
                 //
                 // This one fact had three copies: SwiftUI's own last projection, this view's
@@ -648,7 +663,7 @@ struct TranscriptListView: View {
                 // conversation.
                 drawn = Drawn(
                     session: transcript.session.id,
-                    start: TranscriptResume.window(
+                    window: TranscriptResume.window(
                         remembered,
                         tailStart: TranscriptTail.start(in: transcript.rows.lazy.map(\.kind)),
                         rowCount: transcript.rows.count
@@ -690,13 +705,13 @@ struct TranscriptListView: View {
                 // right, and it is still before anything has been drawn from it.
                 drawn = Drawn(
                     session: transcript.session.id,
-                    start: TranscriptResume.window(
+                    window: TranscriptResume.window(
                         memory?.remembered(session: transcript.session.id),
                         tailStart: TranscriptTail.start(in: transcript.rows.lazy.map(\.kind)),
                         rowCount: transcript.rows.count
                     )
                 )
-                TranscriptDrawn.note(transcript.rows.count - drawn.start)
+                TranscriptDrawn.note(drawn.window.count)
                 // Whatever the session arrived with, taken in without a fade. This runs whether
                 // or not the row count changed, which matters: two sessions can hold the same
                 // number of rows, and then nothing else would have told the tracker it is
@@ -752,10 +767,10 @@ struct TranscriptListView: View {
                 try? await Task.sleep(for: .milliseconds(100))
                 guard !Task.isCancelled else { return }
                 let settled = TranscriptWindow.settling(
-                    from: drawn.start, rowCount: transcript.rows.count
+                    from: drawn.window, rowCount: transcript.rows.count
                 )
-                drawn = Drawn(session: transcript.session.id, start: settled)
-                TranscriptDrawn.note(transcript.rows.count - settled)
+                drawn = Drawn(session: transcript.session.id, window: settled)
+                TranscriptDrawn.note(settled.count)
                 // **The number the whole of this is about.** The work stamp is the instant the
                 // history was asked for; the vsync stamp is the first frame that could show it,
                 // and the display link cannot run while the main thread is laying rows out. The
@@ -995,6 +1010,15 @@ struct TranscriptListView: View {
     /// the pill, which is the whole of what `catchUp` is for.
     private func goToLiveEnd() {
         catchUp?.cancel()
+        // The live end has to be IN the window before anything can travel to it, and a reader who
+        // is far enough from the end to press this is often reading a window that does not hold
+        // it. The tail rather than everything in between, for `TranscriptWindow.liveEnd`'s reason:
+        // the rows being left behind are not rows anybody is about to look at.
+        if drawn.session == transcript.session.id,
+           drawn.window.canGrowDown(rowCount: transcript.rows.count) {
+            drawn.window = TranscriptWindow.liveEnd(rowCount: transcript.rows.count)
+            TranscriptDrawn.note(drawn.window.count)
+        }
 
         let move = TranscriptMotion.liveEndMove(distance: geometry.reachToEnd, reduceMotion: reduceMotion)
         switch move {
@@ -1051,12 +1075,13 @@ struct TranscriptListView: View {
         didPosition = true
 
         // The window this opening is resolved against, pinned before anything below can take the
-        // reason for it away. `windowStart` widens to hold a search result or an unread mark, and
+        // reason for it away. `drawnWindow` moves to hold a search result or an unread mark, and
         // both of those are gone moments from now: the target is taken a few lines down and the
         // session is marked read at the foot of this function. Left computed, the window would
         // narrow again on the next pass and take the rows the reader was just sent to out from
         // under them. See `mustReachIndex`.
-        drawn = Drawn(session: transcript.session.id, start: windowStart)
+        drawn = Drawn(session: transcript.session.id, window: drawnWindow)
+        TranscriptDrawn.note(drawn.window.count)
 
         // A pane coming back to a session it has already drawn is put back where the reader left
         // it, and none of the three openings below applies: they are all answers to "where should
@@ -1130,7 +1155,7 @@ struct TranscriptListView: View {
                 measure: currentMeasure,
                 // The offset above is a number of points into content that starts at this row.
                 // Written down together because they are one measurement: see `TranscriptWindow`.
-                drawnStart: drawn.start
+                drawn: drawn.window
             ),
             session: transcript.session.id
         )
@@ -1173,6 +1198,20 @@ struct TranscriptListView: View {
     /// layout pass the growth causes and not merely the state write that asks for it. Clearing it
     /// moves nothing: by then the content size is settled, and an anchor only does anything on a
     /// change of size.
+    /// Puts the rest of the conversation back, a chunk at a time, below what is drawn.
+    ///
+    /// The mirror of `growWindow` and much the simpler half. Nothing moves when content is added
+    /// under the viewport, so there is no anchor to arrange and no flag to hold: it can run on the
+    /// arrival frame as happily as on a scroll, which matters because a session opened on an old
+    /// row is at the bottom of its own short window from the moment it is drawn.
+    private func growWindowDown() {
+        guard drawn.session == transcript.session.id,
+              drawn.window.canGrowDown(rowCount: transcript.rows.count)
+        else { return }
+        drawn.window = drawn.window.grownDown(rowCount: transcript.rows.count)
+        TranscriptDrawn.note(drawn.window.count)
+    }
+
     private func growWindow() {
         // **Only once the session has finished arriving, and this is the whole of why the first
         // build of this measured worse than no window at all.** A list is at offset nought for the
@@ -1188,12 +1227,12 @@ struct TranscriptListView: View {
         guard arrivalSession == transcript.session.id,
               !geometry.isNearBottom,
               drawn.session == transcript.session.id,
-              TranscriptWindow.canGrow(from: drawn.start),
+              drawn.window.canGrowUp,
               !isGrowing
         else { return }
         isGrowing = true
-        drawn.start = TranscriptWindow.grown(from: drawn.start)
-        TranscriptDrawn.note(transcript.rows.count - drawn.start)
+        drawn.window = drawn.window.grownUp()
+        TranscriptDrawn.note(drawn.window.count)
         Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(120))
             isGrowing = false

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -138,21 +138,10 @@ struct TranscriptListView: View {
         case liveEnd
         /// A row, and where in the pane it was put.
         case row(Int, UnitPoint)
-        /// A number of points down the content, which only a pane coming back to a session it has
-        /// already drawn ever has. See `TranscriptResume`.
-        case offset(Double)
+
     }
 
     @State private var opening: Opening?
-
-    /// Where the scroll view is now, so that leaving the pane can write it down.
-    ///
-    /// In a box rather than in `@State` for the reason `GeometryBox` sets out: this is written on
-    /// every frame of every scroll, and as `@State` every one of those frames would re-run this
-    /// body and with it every realised row, to store a number the body never reads. It is
-    /// deliberately not folded into `TranscriptGeometry` either: every value in there is quantised
-    /// so that a drag stops writing state, and a raw offset would undo that for all of them.
-    @State private var contentOffset = GeometryBox(0.0)
 
     /// How far below the viewport the end of the conversation is, read for one thing only: how
     /// long the jump pill's scroll back to the live end should run for.
@@ -339,6 +328,28 @@ struct TranscriptListView: View {
         )
     }
 
+    /// Everything typed and waiting to go, at the foot of the list.
+    ///
+    /// Lifted out of the stack because the stack's body is at the type checker's limit: adding
+    /// `scrollTargetLayout` to it was enough to push the whole expression past what it will solve
+    /// in reasonable time, and this is the piece with the most inference in it.
+    @ViewBuilder
+    private var queuedRows: some View {
+        ForEach(transcript.waitingDeliveries) { delivery in
+            PendingTurnRowView(
+                delivery: delivery,
+                // One sentence for the queue, at the foot of it. See the note on
+                // `PendingTurnRowView.caption`.
+                hold: delivery.id == transcript.waitingDeliveries.last?.id
+                    ? transcript.deliveryHold
+                    : nil,
+                onDelete: { transcript.askToDiscard(delivery) }
+            )
+            .padding(.horizontal, TranscriptLayout.inset)
+            .id(Self.pendingID(delivery.id))
+        }
+    }
+
     var body: some View {
         // The first pass of this body after a tab switch, which is where the rebuilt list starts.
         // Stamped once per timeline, so the passes that follow it cost nothing to ignore.
@@ -494,20 +505,20 @@ struct TranscriptListView: View {
                     // be said belongs. Drawn from the workspace's queue rather than from a row, so
                     // none of it can reach the agent before it is actually sent: see
                     // `PendingTurnRowView` and `WorkspaceEvent`, which is the same rule.
-                    ForEach(transcript.waitingDeliveries) { delivery in
-                        PendingTurnRowView(
-                            delivery: delivery,
-                            // One sentence for the queue, at the foot of it. See the note on
-                            // `PendingTurnRowView.caption`.
-                            hold: delivery.id == transcript.waitingDeliveries.last?.id
-                                ? transcript.deliveryHold
-                                : nil,
-                            onDelete: { transcript.askToDiscard(delivery) }
-                        )
-                        .padding(.horizontal, TranscriptLayout.inset)
-                        .id(Self.pendingID(delivery.id))
-                    }
+                    //
+                    // Its own property rather than an expression in the stack, because the stack
+                    // is long enough that one more modifier on it tips the type checker over. See
+                    // `queuedRows`.
+                    queuedRows
                 }
+                // What lets `ScrollPosition` say WHICH row is at the top of the pane, which is
+                // what a reader's place is written down as. Without a target layout the position
+                // can only speak in edges and points, and a point into a transcript is not a
+                // place: see `TranscriptPaneState.anchorSeq`.
+                //
+                // No `scrollTargetBehavior` with it, deliberately. That is the modifier that makes
+                // a scroll SNAP to a row, and a conversation is read continuously.
+                .scrollTargetLayout()
                 .padding(.vertical, TranscriptLayout.block)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 // Inside the content, so the scroll view behind the transcript can be found by
@@ -600,14 +611,6 @@ struct TranscriptListView: View {
                 // reader arrives at or leaves the end. So the extra reports are a handful per
                 // scroll, and each of them is a correction the transition form could not make.
                 onScrolledUpChange?(new.isFarFromEnd)
-            }
-            // A second subscription, on the raw offset, and deliberately not folded into the one
-            // above. Everything in `TranscriptGeometry` is quantised precisely so that a drag
-            // stops writing state; a raw offset in that value would undo the quantisation for all
-            // of it. This one writes a box, which SwiftUI cannot see, so a scroll costs one
-            // closure call per frame and no pass over this list. See `contentOffset`.
-            .onScrollGeometryChange(for: Double.self) { $0.contentOffset.y } action: { _, new in
-                contentOffset.value = new
             }
             // Where the reader ends up, written down for the pane that is built next. On the end
             // of a gesture rather than during one: see `remember`.
@@ -1116,13 +1119,16 @@ struct TranscriptListView: View {
         // pane was on another tab and those rows are rows the reader is now looking at.
         switch TranscriptResume.placement(
             for: memory?.remembered(session: transcript.session.id),
-            rowCount: transcript.rows.count,
-            measure: currentMeasure
+            rowCount: transcript.rows.count
         ) {
         case .liveEnd:
             opening = .liveEnd
-        case .offset(let y):
-            opening = .offset(y)
+        case .row(let seq):
+            // At the top of the pane, which is where it was when it was written down: the anchor
+            // IS the row the reader had at the top. Not centred, which is what a search result
+            // gets, because a search result is a row somebody is being shown rather than a place
+            // somebody is being put back.
+            opening = .row(seq, .top)
         case .first:
             // A search result outranks both of the others. Somebody who clicked a line of a
             // transcript in the search screen asked for that line, and taking them to their unread
@@ -1147,21 +1153,6 @@ struct TranscriptListView: View {
 
     // MARK: Remembering where the reader was
 
-    /// What this pane is now, or nothing if it has not been laid out yet.
-    ///
-    /// The bubble cap rather than the container width, because that is the number this view
-    /// actually holds and it is a step function of the width: see `TranscriptGeometry`, which
-    /// explains why the raw width is deliberately not kept. `paneHeight` is nought until the first
-    /// layout, and that is what tells an unmeasured pane apart from a narrow one.
-    ///
-    /// Read off the object rather than out of `geometry` since the cap moved there. Both callers
-    /// are outside `body`, so this reads `cap` without subscribing this view to it, which is the
-    /// whole point of the object.
-    private var currentMeasure: TranscriptPaneState.Measure? {
-        guard geometry.paneHeight > 0 else { return nil }
-        return TranscriptPaneState.Measure(width: bubbleWidth.cap, fontScale: fontScale)
-    }
-
     /// Writes down where the reader is, for the pane to find when it is built again.
     ///
     /// Called when a scroll settles, when a row is folded or unfolded, and when the pane goes
@@ -1176,10 +1167,13 @@ struct TranscriptListView: View {
         memory.remember(
             TranscriptPaneState(
                 expanded: expanded,
-                offset: contentOffset.value,
+                // The row at the top of the pane, which SwiftUI is already tracking for the list:
+                // see `scrollTargetLayout` on the stack. Nil while nothing has been laid out, and
+                // nil for a top row that is not one of the session's own (the setup log's, or a
+                // queued message's), which is the honest answer in both cases.
+                anchorSeq: scrollPosition.viewID(type: Int.self),
                 isAtLiveEnd: geometry.isNearBottom,
                 rowCount: transcript.rows.count,
-                measure: currentMeasure,
                 // The offset above is a number of points into content that starts at this row.
                 // Written down together because they are one measurement: see `TranscriptWindow`.
                 drawn: drawn.window
@@ -1200,13 +1194,6 @@ struct TranscriptListView: View {
             proxy.scrollTo(seq, anchor: anchor)
         case .liveEnd:
             scrollPosition.scrollTo(edge: .bottom)
-        case .offset(let y):
-            // A point rather than an edge or a row, and it needs neither of the two dances above.
-            // The content is already whole on the frame this runs on, so nothing grows underneath
-            // it and there is nothing for the reveal to put back; and the value it is being moved
-            // to is a value the state does not already hold, so one update is a change SwiftUI
-            // applies. See the reveal in `task` for why the LIVE END takes two.
-            scrollPosition.scrollTo(y: y)
         case nil:
             break
         }

--- a/Sources/BloomCore/Presentation/DiffRefreshSchedule.swift
+++ b/Sources/BloomCore/Presentation/DiffRefreshSchedule.swift
@@ -43,22 +43,43 @@ public enum DiffRefreshSchedule {
     public static let tick: TimeInterval = 6
 
     /// How stale a workspace nothing is writing to is allowed to get.
-    public static let idleMaxAge: TimeInterval = 60
+    ///
+    /// **Five minutes rather than one, because this is no longer how a change is noticed.**
+    /// `WorktreeWatcher` reports a worktree the moment anything inside it is written, and the
+    /// caller puts what it reports into `busy`, so a real edit is asked about on the next tick
+    /// whatever this says. What is left for the age to cover is the cases the file system cannot
+    /// tell us about: a volume FSEvents does not report on, and a stream that failed to start. A
+    /// backstop wants to be cheap, not prompt.
+    public static let idleMaxAge: TimeInterval = 300
+
+    /// How stale the workspace on screen is allowed to get.
+    ///
+    /// Shorter than the backstop above and no longer every tick. The workspace somebody is looking
+    /// at used to be refreshed on all of them, which is six or seven `git` processes every six
+    /// seconds for as long as a window sits open on it, and every one of those runs answered "no
+    /// change" on an idle worktree. The watcher answers that question for nothing, so what is left
+    /// here is how long a reader could be looking at a stale number if the watcher ever missed
+    /// one, and half a minute is short enough that nobody would notice it happening.
+    public static let selectedMaxAge: TimeInterval = 30
 
     /// - Parameters:
     ///   - workspaces: every workspace the loop could ask about, in sidebar order.
     ///   - busy: the ones that keep the old cadence. The caller puts the workspaces with a running
-    ///     agent and the selected one in here.
+    ///     agent, and the ones `WorktreeWatcher` says have changed, in here.
+    ///   - selected: the workspace on screen, which is asked about on its own shorter age rather
+    ///     than on every tick. Nil where nothing is selected.
     ///   - lastRefreshed: when each was last asked about, for this launch only. An absent entry
     ///     means never.
     /// - Returns: the workspaces to refresh on this tick, busy ones first.
     public static func due(
         workspaces: [WorkspaceID],
         busy: Set<WorkspaceID>,
+        selected: WorkspaceID? = nil,
         lastRefreshed: [WorkspaceID: Date],
         now: Date,
         tick: TimeInterval = tick,
-        idleMaxAge: TimeInterval = idleMaxAge
+        idleMaxAge: TimeInterval = idleMaxAge,
+        selectedMaxAge: TimeInterval = selectedMaxAge
     ) -> [WorkspaceID] {
         var due: [WorkspaceID] = []
         var stale: [(id: WorkspaceID, age: TimeInterval, place: Int)] = []
@@ -73,6 +94,13 @@ public enum DiffRefreshSchedule {
                 continue
             }
             let age = now.timeIntervalSince(last)
+            if id == selected {
+                // The one on screen is never part of the trickle: it is due on its own age or not
+                // at all, so a sidebar with twenty workspaces in it cannot push the workspace
+                // somebody is reading to the back of a rotation.
+                if age >= selectedMaxAge { due.append(id) }
+                continue
+            }
             guard age >= idleMaxAge else { continue }
             stale.append((id, age, place))
         }
@@ -82,7 +110,7 @@ public enum DiffRefreshSchedule {
         // Sized off every idle workspace rather than off the ones that have come due, so the slice
         // is a steady two or three rather than jumping about as a backlog drains. At least one,
         // because a sidebar of two workspaces would otherwise round down to none and never refresh.
-        let idleCount = workspaces.count { !busy.contains($0) }
+        let idleCount = workspaces.count { !busy.contains($0) && $0 != selected }
         let perTick = max(1, Int((Double(idleCount) * tick / idleMaxAge).rounded(.up)))
 
         // Oldest first, so nothing at the back of a backlog is starved by a shorter list in front

--- a/Sources/BloomCore/System/WorktreeWatcher.swift
+++ b/Sources/BloomCore/System/WorktreeWatcher.swift
@@ -1,0 +1,223 @@
+import Foundation
+import CoreServices
+import Synchronization
+
+/// Tells the app which worktrees have actually changed, so the six second loop stops asking git
+/// about the ones that have not.
+///
+/// # Why this exists
+///
+/// `DiffRefreshSchedule` carries the measurement the polling loop was cut down by: one pass over
+/// one worktree is six `git` processes, seventeen of them cost 2,864ms of process time, and the
+/// answer was to ask about fewer of them per tick. That is the best a poll can do, and it is still
+/// the wrong shape: every one of those processes runs to find out whether anything happened, and
+/// on an idle machine the answer is always no. `IdleProbe` over three of this machine's small
+/// worktrees measures 18 processes and 105ms of CPU per pass with nothing happening at all, and
+/// one pass in five of that run took 3,499ms of child CPU, which is what a big repository costs
+/// when the answer is still no.
+///
+/// So the file system is asked to say when something happens instead. A worktree that has changed
+/// is refreshed on the next tick rather than up to a minute later, and a worktree that has not is
+/// not asked about at all until the backstop age comes round.
+///
+/// # What it reports, and what it deliberately does not
+///
+/// The root that changed, and nothing else. Not the file, not the kind of change: everything the
+/// app does with this is "ask git about that worktree", and git is the only thing here that can
+/// say what a change means. Reporting less is also what makes the coalescing safe, because two
+/// hundred writes inside one directory are one answer.
+///
+/// `.git` is deliberately NOT excluded. A commit, a checkout, a stash and an index update all move
+/// what `git diff` says and all of them land in there, and a watcher that ignored it would leave
+/// the counts stale for exactly the operations an agent performs most.
+///
+/// # Why one stream for every worktree rather than one each
+///
+/// FSEvents takes a list of paths and answers with the path that changed, so a single stream
+/// covers every workspace in the sidebar for the cost of one. Twenty streams would be twenty
+/// kernel subscriptions and twenty queues to shut down in the right order when the list moves,
+/// which it does on every workspace created, archived or restored.
+public final class WorktreeWatcher: Sendable {
+    /// What a batch of file system events becomes: the worktree roots that changed.
+    private let onChange: @Sendable (Set<String>) -> Void
+
+    /// How long FSEvents holds events back to coalesce them.
+    ///
+    /// One second, which is the same order as the tick this feeds and an eternity next to the
+    /// write storm a `git checkout` or an agent's edit produces. The point of the latency is that
+    /// a thousand writes arrive as one wake-up; making it shorter would buy a refresh that lands
+    /// in the same tick either way.
+    public static let latency: TimeInterval = 1
+
+    private struct Watched {
+        var stream: FSEventStreamRef?
+        /// The roots as the caller spelled them, which is what a change is reported back as and
+        /// what a second call is compared against.
+        var given: [String] = []
+        /// The same roots with every symlink resolved, longest first so that a nested worktree is
+        /// matched before the checkout it sits inside. FSEvents answers with the real path
+        /// whatever it was handed, so this is the spelling an event can be compared with.
+        var matching: [String] = []
+        /// Real path back to the spelling the caller uses.
+        var origins: [String: String] = [:]
+    }
+
+    private let watched = Mutex(Watched())
+    private let queue = DispatchQueue(label: "be.spatie.bloom.worktree-watcher", qos: .utility)
+
+    public init(onChange: @escaping @Sendable (Set<String>) -> Void) {
+        self.onChange = onChange
+    }
+
+    deinit {
+        // Not `stop()`, which takes the lock: nothing else can hold a reference by the time this
+        // runs, and the stream still has to be released or the kernel subscription outlives us.
+        watched.withLock { state in
+            Self.tearDown(state.stream)
+            state.stream = nil
+        }
+    }
+
+    /// Points the watcher at exactly these worktrees, replacing whatever it was watching.
+    ///
+    /// Rebuilt rather than amended, because FSEvents has no way to add a path to a running stream
+    /// and the list changes only when a workspace is created, archived or restored. A call that
+    /// names the same roots as last time does nothing at all, which is what makes it safe to call
+    /// from the same place the workspace list is published from.
+    public func watch(roots: [String]) {
+        let wanted = Self.ordered(roots)
+        watched.withLock { state in
+            guard state.given != wanted else { return }
+            Self.tearDown(state.stream)
+            state.given = wanted
+            var origins: [String: String] = [:]
+            for root in wanted { origins[Self.resolve(root)] = root }
+            state.origins = origins
+            state.matching = Self.ordered(Array(origins.keys))
+            state.stream = wanted.isEmpty ? nil : makeStream(for: wanted)
+        }
+    }
+
+    /// Stops watching, permanently. Called when the app is going away; `watch(roots: [])` is the
+    /// way to stop watching and carry on.
+    public func stop() {
+        watched.withLock { state in
+            Self.tearDown(state.stream)
+            state.stream = nil
+            state.given = []
+            state.matching = []
+            state.origins = [:]
+        }
+    }
+
+    // MARK: - The stream
+
+    private func makeStream(for roots: [String]) -> FSEventStreamRef? {
+        var context = FSEventStreamContext(
+            version: 0,
+            info: Unmanaged.passUnretained(self).toOpaque(),
+            retain: nil,
+            release: nil,
+            copyDescription: nil
+        )
+
+        // `.fileEvents` is deliberately absent. Directory level events are what this reports
+        // anyway, and per-file events would be thousands of callbacks for one `npm install`.
+        // `.noDefer` makes the first event of a burst arrive at the start of the latency window
+        // rather than the end, so a single save is seen a second sooner than a storm is.
+        let flags = UInt32(
+            kFSEventStreamCreateFlagUseCFTypes
+                | kFSEventStreamCreateFlagNoDefer
+                | kFSEventStreamCreateFlagWatchRoot
+        )
+
+        guard let stream = FSEventStreamCreate(
+            kCFAllocatorDefault,
+            { _, info, count, paths, _, _ in
+                guard let info, count > 0 else { return }
+                let watcher = Unmanaged<WorktreeWatcher>.fromOpaque(info).takeUnretainedValue()
+                let changed = unsafeBitCast(paths, to: NSArray.self) as? [String] ?? []
+                watcher.report(changed)
+            },
+            &context,
+            roots as CFArray,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            Self.latency,
+            flags
+        ) else { return nil }
+
+        FSEventStreamSetDispatchQueue(stream, queue)
+        guard FSEventStreamStart(stream) else {
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+            return nil
+        }
+        return stream
+    }
+
+    private static func tearDown(_ stream: FSEventStreamRef?) {
+        guard let stream else { return }
+        FSEventStreamStop(stream)
+        FSEventStreamInvalidate(stream)
+        FSEventStreamRelease(stream)
+    }
+
+    /// One batch of events, reduced to the worktrees they happened in.
+    ///
+    /// A path that matches no root is dropped rather than reported: FSEvents answers about the
+    /// directory it watched when a root itself is moved or deleted, and a caller told about a
+    /// worktree it does not have would ask git about a path that is not there.
+    private func report(_ paths: [String]) {
+        let (matching, origins) = watched.withLock { ($0.matching, $0.origins) }
+        let changed = Self.roots(of: paths, in: matching).compactMap { origins[$0] }
+        guard !changed.isEmpty else { return }
+        onChange(Set(changed))
+    }
+
+    // MARK: - The arithmetic, which is the part worth testing
+
+    /// The roots a batch of changed paths belong to.
+    ///
+    /// Longest root first, so a worktree nested inside another checkout is attributed to itself
+    /// rather than to its parent. A trailing separator is required on the match so that
+    /// `/a/workspaces/beta-two` is not read as a change inside `/a/workspaces/beta`.
+    public static func roots(of paths: [String], in roots: [String]) -> Set<String> {
+        var changed: Set<String> = []
+        for path in paths {
+            let standardised = standardise(path)
+            for root in roots where standardised == root || standardised.hasPrefix(root + "/") {
+                changed.insert(root)
+                break
+            }
+        }
+        return changed
+    }
+
+    /// The roots as they are compared: standardised, deduplicated, and longest first.
+    public static func ordered(_ roots: [String]) -> [String] {
+        Array(Set(roots.map(standardise))).sorted { $0.count > $1.count }
+    }
+
+    /// A path with every symlink resolved, which is the spelling FSEvents reports in.
+    ///
+    /// `realpath` rather than `URL.resolvingSymlinksInPath`, which on this platform does the
+    /// opposite of what its name promises for the one directory that needs it: handed
+    /// `/private/var/folders/...` it answers `/var/folders/...`, so a watcher that trusted it
+    /// matched none of its own events under `NSTemporaryDirectory`. Resolved once per change to
+    /// the workspace list rather than per event.
+    ///
+    /// A path that does not exist resolves to itself, which is right: a worktree removed from
+    /// under the watcher has nothing to compare against and nothing left to report.
+    static func resolve(_ path: String) -> String {
+        guard let real = realpath(path, nil) else { return standardise(path) }
+        defer { free(real) }
+        return standardise(String(cString: real))
+    }
+
+    /// A path with its trailing separator removed.
+    private static func standardise(_ path: String) -> String {
+        var trimmed = path
+        while trimmed.count > 1, trimmed.hasSuffix("/") { trimmed.removeLast() }
+        return trimmed
+    }
+}

--- a/Sources/BloomCore/Transcript/TranscriptResume.swift
+++ b/Sources/BloomCore/Transcript/TranscriptResume.swift
@@ -82,12 +82,12 @@ public struct TranscriptPaneState: Equatable, Sendable {
     /// How many rows the session held when this was written. See `TranscriptResume.placement`.
     public var rowCount: Int
     public var measure: Measure?
-    /// The first row the list was drawing when the offset was taken, as an index into the session.
+    /// The rows the list was drawing when the offset was taken.
     ///
-    /// The offset is a number of points into the content, and the content starts at this row, so
-    /// the two are one measurement and are useless apart: restoring the offset into a window that
-    /// starts somewhere else lands the reader somewhere else. See `TranscriptWindow`.
-    public var drawnStart: Int
+    /// The offset is a number of points into the content, and the content is exactly these rows,
+    /// so the two are one measurement and are useless apart: restoring the offset into a window
+    /// that holds different rows lands the reader somewhere else. See `TranscriptWindow`.
+    public var drawn: TranscriptWindow
 
     public init(
         expanded: Set<Int>,
@@ -95,14 +95,14 @@ public struct TranscriptPaneState: Equatable, Sendable {
         isAtLiveEnd: Bool,
         rowCount: Int,
         measure: Measure?,
-        drawnStart: Int = 0
+        drawn: TranscriptWindow = TranscriptWindow(start: 0, end: 0)
     ) {
         self.expanded = expanded
         self.offset = offset
         self.isAtLiveEnd = isAtLiveEnd
         self.rowCount = rowCount
         self.measure = measure
-        self.drawnStart = drawnStart
+        self.drawn = drawn
     }
 }
 
@@ -147,9 +147,11 @@ public enum TranscriptResume {
 
     public static func window(
         _ remembered: TranscriptPaneState?, tailStart: Int, rowCount: Int
-    ) -> Int {
-        guard let remembered else { return min(max(0, tailStart), max(0, rowCount)) }
-        return min(max(0, remembered.drawnStart), max(0, rowCount))
+    ) -> TranscriptWindow {
+        guard let remembered else {
+            return TranscriptWindow.opening(rowCount: rowCount, tailStart: tailStart)
+        }
+        return remembered.drawn.clamped(rowCount: rowCount)
     }
 
     /// Where a pane opens a session, given what it wrote down when it last left one.

--- a/Sources/BloomCore/Transcript/TranscriptResume.swift
+++ b/Sources/BloomCore/Transcript/TranscriptResume.swift
@@ -51,24 +51,6 @@ public struct TranscriptPaneState: Equatable, Sendable {
         }
     }
 
-    /// The width the rows were laid out at and the scale they were drawn at, which are the two
-    /// things that decide how tall a row is and so what a point of offset means.
-    ///
-    /// Optional at both ends, and that is the rule rather than a convenience: a pane that has not
-    /// been laid out yet has no width to offer, and a measurement nobody has taken cannot
-    /// contradict one that was. The alternative was to treat "not measured" as "different" and
-    /// throw away every restored position on the frame the geometry had not landed on yet, which
-    /// is most of them.
-    public struct Measure: Equatable, Sendable {
-        public var width: Double
-        public var fontScale: Double
-
-        public init(width: Double, fontScale: Double) {
-            self.width = width
-            self.fontScale = fontScale
-        }
-    }
-
     /// The sequence numbers of the rows the reader had unfolded.
     public var expanded: Set<Int>
     /// Where the view was, in points from the top of the content.
@@ -81,7 +63,6 @@ public struct TranscriptPaneState: Equatable, Sendable {
     public var isAtLiveEnd: Bool
     /// How many rows the session held when this was written. See `TranscriptResume.placement`.
     public var rowCount: Int
-    public var measure: Measure?
     /// The rows the list was drawing when the offset was taken.
     ///
     /// The offset is a number of points into the content, and the content is exactly these rows,
@@ -94,14 +75,12 @@ public struct TranscriptPaneState: Equatable, Sendable {
         offset: Double,
         isAtLiveEnd: Bool,
         rowCount: Int,
-        measure: Measure?,
         drawn: TranscriptWindow = TranscriptWindow(start: 0, end: 0)
     ) {
         self.expanded = expanded
         self.offset = offset
         self.isAtLiveEnd = isAtLiveEnd
         self.rowCount = rowCount
-        self.measure = measure
         self.drawn = drawn
     }
 }
@@ -168,8 +147,7 @@ public enum TranscriptResume {
     /// the first unread row, which is what a session nobody has read wants.
     public static func placement(
         for remembered: TranscriptPaneState?,
-        rowCount: Int,
-        measure: TranscriptPaneState.Measure?
+        rowCount: Int
     ) -> TranscriptPlacement {
         guard let remembered, rowCount > 0 else { return .first }
         // A session with fewer rows than it had is not the session that offset was measured in.
@@ -181,10 +159,21 @@ public enum TranscriptResume {
         // width change moves nobody who was there, because the end is a place rather than a
         // measurement, so this is asked before the measure is looked at.
         if remembered.isAtLiveEnd { return .liveEnd }
-        // A point into a document laid out at another width, or at another text size, is a point
-        // into a different document. Rather than land the reader at a plausible looking wrong
-        // place, this opens the way a fresh visit does.
-        if let measure, let was = remembered.measure, was != measure { return .first }
+        // **A point measured at another width is used anyway, and that is a reversal.**
+        //
+        // It used to be refused, on the argument that a point into a document laid out at another
+        // width is a point into a different document and landing the reader at a plausible looking
+        // wrong place is worse than opening the way a fresh visit does. The first half of that is
+        // true and the second half turned out to be the bug the owner reported: opening the way a
+        // fresh visit does means opening at the first unread row, and after an agent has worked
+        // while somebody was on another workspace, that row is the middle of a long conversation.
+        // Roughly where they were beats a screen they have never seen.
+        //
+        // What would settle it properly is remembering the ROW rather than the point, which
+        // survives every width and every re-measurement. SwiftUI will say which row is at the top
+        // of a scroll target layout, and measured on this list that layout costs too much to keep:
+        // p99 went from 21.8ms to 39.2ms scrolling a 225 row chat with nothing else changed. So
+        // the row is what an AppKit list would buy, and until then this is the honest fallback.
         guard remembered.offset > 0 else { return .first }
         return .offset(remembered.offset)
     }

--- a/Sources/BloomCore/Transcript/TranscriptResume.swift
+++ b/Sources/BloomCore/Transcript/TranscriptResume.swift
@@ -33,10 +33,9 @@ import Foundation
 ///
 /// `placement` answers about the place, and the folds are handed back whatever it says, because
 /// the two have different lifetimes. A fold is about a row: it survives the pane being made
-/// narrower, the text being made bigger and the session growing.
-///
-/// The place is about a row now too, and it did not used to be. See `TranscriptPaneState.anchorSeq`
-/// for what a point offset cost and why nothing here refuses a restore any more.
+/// narrower, the text being made bigger and the session growing. An offset is a number of points
+/// into a laid out document, and every one of those changes makes it a number into a different
+/// document.
 public struct TranscriptPaneState: Equatable, Sendable {
     /// One pane's memory of one conversation. Both halves are needed: a split tab can hold the
     /// same session in two panes, each scrolled somewhere else, and an unsplit tab's pane is
@@ -52,24 +51,28 @@ public struct TranscriptPaneState: Equatable, Sendable {
         }
     }
 
+    /// The width the rows were laid out at and the scale they were drawn at, which are the two
+    /// things that decide how tall a row is and so what a point of offset means.
+    ///
+    /// Optional at both ends, and that is the rule rather than a convenience: a pane that has not
+    /// been laid out yet has no width to offer, and a measurement nobody has taken cannot
+    /// contradict one that was. The alternative was to treat "not measured" as "different" and
+    /// throw away every restored position on the frame the geometry had not landed on yet, which
+    /// is most of them.
+    public struct Measure: Equatable, Sendable {
+        public var width: Double
+        public var fontScale: Double
+
+        public init(width: Double, fontScale: Double) {
+            self.width = width
+            self.fontScale = fontScale
+        }
+    }
+
     /// The sequence numbers of the rows the reader had unfolded.
     public var expanded: Set<Int>
-    /// The row that was at the top of the viewport, by sequence number.
-    ///
-    /// **A row rather than a point, and that is the whole of this type's history.** It was a
-    /// number of points into the content, with the pane's width and text size written down beside
-    /// it so a restore could refuse when either had changed. Both halves of that were wrong. The
-    /// content height is not stable even when nothing changes: measured on a release build over a
-    /// 225 row chat, after a full warm pass, it moves 4,769 points to 3,730 during a single scroll
-    /// as the lazy stack replaces the heights it guessed with the heights it measured. A point
-    /// into that document names a different row a moment later, and the refusal that was supposed
-    /// to protect the reader dropped them at their first unread row instead, which after an agent
-    /// has worked while they were away is the middle of the conversation.
-    ///
-    /// A row is the same row at any width, at any text size, and whatever the stack currently
-    /// believes the rows above it are worth. Nil for a pane that never saw a row at its top,
-    /// which is a pane that was never laid out.
-    public var anchorSeq: Int?
+    /// Where the view was, in points from the top of the content.
+    public var offset: Double
     /// Whether that offset was the live end.
     ///
     /// Kept as a flag rather than inferred from the offset, because a turn can run while the
@@ -78,6 +81,7 @@ public struct TranscriptPaneState: Equatable, Sendable {
     public var isAtLiveEnd: Bool
     /// How many rows the session held when this was written. See `TranscriptResume.placement`.
     public var rowCount: Int
+    public var measure: Measure?
     /// The rows the list was drawing when the offset was taken.
     ///
     /// The offset is a number of points into the content, and the content is exactly these rows,
@@ -87,15 +91,17 @@ public struct TranscriptPaneState: Equatable, Sendable {
 
     public init(
         expanded: Set<Int>,
-        anchorSeq: Int?,
+        offset: Double,
         isAtLiveEnd: Bool,
         rowCount: Int,
+        measure: Measure?,
         drawn: TranscriptWindow = TranscriptWindow(start: 0, end: 0)
     ) {
         self.expanded = expanded
-        self.anchorSeq = anchorSeq
+        self.offset = offset
         self.isAtLiveEnd = isAtLiveEnd
         self.rowCount = rowCount
+        self.measure = measure
         self.drawn = drawn
     }
 }
@@ -107,8 +113,8 @@ public enum TranscriptPlacement: Equatable, Sendable {
     case first
     /// The reader left at the live end, so that is where they are put back.
     case liveEnd
-    /// The reader left this row at the top of the pane, so that is where it goes back.
-    case row(Int)
+    /// The reader left this many points down, and the document is the same document.
+    case offset(Double)
 }
 
 /// The rule for what a pane may do with what it remembers.
@@ -162,21 +168,24 @@ public enum TranscriptResume {
     /// the first unread row, which is what a session nobody has read wants.
     public static func placement(
         for remembered: TranscriptPaneState?,
-        rowCount: Int
+        rowCount: Int,
+        measure: TranscriptPaneState.Measure?
     ) -> TranscriptPlacement {
         guard let remembered, rowCount > 0 else { return .first }
-        // A session with fewer rows than it had is not the session that anchor was taken in.
+        // A session with fewer rows than it had is not the session that offset was measured in.
         // Rows are appended and never removed while a pane is away, so this is a transcript that
         // was read again from the start rather than one that grew, and nothing written about the
         // old one carries.
         guard remembered.rowCount <= rowCount else { return .first }
         // The end has moved if a turn ran while the reader was away, and it is still the end. A
-        // reader who was at the live end wants the live end, not the row that used to be there.
+        // width change moves nobody who was there, because the end is a place rather than a
+        // measurement, so this is asked before the measure is looked at.
         if remembered.isAtLiveEnd { return .liveEnd }
-        // The row they were reading. There is nothing left to refuse: the width check and the text
-        // size check that used to live here existed to protect a point offset, and a row does not
-        // need protecting from either. See `TranscriptPaneState.anchorSeq`.
-        if let seq = remembered.anchorSeq { return .row(seq) }
-        return .first
+        // A point into a document laid out at another width, or at another text size, is a point
+        // into a different document. Rather than land the reader at a plausible looking wrong
+        // place, this opens the way a fresh visit does.
+        if let measure, let was = remembered.measure, was != measure { return .first }
+        guard remembered.offset > 0 else { return .first }
+        return .offset(remembered.offset)
     }
 }

--- a/Sources/BloomCore/Transcript/TranscriptResume.swift
+++ b/Sources/BloomCore/Transcript/TranscriptResume.swift
@@ -148,7 +148,11 @@ public enum TranscriptResume {
     public static func window(
         _ remembered: TranscriptPaneState?, tailStart: Int, rowCount: Int
     ) -> TranscriptWindow {
-        guard let remembered else {
+        // A remembered window with no rows in it is not a window anybody was reading in: it is
+        // what a pane wrote down before its session had loaded, and restoring it draws a blank
+        // transcript. Measured, and caught only because the probe reports how many rows are in the
+        // stack: a run that looked like the fastest resize yet was a pane with nothing in it.
+        guard let remembered, remembered.drawn.count > 0 else {
             return TranscriptWindow.opening(rowCount: rowCount, tailStart: tailStart)
         }
         return remembered.drawn.clamped(rowCount: rowCount)

--- a/Sources/BloomCore/Transcript/TranscriptResume.swift
+++ b/Sources/BloomCore/Transcript/TranscriptResume.swift
@@ -33,9 +33,10 @@ import Foundation
 ///
 /// `placement` answers about the place, and the folds are handed back whatever it says, because
 /// the two have different lifetimes. A fold is about a row: it survives the pane being made
-/// narrower, the text being made bigger and the session growing. An offset is a number of points
-/// into a laid out document, and every one of those changes makes it a number into a different
-/// document.
+/// narrower, the text being made bigger and the session growing.
+///
+/// The place is about a row now too, and it did not used to be. See `TranscriptPaneState.anchorSeq`
+/// for what a point offset cost and why nothing here refuses a restore any more.
 public struct TranscriptPaneState: Equatable, Sendable {
     /// One pane's memory of one conversation. Both halves are needed: a split tab can hold the
     /// same session in two panes, each scrolled somewhere else, and an unsplit tab's pane is
@@ -51,28 +52,24 @@ public struct TranscriptPaneState: Equatable, Sendable {
         }
     }
 
-    /// The width the rows were laid out at and the scale they were drawn at, which are the two
-    /// things that decide how tall a row is and so what a point of offset means.
-    ///
-    /// Optional at both ends, and that is the rule rather than a convenience: a pane that has not
-    /// been laid out yet has no width to offer, and a measurement nobody has taken cannot
-    /// contradict one that was. The alternative was to treat "not measured" as "different" and
-    /// throw away every restored position on the frame the geometry had not landed on yet, which
-    /// is most of them.
-    public struct Measure: Equatable, Sendable {
-        public var width: Double
-        public var fontScale: Double
-
-        public init(width: Double, fontScale: Double) {
-            self.width = width
-            self.fontScale = fontScale
-        }
-    }
-
     /// The sequence numbers of the rows the reader had unfolded.
     public var expanded: Set<Int>
-    /// Where the view was, in points from the top of the content.
-    public var offset: Double
+    /// The row that was at the top of the viewport, by sequence number.
+    ///
+    /// **A row rather than a point, and that is the whole of this type's history.** It was a
+    /// number of points into the content, with the pane's width and text size written down beside
+    /// it so a restore could refuse when either had changed. Both halves of that were wrong. The
+    /// content height is not stable even when nothing changes: measured on a release build over a
+    /// 225 row chat, after a full warm pass, it moves 4,769 points to 3,730 during a single scroll
+    /// as the lazy stack replaces the heights it guessed with the heights it measured. A point
+    /// into that document names a different row a moment later, and the refusal that was supposed
+    /// to protect the reader dropped them at their first unread row instead, which after an agent
+    /// has worked while they were away is the middle of the conversation.
+    ///
+    /// A row is the same row at any width, at any text size, and whatever the stack currently
+    /// believes the rows above it are worth. Nil for a pane that never saw a row at its top,
+    /// which is a pane that was never laid out.
+    public var anchorSeq: Int?
     /// Whether that offset was the live end.
     ///
     /// Kept as a flag rather than inferred from the offset, because a turn can run while the
@@ -81,7 +78,6 @@ public struct TranscriptPaneState: Equatable, Sendable {
     public var isAtLiveEnd: Bool
     /// How many rows the session held when this was written. See `TranscriptResume.placement`.
     public var rowCount: Int
-    public var measure: Measure?
     /// The rows the list was drawing when the offset was taken.
     ///
     /// The offset is a number of points into the content, and the content is exactly these rows,
@@ -91,17 +87,15 @@ public struct TranscriptPaneState: Equatable, Sendable {
 
     public init(
         expanded: Set<Int>,
-        offset: Double,
+        anchorSeq: Int?,
         isAtLiveEnd: Bool,
         rowCount: Int,
-        measure: Measure?,
         drawn: TranscriptWindow = TranscriptWindow(start: 0, end: 0)
     ) {
         self.expanded = expanded
-        self.offset = offset
+        self.anchorSeq = anchorSeq
         self.isAtLiveEnd = isAtLiveEnd
         self.rowCount = rowCount
-        self.measure = measure
         self.drawn = drawn
     }
 }
@@ -113,8 +107,8 @@ public enum TranscriptPlacement: Equatable, Sendable {
     case first
     /// The reader left at the live end, so that is where they are put back.
     case liveEnd
-    /// The reader left this many points down, and the document is the same document.
-    case offset(Double)
+    /// The reader left this row at the top of the pane, so that is where it goes back.
+    case row(Int)
 }
 
 /// The rule for what a pane may do with what it remembers.
@@ -168,24 +162,21 @@ public enum TranscriptResume {
     /// the first unread row, which is what a session nobody has read wants.
     public static func placement(
         for remembered: TranscriptPaneState?,
-        rowCount: Int,
-        measure: TranscriptPaneState.Measure?
+        rowCount: Int
     ) -> TranscriptPlacement {
         guard let remembered, rowCount > 0 else { return .first }
-        // A session with fewer rows than it had is not the session that offset was measured in.
+        // A session with fewer rows than it had is not the session that anchor was taken in.
         // Rows are appended and never removed while a pane is away, so this is a transcript that
         // was read again from the start rather than one that grew, and nothing written about the
         // old one carries.
         guard remembered.rowCount <= rowCount else { return .first }
         // The end has moved if a turn ran while the reader was away, and it is still the end. A
-        // width change moves nobody who was there, because the end is a place rather than a
-        // measurement, so this is asked before the measure is looked at.
+        // reader who was at the live end wants the live end, not the row that used to be there.
         if remembered.isAtLiveEnd { return .liveEnd }
-        // A point into a document laid out at another width, or at another text size, is a point
-        // into a different document. Rather than land the reader at a plausible looking wrong
-        // place, this opens the way a fresh visit does.
-        if let measure, let was = remembered.measure, was != measure { return .first }
-        guard remembered.offset > 0 else { return .first }
-        return .offset(remembered.offset)
+        // The row they were reading. There is nothing left to refuse: the width check and the text
+        // size check that used to live here existed to protect a point offset, and a row does not
+        // need protecting from either. See `TranscriptPaneState.anchorSeq`.
+        if let seq = remembered.anchorSeq { return .row(seq) }
+        return .first
     }
 }

--- a/Sources/BloomCore/Transcript/TranscriptResume.swift
+++ b/Sources/BloomCore/Transcript/TranscriptResume.swift
@@ -82,19 +82,27 @@ public struct TranscriptPaneState: Equatable, Sendable {
     /// How many rows the session held when this was written. See `TranscriptResume.placement`.
     public var rowCount: Int
     public var measure: Measure?
+    /// The first row the list was drawing when the offset was taken, as an index into the session.
+    ///
+    /// The offset is a number of points into the content, and the content starts at this row, so
+    /// the two are one measurement and are useless apart: restoring the offset into a window that
+    /// starts somewhere else lands the reader somewhere else. See `TranscriptWindow`.
+    public var drawnStart: Int
 
     public init(
         expanded: Set<Int>,
         offset: Double,
         isAtLiveEnd: Bool,
         rowCount: Int,
-        measure: Measure?
+        measure: Measure?,
+        drawnStart: Int = 0
     ) {
         self.expanded = expanded
         self.offset = offset
         self.isAtLiveEnd = isAtLiveEnd
         self.rowCount = rowCount
         self.measure = measure
+        self.drawnStart = drawnStart
     }
 }
 
@@ -111,16 +119,37 @@ public enum TranscriptPlacement: Equatable, Sendable {
 
 /// The rule for what a pane may do with what it remembers.
 public enum TranscriptResume {
-    /// Whether the arrival frame may draw the whole session rather than `TranscriptTail`'s tail.
+    /// The first row of the session a pane draws, given what it wrote down when it last left one.
     ///
     /// **Asked before anything has been laid out**, because it decides what the FIRST pass of the
-    /// list's body draws, so it can read nothing that a measurement has to arrive for. The
-    /// existence of a memory for this pane and this session is the whole of it, and that is enough:
-    /// a pane that has drawn this session before is not arriving at it. The tail exists to keep a
-    /// 269ms layout off the frame that arrives at a session, and the price of it is the same layout
-    /// a hundred milliseconds later; paying that on every return is the trade going the wrong way.
-    public static func drawsInFull(_ remembered: TranscriptPaneState?) -> Bool {
+    /// list's body draws, so it can read nothing that a measurement has to arrive for.
+    ///
+    /// This used to answer a Bool, and the Bool was "draw the whole session". The argument for it
+    /// was sound and is kept: a pane that has drawn this session before is not arriving at it, so
+    /// the tail that keeps a 269ms layout off an arrival frame buys nothing on a return, and
+    /// paying a second layout to reveal the history behind it is the trade going the wrong way.
+    /// What was wrong was the other end of it. The whole session stays in the lazy stack for the
+    /// rest of the visit, and every resize, scroll and streamed token then pays for a stack with
+    /// four thousand children in it. See `TranscriptWindow`, which carries those measurements.
+    ///
+    /// So a return goes back to the window the reader was actually looking at, which is what makes
+    /// the remembered offset mean anything: the same rows above the viewport, in the same order,
+    /// so the same number of points down the content names the same place. A pane with nothing
+    /// written down is arriving, and arrives on the tail.
+    /// Whether this pane is coming back to a session rather than arriving at one.
+    ///
+    /// The existence of a memory for this pane and this session is the whole of it. A reader
+    /// coming back is already where they were, so nothing has to be revealed under them and the
+    /// window stays exactly as `window` restored it.
+    public static func isResuming(_ remembered: TranscriptPaneState?) -> Bool {
         remembered != nil
+    }
+
+    public static func window(
+        _ remembered: TranscriptPaneState?, tailStart: Int, rowCount: Int
+    ) -> Int {
+        guard let remembered else { return min(max(0, tailStart), max(0, rowCount)) }
+        return min(max(0, remembered.drawnStart), max(0, rowCount))
     }
 
     /// Where a pane opens a session, given what it wrote down when it last left one.

--- a/Sources/BloomCore/Transcript/TranscriptWindow.swift
+++ b/Sources/BloomCore/Transcript/TranscriptWindow.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// How much of a session the list hands to its lazy stack, and when that grows.
+/// How much of a session the list hands to its lazy stack, and when that moves.
 ///
 /// **A lazy stack is lazy about realising a row and is not lazy about knowing one.** Placing its
 /// subviews walks every child it has been handed, realised or not, so the cost of a layout pass
@@ -15,14 +15,37 @@ import Foundation
 /// last eighty rows, because resolving a position at the end of a stack realises everything above
 /// it. What it did next was hand the stack the whole session a hundred milliseconds later, so the
 /// saving lasted exactly one frame and every resize, scroll and streamed token for the rest of the
-/// visit paid for four thousand children. This is that second half: the window grows to a few
-/// hundred rows once the arrival is over, and grows again when the reader actually approaches the
-/// top of it.
+/// visit paid for four thousand children. This is that second half.
+///
+/// # Why it has two ends
+///
+/// The first version had one, and a window that started somewhere and ran to the end of the
+/// session. It was measured drawing all 1,582 rows of the fixture anyway, and the reason is the
+/// case Bloom is FOR: an agent works while you are somewhere else, so the first unread row is
+/// often near the beginning of a long conversation. The list opens on that row, a scroll can only
+/// find a row the list is drawing, and a window that starts there and runs to the end is the whole
+/// session with extra steps.
+///
+/// So it is a range. A session opened on an old row draws that row's neighbourhood, and the rows
+/// below it arrive as the reader scrolls down towards them, which costs nothing to arrange:
+/// content added BELOW the viewport moves nothing, where content added above it needs the bottom
+/// anchor to hold the view still.
 ///
 /// **Nothing here decides what a transcript IS.** `TranscriptModel.rows` is the whole session
 /// throughout, which is what the unread counts are computed over and what `TurnScan` walks
 /// backwards through. This is a drawing decision and only the list takes it.
-public enum TranscriptWindow {
+public struct TranscriptWindow: Equatable, Sendable {
+    /// The first row drawn, as an index into the session's rows.
+    public var start: Int
+    /// One past the last row drawn. `rowCount` whenever the live end is in the window, which is
+    /// every state except a session opened on an old row and not yet scrolled down from.
+    public var end: Int
+
+    public init(start: Int, end: Int) {
+        self.start = start
+        self.end = end
+    }
+
     /// How many rows the window holds once the arrival frame is behind it.
     ///
     /// Deliberately several times `TranscriptTail.length` rather than equal to it. The tail is
@@ -43,35 +66,73 @@ public enum TranscriptWindow {
     /// need for a little history above it to scroll back into.
     public static let margin = 80
 
-    /// The first row the list draws, as an index into the session's rows.
+    /// The window the frame that arrives at a session draws.
     ///
     /// `mustReach` is the index of a row the reader has asked for by name, which is a search result
-    /// or an unread mark: a scroll can only find a row the list is drawing, so the window is opened
-    /// wide enough to hold it whatever the tail said.
-    /// A row that is already inside the window leaves it exactly where it was, margin and all: the
-    /// margin is what a row ARRIVING in the window brings with it, not a claim about every row.
-    public static func opening(rowCount: Int, tailStart: Int, mustReach: Int? = nil) -> Int {
-        let start = clamp(tailStart, rowCount: rowCount)
-        guard let mustReach, mustReach < start else { return start }
-        return clamp(mustReach - margin, rowCount: rowCount)
+    /// or an unread mark: a scroll can only find a row the list is drawing, so the window is moved
+    /// to hold it. A row already inside the tail leaves the window exactly where it was, margin and
+    /// all: the margin is what a row ARRIVING in a window brings with it, not a claim about every
+    /// row.
+    public static func opening(rowCount: Int, tailStart: Int, mustReach: Int? = nil) -> Self {
+        let tail = Self(start: clamp(tailStart, rowCount: rowCount), end: max(0, rowCount))
+        guard let mustReach, mustReach < tail.start else { return tail }
+        let start = clamp(mustReach - margin, rowCount: rowCount)
+        return Self(start: start, end: clamp(start + margin + settled, rowCount: rowCount))
     }
 
-    /// The window grown upward by one chunk, which is what the reader approaching the top asks for.
-    public static func grown(from start: Int, by chunk: Int = chunk) -> Int {
-        max(0, start - max(0, chunk))
-    }
-
-    /// Where the window settles once the frame that arrived at the session has been drawn.
+    /// Where the window settles once the frame that arrived has been drawn.
     ///
-    /// Never later than where it already is: a window opened wide because a search result is in it
-    /// must not be narrowed a hundred milliseconds later, which would take the row the reader
-    /// asked for back off the list.
-    public static func settling(from start: Int, rowCount: Int, holding: Int = settled) -> Int {
-        min(start, clamp(rowCount - max(0, holding), rowCount: rowCount))
+    /// Never narrower than it already is, and never moved: a window opened around a search result
+    /// must not be pulled back to the live end a hundred milliseconds later, which would take the
+    /// row the reader asked for off the list.
+    public static func settling(from window: Self, rowCount: Int) -> Self {
+        guard window.end >= rowCount else { return window }
+        return Self(
+            start: min(window.start, clamp(rowCount - settled, rowCount: rowCount)),
+            end: max(0, rowCount)
+        )
+    }
+
+    /// The window grown upward, which is what the reader approaching the top asks for.
+    public func grownUp(by chunk: Int = chunk) -> Self {
+        Self(start: max(0, start - max(0, chunk)), end: end)
+    }
+
+    /// The window grown downward, which is what the reader approaching the bottom of an opened-on-
+    /// an-old-row window asks for.
+    public func grownDown(rowCount: Int, by chunk: Int = chunk) -> Self {
+        Self(start: start, end: min(max(0, rowCount), end + max(0, chunk)))
+    }
+
+    /// The window that holds the live end, which is where the jump pill takes the reader.
+    ///
+    /// The tail rather than everything between here and the end. The reader is being moved to the
+    /// newest row, so the rows they were looking at are not rows they are looking at any more, and
+    /// realising every one of them on the way is the exact cost `TranscriptTail` was written to
+    /// avoid.
+    public static func liveEnd(rowCount: Int) -> Self {
+        Self(start: clamp(rowCount - settled, rowCount: rowCount), end: max(0, rowCount))
     }
 
     /// Whether there is any history left above the window to grow into.
-    public static func canGrow(from start: Int) -> Bool { start > 0 }
+    public var canGrowUp: Bool { start > 0 }
+
+    /// Whether the session runs on below the window.
+    public func canGrowDown(rowCount: Int) -> Bool { end < rowCount }
+
+    /// How many rows are drawn.
+    public var count: Int { max(0, end - start) }
+
+    /// The window clamped to a session, which is what a remembered one has to go through: it was
+    /// written down against a row count that may since have grown.
+    public func clamped(rowCount: Int) -> Self {
+        let end = Self.clamp(self.end, rowCount: rowCount)
+        return Self(start: min(Self.clamp(start, rowCount: rowCount), end), end: end)
+    }
+
+    private static func clamp(_ index: Int, rowCount: Int) -> Int {
+        min(max(0, index), max(0, rowCount))
+    }
 
     /// Where a row with this sequence number sits in the session, or the row after it if that
     /// exact one is not there.
@@ -98,9 +159,5 @@ public enum TranscriptWindow {
             }
         }
         return low < seqs.endIndex ? low - seqs.startIndex : nil
-    }
-
-    private static func clamp(_ index: Int, rowCount: Int) -> Int {
-        min(max(0, index), max(0, rowCount))
     }
 }

--- a/Sources/BloomCore/Transcript/TranscriptWindow.swift
+++ b/Sources/BloomCore/Transcript/TranscriptWindow.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// How much of a session the list hands to its lazy stack, and when that grows.
+///
+/// **A lazy stack is lazy about realising a row and is not lazy about knowing one.** Placing its
+/// subviews walks every child it has been handed, realised or not, so the cost of a layout pass
+/// follows the length of the conversation rather than the height of the pane. Measured on a
+/// release build at 1440 by 900, resizing a window over a 1,582 row chat: 11.1ms per pass of the
+/// centre column with the whole session in the stack, 4.6ms with eighty rows in it and the same
+/// session on screen, against 1.6ms for a pane holding an empty one. A resize is two to three
+/// passes a frame, so that difference is the difference between six frames a second and something
+/// a hand can follow.
+///
+/// `TranscriptTail` already answered half of this: the frame that ARRIVES at a session draws its
+/// last eighty rows, because resolving a position at the end of a stack realises everything above
+/// it. What it did next was hand the stack the whole session a hundred milliseconds later, so the
+/// saving lasted exactly one frame and every resize, scroll and streamed token for the rest of the
+/// visit paid for four thousand children. This is that second half: the window grows to a few
+/// hundred rows once the arrival is over, and grows again when the reader actually approaches the
+/// top of it.
+///
+/// **Nothing here decides what a transcript IS.** `TranscriptModel.rows` is the whole session
+/// throughout, which is what the unread counts are computed over and what `TurnScan` walks
+/// backwards through. This is a drawing decision and only the list takes it.
+public enum TranscriptWindow {
+    /// How many rows the window holds once the arrival frame is behind it.
+    ///
+    /// Deliberately several times `TranscriptTail.length` rather than equal to it. The tail is
+    /// sized for one frame and is about three screens; this is what a reader flicking back through
+    /// the conversation scrolls through without ever waiting for a growth, and at 7µs a row a pass
+    /// four hundred of them is under three milliseconds of layout.
+    public static let settled = 400
+
+    /// How many rows a growth adds. The same figure as `settled`, because the reason for the size
+    /// is the same: enough that reaching the next growth takes a deliberate scroll rather than a
+    /// flick, and small enough that adding it is a layout of a few milliseconds.
+    public static let chunk = 400
+
+    /// How many rows above a row that has to be reachable the window starts.
+    ///
+    /// A search result opens centred in the pane, so the rows above it have to exist or there is
+    /// nothing to centre it against, and an unread mark opens at the top of the pane with the same
+    /// need for a little history above it to scroll back into.
+    public static let margin = 80
+
+    /// The first row the list draws, as an index into the session's rows.
+    ///
+    /// `mustReach` is the index of a row the reader has asked for by name, which is a search result
+    /// or an unread mark: a scroll can only find a row the list is drawing, so the window is opened
+    /// wide enough to hold it whatever the tail said.
+    /// A row that is already inside the window leaves it exactly where it was, margin and all: the
+    /// margin is what a row ARRIVING in the window brings with it, not a claim about every row.
+    public static func opening(rowCount: Int, tailStart: Int, mustReach: Int? = nil) -> Int {
+        let start = clamp(tailStart, rowCount: rowCount)
+        guard let mustReach, mustReach < start else { return start }
+        return clamp(mustReach - margin, rowCount: rowCount)
+    }
+
+    /// The window grown upward by one chunk, which is what the reader approaching the top asks for.
+    public static func grown(from start: Int, by chunk: Int = chunk) -> Int {
+        max(0, start - max(0, chunk))
+    }
+
+    /// Where the window settles once the frame that arrived at the session has been drawn.
+    ///
+    /// Never later than where it already is: a window opened wide because a search result is in it
+    /// must not be narrowed a hundred milliseconds later, which would take the row the reader
+    /// asked for back off the list.
+    public static func settling(from start: Int, rowCount: Int, holding: Int = settled) -> Int {
+        min(start, clamp(rowCount - max(0, holding), rowCount: rowCount))
+    }
+
+    /// Whether there is any history left above the window to grow into.
+    public static func canGrow(from start: Int) -> Bool { start > 0 }
+
+    /// Where a row with this sequence number sits in the session, or the row after it if that
+    /// exact one is not there.
+    ///
+    /// A binary search rather than a scan, because the list asks this on every pass while an
+    /// unread mark or a search result is outstanding, and a scan of a four thousand row session
+    /// to answer it would be exactly the kind of per-pass walk the rest of this file exists to
+    /// remove. Sequence numbers only ever increase down a session, which is what makes the search
+    /// valid; nothing here assumes they are contiguous, because a hidden row leaves a gap.
+    ///
+    /// Nil when every row in the session is older than the one asked about, which is a search
+    /// result or an unread mark from a session that has since been read again from the start.
+    public static func index<Seqs: RandomAccessCollection>(
+        ofSeqAtOrAfter seq: Int, in seqs: Seqs
+    ) -> Int? where Seqs.Element == Int, Seqs.Index == Int {
+        var low = seqs.startIndex
+        var high = seqs.endIndex
+        while low < high {
+            let middle = low + (high - low) / 2
+            if seqs[middle] < seq {
+                low = middle + 1
+            } else {
+                high = middle
+            }
+        }
+        return low < seqs.endIndex ? low - seqs.startIndex : nil
+    }
+
+    private static func clamp(_ index: Int, rowCount: Int) -> Int {
+        min(max(0, index), max(0, rowCount))
+    }
+}

--- a/Tests/BloomCoreTests/DiffRefreshScheduleTests.swift
+++ b/Tests/BloomCoreTests/DiffRefreshScheduleTests.swift
@@ -35,7 +35,7 @@ struct DiffRefreshScheduleTests {
         #expect(due.contains(all[7]))
     }
 
-    @Test("a workspace nobody is watching is left alone until it is a minute old")
+    @Test("a workspace nobody is watching is left alone until the backstop age")
     func idleIsLeftAlone() {
         let all = ids(20)
         let now = Date()
@@ -50,8 +50,8 @@ struct DiffRefreshScheduleTests {
         #expect(due == [all[0]])
     }
 
-    /// The whole point. Twenty idle workspaces at a six second tick and a sixty second age is two
-    /// a tick, not twenty in one tick and none in the next nine.
+    /// The whole point. Twenty idle workspaces at a six second tick and the backstop age is a
+    /// handful a tick, not twenty in one tick and none for the rest of the round.
     @Test("the idle ones come round in a trickle rather than a burst")
     func trickle() {
         let all = ids(20)
@@ -60,23 +60,26 @@ struct DiffRefreshScheduleTests {
         let due = DiffRefreshSchedule.due(
             workspaces: all,
             busy: [],
-            lastRefreshed: justRefreshed(all, at: now.addingTimeInterval(-120)),
+            lastRefreshed: justRefreshed(
+                all, at: now.addingTimeInterval(-DiffRefreshSchedule.idleMaxAge * 2)
+            ),
             now: now
         )
 
-        #expect(due.count == 2)
+        // Twenty workspaces over a five minute round at a six second tick.
+        #expect(due.count == 1)
     }
 
     @Test("the oldest go first, so nothing at the back of a queue is starved")
     func oldestFirst() {
         let all = ids(20)
         let now = Date()
-        var last = justRefreshed(all, at: now.addingTimeInterval(-61))
-        last[all[11]] = now.addingTimeInterval(-600)
-        last[all[4]] = now.addingTimeInterval(-300)
+        var last = justRefreshed(all, at: now.addingTimeInterval(-DiffRefreshSchedule.idleMaxAge - 1))
+        last[all[11]] = now.addingTimeInterval(-3_600)
+        last[all[4]] = now.addingTimeInterval(-1_800)
 
         let due = DiffRefreshSchedule.due(
-            workspaces: all, busy: [], lastRefreshed: last, now: now
+            workspaces: all, busy: [], lastRefreshed: last, now: now, idleMaxAge: 60
         )
 
         #expect(due == [all[11], all[4]])
@@ -86,7 +89,7 @@ struct DiffRefreshScheduleTests {
     func deterministic() {
         let all = ids(20)
         let now = Date()
-        let last = justRefreshed(all, at: now.addingTimeInterval(-61))
+        let last = justRefreshed(all, at: now.addingTimeInterval(-DiffRefreshSchedule.idleMaxAge - 1))
 
         let first = DiffRefreshSchedule.due(
             workspaces: all, busy: [], lastRefreshed: last, now: now
@@ -121,11 +124,88 @@ struct DiffRefreshScheduleTests {
         let due = DiffRefreshSchedule.due(
             workspaces: all,
             busy: [],
-            lastRefreshed: justRefreshed(all, at: now.addingTimeInterval(-61)),
+            lastRefreshed: justRefreshed(
+                all, at: now.addingTimeInterval(-DiffRefreshSchedule.idleMaxAge - 1)
+            ),
             now: now
         )
 
         #expect(due.count == 1)
+    }
+
+    // MARK: The workspace on screen
+
+    @Test("the workspace on screen is not asked about on every tick any more")
+    func selectedIsNotEveryTick() {
+        let all = ids(5)
+        let now = Date()
+
+        let due = DiffRefreshSchedule.due(
+            workspaces: all,
+            busy: [],
+            selected: all[2],
+            lastRefreshed: justRefreshed(all, at: now.addingTimeInterval(-6)),
+            now: now
+        )
+
+        #expect(due.isEmpty)
+    }
+
+    @Test("the workspace on screen is asked about on its own shorter age")
+    func selectedHasItsOwnAge() {
+        let all = ids(5)
+        let now = Date()
+
+        let due = DiffRefreshSchedule.due(
+            workspaces: all,
+            busy: [],
+            selected: all[2],
+            lastRefreshed: justRefreshed(
+                all, at: now.addingTimeInterval(-DiffRefreshSchedule.selectedMaxAge - 1)
+            ),
+            now: now
+        )
+
+        #expect(due == [all[2]])
+    }
+
+    /// What the watcher is for: a worktree something has actually written to is asked about now,
+    /// whatever age it is, including the one on screen.
+    @Test("a worktree the file system says changed is due at once")
+    func changedIsDueAtOnce() {
+        let all = ids(5)
+        let now = Date()
+
+        let due = DiffRefreshSchedule.due(
+            workspaces: all,
+            busy: [all[2]],
+            selected: all[2],
+            lastRefreshed: justRefreshed(all, at: now),
+            now: now
+        )
+
+        #expect(due == [all[2]])
+    }
+
+    /// A sidebar of one selected workspace must not have it counted twice: once as the slice it is
+    /// excluded from and once on its own age.
+    @Test("the workspace on screen is never also part of the trickle")
+    func selectedIsNotInTheTrickle() {
+        let all = ids(20)
+        let now = Date()
+
+        let due = DiffRefreshSchedule.due(
+            workspaces: all,
+            busy: [],
+            selected: all[0],
+            lastRefreshed: justRefreshed(
+                all, at: now.addingTimeInterval(-DiffRefreshSchedule.idleMaxAge * 2)
+            ),
+            now: now
+        )
+
+        #expect(due.contains(all[0]))
+        #expect(due.count == 2)
     }
 
     @Test("nothing open asks git nothing")

--- a/Tests/BloomCoreTests/TranscriptResumeTests.swift
+++ b/Tests/BloomCoreTests/TranscriptResumeTests.swift
@@ -9,18 +9,24 @@ import Testing
 /// inside one is a rule nothing can hold still.
 @Suite("Transcript resume")
 struct TranscriptResumeTests {
+    private func measure(width: Double = 900, fontScale: Double = 1) -> TranscriptPaneState.Measure {
+        TranscriptPaneState.Measure(width: width, fontScale: fontScale)
+    }
+
     private func state(
         expanded: Set<Int> = [],
-        anchorSeq: Int? = 120,
+        offset: Double = 1_200,
         isAtLiveEnd: Bool = false,
         rowCount: Int = 400,
+        measure: TranscriptPaneState.Measure? = nil,
         drawn: TranscriptWindow = TranscriptWindow(start: 0, end: 400)
     ) -> TranscriptPaneState {
         TranscriptPaneState(
             expanded: expanded,
-            anchorSeq: anchorSeq,
+            offset: offset,
             isAtLiveEnd: isAtLiveEnd,
             rowCount: rowCount,
+            measure: measure ?? self.measure(),
             drawn: drawn
         )
     }
@@ -64,65 +70,116 @@ struct TranscriptResumeTests {
 
     @Test("a pane that has never held this session opens the way it always did")
     func nothingRemembered() {
-        #expect(TranscriptResume.placement(for: nil, rowCount: 400) == .first)
+        let placement = TranscriptResume.placement(
+            for: nil, rowCount: 400, measure: measure()
+        )
+        #expect(placement == .first)
     }
 
     @Test("a session with no rows opens the way it always did")
     func emptySession() {
-        #expect(TranscriptResume.placement(for: state(), rowCount: 0) == .first)
+        #expect(TranscriptResume.placement(for: state(), rowCount: 0, measure: measure()) == .first)
     }
 
-    @Test("a reader who left at the end is put back at the end, not at the row that was there")
-    func liveEndOutranksTheAnchor() {
+    @Test("a reader who left at the end is put back at the end, not at the offset")
+    func liveEndOutranksTheOffset() {
         let placement = TranscriptResume.placement(
-            for: state(anchorSeq: 120, isAtLiveEnd: true), rowCount: 400
+            for: state(offset: 9_000, isAtLiveEnd: true), rowCount: 400, measure: measure()
         )
         #expect(placement == .liveEnd)
     }
 
-    /// The case the flag exists for, and the one the owner reported: a turn ran while the pane was
-    /// on another workspace, so the end has moved and the row that used to be at the top of the
-    /// pane is not where anybody wants to be put back.
+    /// The case the flag exists for: a turn ran while the pane was on another tab, so the content
+    /// grew and the number of points that meant the end names the middle now.
     @Test("the end still means the end after the session has grown")
     func liveEndAfterGrowth() {
         let placement = TranscriptResume.placement(
-            for: state(anchorSeq: 120, isAtLiveEnd: true, rowCount: 400), rowCount: 6_000
+            for: state(offset: 9_000, isAtLiveEnd: true, rowCount: 400),
+            rowCount: 6_000, measure: measure()
         )
         #expect(placement == .liveEnd)
     }
 
-    @Test("a reader who left part way up is put back at the row they were reading")
-    func theAnchorRowIsRestored() {
-        #expect(TranscriptResume.placement(for: state(anchorSeq: 120), rowCount: 400) == .row(120))
+    @Test("a reader who left part way up is put back there")
+    func offsetIsRestored() {
+        let placement = TranscriptResume.placement(
+            for: state(offset: 1_200), rowCount: 400, measure: measure()
+        )
+        #expect(placement == .offset(1_200))
     }
 
-    @Test("a session that has grown under a scrolled reader keeps their row")
+    @Test("a session that has grown under a scrolled reader keeps their offset")
     func growthDoesNotMoveAReader() {
         let placement = TranscriptResume.placement(
-            for: state(anchorSeq: 120, rowCount: 400), rowCount: 900
+            for: state(offset: 1_200, rowCount: 400), rowCount: 900, measure: measure()
         )
-        #expect(placement == .row(120))
-    }
-
-    /// The whole reason the place is a row. A width change, a text size change and the lazy stack
-    /// replacing its guessed heights with measured ones all move every point in the document and
-    /// none of them move a row. The three refusals this suite used to hold are gone with the
-    /// offset they existed to protect.
-    @Test("nothing about how the pane is drawn can stale a row")
-    func aRowSurvivesEveryMeasurement() {
-        #expect(TranscriptResume.placement(for: state(anchorSeq: 7), rowCount: 400) == .row(7))
+        #expect(placement == .offset(1_200))
     }
 
     /// Rows are appended and never removed while a pane is away, so fewer of them means the
-    /// session was read again from the start and nothing written about the old one carries.
-    @Test("a session with fewer rows than it had is not the one that anchor was taken in")
+    /// session was read again from the start and nothing measured against the old one carries.
+    @Test("a session with fewer rows than it had is not the one that offset was measured in")
     func shrunkSessionIsNotResumed() {
-        let placement = TranscriptResume.placement(for: state(rowCount: 400), rowCount: 12)
+        let placement = TranscriptResume.placement(
+            for: state(rowCount: 400), rowCount: 12, measure: measure()
+        )
         #expect(placement == .first)
     }
 
-    @Test("a pane that never saw a row at its top opens the way a fresh visit does")
-    func noAnchorOpensFresh() {
-        #expect(TranscriptResume.placement(for: state(anchorSeq: nil), rowCount: 400) == .first)
+    @Test("an offset measured at another width is a point into another document")
+    func widthChangeStalesTheOffset() {
+        let placement = TranscriptResume.placement(
+            for: state(measure: measure(width: 900)), rowCount: 400, measure: measure(width: 640)
+        )
+        #expect(placement == .first)
+    }
+
+    @Test("and so is one measured at another text size")
+    func fontScaleChangeStalesTheOffset() {
+        let placement = TranscriptResume.placement(
+            for: state(measure: measure(fontScale: 1)),
+            rowCount: 400, measure: measure(fontScale: 1.2)
+        )
+        #expect(placement == .first)
+    }
+
+    /// A width change moves nobody who was at the end, because the end is a place rather than a
+    /// measurement.
+    @Test("a width change does not throw away the live end")
+    func widthChangeKeepsTheLiveEnd() {
+        let placement = TranscriptResume.placement(
+            for: state(isAtLiveEnd: true, measure: measure(width: 900)),
+            rowCount: 400, measure: measure(width: 640)
+        )
+        #expect(placement == .liveEnd)
+    }
+
+    /// The frame the geometry has not landed on yet, which is most arrival frames. A measurement
+    /// nobody has taken must not be allowed to contradict one that was.
+    @Test("a pane that has not been measured yet keeps the offset it was given")
+    func unmeasuredPaneKeepsTheOffset() {
+        let placement = TranscriptResume.placement(
+            for: state(offset: 1_200, measure: measure(width: 900)), rowCount: 400, measure: nil
+        )
+        #expect(placement == .offset(1_200))
+    }
+
+    @Test("and so does one whose last visit was never measured")
+    func unmeasuredMemoryKeepsTheOffset() {
+        let unmeasured = TranscriptPaneState(
+            expanded: [], offset: 1_200, isAtLiveEnd: false, rowCount: 400, measure: nil
+        )
+        let placement = TranscriptResume.placement(
+            for: unmeasured, rowCount: 400, measure: measure(width: 640)
+        )
+        #expect(placement == .offset(1_200))
+    }
+
+    @Test("the top of the content is a first open rather than a restored nought")
+    func topIsNotRestored() {
+        let placement = TranscriptResume.placement(
+            for: state(offset: 0), rowCount: 400, measure: measure()
+        )
+        #expect(placement == .first)
     }
 }

--- a/Tests/BloomCoreTests/TranscriptResumeTests.swift
+++ b/Tests/BloomCoreTests/TranscriptResumeTests.swift
@@ -9,16 +9,11 @@ import Testing
 /// inside one is a rule nothing can hold still.
 @Suite("Transcript resume")
 struct TranscriptResumeTests {
-    private func measure(width: Double = 900, fontScale: Double = 1) -> TranscriptPaneState.Measure {
-        TranscriptPaneState.Measure(width: width, fontScale: fontScale)
-    }
-
     private func state(
         expanded: Set<Int> = [],
         offset: Double = 1_200,
         isAtLiveEnd: Bool = false,
         rowCount: Int = 400,
-        measure: TranscriptPaneState.Measure? = nil,
         drawn: TranscriptWindow = TranscriptWindow(start: 0, end: 400)
     ) -> TranscriptPaneState {
         TranscriptPaneState(
@@ -26,7 +21,6 @@ struct TranscriptResumeTests {
             offset: offset,
             isAtLiveEnd: isAtLiveEnd,
             rowCount: rowCount,
-            measure: measure ?? self.measure(),
             drawn: drawn
         )
     }
@@ -68,23 +62,28 @@ struct TranscriptResumeTests {
 
     // MARK: Where it opens
 
+    /// The three tests that used to sit at the foot of this suite are gone with the rule they
+    /// held down: a restore is no longer refused because the pane is a different width or the text
+    /// a different size. See `TranscriptResume.placement`, which carries the reversal and the
+    /// reason for it.
+
     @Test("a pane that has never held this session opens the way it always did")
     func nothingRemembered() {
         let placement = TranscriptResume.placement(
-            for: nil, rowCount: 400, measure: measure()
+            for: nil, rowCount: 400
         )
         #expect(placement == .first)
     }
 
     @Test("a session with no rows opens the way it always did")
     func emptySession() {
-        #expect(TranscriptResume.placement(for: state(), rowCount: 0, measure: measure()) == .first)
+        #expect(TranscriptResume.placement(for: state(), rowCount: 0) == .first)
     }
 
     @Test("a reader who left at the end is put back at the end, not at the offset")
     func liveEndOutranksTheOffset() {
         let placement = TranscriptResume.placement(
-            for: state(offset: 9_000, isAtLiveEnd: true), rowCount: 400, measure: measure()
+            for: state(offset: 9_000, isAtLiveEnd: true), rowCount: 400
         )
         #expect(placement == .liveEnd)
     }
@@ -95,7 +94,7 @@ struct TranscriptResumeTests {
     func liveEndAfterGrowth() {
         let placement = TranscriptResume.placement(
             for: state(offset: 9_000, isAtLiveEnd: true, rowCount: 400),
-            rowCount: 6_000, measure: measure()
+            rowCount: 6_000
         )
         #expect(placement == .liveEnd)
     }
@@ -103,7 +102,7 @@ struct TranscriptResumeTests {
     @Test("a reader who left part way up is put back there")
     func offsetIsRestored() {
         let placement = TranscriptResume.placement(
-            for: state(offset: 1_200), rowCount: 400, measure: measure()
+            for: state(offset: 1_200), rowCount: 400
         )
         #expect(placement == .offset(1_200))
     }
@@ -111,7 +110,7 @@ struct TranscriptResumeTests {
     @Test("a session that has grown under a scrolled reader keeps their offset")
     func growthDoesNotMoveAReader() {
         let placement = TranscriptResume.placement(
-            for: state(offset: 1_200, rowCount: 400), rowCount: 900, measure: measure()
+            for: state(offset: 1_200, rowCount: 400), rowCount: 900
         )
         #expect(placement == .offset(1_200))
     }
@@ -121,64 +120,15 @@ struct TranscriptResumeTests {
     @Test("a session with fewer rows than it had is not the one that offset was measured in")
     func shrunkSessionIsNotResumed() {
         let placement = TranscriptResume.placement(
-            for: state(rowCount: 400), rowCount: 12, measure: measure()
+            for: state(rowCount: 400), rowCount: 12
         )
         #expect(placement == .first)
-    }
-
-    @Test("an offset measured at another width is a point into another document")
-    func widthChangeStalesTheOffset() {
-        let placement = TranscriptResume.placement(
-            for: state(measure: measure(width: 900)), rowCount: 400, measure: measure(width: 640)
-        )
-        #expect(placement == .first)
-    }
-
-    @Test("and so is one measured at another text size")
-    func fontScaleChangeStalesTheOffset() {
-        let placement = TranscriptResume.placement(
-            for: state(measure: measure(fontScale: 1)),
-            rowCount: 400, measure: measure(fontScale: 1.2)
-        )
-        #expect(placement == .first)
-    }
-
-    /// A width change moves nobody who was at the end, because the end is a place rather than a
-    /// measurement.
-    @Test("a width change does not throw away the live end")
-    func widthChangeKeepsTheLiveEnd() {
-        let placement = TranscriptResume.placement(
-            for: state(isAtLiveEnd: true, measure: measure(width: 900)),
-            rowCount: 400, measure: measure(width: 640)
-        )
-        #expect(placement == .liveEnd)
-    }
-
-    /// The frame the geometry has not landed on yet, which is most arrival frames. A measurement
-    /// nobody has taken must not be allowed to contradict one that was.
-    @Test("a pane that has not been measured yet keeps the offset it was given")
-    func unmeasuredPaneKeepsTheOffset() {
-        let placement = TranscriptResume.placement(
-            for: state(offset: 1_200, measure: measure(width: 900)), rowCount: 400, measure: nil
-        )
-        #expect(placement == .offset(1_200))
-    }
-
-    @Test("and so does one whose last visit was never measured")
-    func unmeasuredMemoryKeepsTheOffset() {
-        let unmeasured = TranscriptPaneState(
-            expanded: [], offset: 1_200, isAtLiveEnd: false, rowCount: 400, measure: nil
-        )
-        let placement = TranscriptResume.placement(
-            for: unmeasured, rowCount: 400, measure: measure(width: 640)
-        )
-        #expect(placement == .offset(1_200))
     }
 
     @Test("the top of the content is a first open rather than a restored nought")
     func topIsNotRestored() {
         let placement = TranscriptResume.placement(
-            for: state(offset: 0), rowCount: 400, measure: measure()
+            for: state(offset: 0), rowCount: 400
         )
         #expect(placement == .first)
     }

--- a/Tests/BloomCoreTests/TranscriptResumeTests.swift
+++ b/Tests/BloomCoreTests/TranscriptResumeTests.swift
@@ -52,6 +52,13 @@ struct TranscriptResumeTests {
         #expect(TranscriptResume.isResuming(state()))
     }
 
+    @Test("a window with nothing in it is not restored, because it would draw a blank transcript")
+    func anEmptyWindowIsNotAWindow() {
+        let remembered = state(drawn: TranscriptWindow(start: 0, end: 0))
+        let window = TranscriptResume.window(remembered, tailStart: 3_920, rowCount: 4_000)
+        #expect(window == TranscriptWindow(start: 3_920, end: 4_000))
+    }
+
     @Test("a window from a session that has since been read again is clamped to it")
     func aStaleWindowIsClamped() {
         let remembered = state(drawn: TranscriptWindow(start: 9_000, end: 9_400))

--- a/Tests/BloomCoreTests/TranscriptResumeTests.swift
+++ b/Tests/BloomCoreTests/TranscriptResumeTests.swift
@@ -9,24 +9,18 @@ import Testing
 /// inside one is a rule nothing can hold still.
 @Suite("Transcript resume")
 struct TranscriptResumeTests {
-    private func measure(width: Double = 900, fontScale: Double = 1) -> TranscriptPaneState.Measure {
-        TranscriptPaneState.Measure(width: width, fontScale: fontScale)
-    }
-
     private func state(
         expanded: Set<Int> = [],
-        offset: Double = 1_200,
+        anchorSeq: Int? = 120,
         isAtLiveEnd: Bool = false,
         rowCount: Int = 400,
-        measure: TranscriptPaneState.Measure? = nil,
         drawn: TranscriptWindow = TranscriptWindow(start: 0, end: 400)
     ) -> TranscriptPaneState {
         TranscriptPaneState(
             expanded: expanded,
-            offset: offset,
+            anchorSeq: anchorSeq,
             isAtLiveEnd: isAtLiveEnd,
             rowCount: rowCount,
-            measure: measure ?? self.measure(),
             drawn: drawn
         )
     }
@@ -70,116 +64,65 @@ struct TranscriptResumeTests {
 
     @Test("a pane that has never held this session opens the way it always did")
     func nothingRemembered() {
-        let placement = TranscriptResume.placement(
-            for: nil, rowCount: 400, measure: measure()
-        )
-        #expect(placement == .first)
+        #expect(TranscriptResume.placement(for: nil, rowCount: 400) == .first)
     }
 
     @Test("a session with no rows opens the way it always did")
     func emptySession() {
-        #expect(TranscriptResume.placement(for: state(), rowCount: 0, measure: measure()) == .first)
+        #expect(TranscriptResume.placement(for: state(), rowCount: 0) == .first)
     }
 
-    @Test("a reader who left at the end is put back at the end, not at the offset")
-    func liveEndOutranksTheOffset() {
+    @Test("a reader who left at the end is put back at the end, not at the row that was there")
+    func liveEndOutranksTheAnchor() {
         let placement = TranscriptResume.placement(
-            for: state(offset: 9_000, isAtLiveEnd: true), rowCount: 400, measure: measure()
+            for: state(anchorSeq: 120, isAtLiveEnd: true), rowCount: 400
         )
         #expect(placement == .liveEnd)
     }
 
-    /// The case the flag exists for: a turn ran while the pane was on another tab, so the content
-    /// grew and the number of points that meant the end names the middle now.
+    /// The case the flag exists for, and the one the owner reported: a turn ran while the pane was
+    /// on another workspace, so the end has moved and the row that used to be at the top of the
+    /// pane is not where anybody wants to be put back.
     @Test("the end still means the end after the session has grown")
     func liveEndAfterGrowth() {
         let placement = TranscriptResume.placement(
-            for: state(offset: 9_000, isAtLiveEnd: true, rowCount: 400),
-            rowCount: 6_000, measure: measure()
+            for: state(anchorSeq: 120, isAtLiveEnd: true, rowCount: 400), rowCount: 6_000
         )
         #expect(placement == .liveEnd)
     }
 
-    @Test("a reader who left part way up is put back there")
-    func offsetIsRestored() {
-        let placement = TranscriptResume.placement(
-            for: state(offset: 1_200), rowCount: 400, measure: measure()
-        )
-        #expect(placement == .offset(1_200))
+    @Test("a reader who left part way up is put back at the row they were reading")
+    func theAnchorRowIsRestored() {
+        #expect(TranscriptResume.placement(for: state(anchorSeq: 120), rowCount: 400) == .row(120))
     }
 
-    @Test("a session that has grown under a scrolled reader keeps their offset")
+    @Test("a session that has grown under a scrolled reader keeps their row")
     func growthDoesNotMoveAReader() {
         let placement = TranscriptResume.placement(
-            for: state(offset: 1_200, rowCount: 400), rowCount: 900, measure: measure()
+            for: state(anchorSeq: 120, rowCount: 400), rowCount: 900
         )
-        #expect(placement == .offset(1_200))
+        #expect(placement == .row(120))
+    }
+
+    /// The whole reason the place is a row. A width change, a text size change and the lazy stack
+    /// replacing its guessed heights with measured ones all move every point in the document and
+    /// none of them move a row. The three refusals this suite used to hold are gone with the
+    /// offset they existed to protect.
+    @Test("nothing about how the pane is drawn can stale a row")
+    func aRowSurvivesEveryMeasurement() {
+        #expect(TranscriptResume.placement(for: state(anchorSeq: 7), rowCount: 400) == .row(7))
     }
 
     /// Rows are appended and never removed while a pane is away, so fewer of them means the
-    /// session was read again from the start and nothing measured against the old one carries.
-    @Test("a session with fewer rows than it had is not the one that offset was measured in")
+    /// session was read again from the start and nothing written about the old one carries.
+    @Test("a session with fewer rows than it had is not the one that anchor was taken in")
     func shrunkSessionIsNotResumed() {
-        let placement = TranscriptResume.placement(
-            for: state(rowCount: 400), rowCount: 12, measure: measure()
-        )
+        let placement = TranscriptResume.placement(for: state(rowCount: 400), rowCount: 12)
         #expect(placement == .first)
     }
 
-    @Test("an offset measured at another width is a point into another document")
-    func widthChangeStalesTheOffset() {
-        let placement = TranscriptResume.placement(
-            for: state(measure: measure(width: 900)), rowCount: 400, measure: measure(width: 640)
-        )
-        #expect(placement == .first)
-    }
-
-    @Test("and so is one measured at another text size")
-    func fontScaleChangeStalesTheOffset() {
-        let placement = TranscriptResume.placement(
-            for: state(measure: measure(fontScale: 1)),
-            rowCount: 400, measure: measure(fontScale: 1.2)
-        )
-        #expect(placement == .first)
-    }
-
-    /// A width change moves nobody who was at the end, because the end is a place rather than a
-    /// measurement.
-    @Test("a width change does not throw away the live end")
-    func widthChangeKeepsTheLiveEnd() {
-        let placement = TranscriptResume.placement(
-            for: state(isAtLiveEnd: true, measure: measure(width: 900)),
-            rowCount: 400, measure: measure(width: 640)
-        )
-        #expect(placement == .liveEnd)
-    }
-
-    /// The frame the geometry has not landed on yet, which is most arrival frames. A measurement
-    /// nobody has taken must not be allowed to contradict one that was.
-    @Test("a pane that has not been measured yet keeps the offset it was given")
-    func unmeasuredPaneKeepsTheOffset() {
-        let placement = TranscriptResume.placement(
-            for: state(offset: 1_200, measure: measure(width: 900)), rowCount: 400, measure: nil
-        )
-        #expect(placement == .offset(1_200))
-    }
-
-    @Test("and so does one whose last visit was never measured")
-    func unmeasuredMemoryKeepsTheOffset() {
-        let unmeasured = TranscriptPaneState(
-            expanded: [], offset: 1_200, isAtLiveEnd: false, rowCount: 400, measure: nil
-        )
-        let placement = TranscriptResume.placement(
-            for: unmeasured, rowCount: 400, measure: measure(width: 640)
-        )
-        #expect(placement == .offset(1_200))
-    }
-
-    @Test("the top of the content is a first open rather than a restored nought")
-    func topIsNotRestored() {
-        let placement = TranscriptResume.placement(
-            for: state(offset: 0), rowCount: 400, measure: measure()
-        )
-        #expect(placement == .first)
+    @Test("a pane that never saw a row at its top opens the way a fresh visit does")
+    func noAnchorOpensFresh() {
+        #expect(TranscriptResume.placement(for: state(anchorSeq: nil), rowCount: 400) == .first)
     }
 }

--- a/Tests/BloomCoreTests/TranscriptResumeTests.swift
+++ b/Tests/BloomCoreTests/TranscriptResumeTests.swift
@@ -19,7 +19,7 @@ struct TranscriptResumeTests {
         isAtLiveEnd: Bool = false,
         rowCount: Int = 400,
         measure: TranscriptPaneState.Measure? = nil,
-        drawnStart: Int = 0
+        drawn: TranscriptWindow = TranscriptWindow(start: 0, end: 400)
     ) -> TranscriptPaneState {
         TranscriptPaneState(
             expanded: expanded,
@@ -27,7 +27,7 @@ struct TranscriptResumeTests {
             isAtLiveEnd: isAtLiveEnd,
             rowCount: rowCount,
             measure: measure ?? self.measure(),
-            drawnStart: drawnStart
+            drawn: drawn
         )
     }
 
@@ -35,13 +35,15 @@ struct TranscriptResumeTests {
 
     @Test("a pane that has never held this session draws the tail")
     func nothingRememberedDrawsTheTail() {
-        #expect(TranscriptResume.window(nil, tailStart: 3_920, rowCount: 4_000) == 3_920)
+        let window = TranscriptResume.window(nil, tailStart: 3_920, rowCount: 4_000)
+        #expect(window == TranscriptWindow(start: 3_920, end: 4_000))
     }
 
     @Test("a pane coming back to a session goes back to the window it was reading in")
     func aReturnGoesBackToItsWindow() {
-        let remembered = state(drawnStart: 3_600)
-        #expect(TranscriptResume.window(remembered, tailStart: 3_920, rowCount: 4_000) == 3_600)
+        let remembered = state(drawn: TranscriptWindow(start: 3_600, end: 4_000))
+        let window = TranscriptResume.window(remembered, tailStart: 3_920, rowCount: 4_000)
+        #expect(window == TranscriptWindow(start: 3_600, end: 4_000))
     }
 
     @Test("a pane with nothing written down is arriving, and one with a memory is coming back")
@@ -52,8 +54,9 @@ struct TranscriptResumeTests {
 
     @Test("a window from a session that has since been read again is clamped to it")
     func aStaleWindowIsClamped() {
-        let remembered = state(drawnStart: 9_000)
-        #expect(TranscriptResume.window(remembered, tailStart: 20, rowCount: 100) == 100)
+        let remembered = state(drawn: TranscriptWindow(start: 9_000, end: 9_400))
+        let window = TranscriptResume.window(remembered, tailStart: 20, rowCount: 100)
+        #expect(window == TranscriptWindow(start: 100, end: 100))
     }
 
     // MARK: Where it opens

--- a/Tests/BloomCoreTests/TranscriptResumeTests.swift
+++ b/Tests/BloomCoreTests/TranscriptResumeTests.swift
@@ -18,14 +18,16 @@ struct TranscriptResumeTests {
         offset: Double = 1_200,
         isAtLiveEnd: Bool = false,
         rowCount: Int = 400,
-        measure: TranscriptPaneState.Measure? = nil
+        measure: TranscriptPaneState.Measure? = nil,
+        drawnStart: Int = 0
     ) -> TranscriptPaneState {
         TranscriptPaneState(
             expanded: expanded,
             offset: offset,
             isAtLiveEnd: isAtLiveEnd,
             rowCount: rowCount,
-            measure: measure ?? self.measure()
+            measure: measure ?? self.measure(),
+            drawnStart: drawnStart
         )
     }
 
@@ -33,12 +35,25 @@ struct TranscriptResumeTests {
 
     @Test("a pane that has never held this session draws the tail")
     func nothingRememberedDrawsTheTail() {
-        #expect(TranscriptResume.drawsInFull(nil) == false)
+        #expect(TranscriptResume.window(nil, tailStart: 3_920, rowCount: 4_000) == 3_920)
     }
 
-    @Test("a pane coming back to a session it has drawn draws the whole of it")
-    func aReturnDrawsInFull() {
-        #expect(TranscriptResume.drawsInFull(state()))
+    @Test("a pane coming back to a session goes back to the window it was reading in")
+    func aReturnGoesBackToItsWindow() {
+        let remembered = state(drawnStart: 3_600)
+        #expect(TranscriptResume.window(remembered, tailStart: 3_920, rowCount: 4_000) == 3_600)
+    }
+
+    @Test("a pane with nothing written down is arriving, and one with a memory is coming back")
+    func resumingIsHavingBeenHereBefore() {
+        #expect(TranscriptResume.isResuming(nil) == false)
+        #expect(TranscriptResume.isResuming(state()))
+    }
+
+    @Test("a window from a session that has since been read again is clamped to it")
+    func aStaleWindowIsClamped() {
+        let remembered = state(drawnStart: 9_000)
+        #expect(TranscriptResume.window(remembered, tailStart: 20, rowCount: 100) == 100)
     }
 
     // MARK: Where it opens

--- a/Tests/BloomCoreTests/TranscriptWindowTests.swift
+++ b/Tests/BloomCoreTests/TranscriptWindowTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// How much of a session the list is allowed to hand its lazy stack.
+///
+/// The arithmetic is here rather than in `TranscriptListView` for the reason the whole split
+/// exists: a window worked out inside a view is a window nothing can hold still, and the numbers
+/// this returns are the difference between a resize at six frames a second and one at sixty.
+@Suite("Transcript window")
+struct TranscriptWindowTests {
+    // MARK: Opening
+
+    @Test("a session shorter than the tail is drawn whole")
+    func shortSessionsAreDrawnWhole() {
+        #expect(TranscriptWindow.opening(rowCount: 40, tailStart: 0) == 0)
+    }
+
+    @Test("a long session opens on the tail the arrival frame chose")
+    func longSessionsOpenOnTheTail() {
+        #expect(TranscriptWindow.opening(rowCount: 4_000, tailStart: 3_920) == 3_920)
+    }
+
+    @Test("a row that has to be reachable widens the window to hold it, with room above")
+    func aTargetWidensTheWindow() {
+        let start = TranscriptWindow.opening(rowCount: 4_000, tailStart: 3_920, mustReach: 1_000)
+        #expect(start == 1_000 - TranscriptWindow.margin)
+    }
+
+    @Test("a target already inside the window leaves it where it was")
+    func aTargetInsideChangesNothing() {
+        #expect(TranscriptWindow.opening(rowCount: 4_000, tailStart: 3_920, mustReach: 3_990) == 3_920)
+    }
+
+    @Test("a target near the top of the session cannot push the window past it")
+    func aTargetNearTheTopClamps() {
+        #expect(TranscriptWindow.opening(rowCount: 4_000, tailStart: 3_920, mustReach: 3) == 0)
+    }
+
+    @Test("a tail longer than the session is clamped to the session")
+    func theTailIsClampedToTheSession() {
+        #expect(TranscriptWindow.opening(rowCount: 10, tailStart: 80) == 10)
+    }
+
+    // MARK: Settling
+
+    @Test("the window settles to a few hundred rows once the arrival is over")
+    func settlingHoldsTheSettledLength() {
+        let start = TranscriptWindow.settling(from: 3_920, rowCount: 4_000)
+        #expect(start == 4_000 - TranscriptWindow.settled)
+    }
+
+    @Test("settling never narrows a window that was opened wide for a search result")
+    func settlingNeverNarrows() {
+        #expect(TranscriptWindow.settling(from: 920, rowCount: 4_000) == 920)
+    }
+
+    @Test("a session shorter than the settled length settles at its first row")
+    func shortSessionsSettleAtZero() {
+        #expect(TranscriptWindow.settling(from: 0, rowCount: 120) == 0)
+    }
+
+    // MARK: Growing
+
+    @Test("a growth adds a chunk of history above the window")
+    func growthAddsAChunk() {
+        #expect(TranscriptWindow.grown(from: 1_000) == 1_000 - TranscriptWindow.chunk)
+    }
+
+    @Test("a growth stops at the first row of the session")
+    func growthStopsAtTheTop() {
+        #expect(TranscriptWindow.grown(from: 100) == 0)
+    }
+
+    @Test("a window at the first row has nothing left to grow into")
+    func nothingLeftToGrow() {
+        #expect(TranscriptWindow.canGrow(from: 0) == false)
+        #expect(TranscriptWindow.canGrow(from: 1))
+    }
+
+    // MARK: Finding a row
+
+    @Test("a sequence number that is in the session is found where it sits")
+    func findsAnExactRow() {
+        #expect(TranscriptWindow.index(ofSeqAtOrAfter: 30, in: [0, 10, 20, 30, 40]) == 3)
+    }
+
+    @Test("a sequence number with no row of its own lands on the row after it")
+    func findsTheRowAfterAGap() {
+        #expect(TranscriptWindow.index(ofSeqAtOrAfter: 25, in: [0, 10, 20, 30, 40]) == 3)
+    }
+
+    @Test("the first and last rows are both reachable")
+    func findsTheEnds() {
+        #expect(TranscriptWindow.index(ofSeqAtOrAfter: 0, in: [0, 10, 20]) == 0)
+        #expect(TranscriptWindow.index(ofSeqAtOrAfter: 20, in: [0, 10, 20]) == 2)
+    }
+
+    @Test("a sequence number past the end of the session is not in it")
+    func nothingPastTheEnd() {
+        #expect(TranscriptWindow.index(ofSeqAtOrAfter: 99, in: [0, 10, 20]) == nil)
+        #expect(TranscriptWindow.index(ofSeqAtOrAfter: 0, in: []) == nil)
+    }
+
+    @Test("the answer is an offset from the start, whatever the collection's own indices are")
+    func answersAnOffsetNotAnIndex() {
+        let rows = [0, 10, 20, 30, 40, 50]
+        #expect(TranscriptWindow.index(ofSeqAtOrAfter: 40, in: Array(rows[2...])) == 2)
+    }
+
+    @Test("a thousand row session is searched rather than walked")
+    func findsInALongSession() {
+        let seqs = (0..<1_000).map { $0 * 3 }
+        #expect(TranscriptWindow.index(ofSeqAtOrAfter: 1_500, in: seqs) == 500)
+        #expect(TranscriptWindow.index(ofSeqAtOrAfter: 1_501, in: seqs) == 501)
+    }
+}

--- a/Tests/BloomCoreTests/TranscriptWindowTests.swift
+++ b/Tests/BloomCoreTests/TranscriptWindowTests.swift
@@ -13,69 +13,130 @@ struct TranscriptWindowTests {
 
     @Test("a session shorter than the tail is drawn whole")
     func shortSessionsAreDrawnWhole() {
-        #expect(TranscriptWindow.opening(rowCount: 40, tailStart: 0) == 0)
+        let window = TranscriptWindow.opening(rowCount: 40, tailStart: 0)
+        #expect(window == TranscriptWindow(start: 0, end: 40))
     }
 
     @Test("a long session opens on the tail the arrival frame chose")
     func longSessionsOpenOnTheTail() {
-        #expect(TranscriptWindow.opening(rowCount: 4_000, tailStart: 3_920) == 3_920)
+        let window = TranscriptWindow.opening(rowCount: 4_000, tailStart: 3_920)
+        #expect(window == TranscriptWindow(start: 3_920, end: 4_000))
     }
 
-    @Test("a row that has to be reachable widens the window to hold it, with room above")
-    func aTargetWidensTheWindow() {
-        let start = TranscriptWindow.opening(rowCount: 4_000, tailStart: 3_920, mustReach: 1_000)
-        #expect(start == 1_000 - TranscriptWindow.margin)
+    /// The case that forced the window to have a bottom edge. An agent working while nobody is
+    /// watching leaves the first unread row near the beginning of a long conversation, and a
+    /// window that ran from there to the end was the whole session with extra steps.
+    @Test("a session opened on an old row draws that row's neighbourhood, not the rest of the session")
+    func anOldTargetDoesNotOpenTheWholeSession() {
+        let window = TranscriptWindow.opening(rowCount: 4_000, tailStart: 3_920, mustReach: 100)
+        #expect(window.start == 100 - TranscriptWindow.margin)
+        #expect(window.end == 100 - TranscriptWindow.margin + TranscriptWindow.margin + TranscriptWindow.settled)
+        #expect(window.count < 1_000)
     }
 
-    @Test("a target already inside the window leaves it where it was")
+    @Test("a target already inside the tail leaves the window where it was")
     func aTargetInsideChangesNothing() {
-        #expect(TranscriptWindow.opening(rowCount: 4_000, tailStart: 3_920, mustReach: 3_990) == 3_920)
+        let window = TranscriptWindow.opening(rowCount: 4_000, tailStart: 3_920, mustReach: 3_990)
+        #expect(window == TranscriptWindow(start: 3_920, end: 4_000))
     }
 
-    @Test("a target near the top of the session cannot push the window past it")
+    @Test("a target near the top of the session cannot push the window past its first row")
     func aTargetNearTheTopClamps() {
-        #expect(TranscriptWindow.opening(rowCount: 4_000, tailStart: 3_920, mustReach: 3) == 0)
+        let window = TranscriptWindow.opening(rowCount: 4_000, tailStart: 3_920, mustReach: 3)
+        #expect(window.start == 0)
     }
 
     @Test("a tail longer than the session is clamped to the session")
     func theTailIsClampedToTheSession() {
-        #expect(TranscriptWindow.opening(rowCount: 10, tailStart: 80) == 10)
+        let window = TranscriptWindow.opening(rowCount: 10, tailStart: 80)
+        #expect(window == TranscriptWindow(start: 10, end: 10))
     }
 
     // MARK: Settling
 
     @Test("the window settles to a few hundred rows once the arrival is over")
     func settlingHoldsTheSettledLength() {
-        let start = TranscriptWindow.settling(from: 3_920, rowCount: 4_000)
-        #expect(start == 4_000 - TranscriptWindow.settled)
+        let settled = TranscriptWindow.settling(
+            from: TranscriptWindow(start: 3_920, end: 4_000), rowCount: 4_000
+        )
+        #expect(settled == TranscriptWindow(start: 4_000 - TranscriptWindow.settled, end: 4_000))
     }
 
-    @Test("settling never narrows a window that was opened wide for a search result")
+    @Test("settling never narrows a window that was opened wide")
     func settlingNeverNarrows() {
-        #expect(TranscriptWindow.settling(from: 920, rowCount: 4_000) == 920)
+        let settled = TranscriptWindow.settling(
+            from: TranscriptWindow(start: 920, end: 4_000), rowCount: 4_000
+        )
+        #expect(settled == TranscriptWindow(start: 920, end: 4_000))
+    }
+
+    @Test("settling leaves a window opened around an old row exactly where it is")
+    func settlingLeavesATargetWindow() {
+        let opened = TranscriptWindow(start: 20, end: 500)
+        #expect(TranscriptWindow.settling(from: opened, rowCount: 4_000) == opened)
     }
 
     @Test("a session shorter than the settled length settles at its first row")
     func shortSessionsSettleAtZero() {
-        #expect(TranscriptWindow.settling(from: 0, rowCount: 120) == 0)
+        let settled = TranscriptWindow.settling(
+            from: TranscriptWindow(start: 0, end: 120), rowCount: 120
+        )
+        #expect(settled == TranscriptWindow(start: 0, end: 120))
     }
 
     // MARK: Growing
 
-    @Test("a growth adds a chunk of history above the window")
-    func growthAddsAChunk() {
-        #expect(TranscriptWindow.grown(from: 1_000) == 1_000 - TranscriptWindow.chunk)
+    @Test("a growth upward adds a chunk of history above the window")
+    func growthUpAddsAChunk() {
+        let grown = TranscriptWindow(start: 1_000, end: 2_000).grownUp()
+        #expect(grown == TranscriptWindow(start: 1_000 - TranscriptWindow.chunk, end: 2_000))
     }
 
-    @Test("a growth stops at the first row of the session")
-    func growthStopsAtTheTop() {
-        #expect(TranscriptWindow.grown(from: 100) == 0)
+    @Test("a growth upward stops at the first row of the session")
+    func growthUpStopsAtTheTop() {
+        #expect(TranscriptWindow(start: 100, end: 900).grownUp().start == 0)
     }
 
-    @Test("a window at the first row has nothing left to grow into")
+    @Test("a growth downward adds a chunk of what came after")
+    func growthDownAddsAChunk() {
+        let grown = TranscriptWindow(start: 0, end: 500).grownDown(rowCount: 4_000)
+        #expect(grown == TranscriptWindow(start: 0, end: 500 + TranscriptWindow.chunk))
+    }
+
+    @Test("a growth downward stops at the live end")
+    func growthDownStopsAtTheEnd() {
+        #expect(TranscriptWindow(start: 0, end: 3_900).grownDown(rowCount: 4_000).end == 4_000)
+    }
+
+    @Test("a window at both ends of the session has nothing left to grow into")
     func nothingLeftToGrow() {
-        #expect(TranscriptWindow.canGrow(from: 0) == false)
-        #expect(TranscriptWindow.canGrow(from: 1))
+        let whole = TranscriptWindow(start: 0, end: 100)
+        #expect(whole.canGrowUp == false)
+        #expect(whole.canGrowDown(rowCount: 100) == false)
+        #expect(TranscriptWindow(start: 1, end: 99).canGrowUp)
+        #expect(TranscriptWindow(start: 1, end: 99).canGrowDown(rowCount: 100))
+    }
+
+    // MARK: The live end
+
+    @Test("the live end is the tail rather than everything between here and it")
+    func liveEndIsTheTail() {
+        let window = TranscriptWindow.liveEnd(rowCount: 4_000)
+        #expect(window == TranscriptWindow(start: 4_000 - TranscriptWindow.settled, end: 4_000))
+    }
+
+    @Test("the live end of a short session is the whole of it")
+    func liveEndOfAShortSession() {
+        #expect(TranscriptWindow.liveEnd(rowCount: 30) == TranscriptWindow(start: 0, end: 30))
+    }
+
+    // MARK: Against a session that has moved
+
+    @Test("a remembered window is clamped to the session it is restored into")
+    func clampingARememberedWindow() {
+        let remembered = TranscriptWindow(start: 3_000, end: 4_000)
+        #expect(remembered.clamped(rowCount: 100) == TranscriptWindow(start: 100, end: 100))
+        #expect(remembered.clamped(rowCount: 4_200) == remembered)
     }
 
     // MARK: Finding a row

--- a/Tests/BloomCoreTests/WorktreeWatcherTests.swift
+++ b/Tests/BloomCoreTests/WorktreeWatcherTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Synchronization
+import Testing
+@testable import BloomCore
+
+/// What the file system watcher says changed, and what it refuses to say.
+///
+/// The attribution is the part with a bug in it: a worktree nested inside another checkout, and
+/// two worktrees whose names share a prefix, are both real shapes in `~/bloom/workspaces` and both
+/// answer wrongly under a plain `hasPrefix`.
+@Suite("Worktree watcher")
+struct WorktreeWatcherTests {
+    // MARK: Attribution
+
+    @Test("a file inside a worktree is reported as that worktree")
+    func attributesAFileToItsWorktree() {
+        let changed = WorktreeWatcher.roots(
+            of: ["/a/beta/Sources/App/View.swift"], in: WorktreeWatcher.ordered(["/a/beta"])
+        )
+        #expect(changed == ["/a/beta"])
+    }
+
+    @Test("the worktree's own directory is reported as itself")
+    func attributesTheRootItself() {
+        let changed = WorktreeWatcher.roots(of: ["/a/beta"], in: WorktreeWatcher.ordered(["/a/beta"]))
+        #expect(changed == ["/a/beta"])
+    }
+
+    @Test("a worktree whose name is a prefix of another is not confused with it")
+    func doesNotConfuseAPrefix() {
+        let roots = WorktreeWatcher.ordered(["/a/beta", "/a/beta-two"])
+        #expect(WorktreeWatcher.roots(of: ["/a/beta-two/x.txt"], in: roots) == ["/a/beta-two"])
+        #expect(WorktreeWatcher.roots(of: ["/a/beta/x.txt"], in: roots) == ["/a/beta"])
+    }
+
+    @Test("a worktree nested inside another checkout is reported as itself")
+    func attributesTheNestedWorktree() {
+        let roots = WorktreeWatcher.ordered(["/a/repo", "/a/repo/nested"])
+        #expect(WorktreeWatcher.roots(of: ["/a/repo/nested/x.txt"], in: roots) == ["/a/repo/nested"])
+    }
+
+    @Test("a path in no watched worktree is reported as nothing")
+    func dropsWhatItDoesNotWatch() {
+        #expect(WorktreeWatcher.roots(of: ["/somewhere/else"], in: ["/a/beta"]).isEmpty)
+    }
+
+    @Test("a storm of writes in one worktree is one answer")
+    func coalescesABatch() {
+        let paths = (0..<200).map { "/a/beta/file-\($0)" }
+        #expect(WorktreeWatcher.roots(of: paths, in: ["/a/beta"]) == ["/a/beta"])
+    }
+
+    @Test("trailing separators do not make two roots out of one")
+    func standardisesTrailingSeparators() {
+        let roots = WorktreeWatcher.ordered(["/a/beta/", "/a/beta"])
+        #expect(roots == ["/a/beta"])
+        #expect(WorktreeWatcher.roots(of: ["/a/beta/x"], in: roots) == ["/a/beta"])
+    }
+
+    // MARK: Against the real file system
+
+    @Test("a write inside a watched directory wakes the watcher", .timeLimit(.minutes(1)))
+    func reportsARealWrite() async throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("bloom-watcher-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Deliberately the spelling with the symlink still in it: `NSTemporaryDirectory` says
+        // `/var/folders/...` and FSEvents answers about `/private/var/folders/...`, so watching
+        // this path at all is the test of `WorktreeWatcher.resolve`. What comes back has to be
+        // the spelling that went in, because that is what the caller has a workspace for.
+        let watchedPath = root.path
+
+        let reported = Mutex<Set<String>>([])
+        let watcher = WorktreeWatcher { changed in
+            reported.withLock { $0.formUnion(changed) }
+        }
+        defer { watcher.stop() }
+        watcher.watch(roots: [watchedPath])
+
+        // FSEvents subscribes asynchronously, so a write made in the same instant as the start can
+        // land before the subscription does. This is the one wait in the test and it is why the
+        // whole thing has a time limit rather than a sleep long enough to be sure.
+        try await Task.sleep(for: .milliseconds(300))
+        try Data("hello".utf8).write(to: root.appendingPathComponent("file.txt"))
+
+        var waited = Duration.zero
+        while reported.withLock({ $0.isEmpty }), waited < .seconds(20) {
+            try await Task.sleep(for: .milliseconds(100))
+            waited += .milliseconds(100)
+        }
+        #expect(reported.withLock { $0 } == [watchedPath])
+    }
+
+    @Test("watching nothing tears the stream down without complaint")
+    func stopsCleanly() {
+        let watcher = WorktreeWatcher { _ in }
+        watcher.watch(roots: ["/tmp"])
+        watcher.watch(roots: [])
+        watcher.stop()
+    }
+}


### PR DESCRIPTION
Measured with the probe family against a release build and a copy of the real database, 1440x900 at 120Hz.

| | before | after |
|---|---|---|
| Scroll a 1,855 message chat, worst frame | 1,098 ms | 49 ms |
| Scroll, p99 | 357 ms | 36 ms |
| Window resize over that chat, median frame | 163 ms | 124 ms |
| Window resize, worst frame | 529 ms | 291 ms |
| Streaming at 60 deltas a second, main thread | 398 ms/s | 274 ms/s |
| Streaming, frames late | 30% | 15% |
| Idle git, nothing changed | 18 processes a tick | none |

**The transcript is drawn in a window.** A lazy stack is lazy about realising a row and not about knowing one, so a layout pass cost 11.1 ms over 1,582 rows and 1.6 ms over none. `TranscriptTail` already kept that off the arrival frame and then handed the whole session back a hundred milliseconds later. The window now settles at a few hundred rows and grows upward when the reader approaches the top, under the bottom size-changes anchor so nothing moves, and downward with no anchor at all. It has two ends because a session opened on an old unread row would otherwise be the whole session with extra steps, which is the case Bloom is for.

**A file system watcher replaces most of the polling.** Every git process the refresh loop ran existed to find out whether anything had happened. One FSEvents stream over every active worktree says which ones changed; those are refreshed on the next tick, the backstop rotation went from a minute to five, and the workspace on screen stops being asked about on every tick.

**The live tail redraws twenty times a second** rather than once per delta. The whole answer so far is re-parsed and re-measured on every chunk, so a turn did O(n^2) work to draw one paragraph.

**`StreamProbe` is new**, and is the first probe that measures the app being used rather than a gesture made to it: it types into the real composer and streams real deltas through the transcript's own event handler. Both numbers above come from it. `ComposerRoom` and the reach box are two smaller moves of the same kind the bubble cap already made: keep a number where only its reader is invalidated by it.

Still open, and not in this branch: a resize of a window holding an empty chat is 19 fps, which caps everything above it, and about half of each resize frame is outside the centre column.