### PR TITLE
Bring a hidden project back when work is added to it

### DIFF
--- a/Sources/Bloom/State/AppModel+Workspaces.swift
+++ b/Sources/Bloom/State/AppModel+Workspaces.swift
@@ -252,6 +252,21 @@ extension AppModel {
             self.notice = BloomNotice(message: notice)
         }
 
+        // Said out loud, because this is a preference the owner set that Bloom has just undone,
+        // and the workspace that undid it can have been asked for by an agent on the bridge with
+        // nobody watching. A banner is exactly what `BloomNotice` is for: something the app did
+        // that the user did not ask for and should still know about.
+        //
+        // After the sea rather than before it, so it wins when a first voyage and a project
+        // coming back land together. One of the two is a project changing state under the reader
+        // and the other is decoration.
+        if started.projectCameBack {
+            self.notice = BloomNotice(
+                message: "\(repo.name) is back in Bloom's sidebar. It was hidden, and this "
+                    + "workspace has just been added to it."
+            )
+        }
+
         // The files come across whichever mode asked for the workspace.
         //
         // This used to be inside the `.chat` branch below, so a workspace opened as a terminal

--- a/Sources/BloomCore/Workspace/ProjectVisibility.swift
+++ b/Sources/BloomCore/Workspace/ProjectVisibility.swift
@@ -70,6 +70,29 @@ public enum ProjectVisibility {
         }
     }
 
+    /// Whether a project comes back into the sidebar because a workspace has just been added to
+    /// it.
+    ///
+    /// This does not argue with the paragraph at the top of this file, it follows from it. Hiding
+    /// says "there is nothing going on in this project and the column is 260 points wide". Cutting
+    /// a worktree in it is that stopping, and the row this new workspace lives in is the one place
+    /// in the window the sidebar would be leaving out. The case it was written for is an agent
+    /// calling `workspace_start` over the bridge: the owner did not ask for the workspace, so
+    /// nobody is watching for it, and the only routes back to a hidden project are a filter menu
+    /// and `project_unhide`, neither of which anybody reaches for to find something they do not
+    /// know exists.
+    ///
+    /// It is narrow on purpose. One boolean on one row, only when that row actually says hidden,
+    /// and nothing else about hiding changes: the project keeps its place in the stored order
+    /// (see above), the workspaces of every other hidden project stay exactly where they were,
+    /// and nothing here ever hides anything.
+    ///
+    /// Nil is a project that is no longer in the database, which a create racing a project removal
+    /// can produce, and a project that is gone is not one to bring back.
+    public static func comesBack(_ project: Repo?) -> Bool {
+        project?.hidden == true
+    }
+
     /// What hiding this project would leave the sidebar showing, for a caller that cannot see it.
     ///
     /// The bridge's two tools say this out loud, because an agent hiding the last visible project

--- a/Sources/BloomCore/Workspace/WorkspaceManager.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 public enum WorkspaceError: Error, CustomStringConvertible {
     case notARepository(String)
@@ -79,6 +80,54 @@ public struct WorkspaceManager: Sendable {
         )
         return try await store.upsert(repo)
     }
+
+    /// Puts a project back in the sidebar, because a workspace has just been added to it.
+    ///
+    /// Called by both places a workspace arrives in a project's list, `start` and `restore`, and
+    /// it decides for itself: the answer is `ProjectVisibility.comesBack`, which is where the
+    /// argument for doing this at all is written down. Callers say what happened rather than
+    /// asking first, so there is one place that reads the row and one place that writes it.
+    ///
+    /// **The row is read again here rather than taken from the `Repo` the caller is holding.**
+    /// That value can be minutes old, because it came off the sidebar, out of a create sheet
+    /// somebody left open, or through the bridge from a `project_list` earlier in the same turn,
+    /// and `project_hide` can have landed on the real row since. A stale copy would answer this
+    /// question about a project as it used to be.
+    ///
+    /// **`update(repoID:)`, and only when the fresh row says hidden.** The first half is the
+    /// store's rule: this runs while a diff stat refresh, an icon walk and a rename may each be
+    /// holding their own copy of the same row, and a whole-value write would carry every one of
+    /// their columns back. The second half is why the read above is not wasted work: `update`
+    /// writes and the store announces every commit, so an unconditional write here would tick the
+    /// change hub on every workspace ever created and wake every observer of `repos` to say
+    /// nothing at all.
+    ///
+    /// Returns whether the project actually came back, so a caller with a window can tell the
+    /// owner that Bloom has just undone something they chose.
+    @discardableResult
+    func bringProjectBack(_ repoID: RepoID) async -> Bool {
+        // The rule answers for a project that is no longer there as well, so the read is handed
+        // to it as it came back; the binding after it is only what the log needs.
+        let stored = try? await store.repo(id: repoID)
+        guard ProjectVisibility.comesBack(stored), let stored else { return false }
+        // Nil is the row having gone between the read and the write, which is a project removed
+        // under this and not a project that came back.
+        guard (try? await store.update(repoID: repoID) { $0.hidden = false }) != nil else {
+            return false
+        }
+        // A line in Console because the owner hid this project on purpose and Bloom has just
+        // reversed that without being asked. Logged `public` for the reason `RefusedTransitions`
+        // gives: a project's name is not anybody's data, and a redacted line is the same silence
+        // in a different font.
+        Self.log.info("showing \(stored.name, privacy: .public) again: a workspace was added to it")
+        return true
+    }
+
+    /// Where a project coming back into the sidebar says so. See `bringProjectBack`.
+    private static let log = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "be.spatie.bloom",
+        category: "workspace"
+    )
 
     // MARK: - Creating workspaces
 

--- a/Sources/BloomCore/Workspace/WorkspaceRestore.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceRestore.swift
@@ -239,6 +239,15 @@ public extension WorkspaceManager {
             $0.restore(to: path, hasSetupScript: settings.setupScript != nil)
         }
         guard let restored = updated else { throw WorkspaceError.workspaceGone(workspace.name) }
+
+        // A restore counts as a workspace being added to the project, even though the row was
+        // already there. The archived list is not the sidebar: this workspace was in no project's
+        // list a moment ago and is in one now, which is the event `bringProjectBack` is about. The
+        // case that settles it is the caller: `AppModel.restore` selects the workspace it just
+        // brought back, and a selected row inside a hidden project is a selection the sidebar
+        // cannot draw.
+        await bringProjectBack(repo.id)
+
         return RestoreOutcome(
             workspace: restored,
             source: source,

--- a/Sources/BloomCore/Workspace/WorkspaceStart.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceStart.swift
@@ -102,17 +102,25 @@ public struct StartedWorkspace: Sendable {
     /// different things to tell a caller, and a false meaning either of them is how a workspace
     /// with no dependencies installed gets reported as fine.
     public var setupSucceeded: Bool?
+    /// Whether the project had to come back into the sidebar to hold this workspace.
+    ///
+    /// True only when it was hidden and this workspace is the reason it is not any more, so a
+    /// caller with a window can say so out loud rather than leaving a preference the owner set to
+    /// change behind their back. See `ProjectVisibility.comesBack`.
+    public var projectCameBack: Bool
 
     public init(
         workspace: Workspace,
         session: Session? = nil,
         placeholder: String? = nil,
-        setupSucceeded: Bool? = nil
+        setupSucceeded: Bool? = nil,
+        projectCameBack: Bool = false
     ) {
         self.workspace = workspace
         self.session = session
         self.placeholder = placeholder
         self.setupSucceeded = setupSucceeded
+        self.projectCameBack = projectCameBack
     }
 }
 
@@ -169,6 +177,14 @@ extension WorkspaceManager {
             checkout: request.checkout
         )
 
+        // Here rather than inside `createWorkspace`, for the reason that method's own comment
+        // gives: it is the lower half, the worktree and the row and nothing else, and which list
+        // the window draws the row in is orchestration. This is the one route every caller takes,
+        // the sheet, a `bloom://` link, the Services menu, a Shortcut and the bridge alike, so
+        // both ways a worktree can be made, cut and checkout, are covered by the one call. See
+        // `bringProjectBack`.
+        let projectCameBack = await bringProjectBack(request.repo.id)
+
         var session: Session?
         if request.opensSession {
             let controls = request.controls
@@ -211,7 +227,8 @@ extension WorkspaceManager {
             workspace: workspace,
             session: session,
             placeholder: placeholder,
-            setupSucceeded: setupSucceeded
+            setupSucceeded: setupSucceeded,
+            projectCameBack: projectCameBack
         )
     }
 }

--- a/Tests/BloomCoreTests/ProjectVisibilityTests.swift
+++ b/Tests/BloomCoreTests/ProjectVisibilityTests.swift
@@ -106,3 +106,149 @@ struct HiddenProjectStoreTests {
         #expect(!fresh.hidden)
     }
 }
+
+/// The rule that takes a project back out of hiding, which is the one thing hiding does not
+/// survive: a workspace being added to the project.
+@Suite("A project that comes back")
+struct ProjectReturnTests {
+    @Test("a hidden project comes back and a showing one is left where it is")
+    func theRule() {
+        let hidden = Repo(name: "bloom", path: "/Users/me/dev/bloom", hidden: true)
+        let showing = Repo(name: "flare", path: "/Users/me/dev/flare")
+
+        #expect(ProjectVisibility.comesBack(hidden))
+        #expect(!ProjectVisibility.comesBack(showing))
+    }
+
+    /// A create racing a project removal ends here. There is no sidebar row to bring back and
+    /// nothing to write to.
+    @Test("a project that is no longer in the database is not brought back")
+    func aProjectThatHasGone() {
+        #expect(!ProjectVisibility.comesBack(nil))
+    }
+}
+
+/// The write behind that rule. Both halves matter: which columns move, and whether anything is
+/// written at all.
+@Suite("A project that comes back, written", .tags(.persistence), .scratchDirectory)
+struct ProjectReturnStoreTests {
+    @Test("the flag is cleared and no other column moves with it")
+    func writesOneColumn() async throws {
+        let store = try makeTestStore("comes-back")
+        let manager = WorkspaceManager(store: store)
+        let project = try await store.upsert(
+            Repo(name: "bloom", path: "/tmp/bloom", sortOrder: 3, hidden: true)
+        )
+        // Everything a slower writer could have landed on this row while a worktree was being
+        // cut, none of which a project coming back is allowed to carry away.
+        _ = try await store.update(repoID: project.id) {
+            $0.name = "Bloom"
+            $0.iconPath = "/tmp/bloom/icon.png"
+            $0.iconSource = .chosen
+        }
+
+        #expect(await manager.bringProjectBack(project.id))
+
+        let stored = try #require(try await store.repo(id: project.id))
+        #expect(!stored.hidden)
+        #expect(stored.name == "Bloom")
+        #expect(stored.iconPath == "/tmp/bloom/icon.png")
+        // Its place in the sidebar's order is not something coming back changes either.
+        #expect(stored.sortOrder == 3)
+    }
+
+    /// `update` writes every time it is called and the store announces every commit, so a project
+    /// that is already showing must not be written at all: an unconditional write would wake every
+    /// subscriber of `repos` on every workspace ever created, to say nothing.
+    @Test("a project that is already showing is not written")
+    func showingProjectIsLeftAlone() async throws {
+        let store = try makeTestStore("comes-back-showing")
+        let manager = WorkspaceManager(store: store)
+        let project = try await store.upsert(Repo(name: "flare", path: "/tmp/flare"))
+
+        #expect(await manager.bringProjectBack(project.id) == false)
+        #expect(try await store.repo(id: project.id)?.hidden == false)
+    }
+
+    @Test("a project that is no longer stored is not brought back")
+    func missingProjectIsNotWritten() async throws {
+        let manager = WorkspaceManager(store: try makeTestStore("comes-back-missing"))
+
+        #expect(await manager.bringProjectBack(RepoID.new()) == false)
+    }
+}
+
+/// The two places a workspace arrives in a project's list, against a real repository.
+@Suite(
+    "A project that comes back, in the routes that add a workspace",
+    .tags(.git), .scratchDirectory
+)
+struct ProjectReturnRouteTests {
+    private func makeManager(
+        _ label: String
+    ) async throws -> (repo: TempRepo, registered: Repo, manager: WorkspaceManager, store: Store) {
+        let repo = try await TempRepo()
+        let store = try makeTestStore(label)
+        let manager = WorkspaceManager(store: store)
+        let registered = try await manager.addRepository(at: repo.path)
+        return (repo, registered, manager, store)
+    }
+
+    /// The case the whole change is for: something on the bridge asks for a workspace in a project
+    /// the sidebar is leaving out, and the row it makes would be in no list anybody is looking at.
+    ///
+    /// The `Repo` handed to `start` is the copy read before the project was hidden, deliberately,
+    /// because a stale copy is what every real caller holds. The stored row is what decides.
+    @Test("starting a workspace in a hidden project brings it back, and says so")
+    func startingBringsTheProjectBack() async throws {
+        let (repo, registered, manager, store) = try await makeManager("comes-back-start")
+        defer { repo.cleanUp() }
+        _ = try await store.update(repoID: registered.id) { $0.hidden = true }
+
+        let started = try await manager.start(WorkspaceStartRequest(
+            repo: registered,
+            prompt: "Fix the flaky test",
+            origin: .ownerClient(spawnToolUseID: "toolu_1"),
+            opensSession: false
+        ))
+
+        #expect(started.projectCameBack)
+        #expect(try await store.repo(id: registered.id)?.hidden == false)
+        #expect(ProjectVisibility.listed(try await store.repos(), showingHidden: false).count == 1)
+        #expect(try await store.workspaces().map(\.id) == [started.workspace.id])
+    }
+
+    @Test("starting a workspace in a project that is showing reports nothing")
+    func startingInAShowingProjectReportsNothing() async throws {
+        let (repo, registered, manager, store) = try await makeManager("comes-back-start-showing")
+        defer { repo.cleanUp() }
+
+        let started = try await manager.start(WorkspaceStartRequest(
+            repo: registered, prompt: "Fix the flaky test", origin: .user, opensSession: false
+        ))
+
+        #expect(started.projectCameBack == false)
+        #expect(try await store.repo(id: registered.id)?.hidden == false)
+    }
+
+    /// A restore counts. The row already existed, but it was in no project's list a moment ago and
+    /// is in one now, and the caller selects it: a selected row inside a hidden project is a
+    /// selection the sidebar cannot draw.
+    @Test(
+        "restoring an archived workspace into a hidden project brings it back",
+        .tags(.destructive)
+    )
+    func restoringBringsTheProjectBack() async throws {
+        let (repo, registered, manager, store) = try await makeManager("comes-back-restore")
+        defer { repo.cleanUp() }
+        let workspace = try await manager.createWorkspace(repo: registered, prompt: "Archive me")
+
+        try await manager.archive(workspace: workspace, repo: registered, deleteBranch: false)
+        _ = try await store.update(repoID: registered.id) { $0.hidden = true }
+
+        try await manager.restore(workspace: workspace, repo: registered)
+
+        #expect(try await store.repo(id: registered.id)?.hidden == false)
+        #expect(try await store.workspaces().contains { $0.id == workspace.id })
+    }
+}


### PR DESCRIPTION
Asked for: when a workspace is added to a hidden project, which can happen over MCP, unhide the project.

Hiding is a view preference and not archiving, and this sits inside that argument rather than against it: the owner tidied a project out of the sidebar, and then work arrived in it. A workspace that cannot be seen where somebody will look for it is worse than a slightly longer list.

`ProjectVisibility.comesBack` is the rule, in the file that carries the argument for what hiding means. `WorkspaceManager.bringProjectBack` re-reads the row before deciding, because the caller's copy can be minutes old and a hide can have landed since, and writes with `update(repoID:)` so the other columns are not carried back with it. It writes nothing when the project is already showing, so an ordinary create does not tick the change hub for nothing.

It hangs off `WorkspaceManager.start` rather than the lower half that makes the row, because every route (the sheet, `bloom://`, the Services menu, Shortcuts and the bridge) goes through `start`, and both worktree paths run under it.

Restoring from the archive counts too. The row already existed, but it was in no visible list a moment ago, it is in one now, and the restore selects it: a selected row inside a hidden project is a selection the sidebar cannot draw.

It says so out loud, in the log and in the existing notice band: the project was hidden on purpose and Bloom has just undone that.