### PR TITLE
Let the file tree open and close like Finder's

### DIFF
--- a/Sources/Bloom/Views/Inspector/ChangedFileList.swift
+++ b/Sources/Bloom/Views/Inspector/ChangedFileList.swift
@@ -55,6 +55,8 @@ struct ChangedFileList: View {
     @AppStorage(ChangedFilePresentation.storageKey)
     private var isTree = ChangedFilePresentation.defaultsToTree
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         ScrollViewReader { proxy in
             Group {
@@ -260,36 +262,66 @@ struct ChangedFileList: View {
 
     /// Only the shape on screen is derived, because a running agent rewrites the changed file list
     /// every few seconds and the other shape would be thrown away unseen.
+    ///
+    /// Never animated. This is what a running agent's writes come through, and a list that slid
+    /// every six seconds because a file gained a line would be the tree animating for a reason
+    /// nobody gave it. Opening a folder is the one gesture that reflows: see `toggle`.
     private func rebuild() {
         if isTree {
-            treeRows = ChangedFileTree.rows(
+            adopt(ChangedFileTree.rows(
                 from: ChangedFileTree.build(from: model.changedFiles),
                 collapsed: collapsed
-            )
-            groups = []
-            rowPaths = treeRows.map(\.node.path)
-            rowTitles = treeRows.map(\.node.name)
+            ))
         } else {
             groups = ChangedFileGroup.build(from: model.changedFiles)
             treeRows = []
             let files = groups.flatMap(\.files)
             rowPaths = files.map(\.path)
             rowTitles = files.map(\.filename)
+            forgetMissingCursor()
         }
+    }
 
-        // A file the agent reverted, or a directory that closed under the keyboard, leaves the
-        // cursor naming a row that is not drawn any more, and every key after that would be
-        // measured from nothing.
+    private func adopt(_ rows: [ChangedFileTreeRow]) {
+        treeRows = rows
+        groups = []
+        rowPaths = rows.map(\.node.path)
+        rowTitles = rows.map(\.node.name)
+        forgetMissingCursor()
+    }
+
+    /// A file the agent reverted, or a directory that closed under the keyboard, leaves the cursor
+    /// naming a row that is not drawn any more, and every key after that would be measured from
+    /// nothing.
+    private func forgetMissingCursor() {
         if let cursor, !rowPaths.contains(cursor) { self.cursor = nil }
     }
 
+    /// A folder the reader just opened or closed, with the rows below it travelling to make room.
+    /// See `TreeDisclosureMotion` for the threshold above which they stop travelling.
+    ///
+    /// The new rows are built before anything is written, because their count is what decides
+    /// whether the write is animated at all.
     private func toggle(_ path: String) {
-        if collapsed.contains(path) {
-            collapsed.remove(path)
+        var next = collapsed
+        if next.contains(path) {
+            next.remove(path)
         } else {
-            collapsed.insert(path)
+            next.insert(path)
         }
-        rebuild()
+
+        let rows = ChangedFileTree.rows(
+            from: ChangedFileTree.build(from: model.changedFiles),
+            collapsed: next
+        )
+        let motion = TreeDisclosureMotion.rows(
+            changing: abs(rows.count - treeRows.count), reduceMotion: reduceMotion
+        )
+
+        withAnimation(motion.animation) {
+            collapsed = next
+            adopt(rows)
+        }
     }
 
     // MARK: - The keyboard

--- a/Sources/Bloom/Views/Inspector/ChangedFolderRow.swift
+++ b/Sources/Bloom/Views/Inspector/ChangedFolderRow.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import BloomCore
 
 /// A folder in the changed files tree, said once for a whole chain of directories that only ever
 /// had one child.
@@ -31,13 +32,23 @@ struct ChangedFolderRow: View, Equatable {
     var fullPath: String
     var action: () -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         Button(action: action) {
             HStack(spacing: InspectorLayout.gap) {
-                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                // One chevron turned rather than two symbols swapped, and on its own `.animation`
+                // rather than the list's transaction, exactly as `FileTreeRow` does it: the two
+                // trees share a pane and a folder opening must look the same in both.
+                Image(systemName: "chevron.right")
                     .font(Typo.micro)
                     .imageScale(.small)
                     .foregroundStyle(.tertiary)
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    .animation(
+                        TreeDisclosureMotion.chevron(reduceMotion: reduceMotion).animation,
+                        value: isExpanded
+                    )
                     .frame(width: InspectorLayout.glyphWidth, alignment: .leading)
                     .accessibilityHidden(true)
                 // The same size as the files under it, one step quieter, and said hierarchically

--- a/Sources/Bloom/Views/Inspector/FileTreeRow.swift
+++ b/Sources/Bloom/Views/Inspector/FileTreeRow.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import BloomCore
 
 /// One row of the worktree tree: a disclosure chevron or a document icon, the name, and a dot if
 /// the agent touched it.
@@ -25,6 +26,7 @@ struct FileTreeRow: View, Equatable {
     var action: () -> Void
 
     @Environment(\.isOnEmphasizedSelection) private var isOnSelection
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// The dot marking a file the agent touched. Punctuation, not a badge.
     private static let changedDotSize: CGFloat = 5
@@ -36,6 +38,15 @@ struct FileTreeRow: View, Equatable {
                     .font(Typo.micro)
                     .imageScale(.small)
                     .foregroundStyle(.tertiary)
+                    // One chevron turned rather than two symbols swapped, which is what a
+                    // disclosure triangle on this platform does. Its own `.animation` and not the
+                    // tree's transaction, so it still turns on an expansion too big for the rows
+                    // below to travel. See `TreeDisclosureMotion`.
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    .animation(
+                        TreeDisclosureMotion.chevron(reduceMotion: reduceMotion).animation,
+                        value: isExpanded
+                    )
                     .frame(width: InspectorLayout.glyphWidth, alignment: .leading)
                     .accessibilityHidden(true)
                 // A directory is one step quieter than a file, said with the hierarchical style so
@@ -79,9 +90,9 @@ struct FileTreeRow: View, Equatable {
         return isExpanded ? "Expanded" : "Collapsed"
     }
 
+    /// Always the closed chevron for a directory. Open is the same glyph, turned.
     private var symbol: String {
-        guard item.node.isDirectory else { return "doc" }
-        return isExpanded ? "chevron.down" : "chevron.right"
+        item.node.isDirectory ? "chevron.right" : "doc"
     }
 
     private func copyPath() {

--- a/Sources/Bloom/Views/Inspector/FileTreeView.swift
+++ b/Sources/Bloom/Views/Inspector/FileTreeView.swift
@@ -35,6 +35,8 @@ struct FileTreeView: View {
     /// selection fill and the quiet one. See `RowBackground`.
     @State private var hasKeyboard = false
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private struct LoadID: Hashable {
         var workspaceID: WorkspaceID
         var workspacePath: String
@@ -142,14 +144,20 @@ struct FileTreeView: View {
         toggle(node)
     }
 
+    /// Never animated. The listing lands once when the workspace opens, and eight thousand rows
+    /// arriving is the pane being pointed somewhere else rather than anything the reader did.
     private func rebuildRows() {
-        rows = FileTreeRowItem.flatten(children: model.fileTree, expanded: expanded)
-        rowTitles = rows.map(\.node.name)
+        adopt(FileTreeRowItem.flatten(children: model.fileTree, expanded: expanded))
+    }
+
+    private func adopt(_ items: [FileTreeRowItem]) {
+        rows = items
+        rowTitles = items.map(\.node.name)
 
         // A folder that closed under the keyboard takes its children off the screen, and a cursor
         // naming a row that is not drawn any more would leave every key after it measured from
         // nothing.
-        if let selection, !rows.contains(where: { $0.node.path == selection }) {
+        if let selection, !items.contains(where: { $0.node.path == selection }) {
             self.selection = nil
         }
     }
@@ -209,14 +217,33 @@ struct FileTreeView: View {
         }
     }
 
+    /// The one place in this view that animates: a folder the reader just opened or closed, with
+    /// the rows below it travelling to make room. See `TreeDisclosureMotion` for the threshold
+    /// above which they stop travelling and simply arrive.
+    ///
+    /// The new rows are flattened before anything is written, because their count is what decides
+    /// whether the write is animated at all.
     private func toggle(_ node: FileTreeNode) {
-        selection = node.path
-        if expanded.contains(node.path) {
-            expanded.remove(node.path)
+        var opened = expanded
+        if opened.contains(node.path) {
+            opened.remove(node.path)
         } else {
-            expanded.insert(node.path)
+            opened.insert(node.path)
         }
-        rebuildRows()
+
+        let items = FileTreeRowItem.flatten(children: model.fileTree, expanded: opened)
+        let motion = TreeDisclosureMotion.rows(
+            changing: abs(items.count - rows.count), reduceMotion: reduceMotion
+        )
+
+        // Outside the transaction, so the highlight lands with the click rather than fading in
+        // behind the rows.
+        selection = node.path
+
+        withAnimation(motion.animation) {
+            expanded = opened
+            adopt(items)
+        }
     }
 
     private func fullPath(_ relative: String) -> String {

--- a/Sources/Bloom/Views/Inspector/TreeDisclosure.swift
+++ b/Sources/Bloom/Views/Inspector/TreeDisclosure.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+import BloomCore
+
+extension TreeDisclosureMotion {
+    /// `easeOut`, the curve every reflow in this window travels on. See `SidebarView`, which spells
+    /// the same line for `ProjectVisibilityMotion`.
+    ///
+    /// Nil is not "no opinion": handed to `withAnimation` it explicitly refuses the ambient
+    /// transaction, which is what a change above `rowLimit` wants.
+    var animation: Animation? {
+        seconds.map { .easeOut(duration: $0) }
+    }
+}

--- a/Sources/BloomCore/Presentation/TreeDisclosureMotion.swift
+++ b/Sources/BloomCore/Presentation/TreeDisclosureMotion.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// What opening or closing a folder in the inspector's two trees looks like.
+///
+/// The gesture is one gesture and it has two halves that are decided separately. **The chevron
+/// turns whatever the folder holds**, because it is one small rotation on one glyph and costs the
+/// same on a folder of two files and a folder of two thousand. **The rows below it only travel
+/// while there are rows left on screen to travel**, which is what `rowLimit` is about.
+///
+/// Here rather than in the views because both trees have to answer it identically, and because a
+/// threshold taken inside a view is a threshold nothing can test.
+public enum TreeDisclosureMotion: Equatable, Sendable {
+    /// There instantly, with nothing to watch. Reduce Motion, and an expansion too big to read.
+    case instant
+    /// Rows arrive or leave, and everything below them travels to its new place.
+    case animated(seconds: Double)
+
+    /// How long it takes, or nil when there is nothing to time.
+    public var seconds: Double? {
+        switch self {
+        case .instant: nil
+        case .animated(let seconds): seconds
+        }
+    }
+
+    /// The most rows that can arrive or leave in one gesture and still be worth animating.
+    ///
+    /// At `Metrics.rowHeight`, forty rows is 1,120 points: more than the inspector column is tall
+    /// on any display this window opens on. Above it every row that was under the folder has left
+    /// the pane before the curve is a third through, so nothing is left travelling and all that
+    /// remains is a block of new rows fading in place. That fade is exactly the effect this whole
+    /// change exists to replace, so above the threshold it is more honest to show none of it.
+    ///
+    /// It is a legibility limit and not a cost limit. Both trees draw into a `LazyVStack`, which
+    /// materialises about a screenful of rows however many the folder holds, so a large expansion
+    /// is not the runaway that a per-frame animation over a whole window was: see `BusyPulse` for
+    /// the 320,971 view graph updates that one measured at.
+    public static let rowLimit = 40
+
+    /// The rows making room, or not.
+    ///
+    /// - Parameter count: how many rows arrive or leave, whichever way the folder went. Zero for
+    ///   an empty directory, which has nothing to animate even though its chevron still turns.
+    public static func rows(changing count: Int, reduceMotion: Bool) -> TreeDisclosureMotion {
+        guard count > 0, count <= rowLimit else { return .instant }
+        return chevron(reduceMotion: reduceMotion)
+    }
+
+    /// The disclosure chevron turning.
+    ///
+    /// The length is `TranscriptMotion.disclosure`'s rather than one chosen here: a tool result
+    /// unfolding in the transcript and a folder opening in the inspector are the same gesture in
+    /// two panes, and two lengths would read as two apps. Reduce Motion drops it rather than
+    /// slowing it, matching every other call site.
+    public static func chevron(reduceMotion: Bool) -> TreeDisclosureMotion {
+        guard let seconds = TranscriptMotion.disclosure(reduceMotion: reduceMotion) else {
+            return .instant
+        }
+        return .animated(seconds: seconds)
+    }
+}

--- a/Tests/BloomCoreTests/TreeDisclosureMotionTests.swift
+++ b/Tests/BloomCoreTests/TreeDisclosureMotionTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import BloomCore
+
+/// A folder opening has two halves that are decided separately, and the whole reason this type
+/// exists is that the cheap half must not be lost with the expensive one.
+@Suite struct TreeDisclosureMotionTests {
+    @Test func aFolderOfAFewFilesMakesRoomForThem() {
+        #expect(TreeDisclosureMotion.rows(changing: 6, reduceMotion: false)
+            == .animated(seconds: TranscriptMotion.disclosure(reduceMotion: false) ?? 0))
+    }
+
+    @Test func aFolderTooBigToWatchArrivesInstead() {
+        // Past the limit every row that could travel has left the pane before the curve is a
+        // third through, and what is left is a block fading in place.
+        let limit = TreeDisclosureMotion.rowLimit
+        #expect(TreeDisclosureMotion.rows(changing: limit, reduceMotion: false) != .instant)
+        #expect(TreeDisclosureMotion.rows(changing: limit + 1, reduceMotion: false) == .instant)
+    }
+
+    @Test func anEmptyDirectoryHasNothingToTime() {
+        #expect(TreeDisclosureMotion.rows(changing: 0, reduceMotion: false) == .instant)
+        #expect(TreeDisclosureMotion.instant.seconds == nil)
+    }
+
+    @Test func theChevronTurnsWhateverTheFolderHolds() {
+        // The one thing that is not thresholded: it is a rotation on a single glyph, so it costs
+        // the same on a folder of two files and a folder of two thousand.
+        #expect(TreeDisclosureMotion.chevron(reduceMotion: false).seconds != nil)
+        #expect(TreeDisclosureMotion.rows(changing: 5_000, reduceMotion: false) == .instant)
+    }
+
+    @Test func reduceMotionDropsBothHalvesRatherThanSlowingThem() {
+        #expect(TreeDisclosureMotion.rows(changing: 6, reduceMotion: true) == .instant)
+        #expect(TreeDisclosureMotion.chevron(reduceMotion: true) == .instant)
+    }
+
+    @Test func itTakesTheSameLengthAsARowUnfoldingInTheTranscript() {
+        // One gesture in two panes. Two lengths would read as two apps, which is the argument
+        // `ProjectVisibilityMotion` is pinned to the same number by.
+        #expect(TreeDisclosureMotion.chevron(reduceMotion: false).seconds
+            == TranscriptMotion.disclosure(reduceMotion: false))
+    }
+}


### PR DESCRIPTION
Clicking a folder slides the rows below it down to make room, instead of the tree swapping whole on one frame, and the disclosure triangle turns rather than being swapped for a different glyph.

Both trees, because there are two: the All files tab keeps an expanded set and defaults closed, the Changes tab keeps a collapsed set and defaults open. They deliberately look identical, so animating one would have made the two tabs behave differently.

Only a click reflows. `rebuild` stays untransacted, which is the path a running agent's changed-file rewrite takes every few seconds; animating that would have the tree sliding around on its own while an agent worked.

`TreeDisclosureMotion` in the core holds both decisions with a suite over them, and takes its length from `TranscriptMotion.disclosure` rather than adding a fourth speed. Above 40 rows the reflow falls to instant while the triangle still turns: at that size every row that could travel has left the pane before the curve is a third through, and what is left is a block of rows fading in place, which is the effect this replaces.

Reduce Motion drops both halves and keeps the result.