### PR TITLE
One answer for where the end of a scroll view is

### DIFF
--- a/Sources/Bloom/Design/BusyPulse.swift
+++ b/Sources/Bloom/Design/BusyPulse.swift
@@ -231,4 +231,38 @@ class BusyPulseLayerView: NSView {
         target.removeAnimation(forKey: key)
         target.add(animation, forKey: key)
     }
+
+    /// The pulse every mark here is made of: half a period between the two ends of an envelope the
+    /// core holds, played forwards and then backwards forever.
+    ///
+    /// **It was written twice, as `PulsingDotView.pulse` and `PulsingRuleView.fade`, line for
+    /// line.** They could only ever have been the same: `BusyRule.period` IS `BusyDot.period` by
+    /// construction, so the duration was one number reached down two paths. The frame rate cap is
+    /// the one thing that genuinely differed, so it is a parameter and each caller keeps its own
+    /// argument and the arithmetic behind it.
+    ///
+    /// `easeInEaseOut` and `autoreverses` rather than a keyframed envelope, because both envelopes
+    /// *are* cubic eases and Core Animation's timing functions are cubic beziers. `BusyBreath` is
+    /// sampled instead only because its two eased stretches are power curves, which a bezier could
+    /// approximate and not express. `easeInEaseOut` is symmetric in time, so the return leg is the
+    /// same curve rather than a different one run backwards, and the mark is momentarily still at
+    /// each end.
+    ///
+    /// Half of `period`, because `autoreverses` plays the return leg: one pulse is two of these.
+    final func pulse(
+        _ keyPath: String,
+        from: Double,
+        to: Double,
+        period: TimeInterval,
+        frameRate: CAFrameRateRange
+    ) -> CABasicAnimation {
+        let animation = CABasicAnimation(keyPath: keyPath)
+        animation.fromValue = from
+        animation.toValue = to
+        animation.duration = period / 2
+        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        animation.autoreverses = true
+        animation.preferredFrameRateRange = frameRate
+        return animation
+    }
 }

--- a/Sources/Bloom/Design/JumpProbe.swift
+++ b/Sources/Bloom/Design/JumpProbe.swift
@@ -20,11 +20,11 @@ import BloomCore
 ///     Bloom --jump-probe /tmp/jump.json --jump-workspace <id>
 ///           [--jump-settle 2500] [--window-size 1440x900]
 ///
-/// **The bar is exact and it is not "nearly".** A run passes only when every case ends with the
-/// clip view at the end within `TranscriptAnchor.isAtEnd`'s one point, which is the question
-/// "did the instruction survive" rather than `ScrollEnd.isAtEnd`'s "is the reader still following
-/// along". Ninety points short passes the second and fails the first, and ninety points short is
-/// the newest row half off the bottom of the window.
+/// **The bar is exact and it is not "nearly".** A run passes only where `NSScrollView.isAtEnd`
+/// does, which is `TranscriptAnchor.isAtEnd` asked rather than restated: "did the instruction
+/// survive", not `ScrollEnd.isAtEnd`'s "is the reader still following along". Ninety points short
+/// passes the second and fails this one, and ninety points short is the newest row half off the
+/// bottom of the window.
 ///
 /// Programmatic, and never brought to the front, for the reason at the head of `ProbeHarness`:
 /// the owner is at this Mac while it runs.
@@ -81,7 +81,7 @@ enum JumpProbe {
             harness.fail("no transcript NSScrollView found")
         }
 
-        let travel = ProbeHarness.scrollableHeight(of: scroll)
+        let travel = scroll.endOffset
         guard travel > 1 else {
             harness.fail("the transcript is shorter than its viewport, so there is nowhere to jump from")
         }
@@ -127,7 +127,7 @@ enum JumpProbe {
         // A beat, so the standing instruction is genuinely released by the move above rather than
         // still in force from the last case, which would make this pass without being asked.
         try? await Task.sleep(for: .milliseconds(600))
-        let before = gap(in: scroll)
+        let before = scroll.distanceFromEnd
 
         transcript.jumpToLiveEnd()
         try? await Task.sleep(for: settle)
@@ -146,7 +146,7 @@ enum JumpProbe {
     ) async -> JSONValue {
         put(scroll, at: travel / 2)
         try? await Task.sleep(for: .milliseconds(600))
-        let before = gap(in: scroll)
+        let before = scroll.distanceFromEnd
 
         transcript.jumpToLiveEnd()
         // Deltas across the whole settle, so the tail is still growing when the verdict is taken.
@@ -168,24 +168,18 @@ enum JumpProbe {
     // MARK: - Measuring
 
     private static func verdict(name: String, before: CGFloat, scroll: NSScrollView) -> JSONValue {
-        let after = gap(in: scroll)
+        let after = scroll.distanceFromEnd
         return .object([
             "case": .string(name),
             "pointsFromEndBefore": .number(Double(before)),
             "pointsFromEndAfter": .number(Double(after)),
-            "atEnd": .bool(after <= 1),
+            // The bar itself, asked of the type that owns it rather than written out again here.
+            "atEnd": .bool(scroll.isAtEnd),
             // What the OTHER question would have said, because the two disagreeing is the shape
             // of the bug: a jump that stops ninety points short looks fine to everything that
             // asks whether the reader is following along.
             "wouldPassAsFollowing": .bool(after < ScrollEnd.threshold),
         ])
-    }
-
-    /// How far the bottom of the viewport is from the bottom of the content, in points.
-    private static func gap(in scroll: NSScrollView) -> CGFloat {
-        let content = scroll.documentView?.frame.height ?? 0
-        let viewport = scroll.contentView.bounds.height
-        return max(0, content - scroll.contentView.bounds.origin.y - viewport)
     }
 
     private static func isPass(_ report: JSONValue) -> Bool {

--- a/Sources/Bloom/Design/ProbeHarness.swift
+++ b/Sources/Bloom/Design/ProbeHarness.swift
@@ -211,25 +211,24 @@ struct ProbeHarness {
             for subview in view.subviews { walk(subview) }
         }
         walk(root)
-        return found.max { scrollableHeight(of: $0) < scrollableHeight(of: $1) }
-    }
-
-    static func scrollableHeight(of scroll: NSScrollView) -> CGFloat {
-        let document = scroll.documentView?.frame.height ?? 0
-        return max(0, document - scroll.contentView.bounds.height)
+        return found.max { $0.endOffset < $1.endOffset }
     }
 
     /// Where a transcript is standing, as a report says it.
     ///
     /// `atEnd` is the one that matters to a reader: "I was at the bottom, I went away, I came
-    /// back". A tolerance rather than an exact equality, because the live end of a list whose
-    /// last row has just been measured is a point or two away from the bottom of the content.
+    /// back".
+    ///
+    /// Four points, which is its own number and not `NSScrollView.isAtEnd`'s one: this records
+    /// where a switch left a reader rather than asserting that an instruction survived, and the
+    /// live end of a list whose last row has just been measured is a point or two from the bottom
+    /// of the content. `JumpProbe` is the one that wants the exact question and asks it.
     static func scrollPlace(_ scroll: NSScrollView?) -> [String: JSONValue] {
         guard let scroll else { return ["found": .bool(false)] }
         let offset = Double(scroll.contentView.bounds.origin.y)
         let content = Double(scroll.documentView?.frame.height ?? 0)
         let viewport = Double(scroll.contentView.bounds.height)
-        let reach = max(0, content - viewport - offset)
+        let reach = Double(scroll.distanceFromEnd)
         return [
             "found": .bool(true),
             "offset": .number(offset),

--- a/Sources/Bloom/Design/PulsingDot.swift
+++ b/Sources/Bloom/Design/PulsingDot.swift
@@ -112,6 +112,11 @@ private struct PulsingDotLayer: NSViewRepresentable {
 
 /// One filled circle on a layer, under a repeating scale and a repeating fade.
 final class PulsingDotView: BusyPulseLayerView {
+    /// Capped, and it can afford to be: the dot travels a sixth of its own width, so at twelve
+    /// frames a second its edge moves about a quarter of a point per frame, which is inside the
+    /// softness of a resampled circle. The fade it moves with has no position to stutter at all.
+    private static let frameRate = CAFrameRateRange(minimum: 8, maximum: 15, preferred: 12)
+
     private let dot = CAShapeLayer()
     private var epoch: CFTimeInterval = 0
     private var diameter: CGFloat = 0
@@ -185,35 +190,20 @@ final class PulsingDotView: BusyPulseLayerView {
         CATransaction.commit()
 
         install(
-            pulse("transform.scale", from: BusyDot.pathScale(at: 0), to: BusyDot.pathScale(at: 1)),
+            pulse(
+                "transform.scale",
+                from: BusyDot.pathScale(at: 0), to: BusyDot.pathScale(at: 1),
+                period: BusyDot.period, frameRate: Self.frameRate
+            ),
             on: dot, key: "swell", beginAt: epoch
         )
         install(
-            pulse("opacity", from: BusyDot.opacity(at: 0), to: BusyDot.opacity(at: 1)),
+            pulse(
+                "opacity",
+                from: BusyDot.opacity(at: 0), to: BusyDot.opacity(at: 1),
+                period: BusyDot.period, frameRate: Self.frameRate
+            ),
             on: dot, key: "fade", beginAt: epoch
         )
-    }
-
-    /// Half a pulse, played forwards and then backwards forever.
-    ///
-    /// `easeInEaseOut` and `autoreverses` rather than a keyframed envelope, because this envelope
-    /// *is* a cubic ease and Core Animation's timing functions are cubic beziers. `BusyBreath` is
-    /// sampled instead only because its two eased stretches are power curves, which a bezier could
-    /// approximate and not express. `easeInEaseOut` is symmetric in time, so the return leg is the
-    /// same curve rather than a different one run backwards, and the dot is momentarily still at
-    /// each end of its travel.
-    ///
-    /// Capped, and it can afford to be: the dot travels a sixth of its own width, so at twelve
-    /// frames a second its edge moves about a quarter of a point per frame, which is inside the
-    /// softness of a resampled circle. The fade it moves with has no position to stutter at all.
-    private func pulse(_ keyPath: String, from: Double, to: Double) -> CABasicAnimation {
-        let animation = CABasicAnimation(keyPath: keyPath)
-        animation.fromValue = from
-        animation.toValue = to
-        animation.duration = BusyDot.period / 2
-        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-        animation.autoreverses = true
-        animation.preferredFrameRateRange = CAFrameRateRange(minimum: 8, maximum: 15, preferred: 12)
-        return animation
     }
 }

--- a/Sources/Bloom/Design/ScrollProbe.swift
+++ b/Sources/Bloom/Design/ScrollProbe.swift
@@ -68,7 +68,7 @@ enum ScrollProbe {
         // is one whose rows are still being measured, and every one of those measurements lands
         // on the main thread inside a frame somebody is waiting for.
         let heightBefore = scroll.documentView?.frame.height ?? 0
-        let travel = ProbeHarness.scrollableHeight(of: scroll)
+        let travel = scroll.endOffset
         guard travel > 1 else {
             harness.fail("the transcript is shorter than its viewport, so there is nothing to scroll")
         }

--- a/Sources/Bloom/Views/Chrome/RulePulse.swift
+++ b/Sources/Bloom/Views/Chrome/RulePulse.swift
@@ -6,59 +6,32 @@ import BloomCore
 ///
 /// # What this replaced, and why
 ///
-/// A light used to travel this rule: a 160 point gradient crossing it in three seconds and turning
-/// round on the far end. The complaint that killed it is one about contrast rather than about
-/// motion. The light was a one point hairline in the accent colour, moving along a rule that is
-/// already the accent at `BusyRule.restingOpacity`, so the mark and the line it moved on were the
-/// same hue, and on pale chrome there was nothing to see. Five replacements were drawn and
-/// animated side by side and the owner took the plainest: no light, no travel, the whole width
-/// moving at once. A mark as wide as the window cannot be too small to notice.
-///
-/// It is also simpler in the one place the old figure was hardest. The light had to cross two views
-/// that know nothing about each other, the centre column's tab strip and the inspector's tab row,
-/// which together make the one line under the title bar, so the two segments had to agree where the
-/// rule started and how long it was. `SharedRule` existed for that and for nothing else, and it
-/// published the strip's width so the inspector's half of the light knew where it began. Two layers
-/// brightening off one epoch cannot disagree about anything, so the width plumbing went with the
-/// light.
+/// A light used to travel this rule: a 160 point gradient crossing it in three seconds. What killed
+/// it was contrast rather than motion. The light was a one point hairline in the accent colour on a
+/// rule that is already the accent at `BusyRule.restingOpacity`, so the mark and the line under it
+/// were the same hue and on pale chrome there was nothing to see. Five replacements were drawn side
+/// by side and the owner took the plainest: no light, no travel, the whole width moving at once.
 ///
 /// # Which rule, and why this one
 ///
-/// The owner picked the rule at y=83, the one that closes off the tab strip, and one measurement
-/// from the study that drew the five variations is worth keeping.
-///
-/// **The rule at y=52 does not exist.** The study called it "the only line in the window that
-/// crosses all three columns" and it is not a line at all. Sampled on a two times capture at
-/// 1200 by 760: at y=52 the sidebar is flat chrome, the centre column is the tab strip's recess
-/// tint, and only the inspector carries a hairline, because only the inspector has a white pane
-/// beginning there. Putting the signal there would mean drawing a new full width line across the
-/// window to have something to light up, which is not using an existing rule, it is adding a rule.
-///
-/// The sidebar is not part of this either, measured the same way: at the row the rule occupies the
-/// sidebar is flat chrome from the window's edge to the vertical hairline that closes the column
-/// off. So the signal is the centre column and the inspector, which is the whole of the line that
-/// is actually there.
-///
-/// The selected tab's opaque fill breaks the rule, and it breaks the lit rule on exactly the same
-/// pixels, because this is drawn where the rule is drawn: inside `tabStripMaterial`'s background,
-/// over the hairline and under the tabs. That was delicate while something was crossing it and is
-/// not delicate any more. Nothing travels, so nothing can appear to stutter as it passes the tab:
-/// the rule brightens either side of a tab that stays where it is.
+/// The rule at y=83, the one that closes off the tab strip, and **the rule at y=52 does not
+/// exist.** The study that drew the five variations called it "the only line in the window that
+/// crosses all three columns"; sampled on a two times capture at 1200 by 760, at y=52 the sidebar
+/// is flat chrome, the centre column is the tab strip's recess tint, and only the inspector carries
+/// a hairline. Putting the signal there is not using an existing rule, it is adding one. The
+/// sidebar is out for the same reason, measured the same way.
 ///
 /// # What it costs
 ///
 /// One `CABasicAnimation` on the `opacity` of one hairline layer per segment, added when the signal
-/// appears and never touched again. Core Animation interpolates it in the render server, so the app
-/// is not woken for a frame of it, and this body runs when the heartbeat starts or stops and at no
+/// appears and never touched again, so this body runs when the heartbeat starts or stops and at no
 /// other time.
 ///
-/// The rule was a SwiftUI `.offset` animated by `.animation(_:value:)` before any of it was a
-/// layer, and that is a different thing entirely: SwiftUI interpolates such an animation itself, on
-/// the main thread, re-rendering the display list of the whole hosting view once per display frame.
-/// Measured on a 120Hz panel with five agents running, four interleaved passes back to back: the
-/// rule and the sidebar's dots between them cost a median of 2.96 seconds of CPU every 15, where
-/// the same pair on layers cost 0.13 against a floor of 0.20 with the heartbeat off entirely. See
-/// `BusyPulse` for what Instruments said about where the 2.96 went, and do not put a
+/// The rule was a SwiftUI `.offset` animated by `.animation(_:value:)` before it was a layer, which
+/// SwiftUI interpolates on the main thread, re-rendering the whole hosting view's display list once
+/// per display frame. Measured on a 120Hz panel with five agents running, four interleaved passes:
+/// the rule and the sidebar's dots cost a median of 2.96 seconds of CPU every 15, where the same
+/// pair on layers cost 0.13 against a floor of 0.20 with the heartbeat off. Do not put a
 /// `repeatForever` back on this rule.
 struct RulePulse: View {
     @Environment(AppModel.self) private var app
@@ -131,6 +104,19 @@ private struct PulsingRule: NSViewRepresentable {
 
 /// One accent hairline on a layer, under a repeating fade.
 final class PulsingRuleView: BusyPulseLayerView {
+    /// Capped, but not at the twelve frames a second `PulsingDot` and `BrandWater` settled on, and
+    /// the reason is that comment's own arithmetic rather than a different taste. The water is
+    /// capped that hard because its fastest brightness change is about two of two hundred and
+    /// fifty five levels a second, so a twelfth of a second is a sixth of a level and nothing a
+    /// gradient could show. This fade covers 0.68 of full alpha in three quarters of a second,
+    /// which is a hundred and seventy three levels: nineteen a step at twelve frames, and half as
+    /// much again through the middle of the ease, on a line as wide as the window. Twenty four
+    /// halves that. What it asks of WindowServer is a one point strip rather than the field of
+    /// soft gradients that measurement caught costing forty percent of a core uncapped, and it is
+    /// still a cap, which is the whole reason to name a range instead of letting ProMotion have
+    /// it.
+    private static let frameRate = CAFrameRateRange(minimum: 20, maximum: 30, preferred: 24)
+
     private let rule = CALayer()
     private var epoch: CFTimeInterval = 0
 
@@ -164,10 +150,10 @@ final class PulsingRuleView: BusyPulseLayerView {
         CATransaction.commit()
     }
 
-    /// Guarded, because `updateNSView` runs on every pass SwiftUI makes over this view and a window
-    /// being resized makes a great many of them. Reinstalling an animation that is already correct
-    /// would reset its phase, and the phase is what puts this rule on the same beat as every dot in
-    /// the window.
+    /// Guarded, because `updateNSView` runs on every pass SwiftUI makes over this view and a
+    /// window being resized makes a great many of them. Reinstalling an animation that is already
+    /// correct would reset its phase, and the phase is what puts this rule on the same beat as
+    /// every dot in the window.
     func configure(epoch: CFTimeInterval) {
         guard epoch != self.epoch else { return }
         self.epoch = epoch
@@ -183,40 +169,19 @@ final class PulsingRuleView: BusyPulseLayerView {
         rule.opacity = Float(BusyRule.opacity(at: BusyRule.resting))
         CATransaction.commit()
 
-        install(fade(), on: rule, key: "pulse", beginAt: epoch)
-    }
-
-    /// Half a pulse, played forwards and then backwards forever, which is `PulsingDot`'s own fade
-    /// with different ends. The two share `BusyRule.period` and both begin at their resting figure,
-    /// so the rule is at the top of its pulse on the frame every dot in the window is at the top of
-    /// its swell. The other way round was never available: an animation that began at full accent
-    /// would put the frozen rule and the first frame of the moving one at opposite ends, and the
-    /// frozen one is what `Reduce Motion` and every screenshot draw.
-    ///
-    /// `easeInEaseOut` and `autoreverses` rather than a keyframed envelope, for the reason the dot
-    /// gives: the envelope is a cubic ease and Core Animation's timing functions are cubic beziers.
-    /// `easeInEaseOut` is symmetric in time, so the return leg is the same curve rather than a
-    /// different one run backwards, and the rule is momentarily still at each end.
-    ///
-    /// Capped, but not at the twelve frames a second `PulsingDot` and `BrandWater` settled on, and
-    /// the reason is that comment's own arithmetic rather than a different taste. The water is
-    /// capped that hard because its fastest brightness change is about two of two hundred and
-    /// fifty five levels a second, so a twelfth of a second is a sixth of a level and nothing a
-    /// gradient could show. This fade covers 0.68 of full alpha in three quarters of a second,
-    /// which is a hundred and seventy three levels: nineteen a step at twelve frames, and half as
-    /// much again through the middle of the ease, on a line as wide as the window. Twenty four
-    /// halves that. What it asks of WindowServer is a one point strip rather than the field of
-    /// soft gradients that measurement caught costing forty percent of a core uncapped, and it is
-    /// still a cap, which is the whole reason to name a range instead of letting ProMotion have
-    /// it.
-    private func fade() -> CABasicAnimation {
-        let animation = CABasicAnimation(keyPath: "opacity")
-        animation.fromValue = BusyRule.opacity(at: 0)
-        animation.toValue = BusyRule.opacity(at: 1)
-        animation.duration = BusyRule.period / 2
-        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-        animation.autoreverses = true
-        animation.preferredFrameRateRange = CAFrameRateRange(minimum: 20, maximum: 30, preferred: 24)
-        return animation
+        // The dot's pulse with the rule's ends, which is what `BusyRule.period` being
+        // `BusyDot.period` is for: the rule is at the top of its brightening on the frame every
+        // dot in the window is at the top of its swell. Both begin at their resting figure, and
+        // the other way round was never available: an animation that began at full accent would
+        // put the frozen rule and the first frame of the moving one at opposite ends, and the
+        // frozen one is what `Reduce Motion` and every screenshot draw.
+        install(
+            pulse(
+                "opacity",
+                from: BusyRule.opacity(at: 0), to: BusyRule.opacity(at: 1),
+                period: BusyRule.period, frameRate: Self.frameRate
+            ),
+            on: rule, key: "pulse", beginAt: epoch
+        )
     }
 }

--- a/Sources/Bloom/Views/Transcript/ScrollViewEnd.swift
+++ b/Sources/Bloom/Views/Transcript/ScrollViewEnd.swift
@@ -1,0 +1,46 @@
+import AppKit
+import BloomCore
+
+/// Where the end of a scroll view is, in one spelling.
+///
+/// There were five of them and they were the same number: `TranscriptTable` asked
+/// `TranscriptAnchor.end`, the glide and the follower subtracted two heights each, and the two
+/// probes subtracted a `frame` height from a `bounds` height. They all move the same clip view,
+/// and five copies of a number that has to agree with itself is how a jump lands short of where
+/// the follower thinks the end is.
+///
+/// **`frame` for the document and `bounds` for the clip, which is not a formatting choice.** The
+/// offset all of this is compared against is `contentView.bounds.origin.y`, which is in the clip
+/// view's coordinate space, and the document's `frame` is expressed in that space while its
+/// `bounds` is expressed in its own. AppKit clamps a scroll against the document's frame
+/// (`NSClipView.constrainBoundsRect`), so the frame is the one that cannot disagree with where
+/// the view is allowed to go. The two are equal for a document with no magnification and no
+/// transform, which is every scroll view here today, so nothing changes for the five callers.
+extension NSScrollView {
+    /// The furthest down this view can be scrolled. Never negative: content that fits in the
+    /// viewport has no end below the reader to go to.
+    var endOffset: CGFloat {
+        CGFloat(TranscriptAnchor.end(
+            contentHeight: Double(documentView?.frame.height ?? 0),
+            viewportHeight: Double(contentView.bounds.height)
+        ))
+    }
+
+    /// How far the viewport is from that end, in points.
+    var distanceFromEnd: CGFloat {
+        max(0, endOffset - contentView.bounds.origin.y)
+    }
+
+    /// Whether a viewport put at the end is still exactly there.
+    ///
+    /// `TranscriptAnchor.isAtEnd`'s question, "did the instruction survive", and not
+    /// `ScrollEnd.isAtEnd`'s "is the reader still following along". Ninety points short passes the
+    /// second and fails this one, and ninety points short is the newest row half off the window.
+    var isAtEnd: Bool {
+        TranscriptAnchor.isAtEnd(
+            offset: Double(contentView.bounds.origin.y),
+            contentHeight: Double(documentView?.frame.height ?? 0),
+            viewportHeight: Double(contentView.bounds.height)
+        )
+    }
+}

--- a/Sources/Bloom/Views/Transcript/TranscriptLiveEndFollow.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptLiveEndFollow.swift
@@ -7,45 +7,32 @@ import SwiftUI
 /// something the eye can follow instead of a jolt.
 ///
 /// **The rules are `TranscriptFollow`'s and the frames are here.** What this file owns is when the
-/// following is on at all, and one measurement about SwiftUI that the shape of it depends on.
+/// following is on at all.
 ///
 /// ## Why this is not a `withAnimation` on the scroll position
 ///
-/// For the same reason `TranscriptLiveEndScroller` is not, and that file carries the frame timings
-/// that settled it: on a long transcript SwiftUI's own animated scroll delivered a fifth of the
-/// frames the display wanted at six times the main-thread cost of stepping the clip view by hand.
-/// This one has a second reason on top of that. It runs while a turn streams, which is many
-/// content changes a second, and a state write per frame would re-run the list's body and rebuild
-/// every realised row with it. Nothing here writes any SwiftUI state at all: it reads two heights
-/// off AppKit and sets an origin, and the transcript's own geometry callback picks the result up as
-/// if the reader had scrolled there themselves, so the jump pill keeps working off exactly the
-/// numbers it already did.
+/// For the reason `TranscriptLiveEndScroller`'s header measures, and a second one on top of it:
+/// this runs while a turn streams, so a state write per frame would re-run the list's body and
+/// rebuild every realised row with it. Nothing here writes any SwiftUI state. It reads two heights
+/// off AppKit and sets an origin, and the transcript's geometry callback picks the result up as if
+/// the reader had scrolled there themselves.
 ///
 /// ## The take-back, and why it is the shape of the thing
 ///
-/// Something else keeps the view pinned to the end as the content grows, in the same pass that
-/// grows it: under the lazy stack that was a `ScrollPosition` standing at `.bottom`, and under the
-/// table it is `TranscriptTableController.goToEnd`. Either way there is nothing to animate
-/// afterwards, because by the time any frame is drawn the view is already at the end. So the
-/// travel has to be made rather than intercepted, and that is what `TranscriptFollow.start` is: on
-/// the frame that sees the content grow, the view is put back by what arrived, capped, and then
-/// travels forward to the end again. One frame of the pinned position may be shown before the
-/// take-back lands, which at 120Hz is eight milliseconds and has no visible width.
-///
-/// It costs nothing when nothing is pinning. Then the view is simply behind the end by what
-/// arrived, `start` leaves it there, and the same approach carries it forward. Both worlds end up
-/// travelling the same distance at the same rate.
+/// Something else pins the view to the end in the same pass that grows the content
+/// (`TranscriptTableController.goToEnd`), so by the time any frame is drawn there is nothing left
+/// to animate. The travel has to be made rather than intercepted, which is what
+/// `TranscriptFollow.start` is: the view is put back by what arrived, capped, and travels forward
+/// again. One frame of the pinned position may be shown first, which at 120Hz has no visible
+/// width. With nothing pinning, the view is simply behind by what arrived and the same approach
+/// carries it forward.
 ///
 /// ## What turns it off
 ///
-/// Reduce Motion, which drops the travel rather than slowing it, the way every other movement in
-/// this app does, and which is `TranscriptFollow.travels` rather than a reading of the setting
-/// taken here. A window that is not in front, because a display link in a backgrounded app is
-/// the battery bug `ActivityDot` carries the measurement for and there is nobody watching the
-/// travel anyway. A hand on the wheel, because a view that goes on dragging somebody somewhere
-/// after they have taken hold of it is the worst thing this file could do. And a quiet transcript:
-/// the link is only up while a turn is streaming or for a moment after a row lands, so a session
-/// nobody is running costs nothing at all.
+/// Reduce Motion, through `TranscriptFollow.travels`. A window that is not in front, because a
+/// display link in a backgrounded app is the battery bug `ActivityDot` measured. A hand on the
+/// wheel. And a quiet transcript: the link is up only while a turn streams or for a moment after
+/// a row lands.
 @MainActor
 final class TranscriptLiveEndFollower {
     /// Weak, because the scroll view belongs to the view hierarchy and holding it here would keep
@@ -55,13 +42,9 @@ final class TranscriptLiveEndFollower {
         didSet {
             guard scrollView !== oldValue else { return }
             lastHeight = 0
-            // And re-ask, like every other input below. `wants` reads this property, and the
-            // scroll view arrives late: measured back when it was found by walking up from a
-            // planted view, `enclosingScrollView` was nil on the first update, so a turn that
-            // started streaming before the second layout pass set `isStreaming` while `wants` was
-            // still false for want of a view, and nothing asked again. The following stayed off
-            // until the next `nudge()` or state change. The table hands it over rather than being
-            // walked up from now, and it is still not there on the first pass.
+            // And re-ask, like every other input below: the scroll view arrives after the first
+            // pass, so a turn that started streaming before it landed set `isStreaming` while
+            // `wants` was still false for want of a view, and nothing asked again.
             refresh()
         }
     }
@@ -83,19 +66,9 @@ final class TranscriptLiveEndFollower {
     /// Called when the following stops with the view at the end, so the caller can take its
     /// standing instruction back.
     ///
-    /// **This is not tidiness, it is what stops the transcript falling behind when the following
-    /// is off.** Measured against a hosted `ScrollView` whose `ScrollPosition` was standing at
-    /// `.bottom`: content growing kept the view at the end, to the point, until the clip view was
-    /// moved by hand, and from that moment on it never kept it again. SwiftUI takes a position it
-    /// did not make as the reader having scrolled, which is exactly right and is why the pill
-    /// works, but it means the first frame this follower steps also puts SwiftUI's own following
-    /// down. So when the travel is over, whoever owns the position says so again, and the instant
-    /// pin is back for the window that is behind another app, the reader who has asked for less
-    /// movement, and the quiet transcript nobody is running.
-    ///
-    /// The table has no `ScrollPosition` to be taken down, but it has the same argument: while
-    /// this object is driving, nothing else may put the view at the end, and this is the moment
-    /// the instruction goes back. See `TranscriptTableController.goToEnd`.
+    /// **This is what stops the transcript falling behind when the following is off.** While this
+    /// object is driving, nothing else may put the view at the end, so this is the moment that
+    /// instruction goes back. See `TranscriptTableController.goToEnd`.
     ///
     /// Only at the end, and never mid travel: naming the edge from anywhere else is a jump, and
     /// the reader who has just taken hold of the view is precisely who must not be given one.
@@ -104,29 +77,22 @@ final class TranscriptLiveEndFollower {
     /// Called with the current offset when the following starts, so whoever owns the scroll
     /// position can stop naming an edge.
     ///
-    /// **Without this the follower cannot win an argument it is having every frame.** The lazy
-    /// stack held a `ScrollPosition(edge: .bottom)`, and a position standing at an edge is a
-    /// standing instruction: SwiftUI put the view back at the end on the layout pass that grew the
-    /// content, every time. This writes the clip view's origin directly, so the take-back landed
-    /// and was overwritten before a frame was drawn, and what reached the screen was the instant
-    /// pin with the travel invisible underneath it.
+    /// **Without this the follower cannot win an argument it is having every frame.** Whatever
+    /// pins the view to the end does so on the layout pass that grew the content, so the take-back
+    /// landed and was overwritten before a frame was drawn and what reached the screen was the
+    /// instant pin with the travel invisible underneath it.
     ///
-    /// The offset it hands over is the one the view is already at, so naming it moves nothing:
-    /// what changed for SwiftUI is that the position stopped being an edge and started being a
-    /// number, which is what left the clip view alone until `onRest`. The table's caller ignores
-    /// the number and simply lets go of its own instruction, which is the same hand-off with
-    /// nothing to name.
+    /// The offset it hands over is the one the view is already at, so naming it moves nothing. The
+    /// table's caller ignores the number and simply lets go of its own instruction.
     var onStart: (@MainActor (CGFloat) -> Void)?
 
     /// Called whenever the link goes down, at the end or not.
     ///
-    /// **`onRest` is not enough to hand the view back with, and that is what this is for.** It
-    /// only fires when the travel finished AT the end, which is the case where somebody else
-    /// should take over holding it there. Every other ending, a reader who scrolled away mid
-    /// travel, a window going behind another app, a session being left, leaves the view somewhere
-    /// in the middle with nobody told that this object has stopped driving. Whoever suppressed
-    /// their own scrolling for the duration needs to hear about all of them, or they suppress it
-    /// for ever. See `TranscriptTableController.followerTookOver`.
+    /// **`onRest` is not enough to hand the view back with.** It fires only when the travel
+    /// finished AT the end. A reader who scrolled away mid travel, a window going behind another
+    /// app or a session being left all leave the view in the middle, and whoever suppressed their
+    /// own scrolling for the duration would suppress it for ever. See
+    /// `TranscriptTableController.followerTookOver`.
     ///
     /// Said before `onRest`, so a caller that reacts to both gets "I have stopped" and then "and
     /// you are at the end" in that order.
@@ -216,10 +182,10 @@ final class TranscriptLiveEndFollower {
     }
 
     private var isAtEnd: Bool {
-        guard let scrollView, let document = scrollView.documentView else { return false }
-        let clip = scrollView.contentView
-        return document.bounds.height - clip.bounds.height - clip.bounds.origin.y
-            <= TranscriptFollow.arrived
+        guard let scrollView else { return false }
+        // `TranscriptFollow.arrived`, which is about a travel being spent rather than watched, and
+        // deliberately not `NSScrollView.isAtEnd`'s exact point.
+        return scrollView.distanceFromEnd <= TranscriptFollow.arrived
     }
 
     @objc private func step(_ sender: CADisplayLink) {
@@ -235,11 +201,8 @@ final class TranscriptLiveEndFollower {
             let frame = lastFrame > 0 ? now - lastFrame : 0
             lastFrame = now
 
-            // The clip view's own height, not the scroll view's frame: an inset or a ruler makes
-            // those different, and the one that decides how far the document can go is the area
-            // showing it.
-            let height = document.bounds.height
-            let end = height - clip.bounds.height
+            let height = document.frame.height
+            let end = scrollView.endOffset
             var offset = clip.bounds.origin.y
 
             if lastHeight > 0, height > lastHeight {

--- a/Sources/Bloom/Views/Transcript/TranscriptLiveEndScroll.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptLiveEndScroll.swift
@@ -15,32 +15,14 @@ import SwiftUI
 /// same press with no animation on it costs. WindowServer is not involved either way, which is the
 /// one thing the numbers rule out.
 ///
-/// The travel is not `NSAnimationContext` either, and that is worth a paragraph because it was the
-/// obvious answer and it was tried. `clip.animator().setBoundsOrigin` reads and measures exactly
-/// as well as what is here, and it cannot be stopped: `animator()` writes the model value straight
-/// away and animates the layer towards it, so `bounds.origin` reports the end of the document
-/// from the first frame, the clip view has no presentation layer of its own to ask instead, and a
-/// hand on the wheel therefore froze the view at the bottom rather than where the travel had got
-/// to. That is the teleport this whole branch replaced, performed at the exact moment the reader
+/// **The travel is not `NSAnimationContext` either**, which was the obvious answer and was tried.
+/// `clip.animator().setBoundsOrigin` measures as well as this and cannot be stopped: `animator()`
+/// writes the model value straight away, so `bounds.origin` reports the end of the document from
+/// the first frame and a hand on the wheel froze the view at the bottom rather than where the
+/// travel had got to. That is the teleport this replaced, performed at the moment the reader
 /// grabbed the view. Stepping the origin by hand means the current position is simply known.
 ///
-/// What is given up is that SwiftUI's own `ScrollPosition` does not know where the view ended up,
-/// which is why the caller settles it with an unanimated `scrollTo(edge: .bottom)` on arrival.
-/// That call was already there for the streaming case. It is now what every completed travel ends
-/// with, and a travel that was stopped does not reach it.
-///
-/// It fails safe. The scroll view is handed over by `TranscriptTable`, which owns it, and if there
-/// is none the answer is nil, `glide` returns false, and the caller jumps instead. A press that
-/// arrives instantly is the behaviour this replaced and is not a failure.
-///
-/// **It used to be found rather than handed over**, by planting a zero sized `NSViewRepresentable`
-/// inside the scroll content and walking up through `enclosingScrollView`, because that was the
-/// only way to reach the `NSScrollView` SwiftUI puts behind a `ScrollView`. That view had to be
-/// updated on every layout pass, since the reference went stale whenever SwiftUI rebuilt the
-/// hosting scroll view under a pane that is reused for every workspace the window visits, and it
-/// answered nil on its first update because a representable's view is created before it is put in
-/// the hierarchy. None of that survives the move to a table: the table makes its own scroll view
-/// and says which one it is.
+/// It fails safe: with no scroll view `glide` returns false and the caller jumps instead.
 @MainActor
 @Observable
 final class TranscriptLiveEndScroller {
@@ -65,15 +47,16 @@ final class TranscriptLiveEndScroller {
         guard let scrollView, let document = scrollView.documentView else { return false }
 
         let clip = scrollView.contentView
-        // The clip view's own height, not the scroll view's frame: an inset or a ruler makes those
-        // different, and the one that decides how far the document can go is the area showing it.
-        let reach = document.bounds.height - clip.bounds.height
+        let reach = scrollView.endOffset
         guard reach > 0 else { return false }
 
         // Flipped is what every scroll view in this app is, SwiftUI's included, but it is asked
         // rather than assumed: unflipped, the end of the document is at the origin, and travelling
         // to `reach` would go the wrong way.
         let end = document.isFlipped ? reach : 0
+        // Half a point is under a pixel, so there is nothing to travel. Its own number rather than
+        // `TranscriptFollow.arrived`: the two agree because both are the same claim about a pixel,
+        // not because one owns the other.
         guard abs(clip.bounds.origin.y - end) > 0.5, seconds > 0 else { return false }
 
         stop()

--- a/Sources/Bloom/Views/Transcript/TranscriptTable.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTable.swift
@@ -6,27 +6,21 @@ import SwiftUI
 /// The transcript, drawn by an `NSTableView`.
 ///
 /// **Why not a `LazyVStack`, which is what this replaced.** SwiftUI cannot be told how tall an
-/// unrealised row is, so a `ScrollView` over a lazy stack guesses for every row it has not built
-/// and corrects as they come into view. Measured on an 1,855 message session, the content height
-/// fell from 48,995 points to 17,339 during a single scroll pass, a resize over it ran at eight
-/// frames a second, and a reader's place could not be put back because the offset it was written
-/// down against no longer named the same row. A table knows every row's height, caches it, keeps
-/// the scroll position stable when a height changes, recycles the views, and scrolls to a row
-/// exactly. Measured against each other on an idle machine, twice each: 13.6 frames a second on a
-/// resize against 6.6 to 11.4, 110ms of main thread per second of streaming against 275, half the
-/// worst scroll frame, and a reader put back where they were on four returns out of four where the
-/// stack returned them to the top of the conversation every time.
+/// unrealised row is, so it guesses for every row it has not built. Measured on an 1,855 message
+/// session, the content height fell from 48,995 points to 17,339 during a single scroll pass, and
+/// a reader's place could not be put back because the offset it was written down against no longer
+/// named the same row. Table against stack, twice each on an idle machine: 13.6 frames a second on
+/// a resize against 6.6 to 11.4, 110ms of main thread per second of streaming against 275, and a
+/// reader put back where they were on four returns out of four where the stack returned them to
+/// the top of the conversation every time.
 ///
-/// **The bargain, which is the finding rather than a detail:** the table has to be TOLD each
-/// height, and the only thing that knows a SwiftUI row's height is a laid out `NSHostingView`. So
-/// the heights are measured off screen, one measurement per row per width, and cached. That cost
-/// is paid up front whenever the table is reloaded, and again whenever the pane's width changes,
-/// which are exactly the two moments the lazy stack was cheapest. `TranscriptRowHeights` in the
-/// core is the cache and carries the rules; this file is the AppKit around it.
-///
-/// The width case is handled by not handling it during the gesture: a live resize leaves every
-/// cached height alone, and the whole cache is rebuilt once, anchored, a beat after the drag
-/// stops. So a resize is cheap and wrong for a moment, rather than expensive and right.
+/// **The bargain:** the table has to be TOLD each height, and the only thing that knows a SwiftUI
+/// row's height is a laid out `NSHostingView`. So heights are measured off screen, one per row per
+/// width, and cached by `TranscriptRowHeights` in the core. That cost falls whenever the table is
+/// reloaded and whenever the pane's width changes, which are the two moments the lazy stack was
+/// cheapest. A live resize therefore leaves every cached height alone and rebuilds the cache once,
+/// anchored, a beat after the drag stops: cheap and wrong for a moment rather than expensive and
+/// right.
 struct TranscriptTableEntry: Identifiable {
     /// Stable across passes. See `TranscriptEntryID` for why it is a type rather than a string.
     let id: TranscriptEntryID
@@ -37,9 +31,7 @@ struct TranscriptTableEntry: Identifiable {
     /// **The three entries that re-render from their own observation are not excepted, and used to
     /// be.** The streaming tail, the setup log and the delivery at the head of the queue watch
     /// their own state and redraw inside the cell they are in; handing them a new root view on
-    /// every pass threw that state away and rebuilt the tail several times a second. Their heights
-    /// come from the cache like everything else and are corrected by what the cell actually drew,
-    /// which is a mechanism these three need and nothing else has to pay for.
+    /// every pass threw that state away and rebuilt the tail several times a second.
     let contentKey: String
     /// Built on demand: when the row is measured, and when it is drawn. Nothing is built for a row
     /// that is neither, which is what keeps the pass that assembles these cheap.
@@ -71,18 +63,12 @@ final class TranscriptTableController {
 
     /// **Go to the end of the conversation, and keep being at it until somebody says otherwise.**
     ///
-    /// This is the table's answer to `ScrollPosition(edge: .bottom)`, which is what the lazy stack
-    /// used and which was a standing instruction rather than a movement: SwiftUI reapplied it on
-    /// every layout pass that grew the content, so a row landing kept the reader at the end in the
-    /// same pass that made the content taller. An AppKit scroll view has nothing of the sort. A
-    /// single `setBoundsOrigin` is a movement, and a movement is short of the end the moment
+    /// A single `setBoundsOrigin` is a movement, and a movement is short of the end the moment
     /// anything below it changes size, which in a transcript is constantly: heights are corrected
-    /// after a row has been drawn, the streaming tail grows between rows, and a window that has
-    /// just been moved to the tail has not been laid out yet when the scroll is issued.
-    ///
-    /// So the instruction is held. Every place in the coordinator that can change where the end is
-    /// re-asserts it, and it is let go of by `releaseEnd` and by the reader taking hold of the
-    /// view. See `Coordinator.holdsEnd`.
+    /// after a row is drawn, the streaming tail grows between rows, and a window just moved to the
+    /// tail has not been laid out when the scroll is issued. So the instruction is held: every
+    /// place in the coordinator that can change where the end is re-asserts it, and `releaseEnd`
+    /// or the reader taking hold of the view lets it go. See `Coordinator.holdsEnd`.
     func goToEnd() { coordinator?.goToEnd() }
 
     /// Lets go of the standing instruction above, without moving anything.
@@ -91,14 +77,10 @@ final class TranscriptTableController {
     /// **`TranscriptLiveEndFollower` is driving the clip view from here on, so nothing in the
     /// table may touch it.**
     ///
-    /// Two things move the view at the live end while a turn streams: the follower's display link,
-    /// which takes the view back by what arrived and eases forward again so the movement can be
-    /// followed, and this file, which puts the view at the end the instant a height is corrected.
-    /// Both running is the two of them fighting, one at 120Hz and one per correction, and what
-    /// reaches the screen is the instant pin with the travel invisible underneath it. That is the
-    /// same argument `TranscriptLiveEndFollower.onStart` carries about `ScrollPosition`, and it
-    /// arrives here for the same reason: the follower is the only one of the two that can make a
-    /// movement the eye can read, so it wins for as long as it is running.
+    /// Both moving the view at the live end is the two of them fighting, one at 120Hz and one per
+    /// height correction, and what reaches the screen is the instant pin with the travel invisible
+    /// underneath it. The follower is the only one that can make a movement the eye can read, so
+    /// it wins for as long as it is running.
     func followerTookOver() { coordinator?.followerTookOver() }
 
     /// The follower's link has gone down, wherever it left the view. See
@@ -124,23 +106,14 @@ final class TranscriptTableController {
 /// The transcript's scroll view, which differs from `NSScrollView` in exactly one answer.
 ///
 /// **A markdown table stopped the transcript scrolling under the pointer.** A table and a code
-/// fence are each drawn inside a `ScrollView(.horizontal)` so a wide one can be pushed sideways,
-/// and SwiftUI backs that with a real `NSScrollView` of its own, `SwiftUI.HostingScrollView`. Over
-/// the lazy stack there was a SwiftUI scroll view above it, which it knows about and hands a
-/// vertical wheel straight to. Here there is not, so it falls through to `NSScrollView`'s own
-/// `scrollWheel(with:)` and the answer becomes AppKit's: a scroll view that is already at its edge
-/// in an axis keeps the event and scrolls elastically **unless a responder above it has asked for
-/// one**, and `NSResponder.wantsForwardedScrollEvents(for:)` is false by default, which the header
-/// documents and the runtime confirms: asked on macOS 27, a plain `NSScrollView` answers false for
-/// both axes. Nothing asked, so a wheel over a table rubber-banded the table and left the
-/// transcript standing still.
+/// fence each sit in a `ScrollView(.horizontal)` of their own, and an inner scroll view already at
+/// its edge keeps the wheel and rubber-bands unless a responder above it has asked to be forwarded
+/// one. `wantsForwardedScrollEvents(for:)` is false by default, so nothing asked and the
+/// transcript stood still.
 ///
-/// Asking is the whole fix. AppKit forwards only from an inner view already at its edge in that
-/// axis, which for one with nothing to scroll vertically is always, and it decides the event's
-/// predominant axis itself, so a mostly-horizontal wheel stays with the table it is over and a wide
-/// table still scrolls sideways. One answer here covers everything that scrolls horizontally inside
-/// a row, tables and code fences alike, rather than each of them having to fend off a gesture it
-/// never wanted.
+/// Asking is the whole fix, and it covers tables and code fences alike. AppKit forwards only from
+/// an inner view at its edge in that axis and decides the predominant axis itself, so a wide table
+/// still scrolls sideways.
 final class TranscriptScrollView: NSScrollView {
     override func wantsForwardedScrollEvents(for axis: NSEvent.GestureAxis) -> Bool {
         axis == .vertical
@@ -162,14 +135,11 @@ struct TranscriptTable: NSViewRepresentable {
     /// **The reader has taken hold of the view, or let go of it.** True on the first frame of a
     /// gesture and false when it ends.
     ///
-    /// This is `onScrollPhaseChange` in the shape the lazy stack had it, and it is a real answer
-    /// rather than the debounce the spike used. A debounce over "the clip view moved" cannot tell
-    /// a hand from this app's own travel, so the jump pill's glide reported itself as a scroll on
-    /// its very first frame and the pane's handler stopped it: the press moved the transcript by a
-    /// few points and left it there, with the completion that would have landed it at the end
-    /// never run. `NSScrollView` posts `willStartLiveScroll` and `didEndLiveScroll` for
-    /// user-initiated scrolling only, so this app's own movement is silent here and the follower
-    /// pauses for a hand and for nothing else.
+    /// Not a debounce over "the clip view moved", which cannot tell a hand from this app's own
+    /// travel: the jump pill's glide reported itself as a scroll on its first frame and the pane's
+    /// handler stopped it, leaving the transcript a few points down with the completion never run.
+    /// `NSScrollView` posts `willStartLiveScroll` and `didEndLiveScroll` for user-initiated
+    /// scrolling only, so this app's own movement is silent here.
     let onLiveScrollChange: @MainActor (Bool) -> Void
 
     func makeCoordinator() -> Coordinator { Coordinator() }
@@ -274,10 +244,10 @@ struct TranscriptTable: NSViewRepresentable {
         /// view's.
         ///
         /// **This was half of the wrong heights.** With legacy scrollers the clip view is fifteen
-        /// points wider than the document inside it, so every measurement was taken at a width no
-        /// row is ever laid out at: a paragraph measured at the wider figure wraps to fewer lines
-        /// than it draws at, and the row comes out short with its first line clipped off the top.
-        /// One column and no intercell spacing, so the table's width is the cell's width.
+        /// points wider than the document inside it, so a paragraph measured at the clip's width
+        /// wraps to fewer lines than it draws at and the row comes out short with its first line
+        /// clipped off the top. One column and no intercell spacing, so the table's width is the
+        /// cell's width.
         private var columnWidth: CGFloat {
             if let tableView, tableView.bounds.width > 1 { return tableView.bounds.width }
             return scrollView?.contentView.bounds.width ?? 0
@@ -377,16 +347,8 @@ struct TranscriptTable: NSViewRepresentable {
                 return
             }
 
-            // A reader who is following along is kept at the end, which is what a `ScrollPosition`
-            // standing at `.bottom` did for the lazy stack. `holdsEnd` is the same thing said out
-            // loud by something that asked for it; `wasAtEnd` is the reader who simply has not
-            // scrolled away. Everything else keeps the ROW that was at the top of the pane, which
-            // is the thing a point offset cannot do and the whole reason for the table.
-            let wasAtEnd = ScrollEnd.isAtEnd(
-                contentHeight: currentGeometry.contentHeight,
-                viewportHeight: currentGeometry.viewportHeight,
-                offset: currentGeometry.offset
-            )
+            // Both read before anything moves under the reader. See `keepPlace`.
+            let wasAtEnd = isFollowingAlong
             let anchor = change.movesRows ? anchorEntry() : nil
 
             entries = newEntries
@@ -418,11 +380,7 @@ struct TranscriptTable: NSViewRepresentable {
                 noteHeights(unfolding, over: unfoldSeconds)
             }
 
-            if holdsEnd || (wasAtEnd && !isFollowerDriving) {
-                putEnd()
-            } else if let anchor {
-                restore(anchor)
-            }
+            keepPlace(wasAtEnd: wasAtEnd, anchor: anchor)
             // Off this pass, because this one runs inside `updateNSView` and what it calls writes
             // SwiftUI state. Reporting from here is "Modifying state during view update".
             Task { @MainActor [weak self] in self?.reportGeometry() }
@@ -480,14 +438,12 @@ struct TranscriptTable: NSViewRepresentable {
 
         /// A fresh `NSHostingView` per measurement, at the exact width the cell is laid out at.
         ///
-        /// **The other half of the wrong heights, and it is worth writing down what the shortcut
-        /// cost.** One hosting view reused for every row, with its size invalidated by hand, gave
-        /// a long conversation several hundred points of blank between rows: an `NSHostingView`
-        /// keeps its own fitting size, and `invalidateIntrinsicContentSize` followed by
-        /// `layoutSubtreeIfNeeded` does not reliably make it forget the row before. A fresh one
-        /// has no previous answer to hand back. It builds a whole SwiftUI graph per row, which is
-        /// the expensive thing this arrangement can afford: 2.1ms a layout pass against the lazy
-        /// stack's 11.9ms.
+        /// **The other half of the wrong heights.** One hosting view reused for every row, with
+        /// its size invalidated by hand, gave a long conversation several hundred points of blank
+        /// between rows: an `NSHostingView` keeps its own fitting size and does not reliably
+        /// forget the row before. A fresh one has no previous answer to hand back, and a whole
+        /// SwiftUI graph per row is what this arrangement can afford: 2.1ms a layout pass against
+        /// the lazy stack's 11.9ms.
         ///
         /// The width is a required CONSTRAINT rather than a frame, because that is what makes
         /// `fittingSize` solve the layout at that width instead of handing back the unwrapped
@@ -522,28 +478,18 @@ struct TranscriptTable: NSViewRepresentable {
                 let rows = owedHeights
                 owedHeights = IndexSet()
                 guard !rows.isEmpty else { return }
-                let wasAtEnd = ScrollEnd.isAtEnd(
-                    contentHeight: currentGeometry.contentHeight,
-                    viewportHeight: currentGeometry.viewportHeight,
-                    offset: currentGeometry.offset
-                )
-                // **The row being corrected is usually above the reader**, which is why this needs
-                // the same anchor `apply` takes. Scrolling up through a long conversation brings
-                // rows into view at the top, each of them is drawn and reports a height that
-                // differs from what it was measured at, and every one of those corrections moves
-                // everything below it. Without the anchor the text slides under the eye on the way
-                // up, which is the one thing a reader notices immediately.
+                let wasAtEnd = isFollowingAlong
+                // **The row being corrected is usually above the reader.** Scrolling up brings
+                // rows in at the top, each reports a height that differs from what it was measured
+                // at, and every correction moves everything below it. Without the anchor the text
+                // slides under the eye on the way up.
                 let anchor = anchorEntry()
                 noteHeights(rows)
                 // **The correction is also what leaves a reader short of the end**, and it is the
                 // second half of "the pill does not go all the way down": a scroll that was right
-                // when it was issued is short the moment a row below the fold turns out to be
-                // taller than it was measured at. So the end is said again after every batch.
-                if holdsEnd || (wasAtEnd && !isFollowerDriving) {
-                    putEnd()
-                } else if let anchor {
-                    restore(anchor)
-                }
+                // when it was issued is short the moment a row below the fold turns out taller
+                // than it was measured at.
+                keepPlace(wasAtEnd: wasAtEnd, anchor: anchor)
                 reportGeometry()
             }
         }
@@ -585,12 +531,9 @@ struct TranscriptTable: NSViewRepresentable {
         /// A fold is about to open or close, so the height change it causes is the one this file
         /// may animate.
         ///
-        /// **The height a fold changes is the TABLE's, not the row's**, which is the whole reason
-        /// this has to be said at all. In the lazy stack a `withAnimation` around the state change
-        /// carried into the `if` inside `ToolRowView` and the row grew itself. Here the row is
-        /// remeasured and the table is told a number, and a number arriving is not a transition.
-        /// So the travel is the table's row-height animation, at the length `TranscriptMotion`
-        /// gives every other settle in this app.
+        /// **The height a fold changes is the TABLE's, not the row's.** The row is remeasured
+        /// and the table is told a number, and a number arriving is not a transition, so the
+        /// travel is the table's row-height animation rather than a `withAnimation` inside the row.
         ///
         /// A set rather than a flag, because unfolding one row and folding another in the same
         /// pass is a thing a keyboard can do, and because a fold that is somehow not applied on
@@ -607,6 +550,48 @@ struct TranscriptTable: NSViewRepresentable {
             return TranscriptMotion.disclosure(reduceMotion: rowEnvironment.reduceMotion) ?? 0
         }
 
+        // MARK: Keeping the reader's place
+
+        /// **Where the reader goes after something under them has moved.** One answer, because
+        /// there were three of these and the resize one silently left `wasAtEnd` out: a reader
+        /// sitting at the live end without having asked for it was anchored to their top row by a
+        /// divider drag, while the comment beside it argued that a resize moves the end as much as
+        /// it moves anything. It does, so it gets the same answer as a row landing.
+        ///
+        /// The rule is `TranscriptAnchor.place`, in the core, because it had drifted once already
+        /// and a decision taken in a view is a decision nothing can test. `wasAtEnd` is read
+        /// before the move rather than here. Anything that is not the end keeps the ROW that was
+        /// at the top of the pane, which is the thing a point offset cannot do and the whole
+        /// reason for the table.
+        private func keepPlace(
+            wasAtEnd: Bool, anchor: (id: TranscriptEntryID, delta: CGFloat)?
+        ) {
+            switch TranscriptAnchor.place(
+                holdsEnd: holdsEnd,
+                wasAtEnd: wasAtEnd,
+                followerDriving: isFollowerDriving,
+                hasAnchor: anchor != nil
+            ) {
+            case .end:
+                putEnd()
+            case .anchor:
+                if let anchor { restore(anchor) }
+            case .stay:
+                break
+            }
+        }
+
+        /// Whether the reader is still following along, which is `ScrollEnd`'s question with a
+        /// line or two of slack, and not `TranscriptTableGeometry.isAtEnd`'s exact one.
+        private var isFollowingAlong: Bool {
+            let geometry = currentGeometry
+            return ScrollEnd.isAtEnd(
+                contentHeight: geometry.contentHeight,
+                viewportHeight: geometry.viewportHeight,
+                offset: geometry.offset
+            )
+        }
+
         // MARK: Scrolling
 
         var currentGeometry: TranscriptTableGeometry {
@@ -616,7 +601,9 @@ struct TranscriptTable: NSViewRepresentable {
             let clip = scrollView.contentView
             return TranscriptTableGeometry(
                 offset: clip.bounds.origin.y,
-                contentHeight: document.bounds.height,
+                // `frame` rather than `bounds`, so this agrees with `NSScrollView.endOffset`,
+                // which carries why.
+                contentHeight: document.frame.height,
                 viewportHeight: clip.bounds.height,
                 viewportWidth: clip.bounds.width
             )
@@ -645,14 +632,10 @@ struct TranscriptTable: NSViewRepresentable {
             // standing instruction then.
             guard !isFollowerDriving else { return }
             holdsEnd = true
-            // **And once more on the next turn, which is the table's version of the two-call dance
-            // the lazy stack needed.** There the two calls existed because `ScrollPosition` is a
-            // value and naming the edge it already stood at was not a change SwiftUI could apply.
-            // That argument is obsolete: a call on a table always acts. What is not obsolete is
-            // the reason the second call landed anything, which is that the content this one is
-            // aimed at may not have been laid out yet. A window that has just been moved to the
-            // tail, a bubble drawn on the frame Return was pressed, a row inserted in the same
-            // update: each of them changes where the end is after this line has read it.
+            // **And once more on the next turn**, because the content this one is aimed at may
+            // not have been laid out yet: a window just moved to the tail, a bubble drawn on the
+            // frame Return was pressed, a row inserted in the same update. Each changes where the
+            // end is after the line above has read it.
             endWork?.cancel()
             endWork = Task { @MainActor [weak self] in
                 await Task.yield()
@@ -677,29 +660,20 @@ struct TranscriptTable: NSViewRepresentable {
         }
 
         private func putEnd() {
-            guard let scrollView, let document = scrollView.documentView else { return }
+            guard let scrollView else { return }
             // The only number that means the end. A row being *visible* is not it: the last row of
-            // a transcript is often taller than the pane. See `TranscriptAnchor`.
-            put(
-                TranscriptAnchor.end(
-                    contentHeight: document.bounds.height,
-                    viewportHeight: scrollView.contentView.bounds.height
-                ),
-                in: scrollView
-            )
+            // a transcript is often taller than the pane. See `NSScrollView.endOffset`.
+            put(scrollView.endOffset, in: scrollView)
         }
 
         func scroll(to entryID: TranscriptEntryID, anchor: UnitPoint) {
             // Somewhere that is not the end, so whatever asked to be at the end has been overruled.
             aimingElsewhere()
             put(at: entryID, anchor: anchor)
-            // **And once more on the next turn, for the same reason `goToEnd` says the end twice.**
-            //
-            // A row is scrolled to at the height the table currently believes it is, and that
-            // belief is corrected the moment the row is drawn. The setup log is where this shows:
-            // unfolding 1,381 lines of it and asking to be taken to the end of it lands at the
-            // height the folded row was measured at, thousands of points short of where the log
-            // now ends. The correction arrives one turn later, and so does this.
+            // **And once more on the next turn, for the same reason `goToEnd` says it twice.** A
+            // row is scrolled to at the height the table currently believes it is. Unfolding 1,381
+            // lines of setup log and asking for the end of it lands at the height the folded row
+            // was measured at, thousands of points short; the correction arrives one turn later.
             reaimWork?.cancel()
             reaimWork = Task { @MainActor [weak self] in
                 await Task.yield()
@@ -740,9 +714,13 @@ struct TranscriptTable: NSViewRepresentable {
             let clip = scrollView.contentView
             let target = TranscriptAnchor.clamped(
                 y,
-                contentHeight: Double(scrollView.documentView?.bounds.height ?? 0),
+                contentHeight: Double(scrollView.documentView?.frame.height ?? 0),
                 viewportHeight: clip.bounds.height
             )
+            // Its own tolerance, and a small one on purpose: this asks whether the write would
+            // move anything at all, not whether the view is at the end. A point of slack here,
+            // which is what `TranscriptAnchor.isAtEnd` allows for a clip view's rounding, would
+            // refuse a real correction.
             guard abs(clip.bounds.origin.y - target) > 0.01 else { return }
             // So that the escape in `clipMoved` does not read this file's own arrival at the end
             // as the reader scrolling away from it.
@@ -753,11 +731,9 @@ struct TranscriptTable: NSViewRepresentable {
         }
 
         /// The three ways the table is told rows moved, each with a name of its own **so that the
-        /// next `sample` can tell them apart**. Which branch a scroll actually takes was the one
-        /// thing an earlier profile could not say: `apply` was 47.7 per cent of the main thread
-        /// with `NSHostingView` under it and `measure` at half a per cent, which is a reload
-        /// rebuilding cells rather than heights being taken, but only if the shape really was
-        /// `.rebuilt`. Three symbols answer that without a probe having to carry a counter.
+        /// next `sample` can tell them apart**. An earlier profile put `apply` at 47.7 per cent of
+        /// the main thread with `NSHostingView` under it and `measure` at half a per cent, which
+        /// only means a reload rebuilding cells if the shape really was `.rebuilt`.
         private func rowsArrived(head: Range<Int>, tail: Range<Int>, in tableView: NSTableView) {
             tableView.beginUpdates()
             // The head first, so that the indices the tail is named by are the indices the table
@@ -884,15 +860,12 @@ struct TranscriptTable: NSViewRepresentable {
                 try? await Task.sleep(for: .milliseconds(150))
                 guard !Task.isCancelled, let self else { return }
                 guard heights.reset(width: columnWidth, scale: sizing.scale) else { return }
+                // Read here rather than when the drag began: the rebuild below is what moves the
+                // content, and a width change has not moved anybody off the end before it.
+                let wasAtEnd = isFollowingAlong
                 let anchor = anchorEntry()
                 noteHeights(IndexSet(integersIn: entries.indices))
-                // A resize moves the end as much as it moves anything, so a reader who asked to be
-                // at it is still owed it.
-                if holdsEnd {
-                    putEnd()
-                } else if let anchor {
-                    restore(anchor)
-                }
+                keepPlace(wasAtEnd: wasAtEnd, anchor: anchor)
                 reportGeometry()
             }
             reportGeometry()
@@ -907,44 +880,28 @@ struct TranscriptTable: NSViewRepresentable {
 /// What every cell hosts, and the only place the drawn height is known.
 ///
 /// **`fixedSize` vertically is the whole of it.** A hosting view pinned to the four edges of its
-/// cell proposes the ROW's height to the SwiftUI root inside it, and a root that takes what it is
-/// offered can never report that the row is the wrong size: it is squeezed, or it is padded with
-/// blank, and it says nothing either way. Fixed vertically, the content takes the width it is
-/// given and its own ideal height, the reader sees the row it should have had even before the
-/// correction lands, and the geometry reader behind it has a number worth sending back.
+/// cell proposes the ROW's height to the root inside it, and a root that takes what it is offered
+/// can never report that the row is the wrong size: it is squeezed or padded with blank and says
+/// nothing either way. Fixed vertically, the content takes its own ideal height and the geometry
+/// reader behind it has a number worth sending back.
 ///
-/// The transaction is the SwiftUI half of "the animations get in the way". A cell is recycled: the
-/// same hosting view is handed a different row, and any implicit animation inside turns that swap
-/// into a height or an opacity travelling from what the last row was to what this one is, which
-/// over a scrolling table reads as the whole transcript sliding about. It is cleared here, at the
-/// root of the hosted content, because the row views themselves are shared with everything else
-/// that draws a transcript row and must not be touched.
-///
-/// **The arrival settle survives it**, and that is not an accident of ordering. `ArrivingRow`
-/// animates from its own `onAppear` with an explicit `withAnimation`, which is a transaction it
-/// creates rather than one it inherits, so clearing the inherited one takes nothing away from it.
-/// See `RowArrival`, which measured why the fade has to be started by the cell rather than aimed
-/// at it.
+/// The transaction is the SwiftUI half of "the animations get in the way". A recycled cell is
+/// handed a different row, and any implicit animation turns that swap into a height or an opacity
+/// travelling from the last row's to this one's, which over a scrolling table reads as the whole
+/// transcript sliding about. Cleared here rather than in the row views, which are shared with
+/// everything else that draws a transcript row. `ArrivingRow`'s settle survives it, because an
+/// explicit `withAnimation` creates a transaction rather than inheriting one.
 ///
 /// ## Known unverified: what `.global` means inside here
 ///
-/// **A hover card is positioned by two views agreeing about one coordinate space, and they are no
-/// longer certainly in the same one.** `ToolRowHeader` and `UserTurnRowView` report the chip's
-/// `frame(in: .global)` to `TranscriptHoverHost`, and `TranscriptHoverOverlay` subtracts its own
-/// `frame(in: .global)` to place the popover. Under the lazy stack both were inside one hosting
-/// view, so whatever `.global` resolved to, it resolved to the same thing twice and the
-/// subtraction was right by construction. Here the overlay is still in the pane's hierarchy and
-/// the row is in a hosting view of its own per cell, and if SwiftUI resolves `.global` against the
-/// hosting view rather than the window then the row's answer is its own offset within the cell,
-/// the subtraction is nonsense, and every card appears near the top left of the pane at the chip's
-/// x. If it resolves against the window, nothing has changed and this note can go.
-///
-/// It has not been photographed either way, so it is written down rather than guessed at. The fix,
-/// if it is wrong, is not to fiddle with `.global`: it is for the cell to convert, since the cell
-/// is the only thing that knows where it is. `HostedRow` would name a coordinate space, the
-/// reporters would use it, and an object in the environment carrying the cell's own view would do
-/// the `convert(_:to: nil)`. Reproduction, from the dev database: workspace "#362 Lay the app-side
-/// styling foundation on the", session `369a630d`, file chips in user bubbles at seq 387 and 948.
+/// `ToolRowHeader` and `UserTurnRowView` report a chip's `frame(in: .global)` and
+/// `TranscriptHoverOverlay` subtracts its own to place the popover. Under the lazy stack both were
+/// in one hosting view, so the subtraction was right by construction; here the row is in a hosting
+/// view per cell, and if SwiftUI resolves `.global` against that rather than the window every card
+/// appears near the top left of the pane at the chip's x. Not photographed either way. The fix, if
+/// it is wrong, is for the cell to convert, since it is the only thing that knows where it is.
+/// Reproduction, from the dev database: workspace "#362 Lay the app-side styling foundation on
+/// the", session `369a630d`, file chips in user bubbles at seq 387 and 948.
 private struct HostedRow: View {
     let content: AnyView
     let report: @MainActor (CGFloat) -> Void
@@ -1009,13 +966,10 @@ final class TranscriptTableCell: NSView {
     required init?(coder: NSCoder) { fatalError("not in a nib") }
 
     func apply(entry: TranscriptTableEntry, environment: TranscriptRowEnvironment) {
-        // The recycling. A cell that already holds this content is left exactly as it is, which is
-        // what a table buys over a stack that rebuilds every realised row on every pass.
-        //
-        // The three entries that re-render themselves are NOT excepted, and used to be. The
-        // streaming tail and the setup log watch their own state and re-render inside the cell;
-        // handing them a new root view on every pass threw that state away and rebuilt the tail
-        // several times a second.
+        // The recycling. A cell that already holds this content is left exactly as it is, which
+        // is what a table buys over a stack that rebuilds every realised row on every pass. The
+        // three entries that re-render themselves are NOT excepted, and used to be: handing the
+        // streaming tail a new root view on every pass rebuilt it several times a second.
         guard appliedKey != entry.contentKey else { return }
         appliedKey = entry.contentKey
         let id = entry.id

--- a/Sources/BloomCore/Transcript/TranscriptAnchor.swift
+++ b/Sources/BloomCore/Transcript/TranscriptAnchor.swift
@@ -63,6 +63,35 @@ public enum TranscriptAnchor {
         rowTop + rowHeight * anchor - viewportHeight * anchor
     }
 
+    /// What to do with the viewport after something has moved under the reader.
+    public enum Place: Equatable, Sendable {
+        /// Put it at the end of the content.
+        case end
+        /// Put the anchored row back where it was.
+        case anchor
+        /// Leave it where it is.
+        case stay
+    }
+
+    /// Where the reader goes after rows have landed, a height has been corrected, or the pane has
+    /// been resized.
+    ///
+    /// **Three callers wrote this out and the resize one left `wasAtEnd` off**, so a reader
+    /// sitting at the live end without having asked for it was anchored back to their top row by
+    /// a window resize or a divider drag. It is one answer here because the arithmetic in a view
+    /// is a decision nothing can test, and this one had already drifted.
+    ///
+    /// `holdsEnd` is somebody having asked for the end out loud, and it survives everything.
+    /// `wasAtEnd` is the reader who simply had not scrolled away, read BEFORE the move, and it is
+    /// dropped while a follower is driving the view: two things pinning the same clip view is the
+    /// instant pin winning with the travel invisible underneath it.
+    public static func place(
+        holdsEnd: Bool, wasAtEnd: Bool, followerDriving: Bool, hasAnchor: Bool
+    ) -> Place {
+        if holdsEnd || (wasAtEnd && !followerDriving) { return .end }
+        return hasAnchor ? .anchor : .stay
+    }
+
     /// Whether a viewport that was put at the end is still there.
     ///
     /// **Exact, and deliberately not `ScrollEnd.isAtEnd`.** That one answers "is the reader still

--- a/Tests/BloomCoreTests/TranscriptAnchorTests.swift
+++ b/Tests/BloomCoreTests/TranscriptAnchorTests.swift
@@ -159,4 +159,61 @@ struct TranscriptAnchorTests {
     func shortContentIsAtItsEnd() {
         #expect(TranscriptAnchor.isAtEnd(offset: 0, contentHeight: 300, viewportHeight: 800))
     }
+
+    // MARK: - Where the reader goes when something moves under them
+
+    /// The slip this function exists to stop coming back. `TranscriptTable` wrote the rule out
+    /// three times and the resize path left `wasAtEnd` off, so a reader sitting at the live end
+    /// without having asked for it was thrown back to their top row by a divider drag.
+    @Test("a reader at the end who never asked for it is still kept there")
+    func atTheEndWithoutAsking() {
+        #expect(
+            TranscriptAnchor.place(
+                holdsEnd: false, wasAtEnd: true, followerDriving: false, hasAnchor: true
+            ) == .end
+        )
+    }
+
+    @Test("a reader who scrolled away keeps their own row")
+    func scrolledAwayKeepsTheRow() {
+        #expect(
+            TranscriptAnchor.place(
+                holdsEnd: false, wasAtEnd: false, followerDriving: false, hasAnchor: true
+            ) == .anchor
+        )
+    }
+
+    @Test("asking for the end out loud survives everything")
+    func holdingTheEndWins() {
+        for driving in [false, true] {
+            for wasAtEnd in [false, true] {
+                #expect(
+                    TranscriptAnchor.place(
+                        holdsEnd: true, wasAtEnd: wasAtEnd,
+                        followerDriving: driving, hasAnchor: true
+                    ) == .end
+                )
+            }
+        }
+    }
+
+    /// Two things pinning one clip view is the instant pin winning with the travel invisible
+    /// underneath it, so the follower keeps the view for as long as it is driving.
+    @Test("the follower driving takes the end away from a reader who only happened to be at it")
+    func followerOutranksHavingBeenAtTheEnd() {
+        #expect(
+            TranscriptAnchor.place(
+                holdsEnd: false, wasAtEnd: true, followerDriving: true, hasAnchor: true
+            ) == .anchor
+        )
+    }
+
+    @Test("nothing to anchor to is nothing to do")
+    func noAnchorIsNoMove() {
+        #expect(
+            TranscriptAnchor.place(
+                holdsEnd: false, wasAtEnd: false, followerDriving: false, hasAnchor: false
+            ) == .stay
+        )
+    }
 }


### PR DESCRIPTION
Four duplication findings from the audit of what landed today.

Resizing the window or dragging the split divider while sitting at the live end anchored you to your top row instead of keeping you at the end. The rule that decides this was written three times and the third copy was missing a term. It is now `TranscriptAnchor.place(holdsEnd:wasAtEnd:followerDriving:hasAnchor:)` in the core with tests, and all three paths ask it.

"Where is the end of this scroll view" had five spellings across the transcript and the probes, two using the document's `bounds` and two its `frame`. One extension now, calling `TranscriptAnchor`. `frame` for the document and `bounds` for the clip is the correct pair: the offset everything compares against lives in the clip's space, and AppKit clamps against the document's frame. Equal today since nothing magnifies, so no behaviour change.

`JumpProbe` restated the tolerance its own header names and re-derived the harness that exists because the probes had duplicated their instruments. Both now call the thing they were copying.

The pulse animation was built twice under two names, with the same duration reached by two routes. One factory beside `install`, both frame rate caps kept with their arguments.

The five "at the end" tolerances are deliberately not unified: they answer different questions, and each now says which.

Comments cut back throughout. Every measured number and named bug kept; the design defences for things nobody is about to undo went.