### PR TITLE
Stop drawing the settings gear over every project's mark

### DIFF
--- a/Sources/Bloom/Views/Sidebar/RepoHeaderRow.swift
+++ b/Sources/Bloom/Views/Sidebar/RepoHeaderRow.swift
@@ -319,6 +319,16 @@ struct RepoHeaderRow: View {
     /// Nothing is lost with the pointer away, and that matters more here than it did at the
     /// trailing edge: Project settings… is on this header's own context menu, and File carries
     /// Project Settings at Command Shift comma.
+    ///
+    /// THE INK IS THE CALLER'S AND MUST NOT BE SET HERE. This carried its own
+    /// `.foregroundStyle(Palette.textPrimary)`, which sits nearer the label than the
+    /// `Color.clear` in `mark` above and therefore won every time: the gear was drawn in full
+    /// ink on top of every project's tile, at rest, on every row. It reads as a badly rendered
+    /// mark rather than as a stray control, which is how it survived: a project whose mark is
+    /// artwork came out muddy with a cog stamped through it, and a pale one came out as an
+    /// unreadable grey square. The same artwork in the project's settings window, where there is
+    /// no gear over it, was crisp, so the fault looked like the sidebar rasterising the picture
+    /// badly and was nothing of the kind.
     private var settingsButton: some View {
         Button {
             openWindow(id: RepoSettingsWindow.id, value: repo.id)
@@ -333,7 +343,6 @@ struct RepoHeaderRow: View {
                 .contentShape(RoundedRectangle(cornerRadius: Metrics.cornerSmall))
         }
         .buttonStyle(.plain)
-        .foregroundStyle(Palette.textPrimary)
         .help("Settings for \(repo.name)")
     }
 


### PR DESCRIPTION
Reported: a project's mark renders badly in the sidebar and correctly in the project settings window. One project's artwork came out muddy, another's came out as an unreadable grey square.

It is not rasterisation. Both places draw the same view, the same NSImage, from the same cache, and an SVG keeps its vector representation and is re-rendered per request at the display scale. That was checked before anything was changed.

The header row stacks the project's mark and a settings gear and swaps them on hover, drawing the gear in `Color.clear` at rest. The gear then set its own ink at the end of its own body, which is nearer the label and therefore wins, so the caller's clear never applied: the gear was drawn in full ink, at rest, on top of every project's mark, on every row. A dark cog stamped through the artwork is exactly "muddy", and over a pale mark it is exactly "an unreadable grey square". The settings window has no gear over it, which is why it looked right there.

One deleted modifier, plus a comment saying why it must not come back.