### PR TITLE
Ask GitHub about the branch the worktree is actually on

### DIFF
--- a/Sources/BloomCore/GitHub/PullRequestHead.swift
+++ b/Sources/BloomCore/GitHub/PullRequestHead.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Which branch a workspace's pull request should be looked up by.
+///
+/// A workspace records the branch it was created on, and every pull request lookup used to name
+/// that record. It stops being true the moment the agent moves the worktree, which agents do: a
+/// reset, a `checkout -b` from `origin/main`, a branch renamed to suit the issue it turned out to
+/// be about. The work is then on a name Bloom never wrote down.
+///
+/// That is a real report rather than a hypothetical. An agent opened a pull request, said so in
+/// the transcript, and the strip went on saying "No pull request yet. Target main." with a Create
+/// pull request button over it for as long as the workspace was open. Nothing was stale: every
+/// poll asked gh again, with no cached answer, and got the same nothing back, because
+/// `gh pr view <recorded branch>` is a question about a branch that was never pushed. The unnamed
+/// fallback in `GitHub.snapshotOfCheckedOutBranch` did find the pull request, and then threw it
+/// away again for not matching the name it had been asked about. A button that opens a second
+/// pull request for work that already has one is the worst thing that strip can do, so the
+/// question is asked about the branch the worktree is on **now**.
+///
+/// Two cases keep the recorded name, both because the live one asks a worse question:
+///
+/// - **A detached HEAD has no branch at all**, which is a rebase, a bisect, or a commit checked
+///   out to look at. The recorded name is then the only name there is.
+/// - **A worktree standing on the base branch** is between branches rather than on one of its
+///   own. `gh pr view main` is a question about somebody's fork of this repository, not about this
+///   workspace, and it can answer with a pull request that has nothing to do with either.
+public enum PullRequestHead {
+    /// - Parameter recorded: `Workspace.branch`, the name written when the workspace was created.
+    /// - Parameter checkedOut: what `git rev-parse --abbrev-ref HEAD` says now, or nil for a
+    ///   detached HEAD. See `Git.currentBranch`.
+    /// - Parameter base: `Workspace.baseBranch`.
+    public static func branch(recorded: String, checkedOut: String?, base: String) -> String {
+        let live = (checkedOut ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !live.isEmpty else { return recorded }
+        // A row with no branch name in it is not a name to prefer. Old rows have one, and
+        // `Store.workspace(from:)` reads a missing column as the empty string.
+        guard !recorded.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return live }
+        return live == base ? recorded : live
+    }
+}

--- a/Sources/BloomCore/GitHub/PullRequestOwnership.swift
+++ b/Sources/BloomCore/GitHub/PullRequestOwnership.swift
@@ -88,7 +88,7 @@ public extension GitHub {
     /// is the difference between finding a pull request the agent opened from a branch it cut
     /// itself and offering a button that opens a second one. See `PullRequestHead`.
     static func headBranch(of workspace: Workspace) async -> String {
-        let checkedOut = (try? await Git.currentBranch(of: workspace.path)) ?? nil
+        let checkedOut = try? await Git.currentBranch(of: workspace.path)
         return PullRequestHead.branch(
             recorded: workspace.branch, checkedOut: checkedOut, base: workspace.baseBranch
         )

--- a/Sources/BloomCore/GitHub/PullRequestOwnership.swift
+++ b/Sources/BloomCore/GitHub/PullRequestOwnership.swift
@@ -77,12 +77,32 @@ public extension GitHub {
     static func pullRequest(
         for workspace: Workspace, maxAge: Duration = .zero
     ) async throws -> PullRequest? {
+        try await pullRequest(
+            for: workspace, onBranch: await headBranch(of: workspace), maxAge: maxAge
+        )
+    }
+
+    /// The branch to ask gh about, read from the worktree rather than from the row.
+    ///
+    /// One local `git rev-parse`, which is nothing beside the `gh` call it is correcting, and it
+    /// is the difference between finding a pull request the agent opened from a branch it cut
+    /// itself and offering a button that opens a second one. See `PullRequestHead`.
+    static func headBranch(of workspace: Workspace) async -> String {
+        let checkedOut = (try? await Git.currentBranch(of: workspace.path)) ?? nil
+        return PullRequestHead.branch(
+            recorded: workspace.branch, checkedOut: checkedOut, base: workspace.baseBranch
+        )
+    }
+
+    private static func pullRequest(
+        for workspace: Workspace, onBranch head: String, maxAge: Duration
+    ) async throws -> PullRequest? {
         guard let found = try await pullRequest(
-            forBranch: workspace.branch, worktree: workspace.path, maxAge: maxAge
+            forBranch: head, worktree: workspace.path, maxAge: maxAge
         ) else { return nil }
 
         let checkedOut = await Git.checkedOutPullRequest(
-            branch: workspace.branch, worktree: workspace.path
+            branch: head, worktree: workspace.path
         )
         guard PullRequestOwnership.belongs(
             found, toWorkspaceStartedAt: workspace.createdAt, checkedOutAs: checkedOut
@@ -96,9 +116,11 @@ public extension GitHub {
     /// request that merged before this workspace existed is a green tick over work nobody has run
     /// anything against.
     static func checks(for workspace: Workspace, maxAge: Duration = .zero) async throws -> [CheckRun] {
-        guard try await pullRequest(for: workspace, maxAge: maxAge) != nil else { return [] }
-        return try await checks(
-            forBranch: workspace.branch, worktree: workspace.path, maxAge: maxAge
-        )
+        // The same branch both times, or the rollup is read for one branch and gated on another.
+        let head = await headBranch(of: workspace)
+        guard try await pullRequest(for: workspace, onBranch: head, maxAge: maxAge) != nil else {
+            return []
+        }
+        return try await checks(forBranch: head, worktree: workspace.path, maxAge: maxAge)
     }
 }

--- a/Tests/BloomCoreTests/PullRequestHeadTests.swift
+++ b/Tests/BloomCoreTests/PullRequestHeadTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// Which branch a pull request lookup names.
+///
+/// The report: an agent opened https://github.com/spatie/laravel-mailcoach/pull/2073, said so in
+/// the transcript, and the strip went on offering Create pull request minutes after the turn had
+/// finished. Its head was `fix/issue-2069-transactional-mail-admin-preview`, a branch the agent
+/// cut from `origin/main` itself, and Bloom was asking gh about the branch written down when the
+/// workspace was created. Every poll asked again and got the same nothing, so nothing here is
+/// about a cache: the question was wrong.
+@Suite("Which branch a pull request is looked up by")
+struct PullRequestHeadTests {
+    @Test("The branch the worktree is on now wins over the one recorded at creation")
+    func prefersTheCheckedOutBranch() {
+        #expect(
+            PullRequestHead.branch(
+                recorded: "bloom/preview-crash",
+                checkedOut: "fix/issue-2069-transactional-mail-admin-preview",
+                base: "main"
+            ) == "fix/issue-2069-transactional-mail-admin-preview"
+        )
+    }
+
+    @Test("A detached HEAD leaves the recorded branch as the only name there is")
+    func fallsBackWhenDetached() {
+        // A rebase, a bisect, or a commit checked out to look at.
+        #expect(
+            PullRequestHead.branch(recorded: "bloom/preview-crash", checkedOut: nil, base: "main")
+                == "bloom/preview-crash"
+        )
+        #expect(
+            PullRequestHead.branch(recorded: "bloom/preview-crash", checkedOut: "  ", base: "main")
+                == "bloom/preview-crash"
+        )
+    }
+
+    @Test("A worktree standing on the base branch is not asked about")
+    func refusesTheBaseBranch() {
+        // `gh pr view main` answers about somebody's fork, not about this workspace.
+        #expect(
+            PullRequestHead.branch(recorded: "bloom/preview-crash", checkedOut: "main", base: "main")
+                == "bloom/preview-crash"
+        )
+    }
+
+    @Test("A row with no branch name in it is not a name to prefer")
+    func toleratesAnEmptyRecord() {
+        #expect(PullRequestHead.branch(recorded: "", checkedOut: "main", base: "main") == "main")
+        #expect(PullRequestHead.branch(recorded: "", checkedOut: nil, base: "main") == "")
+    }
+}
+
+@Suite("The branch gh is asked about", .tags(.git), .scratchDirectory)
+struct PullRequestHeadBranchTests {
+    @Test("A worktree the agent moved to a new branch is looked up under that branch")
+    func readsTheBranchOffDisk() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+
+        let workspace = Workspace(
+            repoID: RepoID.new(),
+            name: "Preview crash",
+            branch: "bloom/preview-crash",
+            path: repo.path,
+            baseBranch: "main"
+        )
+
+        // Standing on the base branch, so the recorded name is what gets asked about.
+        #expect(await GitHub.headBranch(of: workspace) == "bloom/preview-crash")
+
+        // Exactly what the agent did: a branch of its own, cut from the base.
+        try await Shell.check(
+            "git", ["checkout", "-q", "-b", "fix/issue-2069-preview"], cwd: repo.path
+        )
+        #expect(await GitHub.headBranch(of: workspace) == "fix/issue-2069-preview")
+    }
+}


### PR DESCRIPTION
Reported: an agent opened a pull request for its workspace, and Bloom's inspector went on saying "No pull request yet" with a Create pull request button, minutes later, idle.

It was not staleness. Every path that refreshes already asks with a zero max age, so the app was asking again and again and getting nothing.

It was the branch. `GitHub.pullRequest(for:)` asked about `workspace.branch`, the name recorded when the workspace was created, and the agent had reset the worktree and cut its own branch. When `gh pr view <recorded>` says there is nothing, the fallback that asks about the checked-out branch found the real pull request and then threw it away, because its head did not match the recorded name. A permanent nil that no poll could recover from, and a button that would have opened a duplicate.

The head branch is now resolved from the worktree, with the recorded name kept for a detached HEAD and for a worktree standing on the base branch, where asking about `main` would answer about somebody else's pull request. `PullRequestHead` carries that decision and its tests.