### PR TITLE
Give the project settings window a real toolbar

### DIFF
--- a/Sources/Bloom/Views/RepoSettings/RepoSettingsPane.swift
+++ b/Sources/Bloom/Views/RepoSettings/RepoSettingsPane.swift
@@ -1,0 +1,54 @@
+import AppKit
+import Foundation
+
+/// Which of the three parts of a project's settings is showing.
+///
+/// A type of its own rather than an enum nested inside the view, because three things outside
+/// that view now answer to it: the toolbar that draws the choice, the window that has to say
+/// which item is selected, and a capture run that names the pane it wants photographed.
+///
+/// Named `Pane` rather than `Tab` because `Tab` is SwiftUI's own type, and because these are not
+/// tabs any more: they are toolbar items. See `RepoSettingsToolbar` for why.
+enum RepoSettingsPane: String, CaseIterable, Hashable {
+    case project
+    case workspaces
+    case scripts
+
+    /// The word under the icon.
+    var title: String {
+        switch self {
+        case .project: "Project"
+        case .workspaces: "Workspaces"
+        case .scripts: "Scripts"
+        }
+    }
+
+    /// The symbol above that word. A preference toolbar is icons with their words underneath, so
+    /// every pane has to have one, which is why this is not optional.
+    var systemImage: String {
+        switch self {
+        case .project: "folder"
+        case .workspaces: "square.stack.3d.up"
+        case .scripts: "terminal"
+        }
+    }
+
+    /// What this pane is called inside the toolbar.
+    ///
+    /// Derived from the case rather than written out a second time in a table beside it. An
+    /// identifier that disagrees with its case is a toolbar item that draws and cannot be
+    /// selected, which is a fault with nothing on screen to say what went wrong.
+    var itemIdentifier: NSToolbarItem.Identifier {
+        NSToolbarItem.Identifier("repo-settings.\(rawValue)")
+    }
+
+    /// Which pane a window opens on, from `BLOOM_PANE=workspaces|scripts`.
+    ///
+    /// A capture run can open this window through `--repo-settings` and cannot press anything in
+    /// it, so without this the other two panes go in unverified. Nil for anything else, including
+    /// nothing at all, and the window falls back to Project.
+    static var requested: RepoSettingsPane? {
+        guard let named = ProcessInfo.processInfo.environment["BLOOM_PANE"] else { return nil }
+        return RepoSettingsPane(rawValue: named)
+    }
+}

--- a/Sources/Bloom/Views/RepoSettings/RepoSettingsTitleBar.swift
+++ b/Sources/Bloom/Views/RepoSettings/RepoSettingsTitleBar.swift
@@ -2,15 +2,14 @@ import AppKit
 import SwiftUI
 import BloomCore
 
-/// Gives the project settings window an ordinary Mac title bar, above its tab bar.
+/// Gives the project settings window an ordinary Mac title bar, above the row that chooses a pane.
 ///
-/// A `TabView` at the root of a window hands its tab bar to the title bar, and SwiftUI hides the
-/// window's title when it does. The title is not lost, only undrawn: `navigationTitle` still sets
-/// `NSWindow.title`, and the window carries the right string the whole time. So the tab bar and a
-/// title are not in competition for one row, and the belief that a window has to choose between
-/// them is wrong. Making the title visible again and asking for the toolbar style a preferences
-/// window uses gives the title a row of its own with the tab bar centred underneath, which is the
-/// shape of the app's own Settings window and the reason a `TabView` was chosen here.
+/// The title and that row are not in competition for one place, which is the belief this modifier
+/// exists to correct. A title lives on its own line and `.preference` puts the toolbar under it,
+/// so the window can have both and the app's own Settings window is the proof. The title itself
+/// is never lost, only undrawn: `navigationTitle` sets `NSWindow.title` whatever else is on the
+/// window, so making it visible again is all this has to do about it. The toolbar under it, and
+/// the style that puts it there, are `RepoSettingsToolbar`.
 ///
 /// The folder comes along as the window's `representedURL`, so the title bar behaves like every
 /// document window on the Mac: the proxy icon beside the title drags into a terminal or an editor,
@@ -20,17 +19,17 @@ import BloomCore
 /// It also refuses the system's window tabbing, which is the one thing on this window that nobody
 /// asked for. macOS groups windows of the same class into one tabbed window by default, so opening
 /// settings for a second project merged it into the first as a tab, and a `+` beside it offered a
-/// third. This window is one project's, and it already has a tab bar of its own directly above:
-/// two rows of tabs, one meaning "which part of this project" and the other "which project", read
-/// as one row meaning neither. There is nothing to gain here from the system's row either, since
-/// the app's own tab bar is what a settings window is for. `.disallowed` is per window rather than
-/// `NSWindow.allowsAutomaticWindowTabbing = false`, which would be the app speaking for windows
-/// this file knows nothing about.
+/// third. This window is one project's, and it already has a row of its own directly above saying
+/// which part of it is showing: two rows, one meaning "which part of this project" and the other
+/// "which project", read as one row meaning neither. There is nothing to gain here from the
+/// system's row either, since the window's own three panes are what a settings window is for.
+/// `.disallowed` is per window rather than `NSWindow.allowsAutomaticWindowTabbing = false`, which
+/// would be the app speaking for windows this file knows nothing about.
 ///
-/// AppKit rather than SwiftUI because SwiftUI models none of the three things this needs.
-/// `windowToolbarStyle` has no case for the preferences style, nothing in SwiftUI un-hides a title
-/// the framework decided to hide, and there is no scene modifier for tabbing at all.
-/// `WindowChrome` reaches for the main window's title bar the same way and for the same reason.
+/// AppKit rather than SwiftUI because SwiftUI models neither of the two things this needs. Nothing
+/// in SwiftUI un-hides a title the framework decided to hide, and there is no scene modifier for
+/// tabbing at all. `WindowChrome` reaches for the main window's title bar the same way and for the
+/// same reason.
 struct RepoSettingsTitleBar: ViewModifier {
     let repo: Repo
 
@@ -50,7 +49,6 @@ struct RepoSettingsTitleBar: ViewModifier {
         // The title itself stays `navigationTitle`'s to set, so there is one place that decides
         // what this window is called.
         window.titleVisibility = .visible
-        window.toolbarStyle = .preference
         window.representedURL = URL(filePath: repo.path)
         window.tabbingMode = .disallowed
         // Refusing tabbing decides what may happen to this window next, not what has already

--- a/Sources/Bloom/Views/RepoSettings/RepoSettingsToolbar.swift
+++ b/Sources/Bloom/Views/RepoSettings/RepoSettingsToolbar.swift
@@ -1,0 +1,153 @@
+import AppKit
+import SwiftUI
+
+/// The project settings window's three panes, drawn as the toolbar macOS gives a preferences
+/// window: icons with their words underneath, centred under the title.
+///
+/// **What was there before, and why it was not this.** The window held a SwiftUI `TabView`, which
+/// is what the app's own Settings window holds, on the reasoning that the same construct in two
+/// windows makes them read as one app. The reasoning was right and the construct is not what
+/// decides it: what a `TabView` comes out as depends on the scene it is in. In the `Settings`
+/// scene it is an `NSToolbar`, measured, and `SettingsView` carries that measurement. This window
+/// is a `WindowGroup`, and there the same code drew a rounded strip inside the content with the
+/// chosen pane in a darker pill, which is what the report that started this was a screenshot of.
+/// Setting `NSWindow.toolbarStyle = .preference` beside it changed nothing, and could not: a
+/// style is a statement about a toolbar, and asking for one without putting a toolbar on the
+/// window leaves nothing for it to be about. So one app had two settings windows whose top rows
+/// were drawn by two different things, and the report said exactly that: it looked like nothing
+/// else in Bloom, and it did not look like the Mac either.
+///
+/// **Why the toolbar and not `PanelTabs`**, which is Bloom's own strip and would have been three
+/// lines. `PanelTabs` is a control for the inside of a panel: it divides a width it is handed
+/// between two or three words, and it is drawn in Bloom's own greys precisely because the things
+/// around it are Bloom's. This row is not inside anything. It is the chrome at the top of a
+/// window, next to a title, a proxy icon and the traffic lights, and the nearest thing to it in
+/// this app is not a panel at all, it is the app's own Settings window one menu item away. Using
+/// Bloom's strip here would have made the two settings windows differ in a second way rather than
+/// stop them differing in the first, and it would have put a hand drawn control in the one row of
+/// this window that belongs to the system. The place Bloom draws its own tabs is where it owns
+/// what is around them.
+///
+/// **AppKit rather than SwiftUI, because SwiftUI models none of this.** There is no `.preference`
+/// case in `windowToolbarStyle`, and no SwiftUI toolbar item can be *selected*: the whole
+/// mechanism is `toolbarSelectableItemIdentifiers` plus `NSToolbar.selectedItemIdentifier`, which
+/// AppKit exposes and SwiftUI does not wrap. `RepoSettingsTitleBar` reaches for the same window
+/// for the same reason and says so at more length.
+@MainActor
+final class RepoSettingsToolbar: NSObject, NSToolbarDelegate {
+    /// Told which pane was clicked. Set by the modifier below, which is where the selection lives.
+    var onChoose: (RepoSettingsPane) -> Void = { _ in }
+
+    private let preferenceToolbar = NSToolbar(identifier: "repo-settings")
+
+    override init() {
+        super.init()
+        // Icons with their words under them. `.preference` asks for this shape anyway, but a
+        // toolbar that says so itself cannot be talked out of it by a saved configuration.
+        preferenceToolbar.displayMode = .iconAndLabel
+        // There is nothing here a user could sensibly rearrange: three panes, in the order the
+        // window's own sentence about them goes.
+        preferenceToolbar.allowsUserCustomization = false
+        preferenceToolbar.delegate = self
+    }
+
+    /// Mounts the toolbar and moves its selection to `pane`.
+    ///
+    /// Idempotent, and both halves are guarded, because this runs on every change the window or
+    /// the selection reports. Assigning `window.toolbar` again rebuilds every item, and assigning
+    /// `selectedItemIdentifier` the value it already holds is what turns a click into a loop:
+    /// AppKit moves the selection itself when a selectable item is clicked, that tells the view,
+    /// and the view comes straight back here to say so.
+    func install(on window: NSWindow, showing pane: RepoSettingsPane) {
+        if window.toolbar !== preferenceToolbar {
+            window.toolbar = preferenceToolbar
+        }
+        // Set here rather than beside the title, because the style is a statement about this
+        // toolbar: `.preference` is the one that puts the label under the icon and the whole row
+        // under the title, instead of on the title's own line.
+        window.toolbarStyle = .preference
+        if preferenceToolbar.selectedItemIdentifier != pane.itemIdentifier {
+            preferenceToolbar.selectedItemIdentifier = pane.itemIdentifier
+        }
+    }
+
+    // MARK: - NSToolbarDelegate
+
+    func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        RepoSettingsPane.allCases.map(\.itemIdentifier)
+    }
+
+    func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        toolbarDefaultItemIdentifiers(toolbar)
+    }
+
+    /// All three, which is what makes the toolbar behave like a row of tabs rather than a row of
+    /// buttons: one of them is lit at any moment, and clicking another moves the light.
+    func toolbarSelectableItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        toolbarDefaultItemIdentifiers(toolbar)
+    }
+
+    func toolbar(
+        _ toolbar: NSToolbar,
+        itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
+        willBeInsertedIntoToolbar flag: Bool
+    ) -> NSToolbarItem? {
+        guard let pane = RepoSettingsPane.allCases.first(where: { $0.itemIdentifier == itemIdentifier })
+        else { return nil }
+
+        let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+        item.label = pane.title
+        item.paletteLabel = pane.title
+        item.image = NSImage(
+            systemSymbolName: pane.systemImage, accessibilityDescription: pane.title
+        )
+        item.target = self
+        item.action = #selector(choose(_:))
+        return item
+    }
+
+    /// The item is asked which pane it is rather than carrying an index in its `tag`, so nothing
+    /// here depends on the order the three were inserted in.
+    @objc private func choose(_ sender: NSToolbarItem) {
+        guard let pane = RepoSettingsPane.allCases
+            .first(where: { $0.itemIdentifier == sender.itemIdentifier })
+        else { return }
+        onChoose(pane)
+    }
+}
+
+/// Mounts the toolbar on the window this view is in, and keeps its selection and the view's the
+/// same one.
+private struct RepoSettingsToolbarInstaller: ViewModifier {
+    @Binding var pane: RepoSettingsPane
+
+    @State private var window: NSWindow?
+    @State private var toolbar = RepoSettingsToolbar()
+
+    func body(content: Content) -> some View {
+        content
+            .background(WindowAccessor(window: $window))
+            // The window is attached a pass after the view exists, so the first of these is what
+            // mounts the toolbar at all, and `initial` is what makes it fire for a window that
+            // was already there. The second carries a selection this view moved, which is every
+            // way into a pane except a click on the toolbar itself.
+            .onChange(of: window, initial: true) { _, _ in apply() }
+            .onChange(of: pane) { _, _ in apply() }
+    }
+
+    private func apply() {
+        // Refreshed rather than set once, because the closure holds the binding it was made with
+        // and a modifier is rebuilt on every update of the view above it.
+        toolbar.onChoose = { pane = $0 }
+        guard let window else { return }
+        toolbar.install(on: window, showing: pane)
+    }
+}
+
+extension View {
+    /// Draws the project settings window's three panes in its title bar, the way a Mac
+    /// preferences window draws its own. See `RepoSettingsToolbar`.
+    func choosesPaneInTheTitleBar(_ pane: Binding<RepoSettingsPane>) -> some View {
+        modifier(RepoSettingsToolbarInstaller(pane: pane))
+    }
+}

--- a/Sources/Bloom/Views/RepoSettings/RepoSettingsView.swift
+++ b/Sources/Bloom/Views/RepoSettings/RepoSettingsView.swift
@@ -8,8 +8,10 @@ import BloomCore
 ///
 /// Three panes rather than one long scroll, because the three are different kinds of thing and
 /// nobody arrives here wanting all of them: what the project IS, what a new workspace STARTS with,
-/// and what Bloom RUNS in it. The tab bar is the one macOS draws for a `TabView`, and it is the
-/// same control the app's own Settings window is built from, so the two windows read as one app.
+/// and what Bloom RUNS in it. Which one is showing is chosen in the title bar, from the same
+/// toolbar the app's own Settings window is chosen from, so the two windows read as one app. It
+/// is an `NSToolbar` rather than the `TabView` that used to be here, and `RepoSettingsToolbar`
+/// says what the difference between those two turned out to be.
 ///
 /// Two kinds of setting live here and they are stored in two different places, which the screen is
 /// explicit about. The name, mark and colour are Bloom's own record of a folder and live in its
@@ -39,16 +41,9 @@ struct RepoSettingsView: View {
     /// same place. See `RepoMonogram.initials(for:)` for what counts as one, which is a single
     /// leading pictograph and nothing else.
     @State private var name = ""
-    /// Which pane a window opens on. `BLOOM_PANE=workspaces|scripts` for a capture run, because
-    /// `--repo-settings` can open this window but cannot press a tab, and a tab nobody can
-    /// photograph is a tab that changes unverified. Anything else, including nothing, is Project.
-    @State private var pane: Pane = {
-        switch ProcessInfo.processInfo.environment["BLOOM_PANE"] {
-        case "workspaces": return .workspaces
-        case "scripts": return .scripts
-        default: return .project
-        }
-    }()
+    /// Which pane the window is showing. What a capture run can ask for, and why, is on
+    /// `RepoSettingsPane.requested`.
+    @State private var pane: RepoSettingsPane = RepoSettingsPane.requested ?? .project
     @State private var isConfirmingRemove = false
     /// What the last thing the Mark row did came to, when it came to nothing. Cleared as soon as
     /// something else is pressed, because it is about that press and not about the project.
@@ -62,15 +57,6 @@ struct RepoSettingsView: View {
         _model = State(initialValue: RepoSettingsModel(repo: repo))
     }
 
-    /// Which pane is showing. An enum rather than an index, so the value says what it selects.
-    ///
-    /// Named `Pane` because `Tab` is SwiftUI's own type, and the tabs below are declared with it.
-    private enum Pane: Hashable {
-        case project
-        case workspaces
-        case scripts
-    }
-
     /// Long enough that the scripts are readable, and no wider than the longest sentence in the
     /// window wants: the rows themselves no longer care how wide it is, since `SettingsRow` keeps
     /// a field beside its label at any width, but a footer set across a very wide pane does not
@@ -80,31 +66,34 @@ struct RepoSettingsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            TabView(selection: $pane) {
-                Tab("Project", systemImage: "folder", value: Pane.project) {
+            // One pane at a time, switched on rather than laid out by a `TabView`. The row that
+            // chooses is the window's toolbar now, and a `TabView` under it would draw a second
+            // row of its own; see `RepoSettingsToolbar`. What that costs is a pane rebuilt on
+            // every return to it, and it costs nothing that can be typed away: every field here
+            // is bound to `RepoSettingsModel`, which outlives all three.
+            Group {
+                switch pane {
+                case .project:
                     Form {
                         projectSection
                         filesSection
                         removeSection
                     }
                     .settingsForm()
-                }
-
-                Tab("Workspaces", systemImage: "square.stack.3d.up", value: Pane.workspaces) {
+                case .workspaces:
                     Form {
                         RepoFilesToCopySection(model: model)
                         branchSection
                     }
                     .settingsForm()
-                }
-
-                Tab("Scripts", systemImage: "terminal", value: Pane.scripts) {
+                case .scripts:
                     Form {
                         RepoScriptsSection(model: model)
                     }
                     .settingsForm()
                 }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             Hairline()
             RepoSettingsSaveBar(model: model)
@@ -113,9 +102,10 @@ struct RepoSettingsView: View {
         .frame(minWidth: Self.minimumSize.width, minHeight: Self.minimumSize.height)
         // There is one of these windows per project, so the window has to say which project it
         // belongs to. It says it the way every other Mac window does, in its own title, above the
-        // tab bar rather than instead of it. See `RepoSettingsTitleBar`.
+        // row that chooses a pane rather than instead of it. See `RepoSettingsTitleBar`.
         .navigationTitle("\(repo.name) Settings")
         .showsProjectInTitleBar(repo)
+        .choosesPaneInTheTitleBar($pane)
         .task {
             // The stored name verbatim. Nothing is written back on load, so a project whose name
             // begins with an emoji keeps it whether or not this window is ever opened.


### PR DESCRIPTION
Reported: the project settings window's toolbar is unique in its design, and that does not look like the intention.

Nothing bespoke was ever drawn. Both settings windows are the same `TabView`, written that way on purpose to get the shape of the app's own Settings window, and what a `TabView` comes out as depends on the scene rather than on the code. In a `Settings` scene SwiftUI realises it as a real `NSToolbar`, which is what the app's own settings window gets. The project settings window is a `WindowGroup`, where the identical code draws SwiftUI's own tab bar inside the content: the rounded strip with the chosen pane in a darker pill. Setting `toolbarStyle = .preference` could not rescue it, because a style is a statement about a toolbar and there was no toolbar on that window to make it about.

So the window owns a real `NSToolbar` now, with the three panes as selectable items, icons over their words, and `.preference` set beside it rather than in a file that cannot see it. The pane enum moves out of the view, since three things read it.

Not `PanelTabs`, and the file says why: that control is drawn in Bloom's own greys because what surrounds it is Bloom's, and this row sits beside a title, a proxy icon and the traffic lights. Using it here would have made the two settings windows differ in a second way rather than stop them differing in the first.