### PR TITLE
Let the bridge start a workspace on a branch that already exists

### DIFF
--- a/Sources/Bloom/State/AppModel+WorkspaceBridge.swift
+++ b/Sources/Bloom/State/AppModel+WorkspaceBridge.swift
@@ -132,15 +132,20 @@ extension AppModel {
             controls.agentKind = agent
         }
 
+        // Both halves of the order's source, handed to the same two arguments the create sheet's
+        // two tabs fill in. Nothing is decided here: `AgentStartSource` has already found the
+        // branch in the project and refused the call if it is not there, so this side is the same
+        // pass-through it always was.
         let workspace = try await startWorkspace(
             in: repo,
             prompt: order.prompt,
-            baseBranch: order.baseBranch,
+            baseBranch: order.source.baseBranch,
             branch: nil,
             controls: controls,
             select: false,
             origin: origin,
-            name: order.name
+            name: order.name,
+            checkout: order.source.checkout
         )
 
         return StartedWorkspaceSummary(

--- a/Sources/BloomCore/Bridge/AgentStartSource.swift
+++ b/Sources/BloomCore/Bridge/AgentStartSource.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+/// Where a workspace an agent asked for starts: a fresh branch cut from one, or a branch that
+/// already exists carried on.
+///
+/// **The choice is the create sheet's, and it is reused rather than restated.** The sheet puts it
+/// in a tab strip, `WorkspaceSourceTab`: "Create new branch", where commits land on a new branch
+/// and merge into the branch you picked, and "Continue on existing branch", where they land on the
+/// branch you picked and merge when it does. Over the bridge the same choice is two arguments, and
+/// everything below is the translation between them. The verbs, the sentence each one carries, the
+/// merging of the local and remote listings (`WorkspaceCheckoutPlan`), what is already sitting on a
+/// branch (`BranchHolder`) and the value `WorkspaceManager` is finally handed (`WorkspaceCheckout`)
+/// all come from there, so the two doors cannot come to describe the same choice differently.
+///
+/// **Why the bridge needed the second verb at all.** `workspace_start` could only cut, so an agent
+/// asked to look at a colleague's branch got a fresh branch off its tip: the worktree opened
+/// identical to that branch, the Changes tab drew nothing, and the workspace was right about the
+/// diff and useless for the job. That is the bug `docs/start-from.html` was written about, arriving
+/// a second time through the other door.
+///
+/// **A pull request is not offered here, and that is a decision.** The sheet's second tab lists
+/// them beside the branches, but resolving one costs a `gh` call and a network round trip on a
+/// path that so far spends only local git, and an agent that wants a pull request's code can name
+/// its head branch, which is what the picker draws a listed pull request by anyway. The case is
+/// already carried by `WorkspaceCheckout`, so the day it is wanted it is an argument rather than a
+/// mechanism.
+public enum AgentStartSource: Sendable, Hashable {
+    /// Cut a fresh branch off a named ref. Nil is the project's default branch, which is what a
+    /// call that says nothing gets and what this tool did before there was a choice at all.
+    case newBranch(from: String?)
+    /// Carry on a branch somebody has already written on.
+    case existingBranch(ExistingBranch)
+
+    /// Which of the sheet's two tabs this is. The tool's description is written out of these, so
+    /// an agent reading the tool list and a person reading the tab strip are told the same thing.
+    public var tab: WorkspaceSourceTab {
+        switch self {
+        case .newBranch: .newBranch
+        case .existingBranch: .existingBranch
+        }
+    }
+
+    /// What the worktree is cut from, for `WorkspaceStartRequest.baseBranch`. Nil for a checkout,
+    /// which brings its own base along with it. See `WorkspaceCheckout.baseBranch(default:)`.
+    public var baseBranch: String? {
+        switch self {
+        case .newBranch(let ref): ref
+        case .existingBranch: nil
+        }
+    }
+
+    /// The existing head to open, for `WorkspaceStartRequest.checkout`, or nil for the ordinary
+    /// route Bloom has always had.
+    public var checkout: WorkspaceCheckout? {
+        switch self {
+        case .newBranch: nil
+        case .existingBranch(let branch): .branch(branch)
+        }
+    }
+
+    /// Whichever branch this call actually named, or nil when it named none.
+    ///
+    /// What a failed start is diagnosed against: `WorkspaceStartTrouble.diagnose` asks the
+    /// repository about one branch, and it has to be the one the caller wrote down, or a call that
+    /// named an existing branch would be answered with a sentence about the default.
+    public var namedBranch: String? {
+        switch self {
+        case .newBranch(let ref): ref
+        case .existingBranch(let branch): branch.name
+        }
+    }
+
+    /// This source's share of the spawn digest, which is what makes a retry of a call the same
+    /// call. See `AgentWorkspaceOrder.spawnID`.
+    ///
+    /// **A new branch contributes exactly what `base_branch` alone used to contribute**, one
+    /// element holding the ref or the empty string, and that is not tidiness: spawn ids are stored
+    /// on workspace rows, so a call made before this argument existed has to digest the same way
+    /// afterwards or its retry cuts a second worktree. The other verb adds an element of its own,
+    /// so "a new branch from x" and "carry on x" can never come out as one call.
+    var digestMaterial: [String] {
+        switch self {
+        case .newBranch(let ref): [ref ?? ""]
+        case .existingBranch(let branch): ["", "on\u{0}" + branch.name]
+        }
+    }
+}
+
+/// What the two arguments name, read before the repository has been asked anything.
+///
+/// Separate from `AgentStartSource` because only one of the two verbs costs a subprocess: a call
+/// that says nothing, which is nearly all of them, is answered here and never touches git.
+public enum AgentStartRequest: Sendable, Equatable {
+    case newBranch(from: String?)
+    /// The name as the caller wrote it. Nothing has been looked up yet.
+    case existingBranch(String)
+    case refused(String)
+
+    /// Which verb `base_branch` and `existing_branch` name between them.
+    ///
+    /// Naming both is refused rather than resolved to whichever was read first. They are one
+    /// keystroke apart in intent and opposite in effect, which is the whole reason the sheet draws
+    /// them as two tabs, and a call that asked for both has not decided which it wants.
+    public static func read(baseBranch: String?, existingBranch: String?) -> AgentStartRequest {
+        switch (baseBranch, existingBranch) {
+        case let (base?, existing?):
+            return .refused(
+                "workspace_start takes base_branch or existing_branch, and this call named both: "
+                    + "'\(base)' and '\(existing)'. base_branch cuts a new branch from the branch "
+                    + "you name, and your commits merge back into it. existing_branch puts the "
+                    + "workspace on the branch you name, and your commits land on that branch "
+                    + "itself. Ask again with the one you meant."
+            )
+        case let (_, existing?):
+            return .existingBranch(existing)
+        case let (base, nil):
+            return .newBranch(from: base)
+        }
+    }
+}
+
+/// The branch an `existing_branch` argument named, found in the project it was named in.
+///
+/// The refusals are the point. A caller with no screen cannot see the picker's list, so being told
+/// that a branch is not there, or that something else is already sitting on it, is the difference
+/// between asking again correctly and a workspace on a branch nobody meant.
+public enum AgentStartBranch: Sendable, Equatable {
+    case found(ExistingBranch)
+    case refused(String)
+
+    /// Every branch of a project, with whatever is already holding each one.
+    ///
+    /// Three git reads and one database read, spent only when a call names an existing branch.
+    /// `WorkspaceCheckoutPlan.everyBranch` merges the two listings the way the picker merges them,
+    /// and `BranchHolder.byBranch` answers what has each one, git's own worktrees included, which
+    /// is what lets a branch another tool is sitting on be refused in words rather than by git
+    /// exiting 128 half way through a start.
+    public static func listing(of repo: Repo, store: Store) async -> [ExistingBranch] {
+        async let local = Git.branches(of: repo.path)
+        async let remote = Git.remoteBranches(of: repo.path)
+        async let worktrees = Git.worktrees(of: repo.path)
+
+        let holders = BranchHolder.byBranch(
+            worktrees: (try? await worktrees) ?? [],
+            projectPath: repo.path,
+            workspaceNames: BranchHolder.names(
+                of: (try? await store.workspaces(repoID: repo.id)) ?? [], in: repo.id
+            )
+        )
+        return WorkspaceCheckoutPlan.everyBranch(
+            local: (try? await local) ?? [], remote: (try? await remote) ?? [], inUse: holders
+        )
+    }
+
+    /// The branch of that name, or the sentence saying why there is not one to open.
+    ///
+    /// `origin/x` resolves to `x`, because a model that has just run `git branch -r` in the
+    /// worktree it is standing in will write the name git printed, and refusing that would be
+    /// refusing the right branch over a prefix Bloom strips everywhere else anyway.
+    ///
+    /// The match is exact otherwise. Branch names are case sensitive to git, and a repository with
+    /// both `Release` and `release` in it is a repository where guessing puts a workspace on the
+    /// wrong one.
+    public static func find(
+        _ name: String, among branches: [ExistingBranch], project: String
+    ) -> AgentStartBranch {
+        let wanted = WorkspaceCheckoutPlan.remoteBranchName(name) ?? name
+
+        if let branch = branches.first(where: { $0.name == wanted }) {
+            guard let holder = branch.inUseBy else { return .found(branch) }
+            return .refused(holder.agentRefusal(branch: branch.name))
+        }
+
+        guard !branches.isEmpty else {
+            return .refused(
+                "Bloom found no branches in the project '\(project)' to continue on. It may have "
+                    + "no commits yet, or Bloom may no longer be able to read the repository. "
+                    + "Leave existing_branch out to have Bloom cut a new branch, which says what "
+                    + "is wrong if it cannot."
+            )
+        }
+
+        return .refused(
+            "The project '\(project)' has no branch called '\(name)', locally or on the remote. "
+                + "It has " + BridgeProjectLookup.listing(branches.map(\.name)) + ". Ask again "
+                + "with one of those as existing_branch, or leave existing_branch out to cut a "
+                + "new branch from the project's default branch."
+        )
+    }
+}

--- a/Sources/BloomCore/Bridge/WorkspaceStartTool.swift
+++ b/Sources/BloomCore/Bridge/WorkspaceStartTool.swift
@@ -21,15 +21,28 @@ public struct AgentWorkspaceOrder: Sendable, Hashable {
     /// only to the tool would make the two doors behave differently for no reason visible from
     /// either. The accidental duplicate, a retried call, is already handled by `spawnID`.
     public let name: String?
-    public let baseBranch: String?
+    /// Which of the create sheet's two routes this call asked for: a fresh branch cut from
+    /// something, or an existing branch carried on. Defaulted to a new branch from the project's
+    /// default, which is what every call made before there was a choice gets. See
+    /// `AgentStartSource`.
+    public let source: AgentStartSource
     /// Nil inherits whatever the calling session is using, which is almost always what is wanted:
     /// an agent asking for help wants help from the thing it already trusts.
     public let agent: AgentKind?
 
-    public init(prompt: String, name: String? = nil, baseBranch: String? = nil, agent: AgentKind? = nil) {
+    /// What the worktree is cut from, or nil for the project's default. Nil for a checkout too,
+    /// which brings its own base.
+    public var baseBranch: String? { source.baseBranch }
+
+    public init(
+        prompt: String,
+        name: String? = nil,
+        source: AgentStartSource = .newBranch(from: nil),
+        agent: AgentKind? = nil
+    ) {
         self.prompt = prompt
         self.name = name
-        self.baseBranch = baseBranch
+        self.source = source
         self.agent = agent
     }
 }
@@ -87,13 +100,13 @@ extension AgentWorkspaceOrder {
     }
 
     private func spawnID(scope: String) -> String {
-        let material = [
+        let material = ([
             scope,
             prompt,
             name ?? "",
-            baseBranch ?? "",
+        ] + source.digestMaterial + [
             agent?.rawValue ?? "",
-        ].joined(separator: "\u{0}")
+        ]).joined(separator: "\u{0}")
 
         let digest = SHA256.hash(data: Data(material.utf8))
 
@@ -183,6 +196,22 @@ public struct WorkspaceStartTool: BridgeToolHandling {
             Use it when a task splits into parts that do not need to see each other's edits, and \
             you want them worked on at the same time rather than one after another.
 
+            There are two ways to start it, the two Bloom's own create sheet offers, and picking \
+            the wrong one is the mistake worth avoiding here.
+
+            '\(WorkspaceSourceTab.newBranch.title)' is the default and needs nothing said. \
+            \(WorkspaceSourceTab.newBranch.explanation) Name the branch to cut from with \
+            'base_branch', or leave it out for the project's default branch.
+
+            '\(WorkspaceSourceTab.existingBranch.title)' is 'existing_branch'. \
+            \(WorkspaceSourceTab.existingBranch.explanation) Use it to carry on, review or fix \
+            work that is already on a branch: cutting a new branch off that branch instead gives \
+            you a workspace whose diff is empty, because it starts out identical to the branch \
+            you named. The branch has to exist already, and git allows one worktree per branch, \
+            so a branch another workspace is sitting on is refused rather than opened twice.
+
+            Name one or the other, never both.
+
             It returns as soon as the workspace exists, not when its work is done. The new agent \
             starts on its own and keeps running while you carry on. There is no way to wait for \
             it from here, so do not ask for one and then sit idle: say what you started and get on \
@@ -220,7 +249,18 @@ public struct WorkspaceStartTool: BridgeToolHandling {
                 "base_branch": .object([
                     "type": .string("string"),
                     "description": .string(
-                        "Branch to cut from. Leave it out for the project's default branch."
+                        "Cut a new branch from this one. Your commits land on the new branch and "
+                            + "merge back into this one. Leave it out for the project's default "
+                            + "branch. Do not name it together with existing_branch."
+                    ),
+                ]),
+                "existing_branch": .object([
+                    "type": .string("string"),
+                    "description": .string(
+                        "Work on this branch itself, instead of cutting a new one. Your commits "
+                            + "land on it. It has to exist already, locally or on the remote, and "
+                            + "it must not be open in another workspace. Do not name it together "
+                            + "with base_branch."
                     ),
                 ]),
                 "agent": .object([
@@ -249,14 +289,8 @@ public struct WorkspaceStartTool: BridgeToolHandling {
             return .failure("workspace_start needs a prompt saying what the new workspace should do.")
         }
 
-        let order = AgentWorkspaceOrder(
-            prompt: prompt,
-            name: filled(request.param("name")),
-            baseBranch: filled(request.param("base_branch")),
-            agent: agent(in: request)
-        )
-
-        if let requested = request.stringParam("agent"), order.agent == nil {
+        let agent = agent(in: request)
+        if let requested = request.stringParam("agent"), agent == nil {
             return .failure(
                 "Bloom cannot run '\(requested)'. It runs "
                     + AgentKind.runnable.map(\.rawValue).joined(separator: " and ")
@@ -266,15 +300,46 @@ public struct WorkspaceStartTool: BridgeToolHandling {
 
         // The project is resolved here rather than only on the happy path, because it is what
         // makes a failed start explicable: `WorkspaceStartTrouble` needs the repository's name,
-        // its path and the branch a call that named none would have been cut from.
+        // its path and the branch a call that named none would have been cut from. It is also what
+        // the branch below is looked for in, and what the spawn key of a caller with no workspace
+        // is scoped by, so it is settled before either.
         let project: Repo
-        let origin: WorkspaceOrigin
-        switch await resolve(request, order: order, as: identity, store: store) {
+        let parent: WorkspaceID?
+        switch await resolve(request, as: identity, store: store) {
         case .refused(let sentence): return .failure(sentence)
-        case let .resolved(repo, resolvedOrigin):
+        case let .resolved(repo, caller):
             project = repo
-            origin = resolvedOrigin
+            parent = caller
         }
+
+        // Which of the sheet's two routes this is, with the branch found in the project rather
+        // than taken on trust. A name that is not there, or one something else is already sitting
+        // on, is answered in a sentence here: the alternative is a start that fails inside git,
+        // or worse, a workspace on a branch nobody asked for. See `AgentStartSource`.
+        let source: AgentStartSource
+        switch AgentStartRequest.read(
+            baseBranch: filled(request.param("base_branch")),
+            existingBranch: filled(request.param("existing_branch"))
+        ) {
+        case .refused(let sentence):
+            return .failure(sentence)
+        case .newBranch(let ref):
+            source = .newBranch(from: ref)
+        case .existingBranch(let named):
+            let branches = await AgentStartBranch.listing(of: project, store: store)
+            switch AgentStartBranch.find(named, among: branches, project: project.name) {
+            case .refused(let sentence): return .failure(sentence)
+            case .found(let branch): source = .existingBranch(branch)
+            }
+        }
+
+        let order = AgentWorkspaceOrder(
+            prompt: prompt,
+            name: filled(request.param("name")),
+            source: source,
+            agent: agent
+        )
+        let origin = origin(of: order, project: project, parent: parent)
 
         if let spawnID = origin.spawnToolUseID {
             do {
@@ -326,27 +391,36 @@ public struct WorkspaceStartTool: BridgeToolHandling {
                 error,
                 project: project.name,
                 projectPath: project.path,
-                baseBranch: order.baseBranch ?? project.defaultBranch,
-                wasRequested: order.baseBranch != nil
+                // Whichever branch this call actually named, which for a checkout is the branch it
+                // asked to carry on. Diagnosing against the default there would answer a call
+                // about one branch with a sentence about another.
+                baseBranch: order.source.namedBranch ?? project.defaultBranch,
+                wasRequested: order.source.namedBranch != nil
             )
             return .failure(trouble.sentence)
         }
     }
 
-    /// Which project this workspace goes in and who is recorded as having asked for it, or the
+    /// Which project this workspace goes in and which workspace, if any, is asking, or the
     /// sentence saying why neither can be answered.
     ///
     /// One function for both roles, because the two answers have to stay opposite: a caller with a
     /// workspace may not name a project and a caller without one must. Split across two call sites
     /// that would eventually become one that does neither.
+    ///
+    /// It answers with the caller rather than with a `WorkspaceOrigin`, because the origin carries
+    /// the spawn key and the spawn key is a digest of the whole order, branch included, which is
+    /// not settled until the branch has been found in this project. `origin(of:project:parent:)`
+    /// puts the two together once both are known.
     enum Resolution {
-        case resolved(Repo, WorkspaceOrigin)
+        /// The project, and the workspace that asked. Nil is the owner's own client, which is
+        /// sitting in none.
+        case resolved(Repo, WorkspaceID?)
         case refused(String)
     }
 
     func resolve(
         _ request: MCPRequest,
-        order: AgentWorkspaceOrder,
         as identity: BridgeIdentity,
         store: Store
     ) async -> Resolution {
@@ -376,9 +450,7 @@ public struct WorkspaceStartTool: BridgeToolHandling {
                 // The rate is not checked here. A retry of a call that already cut a worktree is
                 // not another start, and `call` answers that before it counts anything, or a
                 // duplicate would come back looking like a limit.
-                return .resolved(project, .ownerClient(
-                    spawnToolUseID: order.spawnID(ownerProject: project.id)
-                ))
+                return .resolved(project, nil)
             }
 
             // A caller that is a workspace. Its project is decided for it, so naming one is a
@@ -408,14 +480,28 @@ public struct WorkspaceStartTool: BridgeToolHandling {
                 )
             }
 
-            // A retry of the same call is the same call. See `AgentWorkspaceOrder.spawnID`.
-            return .resolved(project, .agent(
-                parentWorkspaceID: workspaceID,
-                spawnToolUseID: order.spawnID(parentWorkspaceID: workspaceID)
-            ))
+            return .resolved(project, workspaceID)
         } catch {
             return .refused("Bloom could not read its projects: \(error.readableMessage)")
         }
+    }
+
+    /// Who is recorded as having asked for this workspace, and the key that makes a retry of the
+    /// call the same call rather than a second worktree.
+    ///
+    /// One function for both callers, because the difference between them is one thing: what the
+    /// digest is scoped by. A parent scopes it by itself, and the owner's client, which is not a
+    /// workspace, scopes it by the project it named out loud. See `AgentWorkspaceOrder.spawnID`.
+    private func origin(
+        of order: AgentWorkspaceOrder, project: Repo, parent: WorkspaceID?
+    ) -> WorkspaceOrigin {
+        guard let parent else {
+            return .ownerClient(spawnToolUseID: order.spawnID(ownerProject: project.id))
+        }
+        return .agent(
+            parentWorkspaceID: parent,
+            spawnToolUseID: order.spawnID(parentWorkspaceID: parent)
+        )
     }
 
     /// Whether this caller has already had as many as its origin allows, and the sentence saying

--- a/Sources/BloomCore/Workspace/BranchHolder.swift
+++ b/Sources/BloomCore/Workspace/BranchHolder.swift
@@ -94,6 +94,29 @@ public enum BranchHolder: Sendable, Hashable, Codable {
             + " or start a new branch from '\(branch)' on the Create new branch tab,"
             + " which gets you the same code."
     }
+
+    /// The same refusal for a caller with no screen, which is `workspace_start` over the bridge.
+    ///
+    /// Two audiences and one fact, in the shape `FolderRefusal` already uses for the same split:
+    /// the opening and the way out are shared, and only the last clause differs, because a tab
+    /// strip is not something an agent can be sent to. What it can do is ask again, so the offer
+    /// names the argument instead of the tab. Sending a model to a control it cannot see is how
+    /// it ends up describing the app to the owner rather than doing the work.
+    public func agentRefusal(branch: String) -> String {
+        let opening: String
+        switch self {
+        case .workspace(let name):
+            opening = "'\(branch)' is already open in Bloom's workspace '\(name)'."
+        case .projectCheckout(let path):
+            opening = "'\(branch)' is the branch the project itself is on, at \(path)."
+        case .otherWorktree(let path):
+            opening = "'\(branch)' is checked out at \(path), which is not one of Bloom's workspaces."
+        }
+        return opening
+            + " Git allows one worktree per branch, so Bloom cannot open it again."
+            + " Ask again with base_branch '\(branch)' instead of existing_branch, which cuts a"
+            + " new branch from it and starts you on the same code, or leave it and say so."
+    }
 }
 
 public extension BranchHolder {

--- a/Sources/BloomCore/Workspace/WorkspaceCheckout.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceCheckout.swift
@@ -237,6 +237,28 @@ public enum WorkspaceCheckoutPlan {
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
     }
 
+    /// The same merge with nothing dropped: every branch the repository has, local and remote, in
+    /// one list, with whatever is holding each.
+    ///
+    /// What the picker offers is a subset of this, and the difference is that the picker is a list
+    /// somebody reads while a caller that names a branch by name has already read one. The default
+    /// branch is the case that matters: it is dropped from the picker because it is normally the
+    /// branch the project's own checkout is on, and git will not have it twice, but "normally" is
+    /// not always. A project left on a feature branch has its default branch free, and hiding it
+    /// there would refuse a checkout git would have allowed. So nothing is hidden and `inUse`
+    /// answers the question instead, which is git's own worktree listing rather than an assumption
+    /// about which branch the project is on.
+    ///
+    /// Pull request heads are not dropped either, for the same reason: there is no pull request
+    /// row here to offer instead.
+    public static func everyBranch(
+        local: [String], remote: [String], inUse: [String: BranchHolder] = [:]
+    ) -> [ExistingBranch] {
+        // The empty string excludes nothing: `offeredBranches` drops the branch it is given as the
+        // default, and no branch is called "". One merge rule, asked for twice.
+        offeredBranches(local: local, remote: remote, defaultBranch: "", inUse: inUse)
+    }
+
     /// The branches the offered pull requests are already speaking for.
     ///
     /// A fork's head is left out on purpose. It is not a branch of this repository at all, so a

--- a/Tests/BloomCoreTests/AgentStartSourceTests.swift
+++ b/Tests/BloomCoreTests/AgentStartSourceTests.swift
@@ -1,0 +1,202 @@
+import CryptoKit
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// The choice the create sheet draws as two tabs, as `workspace_start` takes it: cut a new branch
+/// from one, or carry on one that already exists.
+///
+/// Everything here is the pure half, which is where the decisions are. What the tool does with
+/// them, and the git reads behind `listing`, are in `WorkspaceStartToolTests`.
+@Suite("workspace_start: which branch")
+struct AgentStartSourceTests {
+    // MARK: Reading the two arguments
+
+    @Test("a call that names neither gets what it has always got")
+    func silenceIsANewBranch() {
+        #expect(AgentStartRequest.read(baseBranch: nil, existingBranch: nil) == .newBranch(from: nil))
+    }
+
+    @Test("each argument names one of the sheet's two tabs")
+    func eachArgumentNamesATab() {
+        #expect(
+            AgentStartRequest.read(baseBranch: "develop", existingBranch: nil)
+                == .newBranch(from: "develop")
+        )
+        #expect(
+            AgentStartRequest.read(baseBranch: nil, existingBranch: "freek/figma")
+                == .existingBranch("freek/figma")
+        )
+    }
+
+    /// Opposite in effect and one keystroke apart in intent, which is why the sheet draws them as
+    /// two tabs rather than as two rows of one list. A call that asked for both has not chosen.
+    @Test("naming both is refused, and the refusal says what each one does")
+    func bothIsRefused() {
+        guard case .refused(let sentence) = AgentStartRequest.read(
+            baseBranch: "main", existingBranch: "freek/figma"
+        ) else {
+            Issue.record("naming both should be refused")
+            return
+        }
+
+        #expect(sentence.contains("'main'"))
+        #expect(sentence.contains("'freek/figma'"))
+        #expect(sentence.contains("base_branch"))
+        #expect(sentence.contains("existing_branch"))
+    }
+
+    // MARK: Finding the branch
+
+    private let branches = [
+        ExistingBranch(name: "freek/figma", isLocal: true),
+        ExistingBranch(name: "main", isLocal: true),
+        ExistingBranch(name: "release/3.0", isLocal: false),
+    ]
+
+    @Test("a branch that is there, local or only on the remote, is found")
+    func found() {
+        #expect(
+            AgentStartBranch.find("freek/figma", among: branches, project: "flare")
+                == .found(branches[0])
+        )
+        #expect(
+            AgentStartBranch.find("release/3.0", among: branches, project: "flare")
+                == .found(branches[2])
+        )
+    }
+
+    /// A model that has just run `git branch -r` writes down what git printed. Refusing that over
+    /// a prefix Bloom strips everywhere else would be refusing the right branch.
+    @Test("the name git prints for a remote branch finds the same branch")
+    func remotePrefixIsStripped() {
+        #expect(
+            AgentStartBranch.find("origin/release/3.0", among: branches, project: "flare")
+                == .found(branches[2])
+        )
+    }
+
+    /// The whole reason the branch is looked up before anything is cut. A caller cannot see the
+    /// picker, so the answer has to carry the list the picker would have shown.
+    @Test("a branch that is not there is refused, and the refusal names what is")
+    func unknownBranch() {
+        guard case .refused(let sentence) = AgentStartBranch.find(
+            "freek/figmaa", among: branches, project: "flare"
+        ) else {
+            Issue.record("an unknown branch should be refused")
+            return
+        }
+
+        #expect(sentence.contains("'flare' has no branch called 'freek/figmaa'"))
+        #expect(sentence.contains("'freek/figma'"))
+        #expect(sentence.contains("'release/3.0'"))
+        #expect(sentence.contains("existing_branch"))
+    }
+
+    @Test("a project with nothing to continue on says that rather than listing nothing")
+    func noBranchesAtAll() {
+        guard case .refused(let sentence) = AgentStartBranch.find(
+            "main", among: [], project: "flare"
+        ) else {
+            Issue.record("an empty project should be refused")
+            return
+        }
+
+        #expect(sentence.contains("no branches in the project 'flare'"))
+        #expect(sentence.contains("no commits yet"))
+    }
+
+    /// Git allows one worktree per branch, so this is a refusal Bloom can make in words instead of
+    /// letting git make it half way through a start.
+    @Test("a branch something else is already on is refused, and the way out is an argument")
+    func heldBranch() {
+        let held = [ExistingBranch(name: "freek/figma", isLocal: true, inUseBy: .workspace("Coral Sea"))]
+
+        guard case .refused(let sentence) = AgentStartBranch.find(
+            "freek/figma", among: held, project: "flare"
+        ) else {
+            Issue.record("a held branch should be refused")
+            return
+        }
+
+        #expect(sentence.contains("Coral Sea"))
+        #expect(sentence.contains("one worktree per branch"))
+        // The offer names the argument rather than the tab, because a tab is not something an
+        // agent can be sent to.
+        #expect(sentence.contains("base_branch"))
+        #expect(!sentence.contains("tab"))
+    }
+
+    @Test("the project's own checkout is named by its path, not called a workspace")
+    func heldByTheProjectItself() {
+        let held = [
+            ExistingBranch(name: "main", isLocal: true, inUseBy: .projectCheckout(path: "/dev/flare")),
+        ]
+
+        guard case .refused(let sentence) = AgentStartBranch.find(
+            "main", among: held, project: "flare"
+        ) else {
+            Issue.record("a held branch should be refused")
+            return
+        }
+
+        #expect(sentence.contains("/dev/flare"))
+        #expect(sentence.contains("the project itself is on"))
+    }
+
+    // MARK: What the source becomes
+
+    @Test("a new branch carries a base and no checkout")
+    func newBranchSource() {
+        let source = AgentStartSource.newBranch(from: "develop")
+
+        #expect(source.tab == .newBranch)
+        #expect(source.baseBranch == "develop")
+        #expect(source.namedBranch == "develop")
+        #expect(source.checkout == nil)
+    }
+
+    /// The point of the whole thing: what reaches `WorkspaceManager` is the same `WorkspaceCheckout`
+    /// the create sheet hands it, so the worktree lands on the branch rather than beside it.
+    @Test("an existing branch carries a checkout and no base")
+    func existingBranchSource() {
+        let branch = ExistingBranch(name: "freek/figma", isLocal: true)
+        let source = AgentStartSource.existingBranch(branch)
+
+        #expect(source.tab == .existingBranch)
+        #expect(source.baseBranch == nil)
+        #expect(source.namedBranch == "freek/figma")
+        #expect(source.checkout == .branch(branch))
+    }
+
+    // MARK: The spawn digest
+
+    /// Spawn ids are stored on workspace rows, so a call made before `existing_branch` existed has
+    /// to digest the same way after it: a key that shifted would answer every retry of an older
+    /// call with a second worktree. Pinned against the digest computed by hand rather than against
+    /// a literal, so the reason survives a change to how the material is joined.
+    @Test("a call that names no existing branch digests exactly as it did before there was one")
+    func digestIsStableForOlderCalls() {
+        let parent = WorkspaceID(rawValue: "w-parent")
+        let order = AgentWorkspaceOrder(prompt: "Import the webhooks", source: .newBranch(from: "develop"))
+
+        let material = [parent.rawValue, "Import the webhooks", "", "develop", ""]
+            .joined(separator: "\u{0}")
+        let expected = SHA256.hash(data: Data(material.utf8))
+            .prefix(8).map { String(format: "%02x", $0) }.joined()
+
+        #expect(order.spawnID(parentWorkspaceID: parent) == expected)
+    }
+
+    @Test("cutting from a branch and carrying it on are two different calls")
+    func digestTellsTheTwoVerbsApart() {
+        let parent = WorkspaceID(rawValue: "w-parent")
+        let cut = AgentWorkspaceOrder(prompt: "look at it", source: .newBranch(from: "freek/figma"))
+        let carryOn = AgentWorkspaceOrder(
+            prompt: "look at it",
+            source: .existingBranch(ExistingBranch(name: "freek/figma", isLocal: true))
+        )
+
+        #expect(cut.spawnID(parentWorkspaceID: parent) != carryOn.spawnID(parentWorkspaceID: parent))
+    }
+}

--- a/Tests/BloomCoreTests/WorkspaceCheckoutTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceCheckoutTests.swift
@@ -91,6 +91,21 @@ struct WorkspaceCheckoutTests {
         #expect(branches.first { $0.name == "wip" }?.inUseBy == nil)
     }
 
+    /// What a caller naming a branch by name is looked up in. The picker drops the default branch
+    /// because it is normally the one the project's own checkout is on, and normally is not always:
+    /// a project left on a feature branch has its default free, and a list that hid it would refuse
+    /// a checkout git would have allowed. Nothing is hidden here, and `inUse` answers instead.
+    @Test("Every branch, for a caller that names one, keeps the default branch in the list")
+    func keepsEverythingWhenNothingIsBeingOffered() {
+        let branches = WorkspaceCheckoutPlan.everyBranch(
+            local: ["main", "wip"],
+            remote: ["origin/main", "origin/theirs", "origin/HEAD"],
+            inUse: ["main": .projectCheckout(path: "/dev/flare")]
+        )
+        #expect(branches.map(\.name) == ["main", "theirs", "wip"])
+        #expect(branches.first { $0.name == "main" }?.inUseBy == .projectCheckout(path: "/dev/flare"))
+    }
+
     @Test("A head with a pull request open on it is offered as the pull request and not twice")
     func skipsBranchesWithAnOpenPullRequest() {
         let requests = [listing(number: 4, head: "figma-mcp-check")]

--- a/Tests/BloomCoreTests/WorkspaceStartToolTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceStartToolTests.swift
@@ -165,6 +165,143 @@ struct WorkspaceStartToolTests {
         #expect(recorder.orders[0].agent == nil)
     }
 
+    // MARK: Which branch it starts on
+
+    /// A caller, a store and a repository that really has the branches, because everything on this
+    /// path is decided by asking git what is there.
+    private func gitFixture(label: String) async throws -> (fixture: Fixture, repo: TempRepo) {
+        let repo = try await TempRepo()
+        try await Shell.check("git", ["branch", "freek/figma"], cwd: repo.path)
+
+        let store = try makeTestStore(label)
+        let project = try await store.upsert(
+            Repo(name: "flare", path: repo.path, defaultBranch: "main")
+        )
+        let workspace = try await store.upsert(Workspace(
+            repoID: project.id,
+            name: "group occurrences",
+            branch: "claude/group-occurrences",
+            path: "/tmp/flare-group",
+            baseBranch: "main"
+        ))
+        let session = try await store.upsert(Session(workspaceID: workspace.id, title: "First chat"))
+
+        return (
+            Fixture(
+                store: store,
+                identity: BridgeIdentity(
+                    sessionID: session.id, workspaceID: workspace.id, role: .parent
+                ),
+                workspace: workspace
+            ),
+            repo
+        )
+    }
+
+    /// The whole point of the second route. Cutting a fresh branch off a colleague's branch gives a
+    /// worktree identical to it, so the Changes tab draws nothing and the workspace is useless for
+    /// the job it was started for. What has to reach the app is a `WorkspaceCheckout`.
+    @Test("a call naming an existing branch starts on that branch", .tags(.git, .subprocess))
+    func startsOnAnExistingBranch() async throws {
+        let (fixture, repo) = try await gitFixture(label: "start-existing")
+        defer { repo.cleanUp() }
+        let recorder = Recorder()
+
+        let result = await recorder.tool().call(
+            request([
+                "prompt": .string("Read what is on this branch and fix the failing test"),
+                "existing_branch": .string("freek/figma"),
+            ]),
+            as: fixture.identity,
+            store: fixture.store
+        )
+
+        #expect(!result.isError)
+        let order = try #require(recorder.orders.first)
+        #expect(order.source.tab == .existingBranch)
+        #expect(order.source.checkout == .branch(ExistingBranch(name: "freek/figma", isLocal: true)))
+        #expect(order.source.baseBranch == nil)
+    }
+
+    @Test("a call naming neither still cuts a new branch, as it always did", .tags(.git, .subprocess))
+    func defaultsToANewBranch() async throws {
+        let (fixture, repo) = try await gitFixture(label: "start-default")
+        defer { repo.cleanUp() }
+        let recorder = Recorder()
+
+        _ = await recorder.tool().call(
+            request(["prompt": .string("do a thing")]), as: fixture.identity, store: fixture.store
+        )
+
+        let order = try #require(recorder.orders.first)
+        #expect(order.source == .newBranch(from: nil))
+        #expect(order.source.checkout == nil)
+    }
+
+    /// The refusal the caller cannot get from a picker it cannot see. Told this, it asks again with
+    /// a name that is there; told nothing, it gets a workspace on a branch nobody meant.
+    @Test("a branch that is not in the project is refused, with what is", .tags(.git, .subprocess))
+    func refusesABranchThatIsNotThere() async throws {
+        let (fixture, repo) = try await gitFixture(label: "start-missing-branch")
+        defer { repo.cleanUp() }
+        let recorder = Recorder()
+
+        let result = await recorder.tool().call(
+            request([
+                "prompt": .string("do a thing"),
+                "existing_branch": .string("freek/figmaa"),
+            ]),
+            as: fixture.identity,
+            store: fixture.store
+        )
+
+        #expect(result.isError)
+        #expect(result.text.contains("no branch called 'freek/figmaa'"))
+        #expect(result.text.contains("'freek/figma'"))
+        #expect(recorder.orders.isEmpty)
+    }
+
+    /// Git allows one worktree per branch, and the project's own checkout is a worktree. Refused in
+    /// words here rather than by git exiting 128 half way through a start.
+    @Test("the branch the project itself is on is refused, by its path", .tags(.git, .subprocess))
+    func refusesTheProjectsOwnBranch() async throws {
+        let (fixture, repo) = try await gitFixture(label: "start-held-branch")
+        defer { repo.cleanUp() }
+        let recorder = Recorder()
+
+        let result = await recorder.tool().call(
+            request(["prompt": .string("do a thing"), "existing_branch": .string("main")]),
+            as: fixture.identity,
+            store: fixture.store
+        )
+
+        #expect(result.isError)
+        #expect(result.text.contains("the project itself is on"))
+        #expect(result.text.contains("base_branch"))
+        #expect(recorder.orders.isEmpty)
+    }
+
+    @Test("naming both branch arguments is refused before anything is looked up")
+    func refusesBothBranchArguments() async throws {
+        let fixture = try await fixture()
+        let recorder = Recorder()
+
+        let result = await recorder.tool().call(
+            request([
+                "prompt": .string("do a thing"),
+                "base_branch": .string("main"),
+                "existing_branch": .string("freek/figma"),
+            ]),
+            as: fixture.identity,
+            store: fixture.store
+        )
+
+        #expect(result.isError)
+        #expect(result.text.contains("base_branch"))
+        #expect(result.text.contains("existing_branch"))
+        #expect(recorder.orders.isEmpty)
+    }
+
     // MARK: What it refuses
 
     @Test("a missing or empty prompt is refused before anything is created")
@@ -398,6 +535,12 @@ struct WorkspaceStartToolTests {
 
         #expect(description.contains("not when its work is done"))
         #expect(description.contains("cannot see this conversation"))
+        // The choice, in the sheet's own words, so a model reading the tool list and a person
+        // reading the tab strip are told the same thing. See `AgentStartSource`.
+        #expect(description.contains(WorkspaceSourceTab.newBranch.title))
+        #expect(description.contains(WorkspaceSourceTab.existingBranch.title))
+        #expect(description.contains(WorkspaceSourceTab.existingBranch.explanation))
+        #expect(description.contains("existing_branch"))
         #expect(description.contains("real money"))
         #expect(!description.lowercased().contains("subagent"))
     }

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -103,7 +103,7 @@ places: the listing, the dispatch and the gate.
 | `project_hide` | Take a project out of the sidebar. A view preference and nothing more | | | ✓ |
 | `project_unhide` | Put it back, in the place it already had | | | ✓ |
 | `workspace_list` | Every workspace, its state, its worktree path, its chats and their cost, what an agent is stopped on, what is queued and why | | | ✓ |
-| `workspace_start` | Cut a worktree on a new branch and put an agent in it with a task | ✓ | | ✓ |
+| `workspace_start` | Cut a worktree and put an agent in it with a task, on a new branch or on a branch that already exists | ✓ | | ✓ |
 | `workspace_merge` | Ask a workspace's own agent to merge its pull request | | | ✓ |
 | `pane_open` | Open a chat, a terminal or a browser in a new tab of the caller's own workspace | ✓ | | |
 | `pane_split` | Put one beside what is on screen rather than behind it | ✓ | | |
@@ -284,6 +284,43 @@ page to be fetched: a tab restored from the last launch that nobody has looked a
 the address it remembers and refused for anything needing a live page. `browser_go` takes the two
 schemes `pane_open` takes and refuses the rest, through the same reading, so neither door will
 render `file:///` in the owner's window on a model's say-so.
+
+### Which branch a workspace starts on
+
+`workspace_start` offers the choice the create sheet offers, and it is the sheet's own choice
+rather than a second one written for the bridge. The sheet draws it as a tab strip,
+`WorkspaceSourceTab`; over the socket it is two arguments, and `AgentStartSource` is the
+translation between them.
+
+| Argument | The tab it is | What happens to a commit |
+| --- | --- | --- |
+| `base_branch`, or nothing | Create new branch | It lands on a new branch, and merges into the branch that was named |
+| `existing_branch` | Continue on existing branch | It lands on the branch that was named, and merges when that branch does |
+
+Nothing said is a new branch from the project's default branch, which is exactly what the tool did
+before there was a choice, so every caller written against the older tool keeps working. Naming
+both arguments is refused rather than resolved to one of them: they are opposite in effect, and a
+call that asked for both has not decided.
+
+**The second one is here because the first one answers the wrong question about somebody else's
+work.** Told to look at a colleague's branch, the tool could only cut a fresh branch off its tip,
+so the worktree opened identical to that branch and the Changes tab drew nothing. It was right and
+it was useless. That is the bug `docs/start-from.html` was written about, arriving a second time
+through the other door.
+
+The branch is found in the project before anything is cut, and both ways of not finding it are a
+sentence rather than a failed start. A name that is not there is answered with the names that are,
+which is the list the picker would have shown somebody who could see one. A branch something else
+is already sitting on is refused with what has it, git's own worktrees included rather than only
+Bloom's rows, because git allows one worktree per branch and the alternative is git exiting 128 in
+the middle of a start. Both refusals end by offering `base_branch` on the same name, which is a
+different intention and Bloom does not take it on a caller's behalf.
+
+A pull request cannot be named, though the sheet's second tab lists them beside the branches.
+Resolving one costs a `gh` call and a network round trip on a path that otherwise spends only local
+git, and an agent that wants a pull request's code can name its head branch, which is what the
+picker draws a listed pull request by anyway. `WorkspaceCheckout` already carries the case, so the
+day it is wanted it is an argument rather than a mechanism.
 
 ### How many a caller may start
 


### PR DESCRIPTION
Asked for: the MCP tool that starts a workspace should offer the choice the New Workspace sheet's tabs offer.

`workspace_start` could only ever cut a new branch. An agent told to look at somebody's branch got a fresh branch off its tip and a workspace whose diff is empty, which is the mistake `docs/start-from.html` was written about, arriving through the other door.

It takes `existing_branch` now, beside `base_branch`, and the pair maps onto the sheet's two tabs: name a base and commits land on a new branch that merges into it; name an existing branch and commits land on that branch itself. Naming neither behaves exactly as before, digest included, so no existing caller changes.

The decision is the sheet's own: `WorkspaceSourceTab` supplies the words in the tool description, so the tool list and the tab strip cannot drift, and `WorkspaceCheckout` is what reaches `WorkspaceManager`, which is the value the sheet already hands over.

A branch that does not exist, one held by another workspace, or one the project itself is checked out on, are each refused with a sentence naming what holds it and offering `base_branch` instead, and nothing is started. Naming both arguments is refused too.

One thing deliberately left out: a pull request cannot be named, though the sheet's second tab lists them. It would cost a `gh` call on a path that otherwise spends only local git, and its head branch is nameable. `docs/BRIDGE.md` says so.