### PR TITLE
Let the inspector's header arrive with the pane rather than before it

### DIFF
--- a/Sources/Bloom/Design/Theme.swift
+++ b/Sources/Bloom/Design/Theme.swift
@@ -723,12 +723,41 @@ enum Metrics {
 
 /// How a pane arrives and leaves.
 ///
-/// One curve for the inspector and for the terminal panel, because two panes that move at
-/// different speeds read as two apps. Short and without overshoot: a pane is furniture, and
-/// furniture that springs is a toy. Call sites drop it for Reduce Motion rather than substituting
-/// a slower one, because the setting is about movement, not about speed.
+/// One curve for every pane SwiftUI draws, because two panes that move at different speeds read as
+/// two apps. Short and without overshoot: a pane is furniture, and furniture that springs is a
+/// toy. Call sites drop it for Reduce Motion rather than substituting a slower one, because the
+/// setting is about movement, not about speed.
+///
+/// The inspector column is the one pane not on this curve, and it is not on it because it is not
+/// SwiftUI's: it is an `NSSplitViewItem` collapsing under AppKit's own animator. `inspector` below
+/// is the number that movement actually runs at, and what it exists for is that something SwiftUI
+/// draws has to travel with it.
 enum Motion {
     static let pane: Animation = .easeOut(duration: 0.18)
+
+    /// The inspector column arriving and leaving, and the pull request band arriving with it.
+    ///
+    /// Two halves of one movement, drawn by two frameworks. The column is an `NSSplitViewItem`
+    /// under AppKit's animator; the band along the top of it is a title bar accessory drawn in
+    /// SwiftUI, because it sits in the title bar rather than inside the pane. That is why they used
+    /// to arrive at different times: the band was drawn or it was not, with nothing in between, so
+    /// it appeared whole on the frame the toolbar button was pressed and the column spent a quarter
+    /// of a second sliding in underneath it. The owner's words were "bit jarring now".
+    ///
+    /// So the number lives here rather than inside either of them, and both read it:
+    /// `DetailSplitViewController` sets it on the `NSAnimationContext` the collapse runs in, and
+    /// `TitleBarStrip` slides the band with it.
+    ///
+    /// A quarter of a second is what an `NSAnimationContext` defaults to, which is what the column
+    /// has always collapsed in, so writing it down changes nothing about how the pane feels. It is
+    /// deliberately not `pane`: this movement belongs to the split view and the band is joining it,
+    /// and a speed chosen here that the split view then declined to use would put the two halves
+    /// back out of step, which is the whole bug.
+    static let inspectorSeconds: TimeInterval = 0.25
+
+    /// `inspectorSeconds` as SwiftUI states it. `easeInEaseOut` is the curve the animation context
+    /// is given below, and both frameworks spell that as the same cubic.
+    static let inspector: Animation = .easeInOut(duration: inspectorSeconds)
 
     /// A hover state fading in, and a disclosure settling. See the sidebar rows.
     ///

--- a/Sources/Bloom/Views/Chrome/Window/DetailSplitViewController.swift
+++ b/Sources/Bloom/Views/Chrome/Window/DetailSplitViewController.swift
@@ -229,16 +229,24 @@ final class DetailSplitViewController: NSSplitViewController {
         inspectorHost.view.postsFrameChangedNotifications = true
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(publishInspectorWidth),
+            selector: #selector(paneFrameChanged),
             name: NSView.frameDidChangeNotification,
             object: inspectorHost.view
         )
     }
 
-    @objc private func publishInspectorWidth() {
-        let pane = inspectorHost.view
-        let width = inspectorItem.isCollapsed ? 0 : pane.frame.width
-        InspectorGeometry.shared.setInspectorWidth(width)
+    /// A drag or a resize. Never a slide: the pane is where it is, and the title bar should follow
+    /// it this frame rather than a quarter of a second from now.
+    @objc private func paneFrameChanged() {
+        publishInspectorWidth(collapsed: inspectorItem.isCollapsed, sliding: false)
+    }
+
+    /// `collapsed` is passed in rather than read back off the item, because the animated setter
+    /// below is told where the pane is going and "where is it now" is a question with two
+    /// defensible answers while it is on its way there.
+    private func publishInspectorWidth(collapsed: Bool, sliding: Bool) {
+        let width = collapsed ? 0 : inspectorHost.view.frame.width
+        InspectorGeometry.shared.setInspectorWidth(width, sliding: sliding)
     }
 
     func update(detail: AnyView, inspector: AnyView, isInspectorPresented: Bool, animated: Bool) {
@@ -250,12 +258,32 @@ final class DetailSplitViewController: NSSplitViewController {
         // The animated setter runs a layout pass on every frame of the transition, and layout churn
         // is the condition this window has crashed under, so Reduce Motion turns it off rather than
         // merely shortening it.
-        if animated {
-            inspectorItem.animator().isCollapsed = shouldCollapse
-        } else {
+        guard animated else {
             inspectorItem.isCollapsed = shouldCollapse
+            publishInspectorWidth(collapsed: shouldCollapse, sliding: false)
+            return
         }
-        publishInspectorWidth()
+
+        // The two halves of the inspector, started together.
+        //
+        // What the user reads as one thing arriving is drawn by two frameworks: this pane, and the
+        // pull request band, which is a title bar accessory because it sits in the title bar rather
+        // than in the pane. The band used to be drawn or not drawn with nothing in between, so it
+        // appeared whole on the frame the toolbar button was pressed while the pane slid in
+        // underneath it a quarter of a second later. Reported as "bit jarring now", and it was two
+        // events rather than one.
+        //
+        // So both are started inside one animation context, off one duration. The context is given
+        // its numbers rather than left at its defaults for the same reason the band is told about
+        // the slide at all: a length nobody wrote down is a length the two halves are free to
+        // disagree about later. `Motion.inspectorSeconds` is what the default already was, so the
+        // pane keeps exactly the speed it has always collapsed at.
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = Motion.inspectorSeconds
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            inspectorItem.animator().isCollapsed = shouldCollapse
+            publishInspectorWidth(collapsed: shouldCollapse, sliding: true)
+        }
     }
 }
 

--- a/Sources/Bloom/Views/Chrome/Window/TitleBarStrip.swift
+++ b/Sources/Bloom/Views/Chrome/Window/TitleBarStrip.swift
@@ -32,18 +32,39 @@ final class InspectorGeometry {
     /// The inspector pane's width in points, zero while it is collapsed.
     private(set) var width: CGFloat = 0
 
-    /// Called when it moves. Not observation: the reader is an `NSView` frame.
-    @ObservationIgnored var onChange: (() -> Void)?
+    /// The width the band is DRAWN at, which is the last width the pane actually had.
+    ///
+    /// Not `width`, and the difference between them is what lets the band leave rather than
+    /// vanish. A hide publishes a zero on the first frame of the transition, and a band drawn zero
+    /// points wide has not slid out, it has gone. This number is only ever raised, so the band
+    /// keeps its shape for the whole of the slide it is in the middle of.
+    private(set) var bandWidth: CGFloat = Metrics.inspectorWidth
+
+    /// Whether the width just published is the column opening or collapsing, rather than a divider
+    /// drag, a window resize or a launch.
+    ///
+    /// The band animates on this and on nothing else, which is what keeps the two halves one
+    /// movement. A drag has to stay live and a launch has to be instant, and both of those publish
+    /// a width too; only the collapse is a slide. Reduce Motion arrives down this same wire, because
+    /// the split view is the thing told not to animate and it then publishes `false`, so the window
+    /// takes one decision about movement rather than two that can disagree.
+    private(set) var isSliding = false
+
+    /// Called when it moves, and told whether the move is a slide. Not observation: the reader is
+    /// an `NSView` frame.
+    @ObservationIgnored var onChange: ((_ sliding: Bool) -> Void)?
 
     private init() {}
 
     /// Below this the pane is closed or mid animation, and the strip should not be drawn.
     var isVisible: Bool { width > 1 }
 
-    func setInspectorWidth(_ value: CGFloat) {
+    func setInspectorWidth(_ value: CGFloat, sliding: Bool = false) {
         guard abs(width - value) > 0.5 else { return }
         width = value
-        onChange?()
+        if value > 1 { bandWidth = value }
+        isSliding = sliding
+        onChange?(sliding)
     }
 }
 
@@ -80,12 +101,29 @@ struct TitleBarStrip: View {
             if let model = app.selectedModel, inspector.isVisible {
                 PullRequestBar(model: model)
                     // As wide as the pane below it, so the band ends where the pane does and the
-                    // split divider runs out of the bottom of it.
-                    .frame(width: inspector.width, height: height)
+                    // split divider runs out of the bottom of it. `bandWidth` rather than `width`
+                    // because a band on its way out is still a band: see `InspectorGeometry`.
+                    .frame(width: inspector.bandWidth, height: height)
                     .background { ground(for: model) }
+                    // The band arrives the way the pane does, from the window's trailing edge, over
+                    // the same quarter of a second. A transition rather than an offset held on a
+                    // view that is always in the tree, because `PullRequestBar` polls GitHub for as
+                    // long as it is on screen and a band parked off the edge of the window is still
+                    // on screen. Nothing needs to fade: the pane does not, and one movement means
+                    // one movement.
+                    .transition(.offset(x: inspector.bandWidth))
             }
         }
+        // The band is drawn at the width the PANE has, and the accessory gives that width back only
+        // once the band has finished leaving it, so for the frame between those two the two numbers
+        // disagree. This is which edge wins: the band keeps its leading edge rather than being
+        // centred in a frame it has outgrown.
+        .frame(maxWidth: .infinity, alignment: .leading)
         .frame(height: height)
+        // Only a collapse is animated, and only because the split view said so. See
+        // `InspectorGeometry.isSliding`, which is also where Reduce Motion arrives: the split view
+        // is told not to animate, publishes no slide, and this is nil.
+        .animation(inspector.isSliding ? Motion.inspector : nil, value: inspector.isVisible)
         // A separate SwiftUI root: the window's environment does not reach a title bar accessory,
         // so the model is handed in rather than inherited.
         .environment(app)
@@ -135,6 +173,11 @@ struct TitleBarStrip: View {
 final class TitleBarStripController: NSTitlebarAccessoryViewController {
     private let height: CGFloat
 
+    /// The pending end of a slide out: the moment the accessory is allowed to give its width back.
+    /// Cancelled by anything that arrives first, so a hide reversed halfway never shrinks the band
+    /// that is already on its way back in. See `resize`.
+    private var handover: Task<Void, Never>?
+
     init(app: AppModel, height: CGFloat) {
         self.height = height
         super.init(nibName: nil, bundle: nil)
@@ -145,23 +188,51 @@ final class TitleBarStripController: NSTitlebarAccessoryViewController {
         // panes: the accessory container sets this view's frame, and an intrinsic content size only
         // gives autolayout a second opinion about it.
         host.sizingOptions = []
+        // The band slides in and out THROUGH this frame, so for a quarter of a second at each end
+        // it is drawn beyond the accessory's trailing edge. That edge is the window's, so the
+        // window would clip it anyway; clipping here says so rather than relying on it, and costs
+        // nothing at rest because the band is exactly this view's size once it has arrived.
+        host.clipsToBounds = true
         view = host
         layoutAttribute = .trailing
         // What the accessory keeps while the title bar is in its full screen state. Without it the
         // strip is the one thing in the title bar that can be given no height at all.
         fullScreenMinHeight = height
 
-        InspectorGeometry.shared.onChange = { [weak self] in self?.resize() }
-        resize()
+        InspectorGeometry.shared.onChange = { [weak self] sliding in self?.resize(sliding: sliding) }
+        resize(sliding: false)
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("not decoded from a nib") }
 
+    /// Follows the pane's width, and lags it by exactly one slide when the pane is going away.
+    ///
     /// One point rather than zero when there is nothing to show, so the accessory is never a view
     /// of no size at all in the title bar's layout. On Home and on Search that is what it is.
-    private func resize() {
+    ///
+    /// The lag is the whole reason this is not a one line setter. The band leaves through this
+    /// frame, so taking the frame away on the first frame of the slide cuts the band off instead of
+    /// letting it go, which is the same pop at the other end of the movement. Only a collapse
+    /// waits: a divider drag publishes `sliding` false and has to stay live, or the band trails the
+    /// divider by a quarter of a second the whole time it is being dragged.
+    private func resize(sliding: Bool) {
+        handover?.cancel()
         let width = max(InspectorGeometry.shared.width, 1)
+        guard sliding, width < view.frame.width else {
+            apply(width)
+            return
+        }
+        handover = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(Motion.inspectorSeconds))
+            guard !Task.isCancelled else { return }
+            // Asked again rather than closed over: a hide reversed before it finished has already
+            // published the width this should settle at, and that is the number to land on.
+            self?.apply(max(InspectorGeometry.shared.width, 1))
+        }
+    }
+
+    private func apply(_ width: CGFloat) {
         guard abs(view.frame.width - width) > 0.5 else { return }
         view.setFrameSize(NSSize(width: width, height: height))
         view.superview?.needsLayout = true


### PR DESCRIPTION
The green pull request band appeared whole on the frame the inspector toggle was pressed, while the tabs and the file tree slid in underneath it. Two events, because they are drawn by two frameworks: the band is a title bar accessory (`TitleBarStrip`), not the pane's first row, so the split view's collapse never reached it.

The collapse and the band now start together, in one `NSAnimationContext`, off one duration in `Motion`. The band slides in from the window's trailing edge the way the pane does, as a transition rather than as an offset held on a view that never leaves, because `PullRequestBar` polls GitHub for as long as it is on screen.

`InspectorGeometry` carries the two numbers that made that possible: the width the band is drawn at, which does not drop to zero when the pane's does, and whether the change is a slide at all, so a divider drag stays live, a launch stays instant, and Reduce Motion cuts straight through (the split view is the one thing told not to animate, and the band takes that decision from it rather than reading the setting a second time).

The accessory gives its width back one slide late, and only for a collapse, because the band leaves through that frame.

Not verified by eye yet: this is a motion change and wants a short recording of the window, not a still.