### PR TITLE
Nothing that touches the branch is pressable while an agent is writing

### DIFF
--- a/Sources/Bloom/Views/Inspector/PullRequestBar.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestBar.swift
@@ -94,7 +94,7 @@ struct PullRequestBar: View {
                 worktree: model.workspace.path,
                 localWork: model.localWork,
                 isWorking: isWorking,
-                isAgentBusy: model.isRunning,
+                branchActions: branchActions,
                 onMerge: merge,
                 onPush: push,
                 onFixConflicts: { fixConflicts(on: pullRequest) },
@@ -106,12 +106,25 @@ struct PullRequestBar: View {
                 branch: model.workspace.branch,
                 baseBranch: model.workspace.baseBranch,
                 isWorking: isWorking || model.isLoadingPullRequest,
-                isAgentBusy: model.isRunning,
+                branchActions: branchActions,
                 worktree: model.workspace.path,
                 hasChanges: hasChanges,
                 action: createPullRequest
             )
         }
+    }
+
+    /// Whether the strip's buttons may touch this branch, decided once for the whole band.
+    ///
+    /// `AppModel.isRunning` rather than `model.isRunning`, though both answer the same question
+    /// with the same rule (`AgentTurns`, over every chat in the workspace, so a workspace with
+    /// four of them is busy if any one is mid turn). It is the one observable mirror every busy
+    /// reader in this window shares, rebuilt whole by `recomputeAgentTurns` from the session rows
+    /// and the live transcripts, so the strip greys out at the same moment the sidebar's row and
+    /// the menu bar say the agent started. A second route to the same fact is how this app came
+    /// to have three answers to it once already.
+    private var branchActions: BranchActionAvailability {
+        .mayActOnBranch(isAgentBusy: app.isRunning(model.workspace))
     }
 
     /// Whether the branch has anything on it. The inspector's own list first, because it is the

--- a/Sources/Bloom/Views/Inspector/PullRequestCreator.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestCreator.swift
@@ -29,9 +29,10 @@ struct PullRequestCreator: View {
     var branch: String
     var baseBranch: String
     var isWorking: Bool
-    /// The workspace's agent is mid turn. The request is a turn of its own, so it has to wait
-    /// rather than interleave with whatever was asked a moment ago.
-    var isAgentBusy: Bool
+    /// Whether this strip may act on the branch at all. Opening a pull request pushes it, so a
+    /// turn already writing to the worktree holds the button back: see
+    /// `BranchActionAvailability`, which decides it for both halves of this band.
+    var branchActions: BranchActionAvailability
     /// Where a sign in would run, if the quiet line below the branch is pressed.
     var worktree: String
     /// Whether this branch has anything on it at all. A worktree identical to its base has nothing
@@ -171,7 +172,13 @@ struct PullRequestCreator: View {
     /// What the branch is for, in the one line under it: where it is headed, or why the button is
     /// not going to do anything yet.
     private var subtitle: String {
-        hasChanges ? "No pull request yet. Target \(baseBranch)." : "Nothing has changed on this branch yet."
+        // The held back band says so on the line it already has, for the reason
+        // `PullRequestSummary.detailLine` gives: a disabled button that explains itself only on
+        // hover is a button most people never get an explanation from.
+        if let note = branchActions.note { return note }
+        return hasChanges
+            ? "No pull request yet. Target \(baseBranch)."
+            : "Nothing has changed on this branch yet."
     }
 
     /// Tinted explicitly. An untinted `.borderedProminent` follows the system accent on this
@@ -182,17 +189,19 @@ struct PullRequestCreator: View {
             .buttonStyle(.borderedProminent)
             .tint(Palette.accentFill)
             .controlSize(.regular)
-            // Never disabled for a turn that is already running: the request queues behind it.
-            // See `PullRequestStatus.agentBusyReason`. A branch with nothing on it does not draw
-            // this button at all: see `body`.
+            // Held back while a turn runs, like every other button in this band: opening the
+            // pull request pushes the branch, and a worktree being written to as it is read
+            // pushes half of something. See `BranchActionAvailability`. A branch with nothing on
+            // it does not draw this button at all: see `body`.
+            .disabled(!branchActions.isAllowed)
             .help(helpText)
     }
 
     private var helpText: String {
         // The same sentence `PullRequestSummary` shows on the buttons it draws in this band once
         // there is a pull request, from the one place it is written: it is a fact about how all
-        // five of these buttons work rather than about this one.
-        if isAgentBusy { return PullRequestStatus.agentBusyReason }
+        // of these buttons work rather than about this one.
+        if let reason = branchActions.reason { return reason }
         // No path named. There are two, the project's own and Bloom's copy of the default, and
         // which one is in play is not something a tooltip should be teaching anybody.
         return "Ask this workspace's agent to push the branch and open a pull request against "

--- a/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
@@ -26,12 +26,13 @@ struct PullRequestSummary: View {
     /// still running, which is not the same as "nothing", and is drawn as nothing extra.
     var localWork: LocalWork?
     var isWorking: Bool
-    /// The workspace's agent is mid turn. Every button in this strip works by composing a turn
-    /// and sending it, and an agent runs one turn at a time, so a press made now joins the chat's
-    /// queue and goes when this turn ends. That is what the buttons say while it is true;
-    /// `PullRequestCreator` takes the same fact for the same reason, and both say it in the same
-    /// words: `PullRequestStatus.agentBusyReason`.
-    var isAgentBusy: Bool
+    /// Whether this strip may act on the branch at all, decided once for the whole band.
+    ///
+    /// Every button here works by composing a turn and sending it, and what the agent then does
+    /// is commit, push, merge, cut a branch or bring the base in. While a turn is already running
+    /// none of that may start: see `BranchActionAvailability`, which holds the reason and the
+    /// words. `PullRequestCreator` takes the same value for the same reason.
+    var branchActions: BranchActionAvailability
     var onMerge: (GitHub.MergeMethod) -> Void
     /// Hands the outstanding work to the workspace's agent to commit and push.
     var onPush: () -> Void
@@ -171,7 +172,7 @@ struct PullRequestSummary: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
 
-            if let detail = status.detail {
+            if let detail = detailLine {
                 Text(detail)
                     .font(Typo.caption)
                     // Grey, and deliberately so: it is a count read off the headline above it, and
@@ -188,6 +189,16 @@ struct PullRequestSummary: View {
         .help(helpText)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityText)
+    }
+
+    /// The one line under the headline, and what takes it over while the agent is working.
+    ///
+    /// A band that is holding its buttons back says so here rather than only in a tooltip.
+    /// "1 check passed" is a fact that will still be true in a minute, and a reader looking at
+    /// four greyed out controls is asking a different question. Nobody hovers a disabled control
+    /// to find out why it is disabled unless they already suspect the answer.
+    private var detailLine: String? {
+        branchActions.note ?? status.detail
     }
 
     /// The one prominent control, whichever it is, and whatever stands beside it.
@@ -214,8 +225,19 @@ struct PullRequestSummary: View {
     /// split button normally carries its chevron on the trailing side. That is worth giving up,
     /// because the alternative is the trailing edge belonging to a 19 point chevron rather than
     /// to the button, which is exactly the misalignment being fixed.
-    @ViewBuilder
     private var trailing: some View {
+        // Disabled here, for the cluster, rather than on each button in it. Everything in this
+        // slot ends in a turn that writes to the worktree or the branch, so it is one question,
+        // and a control added to the cluster later inherits the answer instead of having to
+        // remember to ask it. `BranchActionAvailability` carries what is held back and why.
+        // Nothing outside this slot is touched: the number, the arrow out to the browser and the
+        // strip's own context menu only ever read.
+        trailingControls
+            .disabled(!branchActions.isAllowed)
+    }
+
+    @ViewBuilder
+    private var trailingControls: some View {
         if isWorking {
             ProgressView()
                 .controlSize(.small)
@@ -299,8 +321,9 @@ struct PullRequestSummary: View {
             .tint(tint ?? Palette.accent)
             .controlSize(.regular)
             .help(
-                "Cut a new branch from \(baseBranch) in this worktree and carry on, keeping this "
-                    + "workspace's session, its setup and anything uncommitted."
+                branchActions.reason
+                    ?? "Cut a new branch from \(baseBranch) in this worktree and carry on, "
+                        + "keeping this workspace's session, its setup and anything uncommitted."
             )
     }
 
@@ -340,8 +363,9 @@ struct PullRequestSummary: View {
             .tint(status.tone.fill)
             .controlSize(.regular)
             .help(
-                "Remove this workspace's worktree. #\(pullRequest.number) is merged, so this asks "
-                    + "first only when something here exists nowhere else."
+                branchActions.reason
+                    ?? "Remove this workspace's worktree. #\(pullRequest.number) is merged, so "
+                        + "this asks first only when something here exists nowhere else."
             )
     }
 
@@ -373,11 +397,11 @@ struct PullRequestSummary: View {
             .buttonStyle(.borderedProminent)
             .tint(status.tone.fill)
             .controlSize(.regular)
-            // Not disabled mid turn. See `PullRequestStatus.agentBusyReason`.
+            // Disabled with the rest of the cluster while a turn runs: pushing a worktree that
+            // is being written to as it is read publishes half of something.
             .help(
-                isAgentBusy
-                    ? PullRequestStatus.agentBusyReason
-                    : "Ask this workspace's agent to \(pushLabel.lowercased()) branch "
+                branchActions.reason
+                    ?? "Ask this workspace's agent to \(pushLabel.lowercased()) branch "
                         + "\(pullRequest.branch.isEmpty ? "this branch" : pullRequest.branch), so "
                         + "#\(pullRequest.number) is what is on this disk."
             )
@@ -433,11 +457,11 @@ struct PullRequestSummary: View {
             .buttonStyle(.borderedProminent)
             .tint(status.tone.fill)
             .controlSize(.regular)
-            // Not disabled mid turn. See `PullRequestStatus.agentBusyReason`.
+            // Disabled with the rest of the cluster while a turn runs: merging the base into a
+            // worktree an agent is editing is the same collision as the button above it.
             .help(
-                isAgentBusy
-                    ? PullRequestStatus.agentBusyReason
-                    : "Ask this workspace's agent to bring \(baseBranch) into this worktree and "
+                branchActions.reason
+                    ?? "Ask this workspace's agent to bring \(baseBranch) into this worktree and "
                         + "resolve the conflicts here. Nothing is pushed and #\(pullRequest.number)"
                         + " is not merged."
             )
@@ -460,7 +484,9 @@ struct PullRequestSummary: View {
         // reads as a stray control that wandered into the strip.
         .foregroundStyle(tint ?? Palette.accent)
         .controlSize(.small)
-        .disabled(!status.canMerge || isAgentBusy)
+        // A running agent is not in here: `trailing` disables the whole cluster for that, so the
+        // chevron and the button beside it can never disagree about it.
+        .disabled(!status.canMerge)
         .help(blockedReason ?? "Merge #\(pullRequest.number), by whichever method")
     }
 
@@ -493,8 +519,8 @@ struct PullRequestSummary: View {
             .buttonStyle(.borderedProminent)
             .tint(status.tone.fill)
             .controlSize(.regular)
-            // A busy agent is not in here any more, only a pull request GitHub will not merge.
-            // See `PullRequestStatus.agentBusyReason`.
+            // Only what GitHub says about the pull request. A running agent is the cluster's
+            // answer rather than this button's: see `trailing`.
             .disabled(!status.canMerge)
             // Disabled controls do not explain themselves, and "why is this greyed out" is the
             // whole question a blocked pull request raises.
@@ -505,11 +531,11 @@ struct PullRequestSummary: View {
 
     /// What the Merge button has to say for itself, or nil when there is nothing.
     ///
-    /// The busy turn comes first. It is true of every button in this strip rather than of one of
-    /// them, and it is the reason that goes away on its own, so a reader hovering while their
-    /// agent is working is told where their press will land rather than told about a draft.
+    /// The running agent comes first. It is true of every button in this strip rather than of one
+    /// of them, and it is the reason that goes away on its own, so a reader hovering while their
+    /// agent is working is told what they are waiting for rather than told about a draft.
     private var blockedReason: String? {
-        isAgentBusy ? PullRequestStatus.agentBusyReason : status.blockedReason
+        branchActions.reason ?? status.blockedReason
     }
 
     /// The title belongs somewhere, and a tooltip on the state is where: it answers "which pull

--- a/Sources/BloomCore/GitHub/PullRequestStatus.swift
+++ b/Sources/BloomCore/GitHub/PullRequestStatus.swift
@@ -60,21 +60,10 @@ public struct PullRequestStatus: Sendable, Hashable {
         case fixConflicts
     }
 
-    /// What the strip's buttons say about themselves while the workspace's agent is mid turn.
-    ///
-    /// Here rather than in the two views that say it, because it is one fact about how every one
-    /// of these buttons works: none of them does anything itself, they all compose a turn, and an
-    /// agent runs one turn at a time. `PullRequestCreator` and `PullRequestSummary` both show it,
-    /// and a sentence written out twice is a sentence that gets improved once.
-    ///
-    /// **They used to be dead while it said this, and are not any more.** A disabled button and a
-    /// press that quietly refused were two ways of saying the same thing, and both of them left
-    /// somebody pressing again to find out whether the first press had counted. The turn goes into
-    /// the chat's queue instead, drawn above the composer as a pending message that says when it
-    /// goes and can be cancelled there. See `WorkspaceModel.requestPullRequest`.
-    public static let agentBusyReason =
-        "The agent is working. The request is sent as a turn, so it waits in the queue for this "
-            + "one to finish."
+    // A running agent is not one of the reasons in here: everything in this type is what GitHub
+    // says about the pull request. Whether the strip's buttons may be pressed while this
+    // workspace's agent is mid turn is `BranchActionAvailability`, which answers for the whole
+    // band at once and carries the reason a reader is given.
 
     public init(
         tone: Tone,

--- a/Sources/BloomCore/Presentation/BranchActionAvailability.swift
+++ b/Sources/BloomCore/Presentation/BranchActionAvailability.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Whether the pull request strip may act on this workspace's branch right now.
+///
+/// **One answer for the whole strip, rather than one `if` per button.** Every control in that
+/// band ends in the same place: a turn is composed and sent, and the agent then commits, pushes,
+/// merges, cuts a fresh branch or brings the base in. So the question is asked once, here, and
+/// the strip disables its action cluster on the answer. A button added to that cluster later is
+/// disabled by the cluster rather than by remembering to ask, which is the failure this shape
+/// exists to make impossible.
+///
+/// **Why a running agent is a no.** Merging while an agent is still writing to the worktree
+/// merges a branch whose commits may not all be pushed yet, and it is the kind of mistake that
+/// cannot be undone from inside the app: the commits land on somebody else's branch and the
+/// branch they came from is deleted on the server. The rest of the band is the same mistake a
+/// step short of the server. Commit and push publishes a worktree that is being written to as it
+/// is read, Fix merge conflicts merges the base into that worktree, Continue cuts a new branch
+/// out from under the turn, and Archive deletes the worktree entirely.
+///
+/// **This reverses an earlier decision, deliberately.** These buttons were live mid turn on the
+/// argument that a press queues rather than refusing: the turn goes into the chat's queue, drawn
+/// above the composer, and runs when the current one ends. That is a good answer for asking an
+/// agent to do more work and a bad one for landing a branch, because what the reader saw when
+/// they pressed is not what the queued turn will act on. The queue still exists and the composer
+/// still uses it; the strip's branch actions wait instead.
+///
+/// Nothing that only navigates or reveals is covered by this. The pull request number, the arrow
+/// out to the browser, Copy link and Share, the inspector's own tabs: none of them touches the
+/// worktree, and a reader whose agent is working still wants to read.
+public struct BranchActionAvailability: Sendable, Hashable {
+    /// Whether the strip's branch actions may be pressed.
+    public var isAllowed: Bool
+
+    /// A few words for the strip's own line, where somebody reads it without hovering.
+    ///
+    /// Nil when acting is allowed, and then the strip keeps whatever it says about itself
+    /// ("1 check passed", the branch's target). A disabled control that explains itself only on
+    /// hover is a control most people never get an explanation from, so the reason takes the one
+    /// line of text the band already has for as long as it is true.
+    public var note: String?
+
+    /// The whole of it, for the tooltip every disabled control in the band carries.
+    public var reason: String?
+
+    public init(isAllowed: Bool, note: String? = nil, reason: String? = nil) {
+        self.isAllowed = isAllowed
+        self.note = note
+        self.reason = reason
+    }
+
+    /// Nothing in the way.
+    public static let allowed = BranchActionAvailability(isAllowed: true)
+
+    /// The one decision, for the whole strip.
+    ///
+    /// One parameter today. It is a function rather than a computed property on the flag because
+    /// the next reason to hold the band back (a rebase in flight, a worktree being archived) is a
+    /// second argument here and nothing at all at any call site.
+    public static func mayActOnBranch(isAgentBusy: Bool) -> BranchActionAvailability {
+        guard isAgentBusy else { return .allowed }
+        return BranchActionAvailability(
+            isAllowed: false,
+            note: "The agent is still writing here.",
+            reason: "The agent is still writing to this worktree. Merging or pushing now would "
+                + "act on a branch whose commits may not all be pushed yet, and none of that can "
+                + "be undone from in here. It comes back when the turn ends."
+        )
+    }
+}

--- a/Tests/BloomCoreTests/BranchActionAvailabilityTests.swift
+++ b/Tests/BloomCoreTests/BranchActionAvailabilityTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// Whether the pull request strip may act on the branch.
+///
+/// The report: the green Merge button, and the red Fix merge conflicts button beside the same
+/// headline, were both live while the workspace's agent was mid turn. Merging there lands a
+/// branch whose commits may not all be pushed yet and deletes it on the server, which is the one
+/// thing this app offers that cannot be undone from inside it.
+@Suite("Whether the branch may be acted on")
+struct BranchActionAvailabilityTests {
+    @Test("An idle workspace may act, and says nothing about it")
+    func idleAllows() {
+        let availability = BranchActionAvailability.mayActOnBranch(isAgentBusy: false)
+        #expect(availability.isAllowed)
+        #expect(availability.note == nil)
+        #expect(availability.reason == nil)
+    }
+
+    @Test("A running agent holds every branch action back")
+    func busyBlocks() {
+        #expect(!BranchActionAvailability.mayActOnBranch(isAgentBusy: true).isAllowed)
+    }
+
+    /// Both of them, because they are two different readers. The note is read off the strip by
+    /// somebody who never hovers anything; the reason is what the disabled control answers with
+    /// when they do.
+    @Test("It says why, on the strip and in the tooltip")
+    func busyExplainsItself() {
+        let availability = BranchActionAvailability.mayActOnBranch(isAgentBusy: true)
+        #expect(availability.note?.isEmpty == false)
+        #expect(availability.reason?.isEmpty == false)
+        #expect(availability.reason?.contains("worktree") == true)
+    }
+
+    /// The note shares one line of a strip that is exactly one row tall, beside a headline that
+    /// must not be the thing that truncates. A sentence is not what goes there.
+    @Test("The note is short enough for the line it takes over")
+    func noteIsShort() {
+        let note = BranchActionAvailability.mayActOnBranch(isAgentBusy: true).note ?? ""
+        #expect(note.count <= 40)
+    }
+
+    @Test("Allowed is the same answer as an idle workspace")
+    func allowedMatchesIdle() {
+        #expect(BranchActionAvailability.mayActOnBranch(isAgentBusy: false) == .allowed)
+    }
+}


### PR DESCRIPTION
Asked for: while the AI is busy the Merge button should not be enabled. It can be shown, but disabled. Then: the same for Fix merge conflicts, and probably for any button in that band.

So it is one answer for the whole cluster rather than a check per button. `BranchActionAvailability.mayActOnBranch(isAgentBusy:)` lives in BloomCore with its tests, and returns whether the band may act, a short note for the line under the headline, and the full sentence for a tooltip. The cluster carries one `.disabled`, so a control added there later inherits it rather than having to remember.

Disabled while a turn runs: Merge and its method chevron, Fix merge conflicts, Commit and push, Push, Continue, Archive, Create pull request. Every one of those either writes to the worktree or moves the branch, and merging a branch whose commits may not all be pushed yet cannot be undone from inside the app.

Left alone: the pull request number and the arrow to the browser, the Draft chip, the context menu, Copy Branch Name, and the inspector's own tabs. Navigating and revealing are safe while an agent works, and a control that vanishes is a control somebody hunts for.

Busy is `AppModel.runningWorkspaceIDs`, which is the mirror every busy reader in the window shares, so the band greys out in the same frame as the sidebar's running mark.

The reason is visible rather than implied: the line under the headline says "The agent is still writing here." while it is true, and each disabled control's tooltip carries the longer sentence.