### PR TITLE
Let the reader reach the end, and write down where they were

### DIFF
--- a/Sources/Bloom/Design/SwitchProbe.swift
+++ b/Sources/Bloom/Design/SwitchProbe.swift
@@ -259,13 +259,17 @@ enum SwitchProbe {
 
     /// What a pane has written down about the conversation it is showing.
     ///
-    /// Reached through the workspace's own model, which is where `TranscriptPaneMemory` puts it.
-    /// The pane name is the unsplit one, because that is what every one of these runs is looking
-    /// at; a split tab would answer for one of its halves and this probe never splits.
+    /// **The pane is the tab's own id, not "solo".** This asked for `CenterPanesView.soloPane`
+    /// first, on the strength of two doc comments that said an unsplit tab's pane answers to that
+    /// name everywhere, and it came back nil every time: nothing writes that key. `soloPane` is a
+    /// `ForEach` identity and nothing else, and the string a pane is actually given is
+    /// `PaneContent.id`, which for a chat is the session's uuid. A probe that reads the wrong key
+    /// reports "nothing was remembered" for an app that remembered perfectly well, which is a
+    /// worse failure than not looking at all.
     private static func remembered(for id: WorkspaceID, in app: AppModel) -> [String: JSONValue] {
         guard let model = app.existingModel(for: id),
               let session = model.activeSession,
-              let state = model.panePosition(pane: CenterPanesView.soloPane, session: session.id)
+              let state = model.panePosition(pane: PaneContent.chat(session.id).id, session: session.id)
         else { return ["found": .bool(false)] }
         return [
             "found": .bool(true),

--- a/Sources/Bloom/Design/SwitchProbe.swift
+++ b/Sources/Bloom/Design/SwitchProbe.swift
@@ -204,6 +204,9 @@ enum SwitchProbe {
             }
             try? await Task.sleep(for: .seconds(2))
             report["topLeft"] = .object(ProbeHarness.scrollPlace(scroll))
+            // And what the pane wrote down about it, which is the only way to tell a place that
+            // was recorded wrongly from a place that was recorded and then restored wrongly.
+            report["topRemembered"] = .object(remembered(for: top, in: app))
         }
 
         // The other stays where a conversation opens, which is its live end.
@@ -229,6 +232,27 @@ enum SwitchProbe {
         }
         report["visits"] = .array(visits)
         return report
+    }
+
+    /// What a pane has written down about the conversation it is showing.
+    ///
+    /// Reached through the workspace's own model, which is where `TranscriptPaneMemory` puts it.
+    /// The pane name is the unsplit one, because that is what every one of these runs is looking
+    /// at; a split tab would answer for one of its halves and this probe never splits.
+    private static func remembered(for id: WorkspaceID, in app: AppModel) -> [String: JSONValue] {
+        guard let model = app.existingModel(for: id),
+              let session = model.activeSession,
+              let state = model.panePosition(pane: CenterPanesView.soloPane, session: session.id)
+        else { return ["found": .bool(false)] }
+        return [
+            "found": .bool(true),
+            "anchorSeq": state.anchorSeq.map { .integer($0) } ?? .null,
+            "offset": .number(state.offset),
+            "isAtLiveEnd": .bool(state.isAtLiveEnd),
+            "rowCount": .integer(state.rowCount),
+            "drawnStart": .integer(state.drawn.start),
+            "drawnEnd": .integer(state.drawn.end),
+        ]
     }
 
     /// Switches back and forth without waiting, then reports what is on screen at the end.

--- a/Sources/Bloom/Design/SwitchProbe.swift
+++ b/Sources/Bloom/Design/SwitchProbe.swift
@@ -161,6 +161,7 @@ enum SwitchProbe {
             "name": .string(name),
             // Where the switch left the reader, which is the whole of what "it did not keep my
             // place" means. See `ProbeHarness.scrollPlace`.
+            "drawnRows": .integer(TranscriptDrawn.rows),
             "place": .object(ProbeHarness.scrollPlace(
                 ProbeHarness.transcriptScrollView(in: contentView)
             )),
@@ -231,6 +232,28 @@ enum SwitchProbe {
             ]))
         }
         report["visits"] = .array(visits)
+
+        // **Can the reader get to the end at all?** The reported bug is a conversation that stops
+        // part way down and cannot be scrolled past, because the window the list is drawing ends
+        // there and nothing had told it to grow. Wheeling down as far as it will go and asking
+        // what is left is the whole test.
+        app.selection = .workspace(top)
+        try? await Task.sleep(for: .milliseconds(settle))
+        if let scroll = ProbeHarness.transcriptScrollView(in: contentView) {
+            for _ in 0..<200 {
+                ProbeHarness.wheel(scroll, by: -300)
+                try? await Task.sleep(for: .milliseconds(8))
+            }
+            try? await Task.sleep(for: .seconds(2))
+            var reached = ProbeHarness.scrollPlace(scroll)
+            reached["drawnRows"] = .integer(TranscriptDrawn.rows)
+            if let model = app.existingModel(for: top),
+               let session = model.activeSession,
+               let transcript = model.existingTranscript(for: session.id) {
+                reached["sessionRows"] = .integer(transcript.rows.count)
+            }
+            report["reachesTheEnd"] = .object(reached)
+        }
         return report
     }
 

--- a/Sources/Bloom/Design/SwitchProbe.swift
+++ b/Sources/Bloom/Design/SwitchProbe.swift
@@ -41,6 +41,9 @@ enum SwitchProbe {
     /// switch kicks off has to be allowed to land inside the timeline, or the report is a
     /// measurement of the settle rather than of the switch.
     private static var settle: Int { ProbeHarness.count("--switch-settle", or: 4000) }
+    /// How many wheel steps back the reader is scrolled before being switched away from. Four
+    /// hundred reaches the top of any conversation in the fixture; forty stops part way up.
+    private static var scrollSteps: Int { ProbeHarness.count("--switch-scroll", or: 400) }
 
     // MARK: - Entry
 
@@ -185,12 +188,17 @@ enum SwitchProbe {
         let bottom = order[order.count - 1]
         var report: [String: JSONValue] = [:]
 
-        // One to the top. A wheel scroll rather than a jump, in one large step per frame, because
-        // what is being set up is a reader's position and a reader gets there by scrolling.
+        // One scrolled back, a wheel step per frame, because what is being set up is a reader's
+        // position and a reader gets there by scrolling.
+        //
+        // `--switch-scroll` is how far, and it is a flag because the two ends of the range are two
+        // different questions. All the way to the top is where a place has to be exact; a stop
+        // part way up is where a place has to EXIST, and it is the case the owner reported second:
+        // a reader who is neither at the end nor at the beginning was being put back at the end.
         app.selection = .workspace(top)
         try? await Task.sleep(for: .milliseconds(settle))
         if let scroll = ProbeHarness.transcriptScrollView(in: contentView) {
-            for _ in 0..<400 {
+            for _ in 0..<scrollSteps {
                 ProbeHarness.wheel(scroll, by: 300)
                 try? await Task.sleep(for: .milliseconds(8))
             }

--- a/Sources/Bloom/Views/Sidebar/CreateWorkspaceSheet.swift
+++ b/Sources/Bloom/Views/Sidebar/CreateWorkspaceSheet.swift
@@ -111,7 +111,13 @@ struct CreateWorkspaceSheet: View {
     /// above the box rather than the route beside Create is what hands those labels back, and it
     /// is not a happy accident: a control that says which of two things you are doing does not
     /// belong in the row that qualifies the turn. Do not put a second button back here.
-    private static let width: CGFloat = 620
+    ///
+    /// **And then a fifth control arrived and took the words again.** The row carries fast mode
+    /// now as well as the model, the effort, the output style and the permission mode, and 620
+    /// put every one of them back on the glyph-only rung: a sheet asking what you want to work on
+    /// while showing five unlabelled symbols is a sheet that tells you nothing about what it is
+    /// about to do. The number below is what the same row needs with its words on.
+    private static let width: CGFloat = 700
     /// What the writing area opens at. Five lines, because the question is "what do you want to
     /// work on" and a one-line box answers it with "something short".
     private static let minEditorLines: CGFloat = 5

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -188,6 +188,28 @@ struct TranscriptListView: View {
 
     @State private var drawn: Drawn
 
+    /// Where `remember` writes, captured beside the state it is writing rather than read from the
+    /// body when the write happens.
+    ///
+    /// **This view is not torn down when the reader changes workspace.** The centre column hands
+    /// the same view a different model and a different session (see `CenterPanesView`), so by the
+    /// time anything notices the change, `memory` and `transcript` are already the conversation
+    /// being ARRIVED at, while `drawn`, `contentOffset`, `geometry` and the visible rows still
+    /// describe the one being left. `remember` read one half from each, so a scroll that settled
+    /// in that window wrote the old conversation's place under the new conversation's key, and the
+    /// reader came back to a position that was never theirs. That is the "it does weird things"
+    /// half of the report.
+    ///
+    /// Held as state, so it moves when the drawn window moves and never when the body happens to
+    /// be re-run with somebody else's model.
+    @State private var writingTo: WriteTarget?
+
+    /// The pane and session one write belongs to.
+    private struct WriteTarget {
+        var memory: TranscriptPaneMemory
+        var session: SessionID
+    }
+
     /// The session this pane was restored into, if it was restored rather than arrived at.
     ///
     /// A reader coming back is already where they left off, so the window is whatever they were
@@ -683,14 +705,21 @@ struct TranscriptListView: View {
                 goToLiveEnd()
             }
             .onChange(of: transcript.session.id) { _, _ in
-                // Nothing is written down for the session being left here, and that is deliberate
-                // rather than an omission. Everything `remember` reads describes the pane as it
-                // was laid out a moment ago, and by the time this runs `transcript` is already the
-                // NEW model: the row count would be the wrong session's. What the old session has
-                // is whatever its last settled scroll wrote, which is a position in a document
-                // that has only grown since, and that is exactly what `TranscriptResume` is built
-                // to read back.
+                // **The session being left is written down here, and it used to be nowhere.**
                 //
+                // The comment that stood here said it was deliberate: everything `remember` reads
+                // describes the pane as it was laid out a moment ago, and by this line `transcript`
+                // is already the conversation being arrived at, so the row count would be the wrong
+                // session's. Both halves of that were true and the conclusion was wrong. What was
+                // left instead was a pane that only ever recorded a place when a scroll happened to
+                // settle, so a reader who arrived, read what was on screen and moved to another
+                // workspace had nothing written down at all, and came back to whatever a first
+                // visit does: their first unread row, or the live end.
+                //
+                // It is safe now because the write no longer reads the body. `writingTo` carries
+                // the pane and the session the drawn state belongs to, so this call records the
+                // conversation being left, under its own key, from its own measurements.
+                remember()
                 // Nothing owed to a conversation the pane has left.
                 scroller.stop()
                 follower.stop()
@@ -724,6 +753,7 @@ struct TranscriptListView: View {
                         rowCount: transcript.rows.count
                     )
                 )
+                writingTo = memory.map { WriteTarget(memory: $0, session: transcript.session.id) }
                 resumed = TranscriptResume.isResuming(remembered) ? transcript.session.id : nil
                 isGrowing = false
                 visibleRowSeqs.forget()
@@ -768,6 +798,7 @@ struct TranscriptListView: View {
                     )
                 )
                 TranscriptDrawn.note(drawn.window.count)
+                writingTo = memory.map { WriteTarget(memory: $0, session: transcript.session.id) }
                 // Whatever the session arrived with, taken in without a fade. This runs whether
                 // or not the row count changed, which matters: two sessions can hold the same
                 // number of rows, and then nothing else would have told the tracker it is
@@ -1205,8 +1236,8 @@ struct TranscriptListView: View {
         // over a session that has since loaded. The height is what says a layout has happened, and
         // it is checked HERE rather than where the memory is read, because nought is a real place
         // to a reader who is at the top of a conversation. See `TranscriptResume.placement`.
-        guard let memory, drawn.window.count > 0, geometry.paneHeight > 0 else { return }
-        memory.remember(
+        guard let target = writingTo, drawn.window.count > 0, geometry.paneHeight > 0 else { return }
+        target.memory.remember(
             TranscriptPaneState(
                 expanded: expanded,
                 offset: contentOffset.value,
@@ -1219,7 +1250,7 @@ struct TranscriptListView: View {
                 // Written down together because they are one measurement: see `TranscriptWindow`.
                 drawn: drawn.window
             ),
-            session: transcript.session.id
+            session: target.session
         )
     }
 

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -815,6 +815,18 @@ struct TranscriptListView: View {
                 )
                 TranscriptDrawn.note(drawn.window.count)
                 writingTo = memory.map { WriteTarget(memory: $0, session: transcript.session.id) }
+                // **And the positioning is owed again, because the one that has already run was
+                // run too early to mean anything.**
+                //
+                // `position` latches on `didPosition` so a session is placed once rather than on
+                // every row that lands. The row count's `onChange` fires with `initial: true` the
+                // moment this pane appears, which is before the load above has finished and before
+                // the window has been restored, so that first call latched the latch and then
+                // asked a list that was still the conversation being left to scroll to a row it
+                // had never heard of. Every later call was a no-op, and what the reader saw was
+                // the top of the restored window. Measured: left at row 1,478 of 1,582, written
+                // down correctly, and restored to offset nought.
+                didPosition = false
                 // Whatever the session arrived with, taken in without a fade. This runs whether
                 // or not the row count changed, which matters: two sessions can hold the same
                 // number of rows, and then nothing else would have told the tracker it is

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -749,6 +749,11 @@ struct TranscriptListView: View {
                 // number of rows, and then nothing else would have told the tracker it is
                 // looking at a different list.
                 arrival.adopt(arrivalIDs)
+                // A turn for the body to run with the window set above, so that the list holds the
+                // rows the positioning is about to name. See `open`, which carries what happens
+                // without it.
+                await Task.yield()
+                guard !Task.isCancelled else { return }
                 // And where the session opens, for the same reason: `position` is otherwise
                 // driven by the row count's onChange, so a switch between two sessions holding
                 // the same number of rows never positioned and never marked the session read,
@@ -1204,6 +1209,26 @@ struct TranscriptListView: View {
         switch opening {
         case .row(let seq, let anchor):
             proxy.scrollTo(seq, anchor: anchor)
+            // And again on the next turn, because the first one can be shouting at a list that
+            // does not hold the row yet.
+            //
+            // **This is the bug the owner reported as "it is always at the bottom now", and it was
+            // neither always nor the bottom.** `ScrollViewProxy.scrollTo` acts on the list as it is
+            // laid out at the moment it is called, and the call sites here run inside the same turn
+            // that sets the window the row lives in: the body has not re-run, the `ForEach` is
+            // still the one from the conversation being left, and the id names nothing. What that
+            // looks like is a pane sitting wherever the arrival put it, which for a restored window
+            // is its first row. Measured with `--switch-probe --switch-scroll 25`: left at 11,993
+            // points and back at 32.
+            //
+            // The edge and the point do not need this. Both are values on `ScrollPosition`, which
+            // SwiftUI applies on the next layout pass whenever that happens to be; only the row is
+            // a call. Saying it twice costs one resolved scroll on a list that already holds the
+            // row, which is what the second call finds in every other case.
+            Task { @MainActor in
+                await Task.yield()
+                proxy.scrollTo(seq, anchor: anchor)
+            }
         case .liveEnd:
             scrollPosition.scrollTo(edge: .bottom)
         case .offset(let y):

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -590,7 +590,21 @@ struct TranscriptListView: View {
                 reachToEnd.value = new
             }
             .onScrollGeometryChange(for: TranscriptGeometry.self, of: Self.measure) { _, new in
-                geometry = new
+                // **The end of what is drawn is not the end of the conversation.**
+                //
+                // A window that stops short of the live end is a scroll view whose content ends
+                // where the window does, and every measurement taken from that geometry says the
+                // reader has arrived at the end: the pill that offers to take them to the newest
+                // row is not drawn, the pane is written down as having been left at the live end,
+                // and the rows below are unreachable because the only thing that grows the window
+                // downwards is noticing that the reader wants them. Reported as "sometimes I
+                // cannot scroll to the end any more", with a screenshot of a conversation that
+                // stopped mid turn, and it came right the moment a new message arrived, which is
+                // the row count changing and the window growing behind it.
+                //
+                // So the geometry is corrected before anything reads it, and the correction is
+                // the truth: there is more below.
+                geometry = trueEnd(of: new)
                 // The bottom half of the window, and it needs neither an anchor nor a flag: rows
                 // added BELOW the viewport move nothing at all. A window with a bottom edge only
                 // exists after a session was opened on an old row, and reaching the end of it is
@@ -611,7 +625,7 @@ struct TranscriptListView: View {
                 // moves about once every eleven points of a drag, and the flag moves when the
                 // reader arrives at or leaves the end. So the extra reports are a handful per
                 // scroll, and each of them is a correction the transition form could not make.
-                onScrolledUpChange?(new.isFarFromEnd)
+                onScrolledUpChange?(trueEnd(of: new).isFarFromEnd)
             }
             // A second subscription, on the raw offset, and deliberately not folded into the one
             // above. Everything in `TranscriptGeometry` is quantised precisely so that a drag
@@ -624,7 +638,15 @@ struct TranscriptListView: View {
             // Where the reader ends up, written down for the pane that is built next. On the end
             // of a gesture rather than during one: see `remember`.
             .onScrollPhaseChange { _, phase in
-                if phase == .idle { remember() }
+                if phase == .idle {
+                    remember()
+                    // A scroll that ended against the bottom of a short window is a reader asking
+                    // for what is under it, and the geometry may not have CHANGED while they tried:
+                    // `onScrollGeometryChange` reports transitions, so a view that was already at
+                    // the end of the content when the pane opened never reports anything at all.
+                    // That is the stuck case. See `trueEnd`.
+                    growWindowDown()
+                }
             }
             // And on the way out, which is the case the whole of `TranscriptResume` is about: a
             // tab switch destroys this view, and a reader who arrived, read what was on screen and
@@ -636,6 +658,8 @@ struct TranscriptListView: View {
             .settlesArrivals($arrival)
             .onChange(of: transcript.rows.count, initial: true) { _, _ in
                 position(proxy)
+                // A row arriving is another chance to notice that the window stops short of it.
+                growWindowDown()
                 trackArrivals()
                 // A row has landed, so the end of the content has moved. Between rows the tail
                 // grows without any of this being told, which is what `isStreaming` below is for.
@@ -1256,6 +1280,22 @@ struct TranscriptListView: View {
     /// layout pass the growth causes and not merely the state write that asks for it. Clearing it
     /// moves nothing: by then the content size is settled, and an anchor only does anything on a
     /// change of size.
+    /// A scroll geometry with the rows the window is not drawing taken into account.
+    ///
+    /// Everything `TranscriptGeometry` measures is measured against the CONTENT, and the content
+    /// is the window rather than the conversation. While the two differ, a reader at the bottom of
+    /// the content is not at the end of anything, and saying otherwise is what made the rows below
+    /// unreachable. See the subscription that calls this.
+    private func trueEnd(of measured: TranscriptGeometry) -> TranscriptGeometry {
+        guard drawn.session == transcript.session.id,
+              drawn.window.canGrowDown(rowCount: transcript.rows.count)
+        else { return measured }
+        var corrected = measured
+        corrected.isNearBottom = false
+        corrected.isFarFromEnd = true
+        return corrected
+    }
+
     /// Puts the rest of the conversation back, a chunk at a time, below what is drawn.
     ///
     /// The mirror of `growWindow` and much the simpler half. Nothing moves when content is added

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -1312,6 +1312,15 @@ struct TranscriptListView: View {
     private func open(_ opening: Opening?, with proxy: ScrollViewProxy) {
         switch opening {
         case .row(let seq, let anchor):
+            // **The standing instruction has to be let go of first, or this moves nothing.**
+            //
+            // `.scrollPosition($scrollPosition)` is a VALUE the list reapplies on every layout
+            // pass, and a pane that has just opened is standing at an edge. A proxy scroll is a
+            // call: it moves the view, and the next pass puts it straight back where the standing
+            // value says. `TranscriptLiveEndFollower.onStart` already had to learn this, and its
+            // remedy is the one used here: naming the offset the view is already at moves nothing
+            // and takes the position off its edge, which lets the call below stand.
+            scrollPosition.scrollTo(y: contentOffset.value)
             proxy.scrollTo(seq, anchor: anchor)
             // The second attempt is `position`'s now, so that the live end gets one too.
         case .liveEnd:

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -453,6 +453,14 @@ struct TranscriptListView: View {
                             .onScrollVisibilityChange(threshold: 0.01) { isVisible in
                                 visibleRowSeqs.note(row.seq, isVisible: isVisible)
                             }
+                            // **And when the stack throws the row away, which is not the same
+                            // event.** A row scrolled far enough from the viewport is destroyed
+                            // rather than reported invisible, so without this the set keeps every
+                            // row it ever saw and its minimum is the oldest of them: a reader who
+                            // scrolled back down was written down as being at the top of the
+                            // conversation, and came back there. Measured: left at row 1,399 of
+                            // 1,582, returned at the first row of the window.
+                            .onDisappear { visibleRowSeqs.note(row.seq, isVisible: false) }
                         } else {
                             TranscriptRowView(
                                 row: row,
@@ -480,6 +488,14 @@ struct TranscriptListView: View {
                             .onScrollVisibilityChange(threshold: 0.01) { isVisible in
                                 visibleRowSeqs.note(row.seq, isVisible: isVisible)
                             }
+                            // **And when the stack throws the row away, which is not the same
+                            // event.** A row scrolled far enough from the viewport is destroyed
+                            // rather than reported invisible, so without this the set keeps every
+                            // row it ever saw and its minimum is the oldest of them: a reader who
+                            // scrolled back down was written down as being at the top of the
+                            // conversation, and came back there. Measured: left at row 1,399 of
+                            // 1,582, returned at the first row of the window.
+                            .onDisappear { visibleRowSeqs.note(row.seq, isVisible: false) }
                         }
                     }
 

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -1246,7 +1246,28 @@ struct TranscriptListView: View {
                 opening = .liveEnd
             }
         }
+        // Said now, and said once more on the next update.
+        //
+        // **Both of the ways this view can be told where to go need a second turn, for two
+        // different reasons, and this is the one place that knows it.** The live end is a value on
+        // `ScrollPosition`, and a position that already stands at `.bottom` is not CHANGED by
+        // being told `.bottom` again, so SwiftUI has nothing to apply: the file's own reveal
+        // solved that by naming a point first and the edge in the next update, and a restore has
+        // exactly the same problem. A row is the opposite: it is a call rather than a value, and
+        // it acts on the list as it is laid out at that instant, which on the pass that restores a
+        // window is a list that does not hold the row yet.
+        //
+        // Measured, both of them, with `--switch-probe --switch-scroll 25`: a conversation left at
+        // its live end came back at its first row, and one left at row 1,478 of 1,582 came back at
+        // the top of its window. Neither is a memory that was not written; both are an instruction
+        // that landed on nothing.
+        if case .liveEnd = opening { scrollPosition.scrollTo(y: .greatestFiniteMagnitude) }
         open(opening, with: proxy)
+        let settled = opening
+        Task { @MainActor in
+            await Task.yield()
+            open(settled, with: proxy)
+        }
         Task { await transcript.markAllRead() }
     }
 
@@ -1292,26 +1313,7 @@ struct TranscriptListView: View {
         switch opening {
         case .row(let seq, let anchor):
             proxy.scrollTo(seq, anchor: anchor)
-            // And again on the next turn, because the first one can be shouting at a list that
-            // does not hold the row yet.
-            //
-            // **This is the bug the owner reported as "it is always at the bottom now", and it was
-            // neither always nor the bottom.** `ScrollViewProxy.scrollTo` acts on the list as it is
-            // laid out at the moment it is called, and the call sites here run inside the same turn
-            // that sets the window the row lives in: the body has not re-run, the `ForEach` is
-            // still the one from the conversation being left, and the id names nothing. What that
-            // looks like is a pane sitting wherever the arrival put it, which for a restored window
-            // is its first row. Measured with `--switch-probe --switch-scroll 25`: left at 11,993
-            // points and back at 32.
-            //
-            // The edge and the point do not need this. Both are values on `ScrollPosition`, which
-            // SwiftUI applies on the next layout pass whenever that happens to be; only the row is
-            // a call. Saying it twice costs one resolved scroll on a list that already holds the
-            // row, which is what the second call finds in every other case.
-            Task { @MainActor in
-                await Task.yield()
-                proxy.scrollTo(seq, anchor: anchor)
-            }
+            // The second attempt is `position`'s now, so that the live end gets one too.
         case .liveEnd:
             scrollPosition.scrollTo(edge: .bottom)
         case .offset(let y):

--- a/Sources/Bloom/Views/Transcript/TranscriptPaneMemory.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptPaneMemory.swift
@@ -9,8 +9,10 @@ import BloomCore
 /// at that.
 ///
 /// The pane id is half the key because a split tab can hold the same conversation twice, each half
-/// scrolled somewhere else, and `CenterPanesView.soloPane` means an unsplit tab's pane answers to
-/// the same name in every workspace and every tab. See `TranscriptPaneState.Key`.
+/// scrolled somewhere else. It is the pane's own string, which for an unsplit tab is the tab's id
+/// and therefore the session's uuid; `CenterPanesView.soloPane` is a `ForEach` identity and is
+/// never what a pane is called. A comment here said the opposite for months, and cost an
+/// afternoon: a probe read that key, found nothing, and was believed. See `TranscriptPaneState.Key`.
 ///
 /// Nil for a transcript nobody can scroll back to: the archive sheet draws one and is gone.
 @MainActor

--- a/Sources/Bloom/Views/Transcript/TranscriptVisibleRows.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptVisibleRows.swift
@@ -34,21 +34,35 @@ import Foundation
 final class TranscriptVisibleRows {
     private var seqs: Set<Int> = []
 
+    /// The last answer this could give while it had one.
+    ///
+    /// **Because the set empties at exactly the wrong moment.** A row leaves this set when it
+    /// scrolls out of the viewport and also when the lazy stack throws it away, and a pane being
+    /// taken off screen throws all of them away at once. The place is read while that is happening,
+    /// so a set alone answers nil for the one question it exists to answer. Keeping the last real
+    /// answer costs one integer and is right whenever the set is empty for a reason that is not
+    /// "the reader is looking at nothing".
+    private var lastTop: Int?
+
     func note(_ seq: Int, isVisible: Bool) {
         if isVisible {
             seqs.insert(seq)
         } else {
             seqs.remove(seq)
         }
+        if let top = seqs.min() { lastTop = top }
     }
 
     /// The topmost row on screen, which is where the reader is.
     ///
     /// The minimum rather than the first the set happened to see: a set has no order, and rows
     /// arrive in it in whatever order they crossed the edge.
-    var topmost: Int? { seqs.min() }
+    var topmost: Int? { seqs.min() ?? lastTop }
 
     /// Forgotten when the pane is pointed at another conversation, because a row that is visible
     /// in one session is not a row in another.
-    func forget() { seqs.removeAll() }
+    func forget() {
+        seqs.removeAll()
+        lastTop = nil
+    }
 }

--- a/Sources/BloomCore/Transcript/TranscriptResume.swift
+++ b/Sources/BloomCore/Transcript/TranscriptResume.swift
@@ -38,9 +38,9 @@ import Foundation
 /// document.
 public struct TranscriptPaneState: Equatable, Sendable {
     /// One pane's memory of one conversation. Both halves are needed: a split tab can hold the
-    /// same session in two panes, each scrolled somewhere else, and an unsplit tab's pane is
-    /// called the same thing in every workspace (see `CenterPanesView.soloPane`), so the session
-    /// is what tells two of those apart.
+    /// same session in two panes, each scrolled somewhere else, so the pane alone does not say
+    /// which half. The pane string is the tab's own id, which for an unsplit chat tab is already
+    /// the session's uuid; nothing is ever keyed on a shared name.
     public struct Key: Hashable, Sendable {
         public var pane: String
         public var session: SessionID


### PR DESCRIPTION
Three reports, all from the windowed transcript that shipped in v0.13.0, and one older bug underneath them.

**Sometimes you cannot scroll to the end.** A window that stops short of the live end is a scroll view whose content ends where the window does, so every measurement taken off that geometry said the reader had already arrived: no pill offering the newest row, the pane written down as left at the live end, and the rows below unreachable, because the only thing that grew the window downwards was noticing that the reader wanted them. Sending a message changed the row count and everything appeared at once, which is exactly what was reported. The geometry is corrected before anything reads it, and the growth is now asked for from every place that can notice rather than from one change callback, because a view that was already at the end of its content when the pane opened never reports a change at all.

**Switching workspace lost your place.** The transcript view is not torn down when the reader changes workspace: the centre column hands the same view a different model and session. So `onDisappear` never fired, and the session being left was written down nowhere unless a scroll happened to settle first. Worse, `remember()` read the pane and session from the body and everything else from state, and those two halves disagree for exactly that window, so a scroll settling mid switch wrote one conversation's place under the other's key. The write now goes through a target captured beside the state it describes, and the outgoing session is recorded when the pane is pointed at the next one.

**And the instructions landed on nothing.** A session opened at its live end told a `ScrollPosition` that already stood at `.bottom` to go to `.bottom`, which is not a change and so is not applied; a session opened on a row told a proxy to scroll to a row the list did not hold yet, and then had that scroll undone by the standing position on the next pass. Both are said twice now, and the row case lets go of the standing edge first, which is the remedy `TranscriptLiveEndFollower` already had to learn.

Measured with `--switch-probe --switch-scroll 25`, which wheel-scrolls one conversation back, leaves the other at its end, and switches between them: the live end restores on every visit, and the end of a windowed conversation is reachable (400 rows drawn, 1,582 in the session, nothing below the reader).

The mid-conversation restore is better and is not yet reliable: the row is recorded correctly every time, and lands on some returns and not others. It is honest about failing safe, which is the top of the window rather than an unreachable one.

Also here: the create sheet is 700 points wide, because a fifth control arrived in its footer and put every picker back on the glyph-only rung.