### PR TITLE
Keep the sidebar for agents, and leave the shell commands out of it

### DIFF
--- a/Sources/BloomCore/Transcript/SubagentRetention.swift
+++ b/Sources/BloomCore/Transcript/SubagentRetention.swift
@@ -10,6 +10,9 @@ import Foundation
 /// and the sidebar had become a log of a turn that was still running. A sidebar is a navigation
 /// surface. Eight finished rows is a transcript in the wrong pane.
 ///
+/// Before any of that: a backgrounded shell command has no row at all, whatever state it is in.
+/// See `keeps`. The rest of this file is about the rows that remain, which are agents.
+///
 /// So a finished row goes, with three exemptions, each of which is a thing you would otherwise
 /// have to go and look for.
 ///
@@ -74,9 +77,11 @@ public enum SubagentRetention: Sendable {
     /// How many of this turn's subagents failed, whether or not they still have a row.
     ///
     /// What the workspace row says, and the reason the cap above is safe: the count is of every
-    /// failure, so the three crosses and the number never disagree about how bad it was.
+    /// failure, so the three crosses and the number never disagree about how bad it was. Every
+    /// failure this pane would ever draw, that is: a background command has no row here, so
+    /// counting one would put a number on the workspace row that nothing under it explains.
     public static func failureCount(_ roster: SubagentRoster) -> Int {
-        roster.subagents.count { $0.state == .failed }
+        roster.subagents.count { $0.kind == .agent && $0.state == .failed }
     }
 
     /// When the row set next changes on its own, or nil when nothing is on a clock.
@@ -105,6 +110,16 @@ public enum SubagentRetention: Sendable {
     private static func keeps(
         _ subagent: Subagent, now: Date, opened: SubagentID?, failuresKept: inout Int
     ) -> Bool {
+        // A backgrounded shell command never has a row. Both arrive on `system/task_started` and
+        // `SubagentKind` is what tells them apart, so the pane had been drawing whichever the CLI
+        // happened to start: three lines reading `agent-browser set viewport 1440 900 >/dev/null`
+        // under a workspace, two of them crossed, which is a shell log in a navigation pane. What
+        // this pane is for is the other AI working on the workspace, and a command is not one.
+        // The roster still holds them and the transcript still draws their panes, both unchanged:
+        // the command's output is worth reading, it is just not worth a permanent row beside the
+        // workspace it was run in.
+        guard subagent.kind == .agent else { return false }
+
         if subagent.state == .failed {
             let kept = subagent.id == opened || failuresKept < failureLimit
             if kept { failuresKept += 1 }

--- a/Tests/BloomCoreTests/SubagentRetentionTests.swift
+++ b/Tests/BloomCoreTests/SubagentRetentionTests.swift
@@ -31,6 +31,19 @@ import Foundation
         return SubagentRoster(subagents)
     }
 
+    /// The same row, started as a backgrounded shell command rather than as an agent. `local_bash`
+    /// is the one word the CLI uses for it, and `SubagentKind` matches it exactly.
+    private func command(
+        _ id: String,
+        state: SubagentState = .running,
+        finishedAt: Date? = nil,
+        summary: String = ""
+    ) -> Subagent {
+        Subagent(id: SubagentID(id), description: "agent-browser open \"/settings\"",
+                 taskType: "local_bash", state: state, summary: summary,
+                 outputFile: "/x", finishedAt: finishedAt)
+    }
+
     private func ids(_ rows: [SubagentRow]) -> [String] { rows.map(\.id.rawValue) }
 
     // MARK: Working rows are never touched
@@ -244,6 +257,52 @@ import Foundation
         #expect(SubagentRetention.failureCount(roster) == 3)
         let later = now.addingTimeInterval(600)
         #expect(SubagentRetention.rows(roster, now: later).count == 3)
+    }
+
+    // MARK: A shell command is not a subagent
+
+    /// `system/task_started` is sent for a Task subagent and for a backgrounded shell command
+    /// alike, and `task_type` is the only field between them. The pane had been drawing both, so
+    /// three rows reading `agent-browser set viewport 1440 900 >/dev/null` stood under a
+    /// workspace, two of them crossed. This pane is for the other AI working on the workspace.
+    @Test func aBackgroundedShellCommandNeverHasARow() {
+        let roster = SubagentRoster([
+            command("1"),
+            command("2", state: .failed, finishedAt: Self.start, summary: "exit 1"),
+            command("3", state: .completed, finishedAt: Self.start, summary: "exit 0"),
+        ])
+        #expect(SubagentRetention.rows(roster, now: Self.start).isEmpty)
+    }
+
+    /// Including one somebody opened. The exemption that keeps an opened row is about a reader
+    /// looking at a row this pane drew, and it never drew this one.
+    @Test func evenAnOpenedCommandHasNoRow() {
+        let roster = SubagentRoster([command("1", state: .failed, finishedAt: Self.start)])
+        #expect(SubagentRetention.rows(roster, now: Self.start, opened: SubagentID("1")).isEmpty)
+    }
+
+    /// The agents beside it are untouched, which is the half that has to keep working.
+    @Test func theAgentsBesideItKeepTheirRows() {
+        let roster = SubagentRoster([subagent("1"), command("2"), subagent("3")])
+        #expect(ids(SubagentRetention.rows(roster, now: Self.start)) == ["1", "3"])
+    }
+
+    /// A failed command must not put a number on the workspace row that nothing under it explains.
+    @Test func aFailedCommandIsNotCountedOnTheWorkspaceRow() {
+        let roster = SubagentRoster([
+            command("1", state: .failed, finishedAt: Self.start),
+            command("2", state: .failed, finishedAt: Self.start),
+            subagent("3", state: .failed, finishedAt: Self.start),
+        ])
+        #expect(SubagentRetention.failureCount(roster) == 1)
+    }
+
+    /// Nothing is on a clock for a row that was never drawn, so no sweep is scheduled for one.
+    @Test func aCommandPutsNothingOnTheClock() {
+        let roster = SubagentRoster([
+            command("1", state: .completed, finishedAt: Self.start, summary: "exit 0"),
+        ])
+        #expect(SubagentRetention.nextChange(roster, now: Self.start) == nil)
     }
 }
 


### PR DESCRIPTION
`system/task_started` is sent for a Task subagent and for a backgrounded shell command alike, and `task_type` is the only field between them. The sidebar drew both, so three rows reading `agent-browser set viewport 1440 900 >/dev/null` stood under a workspace, two of them crossed, and the failure count on the workspace row included them.

The pane is for the other AI working on the workspace, so a command has no row in it, in any state, including one somebody has opened. The roster still holds them and the transcript still draws their panes, both unchanged.