### PR TITLE
Push the conflict resolution, unless the agent is unsure of it

### DIFF
--- a/Sources/Bloom/Views/Inspector/PullRequestBar.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestBar.swift
@@ -199,8 +199,13 @@ struct PullRequestBar: View {
     ///
     /// Nothing here runs git, and there is nothing to report on success either: what comes back is
     /// an ordinary turn in the transcript, and the strip notices the resolved worktree on its next
-    /// refresh like any other change on this disk. The pull request stays conflicted on GitHub
-    /// until the reader presses Commit and push, which is the button the strip offers next.
+    /// refresh like any other change on this disk.
+    ///
+    /// The turn pushes the resolution itself unless it is unsure of it, so the pull request stops
+    /// being conflicted on GitHub without anybody pressing anything else. It used to stop at the
+    /// commit and leave Commit and push to the reader, which read as finished and was not: see the
+    /// argument on `PromptRegistry.fixConflicts`. Commit and push is still the button the strip
+    /// offers when an agent stopped short.
     private func fixConflicts(on pullRequest: PullRequest) {
         isWorking = true
         report = nil

--- a/Sources/BloomCore/Transcript/PromptRegistry.swift
+++ b/Sources/BloomCore/Transcript/PromptRegistry.swift
@@ -320,9 +320,24 @@ public enum PromptRegistry {
     /// conventions for it are already in front of the agent in the project's own instruction
     /// files. A second file repeating them would be a second place to keep them right.
     ///
-    /// The template pushes nothing and merges nothing on the server. What comes out is a resolved
-    /// worktree with a commit in it, which is exactly the state the strip's Commit and push button
-    /// is for, so the next press is the reader's rather than this turn's.
+    /// **The template pushes the resolution, and it used to stop short of that.** The argument for
+    /// stopping was that a resolved worktree is the state the strip's Commit and push button is
+    /// for, so the next press could be the reader's. What that produced in practice was a turn
+    /// that reported success on a pull request GitHub still refused to merge, because a conflict
+    /// resolved in a worktree nobody has pushed is still a conflict to everybody else: the owner
+    /// asked "does the merge conflict still exist", was told "locally no, on GitHub yes", and had
+    /// to type "push" himself. A button called Fix merge conflicts that leaves the conflict
+    /// standing is not finished.
+    ///
+    /// It still merges nothing. Pushing is what makes the resolution real; merging is a decision
+    /// about whether the work is good, and that one stays with the reader.
+    ///
+    /// The push is conditional on the agent being sure, and that is not a hedge. Bringing a base
+    /// branch in is the one ordinary operation that regularly needs a person: two changes that
+    /// genuinely disagree, a test that now fails for a reason neither branch expected, a rebase
+    /// that rewrote history somebody else may have pulled. An agent that pushes a resolution it
+    /// does not believe in has made the problem harder to see, so the template tells it to stop
+    /// and say so instead.
     static let fixConflicts = PromptDefinition(
         id: .fixConflicts,
         title: "Fix merge conflicts",
@@ -330,8 +345,10 @@ public enum PromptRegistry {
         Sent to the workspace's agent when you press Fix merge conflicts, which is what the strip \
         offers in place of Merge once GitHub reports that the branch conflicts with its base. It \
         asks for the base branch to be brought into this worktree and the conflicts resolved \
-        here. Nothing is pushed and nothing is merged on GitHub: what you get back is a resolved \
-        worktree, and the strip then offers Commit and push in the ordinary way.
+        here, and the resolution pushed so that GitHub stops refusing the pull request. Nothing is \
+        merged: what you get back is a branch that can be merged, and the decision to merge it \
+        stays yours. An agent that is not sure about a resolution stops and says so rather than \
+        pushing it.
         """,
         variables: [
             PromptVariable(name: FixConflicts.workspace, summary: "The workspace's name."),
@@ -359,9 +376,21 @@ public enum PromptRegistry {
         around them to work out which is right instead of taking a side. Follow this project's \
         conventions, and run whatever it uses to check itself before you call anything resolved.
 
-        Commit the resolution, with a message worded the way this project words one. Do not push \
-        it, and do not merge the pull request. Finish by saying which files conflicted, what you \
-        decided in each of them, and anything you are not sure about.
+        Commit the resolution, with a message worded the way this project words one.
+
+        Then push it. A conflict resolved only in this worktree is still a conflict to everybody \
+        else, and pull request #{{number}} goes on refusing to merge until the branch on the \
+        server carries the resolution. If bringing {{base_branch}} in rewrote this branch's \
+        commits, which a rebase does, the push needs `--force-with-lease`, and it may only ever go \
+        to {{branch}}, never to {{base_branch}} and never to any other branch.
+
+        Do not push if you are not sure. Genuine uncertainty about what a resolution should be, a \
+        check that fails for a reason neither branch explains, or anything you had to guess at: \
+        leave the commit here, say what you are unsure about, and let a person look. A resolution \
+        nobody believes in is worse on the server than in a worktree.
+
+        Do not merge the pull request whatever happens. Finish by saying which files conflicted, \
+        what you decided in each of them, whether you pushed, and anything you are not sure about.
         """
     )
 

--- a/Tests/BloomCoreTests/FixConflictsPromptTests.swift
+++ b/Tests/BloomCoreTests/FixConflictsPromptTests.swift
@@ -62,16 +62,28 @@ struct FixConflictsPromptTests {
         #expect(render.text.contains("feature/glyphs"))
     }
 
-    /// The two things this turn is not allowed to do, asserted rather than trusted. A prompt that
-    /// pushed would put a half resolved branch on the server, and one that merged would be the
-    /// button this whole change exists to remove.
-    @Test("the default prompt pushes nothing and merges nothing on GitHub")
-    func staysOnThisMachine() {
+    /// What this turn may and may not do, asserted rather than trusted.
+    ///
+    /// The push is the point: a conflict resolved in a worktree nobody has pushed is still a
+    /// conflict to GitHub, and the button is called Fix merge conflicts. The merge is still the
+    /// reader's, and a rewritten history needs the lease, or a push lands on top of somebody.
+    @Test("the default prompt pushes the resolution and merges nothing")
+    func pushesButDoesNotMerge() {
         let text = PromptRegistry.definition(for: .fixConflicts).defaultTemplate
 
-        #expect(text.contains("Do not push"))
-        #expect(text.contains("do not merge the pull request"))
+        #expect(text.contains("Then push it."))
+        #expect(text.contains("--force-with-lease"))
+        #expect(text.contains("Do not merge the pull request"))
         #expect(!text.contains("gh pr merge"))
+    }
+
+    /// The half of the instruction that keeps a bad resolution off the server. An agent that is
+    /// guessing has to stop, and the sentence that tells it so has to survive an edit of the rest.
+    @Test("the default prompt tells an agent that is unsure not to push")
+    func uncertaintyStops() {
+        let text = PromptRegistry.definition(for: .fixConflicts).defaultTemplate
+
+        #expect(text.contains("Do not push if you are not sure."))
     }
 
     /// The direction of the merge is the one thing in this prompt that must not be guessed, so


### PR DESCRIPTION
Pressing Fix merge conflicts resolved the conflict in the worktree and stopped. GitHub went on refusing the pull request, because a resolution nobody has pushed is not a resolution as far as anybody else is concerned: the owner asked "does the merge conflict still exist", was told "locally no, on GitHub yes", and had to type push himself.

The prompt pushes now, and says the two things that make a push safe: a rebase rewrote the branch, so the push needs `--force-with-lease`, and it may only ever go to this pull request's own branch.

It still merges nothing. Merging is a decision about whether the work is good and that stays with the reader.

And it stops rather than pushing when it is not sure, which is the case that made the old instruction defensible in the first place: two changes that genuinely disagree, a check failing for a reason neither branch explains, anything guessed at. Then the commit stays here and the turn says why.