### PR TITLE
Put a reader back where they were

### DIFF
--- a/Sources/Bloom/Design/ProbeHarness.swift
+++ b/Sources/Bloom/Design/ProbeHarness.swift
@@ -240,6 +240,33 @@ struct ProbeHarness {
         ]
     }
 
+    /// Scrolls a view the way a wheel does, from inside this process.
+    ///
+    /// **Writing the clip view's bounds is not scrolling, and the difference is what this exists
+    /// for.** SwiftUI's `ScrollPosition` never sees a bounds write, so it goes on standing at
+    /// whatever edge it was left at and the next layout pass that grows the content puts the view
+    /// back there: a probe that asked for two thousand points off the live end reported `atEnd` on
+    /// both samples. A scroll wheel event goes through the same path a hand does, so the position
+    /// moves off its edge exactly as it would for a reader.
+    ///
+    /// Delivered by calling `scrollWheel(with:)` on the view rather than by posting to the window
+    /// server. Posting would route by where the pointer is, which is somewhere in the owner's own
+    /// window, and would need this app in front. Nothing here takes the pointer, the focus or the
+    /// front. See the head of `window`.
+    static func wheel(_ view: NSView, by points: CGFloat, steps: Int = 1) {
+        for _ in 0..<max(1, steps) {
+            guard let scroll = CGEvent(
+                scrollWheelEvent2Source: nil,
+                units: .pixel,
+                wheelCount: 1,
+                wheel1: Int32(points),
+                wheel2: 0,
+                wheel3: 0
+            ), let event = NSEvent(cgEvent: scroll) else { return }
+            view.scrollWheel(with: event)
+        }
+    }
+
     // MARK: - What a report says about the run
 
     /// Which build, how loaded the machine was, and what the window was.

--- a/Sources/Bloom/Design/SwitchProbe.swift
+++ b/Sources/Bloom/Design/SwitchProbe.swift
@@ -170,58 +170,56 @@ enum SwitchProbe {
         ]
     }
 
-    /// Leaves a reader part way up a conversation, goes somewhere else, and comes back.
+    /// The owner's own report, driven: one conversation left at its top, one at its live end, and
+    /// then switched between.
     ///
-    /// The offsets either side are the whole report. They are not required to be equal to the
-    /// point: the rows above the viewport are re-measured on the way back, so an anchor that lands
-    /// the same ROW at the top can legitimately land a few points from where it was. What would
-    /// fail is landing at the live end (the flag was written when it should not have been), at the
-    /// top (nothing was restored), or at the first unread row, which is what a refused restore
-    /// used to do and is halfway up a long conversation.
+    /// "Scroll one to the top, one to the bottom, switch between them and the position is never
+    /// right." Every earlier run here sat at the live end, which is the one place the flag alone
+    /// can restore, so none of them could see it. The wheel is what makes this faithful: see
+    /// `ProbeHarness.wheel`.
     private static func keepsItsPlace(
         contentView: NSView, ticker: Ticker
     ) async -> [String: JSONValue] {
         guard let app = ProbeHarness.appModel, order.count >= 2 else { return [:] }
-        let subject = order[0]
+        let top = order[0]
+        let bottom = order[order.count - 1]
+        var report: [String: JSONValue] = [:]
 
-        app.selection = .workspace(subject)
+        // One to the top. A wheel scroll rather than a jump, in one large step per frame, because
+        // what is being set up is a reader's position and a reader gets there by scrolling.
+        app.selection = .workspace(top)
         try? await Task.sleep(for: .milliseconds(settle))
-        guard let scroll = ProbeHarness.transcriptScrollView(in: contentView) else { return [:] }
+        if let scroll = ProbeHarness.transcriptScrollView(in: contentView) {
+            for _ in 0..<400 {
+                ProbeHarness.wheel(scroll, by: 300)
+                try? await Task.sleep(for: .milliseconds(8))
+            }
+            try? await Task.sleep(for: .seconds(2))
+            report["topLeft"] = .object(ProbeHarness.scrollPlace(scroll))
+        }
 
-        // A long way up, so the answer cannot be confused with a reader who never left the end.
-        let travel = ProbeHarness.scrollableHeight(of: scroll)
-        let target = max(0, travel - 2_000)
-        scroll.contentView.setBoundsOrigin(CGPoint(x: 0, y: target))
-        scroll.reflectScrolledClipView(scroll.contentView)
-        // Long enough for the scroll to settle and for the pane to write down where it is: the
-        // record is made when a scroll ENDS, which is a phase change rather than a frame.
-        try? await Task.sleep(for: .seconds(2))
-        let left = ProbeHarness.scrollPlace(scroll)
-
-        await switchTo(order[order.count - 1], contentView: contentView, ticker: ticker)
-        await switchTo(subject, contentView: contentView, ticker: ticker)
-
-        let returned = ProbeHarness.scrollPlace(
+        // The other stays where a conversation opens, which is its live end.
+        app.selection = .workspace(bottom)
+        try? await Task.sleep(for: .milliseconds(settle))
+        report["bottomLeft"] = .object(ProbeHarness.scrollPlace(
             ProbeHarness.transcriptScrollView(in: contentView)
-        )
-        var report: [String: JSONValue] = ["left": .object(left), "returned": .object(returned)]
-        if case .number(let before)? = left["offset"], case .number(let after)? = returned["offset"] {
-            report["movedPoints"] = .number(abs(after - before))
+        ))
+
+        // And now the switching, which is the report.
+        var visits: [JSONValue] = []
+        for step in 0..<4 {
+            let target = step.isMultiple(of: 2) ? top : bottom
+            await switchTo(target, contentView: contentView, ticker: ticker)
+            let place = ProbeHarness.scrollPlace(
+                ProbeHarness.transcriptScrollView(in: contentView)
+            )
+            visits.append(.object([
+                "step": .integer(step),
+                "workspace": .string(target == top ? "topOne" : "bottomOne"),
+                "place": .object(place),
+            ]))
         }
-        // **Whether the run tested anything at all**, and it often does not.
-        //
-        // Writing the clip view's origin is not a hand on the wheel: SwiftUI never sees it, so the
-        // list's own `ScrollPosition` goes on standing at `.bottom`, and the next layout pass that
-        // grows the content reapplies that edge and puts the view back at the end. Measured: this
-        // probe asked for two thousand points off the end and reported `atEnd` on both samples.
-        //
-        // So the report says whether the reader was actually moved, and a run that could not move
-        // them is a run whose numbers say nothing about the anchor. Driving it faithfully needs
-        // real scroll wheel events, which need the window in front, which is the owner's keyboard.
-        // See the head of `ProbeHarness.window`.
-        if case .bool(let wasAtEnd)? = left["atEnd"] {
-            report["drove"] = .bool(!wasAtEnd)
-        }
+        report["visits"] = .array(visits)
         return report
     }
 

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -69,6 +69,10 @@ struct TranscriptListView: View {
     /// re-runs this body. See `TranscriptHoverHost`.
     @State private var hoverHost = TranscriptHoverHost()
 
+    /// Which rows are on screen, so leaving can write down which one the reader was at. Not
+    /// observed and read only outside a body: see `TranscriptVisibleRows`.
+    @State private var visibleRowSeqs = TranscriptVisibleRows()
+
     /// Two things, and the comment used to claim one.
     ///
     /// `linkActions` reaches the workspace's model, which is what a link opened in a browser tab
@@ -424,6 +428,9 @@ struct TranscriptListView: View {
                             .padding(.horizontal, TranscriptLayout.inset)
                             .padding(.bottom, TranscriptLayout.turnGap)
                             .id(row.seq)
+                            .onScrollVisibilityChange(threshold: 0.01) { isVisible in
+                                visibleRowSeqs.note(row.seq, isVisible: isVisible)
+                            }
                         } else {
                             TranscriptRowView(
                                 row: row,
@@ -446,6 +453,11 @@ struct TranscriptListView: View {
                             .arrivingRow(isArriving(row))
                             .padding(.horizontal, TranscriptLayout.inset)
                             .id(row.seq)
+                            // Twice per pass over this row, rather than once a frame for the whole
+                            // stack. See `TranscriptVisibleRows` for what this replaced and why.
+                            .onScrollVisibilityChange(threshold: 0.01) { isVisible in
+                                visibleRowSeqs.note(row.seq, isVisible: isVisible)
+                            }
                         }
                     }
 
@@ -690,6 +702,7 @@ struct TranscriptListView: View {
                 )
                 resumed = TranscriptResume.isResuming(remembered) ? transcript.session.id : nil
                 isGrowing = false
+                visibleRowSeqs.forget()
                 // And nothing in the session being arrived at counts as having arrived. Cleared
                 // here as well as set in `task` for the same reason the window is: leaving a
                 // session before it had settled and coming straight back must not find its own
@@ -1122,6 +1135,11 @@ struct TranscriptListView: View {
             opening = .liveEnd
         case .offset(let y):
             opening = .offset(y)
+        case .row(let seq):
+            // At the top of the pane, which is where it was: the anchor IS the row the reader had
+            // at the top. Not centred, which is what a search result gets, because a search result
+            // is a row somebody is being shown rather than a place somebody is being put back.
+            opening = .row(seq, .top)
         case .first:
             // A search result outranks both of the others. Somebody who clicked a line of a
             // transcript in the search screen asked for that line, and taking them to their unread
@@ -1163,6 +1181,9 @@ struct TranscriptListView: View {
             TranscriptPaneState(
                 expanded: expanded,
                 offset: contentOffset.value,
+                // The row at the top of the pane, which is the place; the offset above is what
+                // answers when there is no row to name. See `TranscriptVisibleRows`.
+                anchorSeq: visibleRowSeqs.topmost,
                 isAtLiveEnd: geometry.isNearBottom,
                 rowCount: transcript.rows.count,
                 // The offset above is a number of points into content that starts at this row.

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -1153,10 +1153,12 @@ struct TranscriptListView: View {
     /// dropped: a reader who arrives, reads what is on screen and switches tab has scrolled
     /// nothing and folded nothing, and is exactly the case this whole file is about.
     private func remember() {
-        // Nothing is written down about a pane that has not drawn anything yet. Its window is
-        // empty, its offset is nought, and both would be restored over a session that has since
-        // loaded. See `TranscriptResume.window`.
-        guard let memory, drawn.window.count > 0 else { return }
+        // Nothing is written down about a pane that has not drawn anything yet, or has not been
+        // laid out yet. Its window is empty and its offset is nought, and both would be restored
+        // over a session that has since loaded. The height is what says a layout has happened, and
+        // it is checked HERE rather than where the memory is read, because nought is a real place
+        // to a reader who is at the top of a conversation. See `TranscriptResume.placement`.
+        guard let memory, drawn.window.count > 0, geometry.paneHeight > 0 else { return }
         memory.remember(
             TranscriptPaneState(
                 expanded: expanded,

--- a/Sources/Bloom/Views/Transcript/TranscriptVisibleRows.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptVisibleRows.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Which rows are on screen, so that leaving a conversation can write down WHICH row the reader
+/// was at rather than how many points down they were.
+///
+/// # Why a point is not a place
+///
+/// The content height of a transcript is not a fact about the conversation, it is a fact about
+/// what the lazy stack has bothered to measure. Driven through the owner's own report, one chat
+/// left at its top and visited three times, the same session's content came out 35,246 points,
+/// then 17,235, then 24,407: the rows near the viewport get measured and everything else is
+/// guessed, and the guess depends on which rows happened to be realised. A point offset written
+/// against one of those numbers and read against another names a different row, which is what
+/// "the position does weird things" is.
+///
+/// A row is a row at every one of those heights.
+///
+/// # Why this rather than `scrollTargetLayout`
+///
+/// SwiftUI will hand over the row at the top of a scroll target layout, and that layout was
+/// measured on this list and is too expensive to keep: scrolling a 225 row chat, p99 went from
+/// 21.8ms to 39.2ms and the worst frame from 35.8ms to 70.7ms with nothing else changed, because
+/// it computes target geometry for every subview on every pass.
+///
+/// A visibility callback is a different shape of cost. It fires when a row ENTERS or LEAVES the
+/// viewport, which is twice per row per pass over it, rather than once per subview per frame. The
+/// set it maintains is read once, when the pane is asked to remember where it was.
+///
+/// **Not observed, deliberately.** This is written on every row that crosses the edge of the
+/// viewport, which during a flick is dozens a second, and nothing draws from it: it is read by
+/// `remember`, outside a body. As `@Observable` it would invalidate the list on every row that
+/// scrolled past, which is the opposite of the point. See `GeometryBox` for the same argument.
+@MainActor
+final class TranscriptVisibleRows {
+    private var seqs: Set<Int> = []
+
+    func note(_ seq: Int, isVisible: Bool) {
+        if isVisible {
+            seqs.insert(seq)
+        } else {
+            seqs.remove(seq)
+        }
+    }
+
+    /// The topmost row on screen, which is where the reader is.
+    ///
+    /// The minimum rather than the first the set happened to see: a set has no order, and rows
+    /// arrive in it in whatever order they crossed the edge.
+    var topmost: Int? { seqs.min() }
+
+    /// Forgotten when the pane is pointed at another conversation, because a row that is visible
+    /// in one session is not a row in another.
+    func forget() { seqs.removeAll() }
+}

--- a/Sources/BloomCore/Transcript/TranscriptResume.swift
+++ b/Sources/BloomCore/Transcript/TranscriptResume.swift
@@ -54,7 +54,21 @@ public struct TranscriptPaneState: Equatable, Sendable {
     /// The sequence numbers of the rows the reader had unfolded.
     public var expanded: Set<Int>
     /// Where the view was, in points from the top of the content.
+    ///
+    /// The fallback, not the answer. See `anchorSeq`.
     public var offset: Double
+
+    /// The row that was at the top of the viewport, by sequence number.
+    ///
+    /// **A row rather than a point, because a point is not a place here.** The content height of a
+    /// transcript is a fact about what the lazy stack has bothered to measure rather than about the
+    /// conversation: driven through the owner's own report, one chat visited three times reported
+    /// 35,246 points, then 17,235, then 24,407 for the same session. An offset written against one
+    /// of those and read against another names a different row.
+    ///
+    /// Nil when the pane had no row on screen to name, which is an empty conversation and the
+    /// frames before the first layout. The offset carries those.
+    public var anchorSeq: Int?
     /// Whether that offset was the live end.
     ///
     /// Kept as a flag rather than inferred from the offset, because a turn can run while the
@@ -73,12 +87,14 @@ public struct TranscriptPaneState: Equatable, Sendable {
     public init(
         expanded: Set<Int>,
         offset: Double,
+        anchorSeq: Int? = nil,
         isAtLiveEnd: Bool,
         rowCount: Int,
         drawn: TranscriptWindow = TranscriptWindow(start: 0, end: 0)
     ) {
         self.expanded = expanded
         self.offset = offset
+        self.anchorSeq = anchorSeq
         self.isAtLiveEnd = isAtLiveEnd
         self.rowCount = rowCount
         self.drawn = drawn
@@ -92,8 +108,10 @@ public enum TranscriptPlacement: Equatable, Sendable {
     case first
     /// The reader left at the live end, so that is where they are put back.
     case liveEnd
-    /// The reader left this many points down, and the document is the same document.
+    /// The reader left this many points down. The fallback, for a pane that could not name a row.
     case offset(Double)
+    /// The reader left this row at the top of the pane, so that is where it goes back.
+    case row(Int)
 }
 
 /// The rule for what a pane may do with what it remembers.
@@ -174,6 +192,9 @@ public enum TranscriptResume {
         // of a scroll target layout, and measured on this list that layout costs too much to keep:
         // p99 went from 21.8ms to 39.2ms scrolling a 225 row chat with nothing else changed. So
         // the row is what an AppKit list would buy, and until then this is the honest fallback.
+        // The row they were reading, which survives every re-measurement and every width. See
+        // `TranscriptPaneState.anchorSeq`.
+        if let seq = remembered.anchorSeq { return .row(seq) }
         // **Nought is a place: it is the top of the conversation.** This used to refuse it, on the
         // reasoning that a pane which has never been laid out reports nought and restoring that
         // would be a restore of nothing. The pane not being laid out is a fact about the PANE, and

--- a/Sources/BloomCore/Transcript/TranscriptResume.swift
+++ b/Sources/BloomCore/Transcript/TranscriptResume.swift
@@ -174,7 +174,13 @@ public enum TranscriptResume {
         // of a scroll target layout, and measured on this list that layout costs too much to keep:
         // p99 went from 21.8ms to 39.2ms scrolling a 225 row chat with nothing else changed. So
         // the row is what an AppKit list would buy, and until then this is the honest fallback.
-        guard remembered.offset > 0 else { return .first }
+        // **Nought is a place: it is the top of the conversation.** This used to refuse it, on the
+        // reasoning that a pane which has never been laid out reports nought and restoring that
+        // would be a restore of nothing. The pane not being laid out is a fact about the PANE, and
+        // it belongs where the memory is written rather than where it is read: `remember` declines
+        // to write anything until the pane has a height. What was left here was a reader who had
+        // scrolled to the very top of a long conversation being told they had no place at all, and
+        // sent to their first unread row instead. That is the second half of the report.
         return .offset(remembered.offset)
     }
 }

--- a/Tests/BloomCoreTests/TranscriptResumeTests.swift
+++ b/Tests/BloomCoreTests/TranscriptResumeTests.swift
@@ -125,11 +125,9 @@ struct TranscriptResumeTests {
         #expect(placement == .first)
     }
 
-    @Test("the top of the content is a first open rather than a restored nought")
-    func topIsNotRestored() {
-        let placement = TranscriptResume.placement(
-            for: state(offset: 0), rowCount: 400
-        )
-        #expect(placement == .first)
+    @Test("the top of a conversation is a place, and is restored")
+    func theTopIsAPlace() {
+        #expect(TranscriptResume.placement(for: state(offset: 0), rowCount: 400) == .offset(0))
     }
+
 }

--- a/Tests/BloomCoreTests/TranscriptResumeTests.swift
+++ b/Tests/BloomCoreTests/TranscriptResumeTests.swift
@@ -12,6 +12,7 @@ struct TranscriptResumeTests {
     private func state(
         expanded: Set<Int> = [],
         offset: Double = 1_200,
+        anchorSeq: Int? = nil,
         isAtLiveEnd: Bool = false,
         rowCount: Int = 400,
         drawn: TranscriptWindow = TranscriptWindow(start: 0, end: 400)
@@ -19,6 +20,7 @@ struct TranscriptResumeTests {
         TranscriptPaneState(
             expanded: expanded,
             offset: offset,
+            anchorSeq: anchorSeq,
             isAtLiveEnd: isAtLiveEnd,
             rowCount: rowCount,
             drawn: drawn
@@ -61,6 +63,33 @@ struct TranscriptResumeTests {
     }
 
     // MARK: Where it opens
+
+    @Test("a reader is put back at the row they had at the top of the pane")
+    func theAnchorRowIsRestored() {
+        #expect(TranscriptResume.placement(for: state(anchorSeq: 120), rowCount: 400) == .row(120))
+    }
+
+    @Test("the row outranks the point, because the point is what answers without one")
+    func theRowOutranksThePoint() {
+        let placement = TranscriptResume.placement(
+            for: state(offset: 9_000, anchorSeq: 120), rowCount: 400
+        )
+        #expect(placement == .row(120))
+    }
+
+    @Test("a reader who left at the end is put back at the end whatever row was on top")
+    func liveEndOutranksTheRow() {
+        let placement = TranscriptResume.placement(
+            for: state(anchorSeq: 120, isAtLiveEnd: true), rowCount: 400
+        )
+        #expect(placement == .liveEnd)
+    }
+
+    @Test("a pane that could name no row falls back to the point it was at")
+    func noRowFallsBackToThePoint() {
+        let placement = TranscriptResume.placement(for: state(offset: 1_200), rowCount: 400)
+        #expect(placement == .offset(1_200))
+    }
 
     /// The three tests that used to sit at the foot of this suite are gone with the rule they
     /// held down: a restore is no longer refused because the pane is a different width or the text


### PR DESCRIPTION
Reported: two long transcripts, one scrolled to the top and one at the bottom, switch between them and the position is never right.

Two bugs, both measured with a new probe that drives the report itself: it wheel-scrolls one conversation to its top, leaves the other at its live end, and switches between them recording where each lands. Earlier runs could not see any of this because writing a clip view's bounds is not scrolling, so every one of them sat at the live end, which is the one place the flag alone restores.

**The top of a conversation was not a place.** A reader at the very top records an offset of nought, and nought was read as "nothing remembered", which opens the session the way a fresh visit does: at the first unread row. After an agent has worked while you were on another workspace, that is the middle of the conversation.

**A point offset is not a place either.** The content height of a transcript is a fact about what the lazy stack has bothered to measure, not about the conversation. The same session, visited three times in the probe, reported 35,246 points, then 17,235, then 24,407. An offset written against one and read against another names a different row.

So the place is the row at the top of the viewport now. Rows report their own visibility, which fires when one crosses the edge rather than once a frame for the whole stack, and the topmost is what is written down. `scrollTargetLayout`, which is how SwiftUI would hand over the same row, was tried first and measured too expensive to keep: p99 21.8ms to 39.2ms scrolling a 225 row chat, worst frame 35.8ms to 70.7ms. The visibility callback costs nothing measurable: 17.9/25.0/35.9 against 18.9/25.8/39.1 without it.

After: the top one comes back at its top on every visit, the bottom one within 17 points of its end.