### PR TITLE
Edit a queued message instead of retyping it

### DIFF
--- a/Sources/Bloom/Design/PendingDeleteSnapshotGallery.swift
+++ b/Sources/Bloom/Design/PendingDeleteSnapshotGallery.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 import BloomCore
 
-/// Every state of deleting a queued message on one page: the bubble at rest, under the pointer,
-/// the question, and what the queue looks like once the answer is Delete.
+/// Every state of taking a queued message back on one page: the bubble at rest, under the pointer,
+/// the one Edit is not offered for, the question, and what the queue looks like once the answer is
+/// Delete.
 ///
 /// It exists because the change is mostly about what a control looks like when nobody is pointing
 /// at it. Delete used to be drawn at opacity zero until the pointer arrived, which is why the
@@ -41,6 +42,7 @@ struct PendingDeleteSnapshotGallery: View {
                 PendingTurnRowView(
                     delivery: Self.delivery(Self.typed),
                     hold: .question,
+                    onEdit: {},
                     onDelete: {}
                 )
             }
@@ -49,6 +51,7 @@ struct PendingDeleteSnapshotGallery: View {
                 PendingTurnRowView(
                     delivery: Self.delivery(Self.typed),
                     hold: .question,
+                    onEdit: {},
                     onDelete: {},
                     pointerInside: true
                 )
@@ -62,20 +65,37 @@ struct PendingDeleteSnapshotGallery: View {
                     PendingTurnRowView(
                         delivery: Self.delivery("Also check the migration."),
                         hold: nil,
-                            onDelete: {}
+                        onEdit: {},
+                        onDelete: {}
                     )
                     PendingTurnRowView(
                         delivery: Self.delivery(Self.typed),
                         hold: nil,
-                            onDelete: {},
+                        onEdit: {},
+                        onDelete: {},
                         pointerInside: true
                     )
                     PendingTurnRowView(
                         delivery: Self.delivery("And run the tests when you are done."),
                         hold: .turn,
-                            onDelete: {}
+                        onEdit: {},
+                        onDelete: {}
                     )
                 }
+            }
+
+            // Its words cannot come back as text, so Edit is not drawn at all rather than drawn
+            // dead. See `PendingMessageEdit.canEdit`.
+            group("A message carrying a file, which Edit is not offered for") {
+                PendingTurnRowView(
+                    delivery: Self.delivery(
+                        AttachmentTrailer.compose(text: "Look at this.", paths: ["/tmp/shot.png"])
+                    ),
+                    hold: .turn,
+                    onEdit: {},
+                    onDelete: {},
+                    pointerInside: true
+                )
             }
 
             group("The question, when the composer is empty") {

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -193,6 +193,11 @@ final class TranscriptModel {
     /// clear afterwards. See `jumpToLiveEnd`.
     private(set) var liveEndRequests = 0
 
+    /// Bumped when something outside the composer has put words in the draft that the owner is
+    /// meant to carry on writing. A counter for `liveEndRequests`'s reason: two requests in a row
+    /// are two requests, and the composer has nothing to clear afterwards.
+    private(set) var composerFocusRequests = 0
+
     private var runner: (any SessionRunner)?
     private var pumpTask: Task<Void, Never>?
     private var indexByRefID: [String: Int] = [:]
@@ -577,6 +582,33 @@ final class TranscriptModel {
             draft = text
             await saveDraft()
         }
+    }
+
+    /// Takes one back out of the queue and into the composer, to be changed before it goes.
+    ///
+    /// No confirmation, because nothing is lost: the words end up in the box the owner is looking
+    /// at. `Store.cancelDelivery` is the same way out Delete uses, so the drain cannot fire on a
+    /// message this has already handed back, and the same lost race is possible and says so.
+    ///
+    /// The join is worked out after the row is gone rather than before, so the words go in front
+    /// of whatever the box holds by then rather than in front of what it held a round trip ago.
+    func editPending(_ delivery: Delivery) async {
+        guard PendingMessageEdit.canEdit(delivery), let store else { return }
+        let removed = (try? await store.cancelDelivery(id: delivery.id)) ?? false
+        await refreshQueue()
+
+        guard removed else {
+            app.notice = BloomNotice(message: PendingMessageEdit.alreadySentSentence)
+            return
+        }
+
+        draft = PendingMessageEdit.draft(taking: delivery, into: draft)
+        // Both before the write, the way `submit` draws and jumps before it awaits anything: the
+        // box the words landed in is where the owner should be on that frame, not a round trip
+        // later.
+        composerFocusRequests += 1
+        jumpToLiveEnd()
+        await saveDraft()
     }
 
     /// Closes the question when the message it is about is no longer waiting.

--- a/Sources/Bloom/Views/Center/Composer/ComposerView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerView.swift
@@ -116,6 +116,13 @@ struct ComposerView: View {
         .padding(.bottom, Metrics.gutter)
         .task(id: transcript.session.id) { await prepare() }
         .onChange(of: transcript.draft) { _, _ in scheduleDraftSave() }
+        // Something put words in the box for the owner to carry on writing, which today is Edit on
+        // a queued message. The caret goes to the start rather than the end, because the words that
+        // just arrived are at the front and are the ones the button was pressed to change.
+        .onChange(of: transcript.composerFocusRequests) { _, _ in
+            isFocused = true
+            caret = 0
+        }
         .onDisappear(perform: saveDraftNow)
     }
 

--- a/Sources/Bloom/Views/Transcript/PendingTurnRowView.swift
+++ b/Sources/Bloom/Views/Transcript/PendingTurnRowView.swift
@@ -31,6 +31,9 @@ struct PendingTurnRowView: View {
     /// a divider somebody had left in. At the foot of the run it reads as what it is, which is a
     /// note about everything above it.
     var hold: DeliveryHold?
+    /// Takes this one out of the queue and puts its words back in the composer. No question first:
+    /// nothing is lost, so a dialog would only be in the way. See `PendingMessageEdit`.
+    var onEdit: @MainActor () -> Void
     /// Asks to delete this one. It asks rather than deletes: the confirmation and the promise
     /// about where the sentence ends up are `PendingMessageDiscard`'s, through `TranscriptModel`.
     var onDelete: @MainActor () -> Void
@@ -108,7 +111,7 @@ struct PendingTurnRowView: View {
     /// what was asked for: the bubble holds the owner's words and nothing else, so that the words
     /// look the same before and after they go.
     ///
-    /// **Delete is drawn at rest and lights up under the pointer**, where it used to be drawn at
+    /// **Both are drawn at rest and light up under the pointer**, where Delete used to be drawn at
     /// opacity zero until the pointer arrived. The owner asked for the ability to delete a pending
     /// message that the app already had, which is what a control nobody can see amounts to. At
     /// rest it is the tertiary ink of the sentence beside it, so the row reads as one caption
@@ -133,16 +136,15 @@ struct PendingTurnRowView: View {
     @ViewBuilder
     private var caption: some View {
         HStack(spacing: Metrics.gutter) {
-            // Not `linkButton()`, and not `.link` with a tint of its own: measured on this SDK,
-            // `.buttonStyle(.link)` paints the system link colour whatever `.tint` says, so the
-            // resting state came out the same blue as the pointed-at one and the whole point of
-            // the two states was lost. A plain button takes the colour it is given, and
-            // `.pointerStyle` puts back the one thing the link style was buying.
-            Button("Delete", action: onDelete)
-                .buttonStyle(.plain)
-                .foregroundStyle(isPointedAt ? Palette.link : Palette.textTertiary)
-                .pointerStyle(.link)
-                .help("Takes this message back out of the queue. It is not sent.")
+            // First, because it is the safer of the two and the one wanted more often. Offered
+            // only for a message the composer could actually be handed back as text, which is
+            // `PendingMessageEdit.canEdit`: a disabled button with no explanation says less than
+            // no button at all.
+            if PendingMessageEdit.canEdit(delivery) {
+                action("Edit", help: "Takes this message back into the composer to change it.", run: onEdit)
+            }
+
+            action("Delete", help: "Takes this message back out of the queue. It is not sent.", run: onDelete)
 
             if let hold {
                 Text(hold.sentence)
@@ -150,5 +152,20 @@ struct PendingTurnRowView: View {
             }
         }
         .font(Typo.caption)
+    }
+
+    /// Not `linkButton()`, and not `.link` with a tint of its own: measured on this SDK,
+    /// `.buttonStyle(.link)` paints the system link colour whatever `.tint` says, so the resting
+    /// state came out the same blue as the pointed-at one and the whole point of the two states
+    /// was lost. A plain button takes the colour it is given, and `.pointerStyle` puts back the
+    /// one thing the link style was buying.
+    private func action(
+        _ label: String, help: String, run: @escaping @MainActor () -> Void
+    ) -> some View {
+        Button(label, action: run)
+            .buttonStyle(.plain)
+            .foregroundStyle(isPointedAt ? Palette.link : Palette.textTertiary)
+            .pointerStyle(.link)
+            .help(help)
     }
 }

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -472,6 +472,7 @@ struct TranscriptListView: View {
                         PendingTurnRowView(
                             delivery: delivery,
                             hold: hold,
+                            onEdit: { Task { await transcript.editPending(delivery) } },
                             onDelete: { transcript.askToDiscard(delivery) }
                         )
                         .padding(.horizontal, TranscriptLayout.inset)

--- a/Sources/BloomCore/Transcript/PendingMessageDiscard.swift
+++ b/Sources/BloomCore/Transcript/PendingMessageDiscard.swift
@@ -60,7 +60,10 @@ public enum PendingMessageDiscard {
     /// Both trailers are machine writing appended at send time, and neither survives a round trip
     /// through a text box: the chips would come back as their rendered prompt, and the attachment
     /// paths would come back as a list the composer draws from its own staging instead.
-    private static func isPlainText(_ body: String) -> Bool {
+    ///
+    /// `PendingMessageEdit` asks this too, and it is the one question the two of them share: it is
+    /// a fact about the body, where everything else here is a policy about the box.
+    public static func isPlainText(_ body: String) -> Bool {
         ReviewTurn.split(body) == nil && AttachmentTrailer.split(body).paths.isEmpty
     }
 

--- a/Sources/BloomCore/Transcript/PendingMessageEdit.swift
+++ b/Sources/BloomCore/Transcript/PendingMessageEdit.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Taking a queued message back into the composer to change it before it goes.
+///
+/// The sibling of `PendingMessageDiscard`, and deliberately not the same function. Delete refuses
+/// to hand the words back when the box is in use, because pasting over what somebody is typing to
+/// rescue what they typed earlier trades one loss for another. Edit is somebody asking for that
+/// move, so it always hands them back and joins the two rather than choosing between them. The
+/// only question both ask is `isPlainText`, which is a fact about the body rather than a policy
+/// about the box.
+public enum PendingMessageEdit {
+    /// Whether Edit may be offered for this one at all.
+    ///
+    /// A body carrying review chips or attached files cannot come back as text, and there is
+    /// nothing honest to draw for it: a disabled button with no explanation says less than no
+    /// button, so the row simply does not offer one.
+    public static func canEdit(_ delivery: Delivery) -> Bool {
+        PendingMessageDiscard.canDiscard(delivery) && PendingMessageDiscard.isPlainText(delivery.body)
+    }
+
+    /// What the composer is left holding once this message has been taken out of the queue.
+    ///
+    /// The words go at the front, because they were asked for first and reading them from the top
+    /// is how they get changed. `composerDraft` blank counts as empty, the same reading
+    /// `PendingMessageDiscard.recovery` takes: a box holding three newlines is not something
+    /// anybody is in the middle of writing, so it gets the words alone rather than the words and a
+    /// blank line and its own whitespace.
+    public static func draft(taking delivery: Delivery, into composerDraft: String) -> String {
+        guard !composerDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return delivery.body
+        }
+        return delivery.body + "\n\n" + composerDraft
+    }
+
+    /// What the owner is told when the message went between pressing Edit and the row being taken
+    /// out of the queue. The same race `PendingMessageDiscard.alreadySentSentence` names, said in
+    /// this button's own verb so it does not report a delete nobody asked for.
+    public static let alreadySentSentence =
+        "That message had already gone to the agent, so it could not be edited."
+}

--- a/Tests/BloomCoreTests/PendingMessageEditTests.swift
+++ b/Tests/BloomCoreTests/PendingMessageEditTests.swift
@@ -1,0 +1,93 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+/// Taking a queued message back into the composer, and how its words join what is already there.
+@Suite("Editing a pending message")
+struct PendingMessageEditTests {
+    private func delivery(_ body: String, delivered: Bool = false) -> Delivery {
+        Delivery(
+            targetSessionID: SessionID("s"),
+            body: body,
+            deliveredAt: delivered ? Date() : nil
+        )
+    }
+
+    @Test("an empty composer gets the words alone")
+    func emptyComposerTakesTheWords() {
+        #expect(PendingMessageEdit.draft(taking: delivery("one"), into: "") == "one")
+    }
+
+    /// The same reading `PendingMessageDiscard.recovery` takes, rather than a second answer to the
+    /// same question: a box holding whitespace is not a box somebody is writing in.
+    @Test("a blank composer counts as empty, and its whitespace does not survive")
+    func blankComposerTakesTheWords() {
+        #expect(PendingMessageEdit.draft(taking: delivery("one"), into: " \n\n ") == "one")
+    }
+
+    @Test("the words go in front of what is already there, with a blank line between")
+    func textComposerIsPrepended() {
+        let joined = PendingMessageEdit.draft(taking: delivery("one"), into: "half a thought")
+        #expect(joined == "one\n\nhalf a thought")
+    }
+
+    /// The words are not reflowed on the way back: a message written over several lines is the
+    /// same message when it lands in the box.
+    @Test("a multi-line message keeps its own newlines")
+    func multiLineBodySurvives() {
+        let joined = PendingMessageEdit.draft(taking: delivery("one\ntwo"), into: "three")
+        #expect(joined == "one\ntwo\n\nthree")
+    }
+
+    // MARK: - When it is offered
+
+    @Test("offered for a message still in the queue")
+    func pendingPlainTextIsEditable() {
+        #expect(PendingMessageEdit.canEdit(delivery("one")))
+    }
+
+    @Test("not offered for a message that has gone")
+    func deliveredIsNotEditable() {
+        #expect(!PendingMessageEdit.canEdit(delivery("one", delivered: true)))
+    }
+
+    /// Attachments come back from the composer's own staging rather than from the text, so a body
+    /// carrying them cannot be handed to the box as words. No button, rather than a dead one.
+    @Test("not offered for a message with attached files")
+    func attachmentsAreNotEditable() {
+        let body = AttachmentTrailer.compose(text: "look at this", paths: ["/tmp/shot.png"])
+        #expect(!PendingMessageEdit.canEdit(delivery(body)))
+    }
+
+    @Test("not offered for a message carrying review comments")
+    func reviewTurnsAreNotEditable() {
+        let comment = ReviewComment(
+            id: ReviewCommentID("Sources/Widget.swift#3#new"),
+            workspaceID: WorkspaceID("w"),
+            filePath: "Sources/Widget.swift",
+            side: .new,
+            anchor: ReviewCommentAnchor.make(line: 1, in: ["struct Widget {}"]),
+            body: "rename this",
+            createdAt: Date(timeIntervalSince1970: 1)
+        )
+        let body = ReviewTurn.compose(
+            message: "Fix this.",
+            comments: [comment],
+            worktreePath: nil,
+            template: PromptRegistry.definition(for: .review).defaultTemplate
+        )
+        #expect(!PendingMessageEdit.canEdit(delivery(body)))
+    }
+
+    /// Delete refuses to hand the words back into a box that is in use. Edit is somebody asking
+    /// for exactly that, so the two must not end up sharing one answer.
+    @Test("edit hands the words back where delete would not")
+    func editDisagreesWithDiscardOnPurpose() {
+        let one = delivery("one")
+        #expect(
+            PendingMessageDiscard.recovery(of: one, composerDraft: "half a thought")
+                == .discarded(.composerInUse)
+        )
+        #expect(PendingMessageEdit.draft(taking: one, into: "half a thought") == "one\n\nhalf a thought")
+    }
+}


### PR DESCRIPTION
An Edit button beside Delete on a message waiting in the queue. It takes the message out and puts its words at the front of the composer, separated from whatever was already there by a blank line. An empty box, or one holding only whitespace, gets the words alone.

The joining rule is `PendingMessageEdit` in the core with a suite over it, because "two newlines only when the box is not empty" is a decision rather than a drawing.

Delete already refuses to hand words back into a box somebody is typing in, on the grounds that it trades one loss for another. Edit does it, because pressing Edit is the consent. The two stay separate functions; they share only the test for whether a body is plain text, which is a fact about the message rather than a policy about the box.

A message carrying attachments or review chips gets no Edit button at all. The chips would come back as their rendered prompt and the files as paths the composer stages separately, so there is no honest version of it. Delete stays available.

No confirmation, since nothing is lost. If the turn ends between the press and the message leaving the queue, the store's WHERE refuses, nothing is prepended and the notice says so.