### PR TITLE
List Fable 5, which the rest of the app already knew about

### DIFF
--- a/Sources/Bloom/Views/Center/Composer/ComposerOption.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerOption.swift
@@ -9,6 +9,7 @@ struct ComposerOption: Identifiable, Hashable {
     static let models = [
         ComposerOption(id: "opus", label: "Opus 5"),
         ComposerOption(id: "sonnet", label: "Sonnet 5"),
+        ComposerOption(id: "fable", label: "Fable 5"),
         ComposerOption(id: "haiku", label: "Haiku 4.5"),
     ]
 

--- a/Sources/BloomCore/Agent/ModelAlias.swift
+++ b/Sources/BloomCore/Agent/ModelAlias.swift
@@ -12,7 +12,7 @@ import Foundation
 /// settings file, the Models screen or the composer's picker.
 public enum ModelAlias {
     /// The families the CLI names, in the order a longest-match check needs them.
-    private static let families = ["opus", "sonnet", "haiku"]
+    private static let families = ["opus", "sonnet", "fable", "haiku"]
 
     public static func cliValue(for model: String) -> String {
         let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()

--- a/Tests/BloomCoreTests/ModelAliasTests.swift
+++ b/Tests/BloomCoreTests/ModelAliasTests.swift
@@ -28,7 +28,7 @@ struct ModelAliasTests {
 
     @Test("leaves alone anything the CLI already understands", arguments: [
         // The CLI's own shorthand.
-        "opus", "sonnet", "haiku",
+        "opus", "sonnet", "fable", "haiku",
         // Someone who typed an exact build knows what they want, and rewriting it would be worse
         // than passing it through.
         "claude-opus-5", "claude-opus-5[1m]", "claude-haiku-4-5-20251001",


### PR DESCRIPTION
The composer's model picker offered three models and `ModelAlias.families` held three families, while `ModelLabel` already renders `claude-fable-5` as "Fable 5" and the quota panel already draws a "Week (Fable)" window.

The alias list is the half that was wrong rather than merely incomplete: a settings file saying `fable-5-1m` matched no family, so it went to the CLI verbatim instead of becoming `claude-fable-5[1m]`, which is exactly the failure that header describes happening to `opus-5-1m`.