### PR TITLE
Say when a turn's process goes away

### DIFF
--- a/Sources/BloomCore/Agent/AgentExit.swift
+++ b/Sources/BloomCore/Agent/AgentExit.swift
@@ -17,6 +17,11 @@ public enum AgentExitCause: Sendable, Hashable {
     case reported(String)
     /// It printed nothing at all.
     case silent
+    /// The process went away in the middle of a turn, on a clean status and with nothing on
+    /// stderr. Its own case rather than `.silent` because "Agent exited (0)" reads as nothing
+    /// having gone wrong, and a turn that stopped dead is the one ending a person most needs
+    /// named. See `UnfinishedRun`.
+    case endedMidTurn
     /// Bloom could not write the row. The agent is not what failed.
     case storage(String)
     /// The turn never reached a process. Nothing was launched and nothing was said to the agent,
@@ -61,6 +66,9 @@ public struct AgentExit: Sendable, Hashable {
     public var title: String {
         if case .storage = cause { return "Not saved" }
         if case .notStarted = cause { return "Not sent" }
+        // Deliberately not "Agent exited (0)". The status is true and it is also the least useful
+        // thing that could be said about a turn nothing will ever close.
+        if case .endedMidTurn = cause { return "Turn never finished" }
         return status.map { "Agent exited (\($0))" } ?? "Agent error"
     }
 
@@ -75,6 +83,9 @@ public struct AgentExit: Sendable, Hashable {
             Self.oneLine(text)
         case .silent:
             "It stopped without printing anything."
+        case .endedMidTurn:
+            "The agent's process ended in the middle of this turn, without an error and without "
+                + "finishing."
         case .storage(let message):
             Self.oneLine(message)
         case .notStarted(let message):
@@ -109,6 +120,13 @@ public struct AgentExit: Sendable, Hashable {
             Nothing in this conversation was lost, and everything the agent had already changed is \
             still in the worktree. Send the turn again, and if it stops here a second time, run \
             the CLI once in a terminal to see what it says.
+            """ + ranCommand
+        case .endedMidTurn:
+            """
+            Nothing in this conversation was lost, and everything the agent had already changed is \
+            still in the worktree. Send the turn again. It is worth checking the limits panel \
+            first: the CLI has been seen to end a turn this way with the weekly allowance nearly \
+            spent.
             """ + ranCommand
         case .storage:
             """
@@ -169,6 +187,13 @@ public struct AgentExit: Sendable, Hashable {
             let message = json?["message"]?.stringValue ?? ""
             let cause: AgentExitCause = message.isEmpty ? .silent : .notStarted(message)
             return AgentExit(status: status, cause: cause, detail: message)
+        }
+
+        // A turn nothing closed, written by `UnfinishedRun` when the process went away with a
+        // clean status and nothing to say. It carries no stderr by construction, so classifying
+        // it by its output would land on `.silent` and draw "Agent exited (0)".
+        if json?["subtype"]?.stringValue == UnfinishedRun.abandonedSubtype {
+            return AgentExit(status: status, cause: .endedMidTurn, detail: stderr, command: command)
         }
 
         return AgentExit(

--- a/Sources/BloomCore/Agent/AgentRunner.swift
+++ b/Sources/BloomCore/Agent/AgentRunner.swift
@@ -846,17 +846,23 @@ public actor AgentRunner {
             return
         }
 
-        if status != 0, !sawResult {
-            let tail = stderrTail.joined(separator: "\n")
-            let message = "The agent exited with status \(status)."
-            let payload = (try? JSONEncoder().encode(
-                ProcessFailure(status: Int(status), stderr: tail, command: launchedCommand)
-            )) ?? Data(#"{"type":"error"}"#.utf8)
+        // The state is read before anything is applied to it, because it is the question being
+        // asked: was a turn open at the moment this process went away. See `UnfinishedRun`, which
+        // is the bug the owner reported as "sometimes the AI just stops dead in the water".
+        if let unfinished = UnfinishedRun.of(
+            status: status,
+            sawResult: sawResult,
+            state: session.state,
+            stderr: stderrTail.joined(separator: "\n"),
+            command: launchedCommand
+        ) {
+            Self.log.error("""
+                the agent for \(self.session.id.rawValue, privacy: .public) ended on status \
+                \(status, privacy: .public) with the session \
+                \(self.session.state.rawValue, privacy: .public)
+                """)
 
-            await ingest(.error(AgentError(
-                message: tail.isEmpty ? message : "\(message)\n\(tail)",
-                raw: payload
-            )))
+            await ingest(.error(AgentError(message: unfinished.message, raw: unfinished.payload)))
 
             session.apply(.processFailed)
             await save(session)
@@ -972,17 +978,6 @@ public actor AgentRunner {
         init(text: String) {
             message = Body(content: [Block(text: text)])
         }
-    }
-
-    /// Stored as the `.error` row when the process dies without ever emitting a `result`.
-    private struct ProcessFailure: Encodable {
-        let type = "error"
-        let subtype = "process_exit"
-        let status: Int
-        let stderr: String
-        /// The resolved path of what was launched, so a row can name the binary that died rather
-        /// than the name it was asked for.
-        let command: String
     }
 
 }

--- a/Sources/BloomCore/Agent/UnfinishedRun.swift
+++ b/Sources/BloomCore/Agent/UnfinishedRun.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// A run whose process is gone while the turn it was serving is still open, and the row that says
+/// so.
+///
+/// **The bug: "sometimes the AI just stops dead in the water".** The owner's transcript ended on a
+/// tool call with no result under it, no prose after it, no error row and no footer, while the
+/// status bar went on counting the turn as one of three running. His database holds the whole of
+/// it. Four `claude` children fell silent between 11:10:31 and 11:11:06 on 26 August 2026, every
+/// one of them in the middle of a turn, and every one of those transcripts ends on a
+/// `content_block_start` stream event with nothing after it until he typed again ten minutes
+/// later. `ps` says the children serving those sessions started at 11:17:28 and 11:21:29, which is
+/// when he typed, so the processes he was waiting on had exited long before. Not one `.error` row
+/// exists anywhere in that database.
+///
+/// That last fact is the fault, and it is one line of `AgentRunner`. A run that ended was only
+/// worth a row when its exit status said something had gone wrong: `if status != 0, !sawResult`.
+/// A CLI that exits **cleanly** in the middle of a turn took the quiet branch instead, moved the
+/// session to `idle`, and yielded nothing at all to the event sink. Nothing therefore reached
+/// `TranscriptModel`, so `isRunning` stayed true for the rest of the launch, the composer kept its
+/// working state, the subagent roster was never told the turn had ended, and the sidebar, the Dock
+/// badge and the status bar all went on counting a turn that had no process behind it.
+///
+/// So the test is no longer the exit status. **It is whether a turn was open when the process
+/// went away**, which is a question the session's own state machine already answers, and which is
+/// right for the two cases the old rule also missed: a run that served an earlier turn
+/// successfully and then died during a later one, where `sawResult` is stale and true; and a turn
+/// blocked on a permission question, where the pipe closing means the question can never be
+/// answered.
+///
+/// Here rather than in the runner because it is a decision about what an ending means and what it
+/// is worth saying, and the test target cannot launch a CLI. See `AgentExit` for the words the row
+/// draws, and `SessionLifecycle` for why `processFailed` rather than `processExited`.
+public struct UnfinishedRun: Sendable, Hashable {
+    /// What the process exited with. Kept even when it is zero, because a clean status is part of
+    /// the account rather than a reason to say nothing.
+    public let status: Int32
+    /// The tail of what the CLI wrote to stderr, whole.
+    public let stderr: String
+    /// The resolved path of what was launched, so a row can name the binary rather than the name
+    /// it was asked for.
+    public let command: String
+    /// Whether a turn was open at the moment the process went away.
+    public let leftATurnOpen: Bool
+
+    public init(status: Int32, stderr: String, command: String, leftATurnOpen: Bool) {
+        self.status = status
+        self.stderr = stderr
+        self.command = command
+        self.leftATurnOpen = leftATurnOpen
+    }
+
+    /// What a finished run owes the transcript, or nothing when it owes it nothing.
+    ///
+    /// - Parameter state: the session's state at the moment the process went away, which is what
+    ///   says whether a turn was open. A `result` has already moved it off `running` by the time
+    ///   this is asked, because both run on the same actor and the read loop drains before the
+    ///   process is reaped.
+    /// - Parameter sawResult: whether this run reported at least one result of its own. Only used
+    ///   for the second rule below, where there is no open turn to reason about.
+    public static func of(
+        status: Int32,
+        sawResult: Bool,
+        state: SessionState,
+        stderr: String,
+        command: String
+    ) -> UnfinishedRun? {
+        if state.isMidTurn {
+            return UnfinishedRun(status: status, stderr: stderr, command: command, leftATurnOpen: true)
+        }
+        // The rule this type was grown from, kept for the case it was written for: a CLI that
+        // falls over between turns, having reported nothing, is still worth a row even though
+        // there is no turn hanging on it.
+        guard status != 0, !sawResult else { return nil }
+        return UnfinishedRun(status: status, stderr: stderr, command: command, leftATurnOpen: false)
+    }
+
+    /// Whether the exit gave any account of itself at all.
+    ///
+    /// A non-zero status is an account, and so is anything on stderr. Neither, in the middle of a
+    /// turn, is the silence this type is named for, and it gets its own words rather than being
+    /// reported as "Agent exited (0)", which reads as nothing being wrong.
+    public var wasSilent: Bool {
+        leftATurnOpen && status == 0 && stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// What the payload's `subtype` says, which is what `AgentExit.read` reads it back as.
+    public var subtype: String { wasSilent ? Self.abandonedSubtype : Self.exitSubtype }
+
+    /// The one string both ends agree on, so the writer and the reader cannot drift apart.
+    public static let abandonedSubtype = "turn_abandoned"
+    public static let exitSubtype = "process_exit"
+
+    /// The `.error` event's message, which is what the alert and the notification say.
+    public var message: String {
+        guard !wasSilent else { return Self.silentSentence }
+        let opening = "The agent exited with status \(status)."
+        let tail = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        return tail.isEmpty ? opening : "\(opening)\n\(stderr)"
+    }
+
+    /// Said in the same register as `AgentExit.advice`, and for the same worry: what a person
+    /// wants to know the moment a turn stops is whether their work survived.
+    public static let silentSentence = "The agent's process ended in the middle of this turn."
+
+    /// The stored `.error` row.
+    ///
+    /// Built here rather than in the runner so the shape `AgentExit.read` decodes is written in
+    /// one place. Encoding a struct of two strings and two numbers cannot fail, and the fallback
+    /// exists so that a turn which ended badly cannot also end silently.
+    public var payload: Data {
+        (try? JSONEncoder().encode(Stored(
+            subtype: subtype, status: Int(status), stderr: stderr, command: command
+        ))) ?? Data(#"{"type":"error"}"#.utf8)
+    }
+
+    private struct Stored: Encodable {
+        let type = "error"
+        let subtype: String
+        let status: Int
+        let stderr: String
+        let command: String
+    }
+}

--- a/Tests/BloomCoreTests/AgentExitTests.swift
+++ b/Tests/BloomCoreTests/AgentExitTests.swift
@@ -257,6 +257,7 @@ struct AgentExitTests {
             .missing,
             .reported("Error: x"),
             .silent,
+            .endedMidTurn,
             .storage("storing an event: disk full"),
             .notStarted("Bloom could not open an agent for this chat."),
         ]

--- a/Tests/BloomCoreTests/AgentRunnerTests.swift
+++ b/Tests/BloomCoreTests/AgentRunnerTests.swift
@@ -760,6 +760,76 @@ struct AgentRunnerProcessTests {
         #expect(payload["stderr"]?.stringValue == "error: not logged in")
     }
 
+    /// **The turn that stopped dead.** A `claude` that exits cleanly in the middle of a turn used
+    /// to take the quiet branch of `finish`: the session row went to `idle` and nothing at all
+    /// reached the event sink, so the transcript ended on whatever row had arrived last and the
+    /// composer kept its working state for the rest of the launch. Four of the owner's chats did
+    /// exactly this within thirty five seconds of each other. The row and the event are what make
+    /// the stall something the transcript states. See `UnfinishedRun`.
+    @Test("a clean exit in the middle of a turn ends it rather than leaving it running")
+    func cleanExitMidTurnEndsTheTurn() async throws {
+        let store = try makeTestStore("agent")
+        let session = try await makeSession(store)
+        let recorder = ProcessRecorder(status: 0)
+        let runner = AgentRunner(
+            workspacePath: "/tmp/w", session: session, store: store, makeProcess: recorder.factory
+        )
+
+        // The event matters as much as the row: the row is what the transcript keeps, and the
+        // event is what unlocks the composer and stops the status bar counting this turn.
+        let stream = runner.events
+        let sawError = Task<Bool, Never> {
+            for await event in stream {
+                if case .error = event { return true }
+            }
+            return false
+        }
+
+        try await runner.send("run phpstan")
+        let process = try #require(recorder.last)
+        process.emit(#"{"type":"system","subtype":"init","session_id":"s","cwd":"/tmp/w"}"#)
+        // Nothing else. This is the whole of the bug: the child goes away with a clean status and
+        // never says the turn is over.
+        process.endOutput()
+
+        await waitUntil("the session stopped claiming a turn was running") {
+            (try? await store.session(id: session.id)?.state) == .failed
+        }
+
+        let errors = try await store.messages(sessionID: session.id).filter { $0.kind == .error }
+        #expect(errors.count == 1)
+        let exit = AgentExit.decode(errors[0].payload)
+        #expect(exit.cause == .endedMidTurn)
+
+        #expect(await sawError.value)
+        #expect(await runner.isRunning == false)
+    }
+
+    /// The other half of the same rule, and the reason it is a rule rather than "always draw a
+    /// row": a process that exits after finishing its turn is an ordinary ending and has nothing
+    /// to report.
+    @Test("a clean exit after a result reports nothing")
+    func cleanExitAfterResultIsQuiet() async throws {
+        let store = try makeTestStore("agent")
+        let session = try await makeSession(store)
+        let recorder = ProcessRecorder(status: 0)
+        let runner = AgentRunner(
+            workspacePath: "/tmp/w", session: session, store: store, makeProcess: recorder.factory
+        )
+
+        try await runner.send("hello")
+        let process = try #require(recorder.last)
+        process.emit(#"""
+        {"type":"result","subtype":"success","is_error":false,"duration_ms":10,"session_id":"s"}
+        """#)
+        process.endOutput()
+
+        await waitUntil("the turn landed idle") { (try? await store.session(id: session.id)?.state) == .idle }
+
+        let errors = try await store.messages(sessionID: session.id).filter { $0.kind == .error }
+        #expect(errors.isEmpty)
+    }
+
     @Test("cancelling terminates the process and marks the session cancelled")
     func cancels() async throws {
         let store = try makeTestStore("agent")

--- a/Tests/BloomCoreTests/UnfinishedRunTests.swift
+++ b/Tests/BloomCoreTests/UnfinishedRunTests.swift
@@ -1,0 +1,133 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+/// The turn that stopped dead, written down.
+///
+/// The shape every case here is measured against came out of the owner's own database on 26
+/// August 2026: four transcripts ending on a `content_block_start` with no result, no error and no
+/// footer, and `ps` proving the processes behind them had exited. The rule that let that happen
+/// was "only say something when the exit status is non-zero", so the first two tests are the two
+/// halves of replacing it.
+@Suite("UnfinishedRun")
+struct UnfinishedRunTests {
+    @Test("a clean exit in the middle of a turn is still worth a row")
+    func cleanExitMidTurn() throws {
+        let run = UnfinishedRun.of(
+            status: 0, sawResult: false, state: .running, stderr: "", command: "/usr/bin/claude"
+        )
+
+        let unfinished = try #require(run)
+        #expect(unfinished.leftATurnOpen)
+        #expect(unfinished.wasSilent)
+        #expect(unfinished.message == UnfinishedRun.silentSentence)
+    }
+
+    @Test("a clean exit with no turn open says nothing")
+    func cleanExitBetweenTurns() {
+        for state in [SessionState.idle, .failed, .cancelled] {
+            #expect(UnfinishedRun.of(
+                status: 0, sawResult: true, state: state, stderr: "", command: ""
+            ) == nil)
+        }
+    }
+
+    /// The rule this type grew from, kept: a CLI that falls over between turns is news even though
+    /// no turn is hanging on it.
+    @Test("a non-zero exit with nothing reported is still a row between turns")
+    func failsBetweenTurns() throws {
+        let run = UnfinishedRun.of(
+            status: 2, sawResult: false, state: .idle, stderr: "error: not logged in", command: "c"
+        )
+
+        let unfinished = try #require(run)
+        #expect(unfinished.leftATurnOpen == false)
+        #expect(unfinished.wasSilent == false)
+        #expect(unfinished.message.contains("status 2"))
+        #expect(unfinished.message.contains("not logged in"))
+    }
+
+    /// `sawResult` is one flag for a run that serves many turns, so it is true for the rest of the
+    /// run the moment the first turn closes. A process that died during turn five therefore read
+    /// as a process with nothing left to report. The state does not go stale that way.
+    @Test("a stale sawResult cannot silence a turn that is still open")
+    func staleSawResult() {
+        let run = UnfinishedRun.of(
+            status: 0, sawResult: true, state: .running, stderr: "", command: ""
+        )
+
+        #expect(run?.leftATurnOpen == true)
+    }
+
+    /// The CLI holds a blocked turn open until it gets an answer. Once the pipe is gone the answer
+    /// can never arrive, so `waiting` is as abandoned as `running` is.
+    @Test("a turn blocked on a question is abandoned too")
+    func waitingIsMidTurn() {
+        let run = UnfinishedRun.of(
+            status: 0, sawResult: false, state: .waiting, stderr: "", command: ""
+        )
+
+        #expect(run?.leftATurnOpen == true)
+    }
+
+    @Test("an exit that said something is reported in its own words, not as silence")
+    func spokeOnTheWayOut() throws {
+        let run = UnfinishedRun.of(
+            status: 0, sawResult: false, state: .running,
+            stderr: "Error: the weekly limit has been reached", command: ""
+        )
+
+        let unfinished = try #require(run)
+        #expect(unfinished.wasSilent == false)
+        #expect(unfinished.message.contains("weekly limit"))
+        #expect(unfinished.subtype == UnfinishedRun.exitSubtype)
+    }
+
+    @Test("whitespace on stderr is not something said")
+    func blankStderrIsSilence() {
+        let run = UnfinishedRun.of(
+            status: 0, sawResult: false, state: .running, stderr: "  \n \n", command: ""
+        )
+
+        #expect(run?.wasSilent == true)
+    }
+
+    // MARK: The row
+
+    @Test("the payload is what AgentExit reads back")
+    func payloadRoundTrips() throws {
+        let run = try #require(UnfinishedRun.of(
+            status: 0, sawResult: false, state: .running, stderr: "", command: "/opt/bin/claude"
+        ))
+
+        let exit = AgentExit.decode(run.payload)
+        #expect(exit.cause == .endedMidTurn)
+        #expect(exit.command == "/opt/bin/claude")
+        #expect(exit.title == "Turn never finished")
+        #expect(exit.summary.contains("middle of this turn"))
+        #expect(exit.advice.contains("still in the worktree"))
+        #expect(exit.advice.contains("/opt/bin/claude"))
+    }
+
+    /// A status of nought must not be drawn as "Agent exited (0)", which reads as nothing having
+    /// gone wrong next to a turn that never finished.
+    @Test("a clean status is never drawn as a clean ending")
+    func cleanStatusIsNotACleanEnding() throws {
+        let run = try #require(UnfinishedRun.of(
+            status: 0, sawResult: false, state: .running, stderr: "", command: ""
+        ))
+
+        #expect(AgentExit.decode(run.payload).title.contains("(0)") == false)
+    }
+
+    @Test("a run that spoke on the way out keeps the old payload shape")
+    func spokenPayloadIsAProcessExit() throws {
+        let run = try #require(UnfinishedRun.of(
+            status: 1, sawResult: false, state: .running, stderr: "Error: no credentials", command: ""
+        ))
+
+        let exit = AgentExit.decode(run.payload)
+        #expect(exit.status == 1)
+        #expect(exit.cause == .reported("Error: no credentials"))
+    }
+}


### PR DESCRIPTION
Reported as "sometimes the AI just stops dead in the water", with a screenshot of a chat whose last row is a tool call with no result under it, an idle composer, and a status bar saying 3 running.

The `claude` child exits mid turn with a clean status. `AgentRunner.finish` only drew an error row when the status was non-zero, so a clean exit took the quiet branch: the session row went idle and nothing at all was yielded to the sink. `TranscriptModel` therefore never ran its error or result arm, `isRunning` stayed true for the rest of the launch, the label stayed "Working", the subagent roster was never ended, and the running count kept counting. That is the "3 running" with nothing running.

Evidence, from a copy of the owner's database taken the way `Tools/dev-db.sh` takes one: four sessions stop dead within 35 seconds of each other, each on a `content_block_start`, with no result and no error after it, and nothing until he typed again minutes later. The whole database contains no rows of kind `error` at all. The CLI's own log got further than Bloom did, so what was lost was buffered stdout on exit, and `ps` shows the processes serving those sessions started at the moment he typed rather than when the turns did.

The test is no longer the exit status but whether a turn was open when the process went away, read off `SessionState.isMidTurn`. That also covers two cases the old rule missed: `sawResult` is one flag per run, so it goes stale true after the first turn a long lived process closes, and a session waiting on a permission question can never be answered once the pipe is gone.

What killed four processes in one window is not established. Every one of those turns carried a seven day rate limit notice at 99% utilisation, which is the obvious suspect, but its payload says allowed, no stderr survived and there are no crash reports. The fix deliberately does not depend on knowing: a process that goes away mid turn is worth saying whatever took it.

No heartbeat for a child that is alive but silent. Nothing in the evidence shows that case, and a timer that guessed would be a claim Bloom cannot support.