### PR TITLE
A browser bar that looks like it belongs on macOS 26

### DIFF
--- a/Sources/Bloom/Design/BrowserToolbarGallery.swift
+++ b/Sources/Bloom/Design/BrowserToolbarGallery.swift
@@ -4,9 +4,9 @@ import BloomCore
 /// The browser pane's toolbar in each state its controls can be in, on one page.
 ///
 /// It exists because the bar is a set of controls whose shape is the thing under review: which
-/// arrows can be pressed, whether the third glyph is Reload or Stop, and whether there is anything
-/// to share. One pane shows one of those at a time, and no screen in the app puts a page four
-/// links deep beside a pane that has never been anywhere.
+/// arrows can be pressed, whether the glyph in the field is Reload or Stop, and whether there is
+/// anything to share. One pane shows one of those at a time, and no screen in the app puts a page
+/// four links deep beside a pane that has never been anywhere.
 ///
 /// Drawn from `BrowserToolbarView` rather than from a browser pane, which is why that view was
 /// split out: a pane needs a live `BrowserSession` behind it, and an offscreen render paints
@@ -46,11 +46,24 @@ struct BrowserToolbarGallery: View {
             )
             row(
                 "Loading",
-                "Reload becomes Stop in place, so nothing beside it moves for the second it takes.",
+                "Reload becomes Stop in place, and the fill behind the address is how far it has got.",
                 BrowserToolbar(
                     page: page("https://spatie.be/docs", "Docs"),
                     canGoBack: true,
-                    isLoading: true
+                    isLoading: true,
+                    loadProgress: 0.45
+                )
+            )
+            row(
+                "A URL longer than the pane",
+                "Cut at the tail, so the host is the part that always survives.",
+                BrowserToolbar(
+                    page: page(
+                        "https://github.com/spatie/laravel-medialibrary/pull/3812/files"
+                            + "#diff-a7b3f2c9?utm_source=bloom&expand=1",
+                        "Files changed"
+                    ),
+                    canGoBack: true
                 )
             )
             row(
@@ -123,7 +136,7 @@ extension Gallery {
     static let browserToolbar = Gallery(
         name: "browser-toolbar",
         title: "Browser toolbar",
-        size: CGSize(width: 570, height: 640),
+        size: CGSize(width: 570, height: 740),
         needsFocus: false,
         view: { _ in AnyView(BrowserToolbarGallery()) }
     )

--- a/Sources/Bloom/Design/Theme.swift
+++ b/Sources/Bloom/Design/Theme.swift
@@ -719,6 +719,10 @@ enum Metrics {
     /// A strip of small controls along the edge of a pane: the sidebar's status bar, the
     /// inspector's pull request strip and its tab row.
     static let barHeight: CGFloat = 32
+    /// A control drawn with a fill of its own inside one of those strips: Home's search field, the
+    /// browser bar's address pill and the capsule its arrows sit in. Five points of ground above
+    /// and below, which is the clearance a bare glyph in the same strip already has.
+    static let controlHeight: CGFloat = 22
 }
 
 /// How a pane arrives and leaves.

--- a/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
@@ -32,6 +32,12 @@ final class BrowserSession {
     private(set) var canGoBack = false
     private(set) var canGoForward = false
     private(set) var isLoading = false
+    /// How far the fetch in flight has got, rounded to hundredths.
+    ///
+    /// Rounded because WebKit reports this continuously and every write redraws the pane. A
+    /// hundredth is under four points of the field the fill is drawn in, so nothing is lost and
+    /// the number of redraws a load can cost is capped at a hundred.
+    private(set) var loadProgress: Double = 0
     /// Where the page actually is, which is not what the user has typed into the address field.
     private(set) var currentURL: URL?
     /// Where the page is and what it says it is called, as one value.
@@ -83,23 +89,19 @@ final class BrowserSession {
     /// navigation.
     ///
     /// It started as KVO on `title` alone, since there is no delegate callback for a title:
-    /// `didFinish` fires before the title of a page that sets it from script, and a page that
-    /// renames itself while you are reading it fires nothing at all.
+    /// `didFinish` fires before the title of a page that sets it from script.
     ///
-    /// **The address needed exactly the same treatment and did not have it, which is the bug.** A
-    /// single page app navigates with `history.pushState`, which is a SAME DOCUMENT navigation:
-    /// WebKit updates `url` and the back list, and neither `didCommit` nor `didFinish` fires,
-    /// because no document was loaded. There is no public delegate callback for one either, and
-    /// this was checked rather than assumed: `WKNavigationDelegate` has nothing with "same
-    /// document" in its name. So the field sat on `/login` while the reader walked four pages into
-    /// an Inertia site, and the tab strip beside it kept up perfectly, because the title was on
-    /// KVO and the address was not.
+    /// **The address needed exactly the same treatment and did not have it, which was the bug.** A
+    /// single page app navigates with `history.pushState`, which is a same document navigation:
+    /// WebKit updates `url` and the back list, neither `didCommit` nor `didFinish` fires, and
+    /// there is no public delegate callback for one. So the field sat on `/login` while the reader
+    /// walked four pages into an Inertia site.
     ///
     /// `canGoBack` and `canGoForward` were stale in the same way and for the same reason: a
     /// `pushState` pushes a back entry without loading anything, so Back was dead on a page you
     /// really could go back from. `isLoading` is watched with them because the header documents it
-    /// as KVO compliant alongside the other three and one line is cheaper than the argument about
-    /// which callbacks cover it.
+    /// as KVO compliant with the rest, and `estimatedProgress` is watched for the fill behind the
+    /// address.
     ///
     /// The delegate stays. It is what reports a failure, and having both is two mechanisms
     /// agreeing rather than a duplicate: `refresh` reads the web view and writes what changed.
@@ -131,9 +133,9 @@ final class BrowserSession {
                     self?.adopt(BrowserTabTitle.BrowserPage(title: view.title ?? ""))
                 }
             },
-            // No `.initial` on these four, unlike the title: the three lines below set the same
-            // facts from the address this tab is opening on, and an initial notification would
-            // land before them and read an empty web view.
+            // No `.initial` on these, unlike the title: the three lines at the end of this
+            // initialiser set the same facts from the address the tab is opening on, and an
+            // initial notification would land before them and read an empty web view.
             webView.observe(\.url) { [weak self] _, _ in
                 MainActor.assumeIsolated { self?.refresh() }
             },
@@ -144,6 +146,9 @@ final class BrowserSession {
                 MainActor.assumeIsolated { self?.refresh() }
             },
             webView.observe(\.isLoading) { [weak self] _, _ in
+                MainActor.assumeIsolated { self?.refresh() }
+            },
+            webView.observe(\.estimatedProgress) { [weak self] _, _ in
                 MainActor.assumeIsolated { self?.refresh() }
             },
         ]
@@ -464,16 +469,17 @@ final class BrowserSession {
 
     /// Reads the whole of the web view's state and writes back only what moved.
     ///
-    /// **Only what moved, because `@Observable` does not compare.** Setting a property to the value
-    /// it already holds still tells every view reading it to redraw, and one navigation now calls
-    /// this five times: the delegate on start, commit and finish, and KVO on each of the four
-    /// properties it watches. Writing all four every time made a single page load a dozen redraws
-    /// of the centre column for three actual changes. `adopt` has always compared, for the same
-    /// reason and one level down.
+    /// **Only what moved, because `@Observable` does not compare.** Setting a property to the
+    /// value it already holds still tells every view reading it to redraw, and one navigation
+    /// calls this a dozen times over: the delegate on start, commit and finish, and KVO on each of
+    /// the five properties it watches. Writing every field each time made a single page load a
+    /// dozen redraws of the centre column for three actual changes.
     fileprivate func refresh() {
         if canGoBack != webView.canGoBack { canGoBack = webView.canGoBack }
         if canGoForward != webView.canGoForward { canGoForward = webView.canGoForward }
         if isLoading != webView.isLoading { isLoading = webView.isLoading }
+        let progress = (webView.estimatedProgress * 100).rounded() / 100
+        if loadProgress != progress { loadProgress = progress }
         // Nil is a web view that has not loaded anything rather than a page at no address, so the
         // tab keeps the address it was opened on. See `reload`, which is the other half of that.
         if let url = webView.url, url != currentURL { currentURL = url }

--- a/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
@@ -106,6 +106,7 @@ struct BrowserTabView: View {
                 canGoBack: session.canGoBack,
                 canGoForward: session.canGoForward,
                 isLoading: session.isLoading,
+                loadProgress: session.loadProgress,
                 isCapturing: isCapturing
             ),
             address: $address,

--- a/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
@@ -1,21 +1,15 @@
 import SwiftUI
 import BloomCore
 
-/// One button in the browser pane's bar.
+/// One bare glyph in the browser pane's bar.
 ///
-/// **`.accessoryBar`, which is what the rest of this app's strips of small controls already use.**
-/// `SidebarStatusBar` and `InspectorLayout.inspectorBarControl` both reached for it and both wrote
-/// down why: it is the system's own style for a row of small controls along the edge of a pane, it
-/// brings one hit box, one hover fill and one pressed state to the whole set, and it leaves the
-/// glyph at label weight where `.borderless` draws it in the accent colour. This bar was the last
-/// one in the window still hand rolling that with a fixed frame and two foreground colours, which
-/// is exactly the "app's approximation of a Mac control" the pane is meant to stop looking like.
+/// `.accessoryBar` is the system's own style for a row of small controls along the edge of a pane,
+/// and it brings one hit box, one hover fill and one pressed state to the whole set.
 ///
-/// The disabled colour stays explicit, because a foreground style set here is a style
-/// `.accessoryBar` will not dim on its own: with `Palette.textTertiary`, which is the rung this
-/// window uses for small print, a dead Back arrow was a shade off the live Forward arrow next to it
-/// and read as pressable. `Palette.textDisabled` is the system's own answer for a control that is
-/// there and cannot be pressed, and its note carries what that page showed.
+/// The disabled colour stays explicit, because a foreground style set here is one `.accessoryBar`
+/// will not dim on its own. At `Palette.textTertiary` a dead Back arrow was a shade off the live
+/// Forward arrow beside it and read as pressable; `Palette.textDisabled` is the system's answer
+/// for a control that is there and cannot be pressed.
 struct BrowserToolbarButton: View {
     var control: BrowserToolbar.Control
     var action: @MainActor () -> Void
@@ -32,18 +26,24 @@ struct BrowserToolbarButton: View {
     }
 }
 
-/// The browser pane's toolbar: what you do to the page, where the page is, and the share sheet.
+/// The browser pane's toolbar: where you have been, where you are, and who else gets the page.
 ///
-/// Its own view rather than a method on `BrowserTabView` so that it can be drawn from a fixture.
-/// The pane's toolbar needs a live `BrowserSession` behind it, which owns a `WKWebView`, and a
-/// gallery page can neither make one nor photograph it. See `BrowserToolbarGallery`.
+/// Its own view rather than a method on `BrowserTabView` so that a fixture can draw it. The pane
+/// needs a live `BrowserSession` behind it, which owns a `WKWebView`, and a gallery page can
+/// neither make one nor photograph it. See `BrowserToolbarGallery`.
 ///
-/// **Left to right: back, forward, reload or stop, the camera, the address, share.** That is
-/// Safari's order, with the two exceptions this app has reasons for. The camera is left of the
-/// address with the other things you do to the page, which is `BrowserTabView`'s own note and
-/// still holds. Share is right of the address because that is where every Mac browser puts it: the
-/// controls left of the field move you between pages, and the ones right of it hand the page you
-/// are on to something else.
+/// **Three groups, which is the anatomy every Mac browser's bar has.** Back and forward joined in
+/// one capsule; the address in a capsule of its own, with the connection glyph at one end and
+/// Reload at the other; then the two glyphs that hand this page to somebody else, bare. There is
+/// no stock component for any of it, and `BrowserToolbar` says why: the toolbar, the joined pair
+/// and the search item are all `NSWindow`'s, and this is a pane inside a split inside a tab.
+///
+/// Two notes this file used to carry are overturned by that, both knowingly. The pair had no
+/// plate, because `surfaceRaised` means *switched on* in this window and a fill round two of five
+/// glyphs would have read that way; it cannot now, since the pair and the field wear the same fill
+/// and the same radius, so the bar reads as two raised controls beside three bare glyphs. And the
+/// camera has crossed the field, because with Reload inside the field what is left on the right is
+/// the two controls that take this page elsewhere.
 struct BrowserToolbarView: View {
     var toolbar: BrowserToolbar
     /// What the field shows, which is not where the page is. See `BrowserTabView.address`.
@@ -63,40 +63,23 @@ struct BrowserToolbarView: View {
     var capture: @MainActor () -> Void = {}
     var submit: @MainActor () -> Void = {}
 
-    /// Drawn inside the field's own edge rather than outside it, so the toolbar does not have to
-    /// give the ring clearance. See `HomeBar.focusRingWidth`.
+    /// Drawn inside the field's own edge rather than outside it, so the bar does not have to give
+    /// the ring clearance. See `HomeBar.focusRingWidth`.
     private static let focusRingWidth: CGFloat = 2
+
+    /// Somebody has the field, so it shows the string they are editing rather than a split of it.
+    private var isEditing: Bool { addressFocus.wrappedValue }
+
+    /// How the address is drawn when nobody is typing into it. The rule is in the core, because
+    /// which run of the string is the host is the one thing here that can be got dangerously
+    /// wrong. See `BrowserAddressDisplay`.
+    private var display: BrowserAddressDisplay { .of(address) }
 
     var body: some View {
         HStack(spacing: Metrics.spacingWide) {
-            // **The pair, joined by air rather than by a plate.** Safari draws back and forward as
-            // one control, and the honest way to say that in this window is the spacing scale:
-            // nothing at all between these two, and `spacingWide`, which is named for the gap
-            // between the groups a row falls into, on either side of the pair.
-            //
-            // A shared fill was the other option and it was rejected. `Palette.surfaceRaised` is
-            // this window's raised control, meaning a selected segment or a chip, so a filled pill
-            // around two of the five glyphs in this bar would read as those two being switched on.
-            // The bar has exactly one filled thing in it and it is the address field, which is a
-            // place to type rather than a pair of buttons. What that costs is honest: the pair is
-            // a group and not a single control, and a reader who is looking for Safari's one piece
-            // of chrome will notice.
-            HStack(spacing: 0) {
-                BrowserToolbarButton(control: toolbar.back, action: goBack)
-                    .modifier(HistoryMenu(entries: backHistory, go: goToHistory))
-                BrowserToolbarButton(control: toolbar.forward, action: goForward)
-                    .modifier(HistoryMenu(entries: forwardHistory, go: goToHistory))
-            }
-
-            BrowserToolbarButton(control: toolbar.reload, action: reloadOrStop)
-
-            // Left of the address rather than right of it, with the other three: they are all
-            // things you do to the page, and the address field is where the page is. Its own group
-            // on the right would have read as belonging to the field.
-            BrowserToolbarButton(control: toolbar.screenshot, action: capture)
-
+            navigation
             addressField
-
+            BrowserToolbarButton(control: toolbar.screenshot, action: capture)
             BrowserShareButton(control: toolbar.share, shareable: toolbar.shareable)
         }
         .padding(.horizontal, Metrics.spacingSmall)
@@ -104,43 +87,112 @@ struct BrowserToolbarView: View {
         .background(Palette.surfaceSunken)
     }
 
+    /// The pair, as one control with a divider through it, which is what `NSToolbarItemGroup`
+    /// draws for Safari and what nothing in a pane can ask for.
+    private var navigation: some View {
+        HStack(spacing: 0) {
+            BrowserToolbarButton(control: toolbar.back, action: goBack)
+                .modifier(HistoryMenu(entries: backHistory, go: goToHistory))
+            Hairline(axis: .vertical)
+            BrowserToolbarButton(control: toolbar.forward, action: goForward)
+                .modifier(HistoryMenu(entries: forwardHistory, go: goToHistory))
+        }
+        .frame(height: Metrics.controlHeight)
+        .background(Palette.surfaceRaised)
+        // Before the border, so the clip takes the hover fills of the two buttons and not the
+        // stroke, which `strokeBorder` already draws inside the edge.
+        .clipShape(Capsule())
+        .overlay { Capsule().strokeBorder(Palette.border, lineWidth: Metrics.hairline) }
+    }
+
     private var addressField: some View {
-        TextField("Address", text: $address)
-            .textFieldStyle(.plain)
-            .font(Typo.label)
-            .focused(addressFocus)
-            .autocorrectionDisabled()
-            .padding(.horizontal, Metrics.spacingWide)
-            .padding(.vertical, Metrics.spacingSmall)
-            .background(Palette.surfaceRaised, in: .rect(cornerRadius: Metrics.cornerSmall))
-            // A hand-built field gets no focus ring from AppKit, and an address bar that looks
-            // identical whether or not it has the keyboard is the single most reliable way to make
-            // a Mac window feel like a web page. The same overlay `HomeBar`'s search field uses, in
-            // the same colour macOS draws a real one in, so it follows Full Keyboard Access and
-            // Increase Contrast with it.
-            .overlay {
-                RoundedRectangle(cornerRadius: Metrics.cornerSmall)
-                    .strokeBorder(
-                        isRingVisible ? Palette.focusRing : Palette.border,
-                        lineWidth: isRingVisible ? Self.focusRingWidth : Metrics.hairline
-                    )
+        HStack(spacing: Metrics.spacingSmall) {
+            // Never while the field is being typed into: a lock beside a string somebody is
+            // halfway through entering is a lock making a promise about nothing.
+            if !isEditing, let symbol = display.security.symbol {
+                Image(systemName: symbol)
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textTertiary)
+                    .help(display.security.help ?? "")
+                    .accessibilityLabel(display.security.help ?? "")
             }
-            .onSubmit(submit)
+            field
+            BrowserToolbarButton(control: toolbar.reload, action: reloadOrStop)
+        }
+        .padding(.leading, Metrics.spacing)
+        .padding(.trailing, Metrics.spacingTight)
+        .frame(height: Metrics.controlHeight)
+        .background(alignment: .leading) { fill }
+        .clipShape(Capsule())
+        .overlay {
+            Capsule().strokeBorder(
+                isRingVisible ? Palette.focusRing : Palette.border,
+                lineWidth: isRingVisible ? Self.focusRingWidth : Metrics.hairline
+            )
+        }
+    }
+
+    /// The field's ground, with the load behind it.
+    ///
+    /// `Palette.selected` rather than a tint: it is the step of Bloom's ramp meant to sit under
+    /// content in a list that has not got the keyboard, which is exactly what is wanted behind a
+    /// line of text, and it keeps the accent out of a bar that has nothing else tinted in it.
+    @ViewBuilder private var fill: some View {
+        Palette.surfaceRaised
+        if let progress = toolbar.progress {
+            GeometryReader { proxy in
+                Palette.selected.frame(width: proxy.size.width * progress)
+            }
+            .animation(Motion.pane, value: progress)
+        }
+    }
+
+    /// **The real field is always here, and the two-tone address is drawn over it.**
+    ///
+    /// Swapping a `Text` in for the `TextField` was the other way round, and it costs the field
+    /// everything AppKit does for it: a click lands on the label, so focus has to be set by hand,
+    /// and with it go caret placement, drag selection and select-all on focus. Hidden text with a
+    /// label over it keeps all of that, because what is clicked is still the field.
+    private var field: some View {
+        ZStack(alignment: .leading) {
+            TextField("Address", text: $address)
+                .textFieldStyle(.plain)
+                .font(Typo.label)
+                .focused(addressFocus)
+                .autocorrectionDisabled()
+                .foregroundStyle(isEditing ? Palette.textPrimary : .clear)
+                .onSubmit(submit)
+
+            // Nothing over an empty field, so the placeholder is the one AppKit draws.
+            if !isEditing, !display.isEmpty {
+                addressLabel.allowsHitTesting(false)
+            }
+        }
+    }
+
+    private var addressLabel: some View {
+        (Text(display.leading).foregroundStyle(Palette.textTertiary)
+            + Text(display.host).foregroundStyle(Palette.textPrimary)
+            + Text(display.trailing).foregroundStyle(Palette.textTertiary))
+            .lineLimit(1)
+            // The tail, which is where a query string lives. The host is the part worth reading
+            // and it is at the head, so it is the part that always survives the cut.
+            .truncationMode(.tail)
+            .font(Typo.label)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
 /// The pages an arrow can jump past, under a right click on it.
 ///
-/// The one affordance that most makes a pair of arrows read as a browser's rather than as two
-/// buttons: a reader who has clicked four links deep asks to go back to the page they started on,
-/// not to click Back four times. Right click only. Safari opens the same menu on a press and hold
-/// as well, and there is no way to ask a SwiftUI `Button` for that without rebuilding the control
-/// in AppKit, which would cost this bar the system style every other control in it is drawn with.
+/// The one affordance that most makes a pair of arrows read as a browser's: a reader four links
+/// deep asks to go back to the page they started on, not to click Back four times. Right click
+/// only. Safari opens the same menu on a press and hold, and there is no way to ask a SwiftUI
+/// `Button` for that without rebuilding the control in AppKit, which would cost this bar the
+/// system style every control in it is drawn with.
 ///
-/// A modifier rather than a `.contextMenu` written twice, because an empty menu is a menu: SwiftUI
-/// will happily open a blank one on an arrow whose history is empty, so the whole thing is left off
-/// instead. That is never a control losing a menu it had, since an arrow with no history behind it
-/// is an arrow that cannot be pressed either.
+/// A modifier rather than a `.contextMenu` written twice, because SwiftUI will happily open a
+/// blank menu on an arrow whose history is empty, so the whole thing is left off instead.
 private struct HistoryMenu: ViewModifier {
     var entries: [BrowserToolbar.HistoryEntry]
     var go: @MainActor (Int) -> Void

--- a/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
@@ -170,10 +170,14 @@ struct BrowserToolbarView: View {
         }
     }
 
+    private func tinted(_ string: String, _ colour: Color) -> Text {
+        Text(string).foregroundStyle(colour)
+    }
+
     private var addressLabel: some View {
-        (Text(display.leading).foregroundStyle(Palette.textTertiary)
-            + Text(display.host).foregroundStyle(Palette.textPrimary)
-            + Text(display.trailing).foregroundStyle(Palette.textTertiary))
+        // Interpolated rather than concatenated: `Text.+` is deprecated in macOS 26 and the app
+        // target builds with -warnings-as-errors.
+        Text("\(tinted(display.leading, Palette.textTertiary))\(tinted(display.host, Palette.textPrimary))\(tinted(display.trailing, Palette.textTertiary))")
             .lineLimit(1)
             // The tail, which is where a query string lives. The host is the part worth reading
             // and it is at the head, so it is the part that always survives the cut.

--- a/Sources/Bloom/Views/Home/HomeBar.swift
+++ b/Sources/Bloom/Views/Home/HomeBar.swift
@@ -102,7 +102,7 @@ struct HomeBar: View {
             }
         }
         .padding(.horizontal, Metrics.spacing)
-        .frame(width: Self.fieldWidth, height: Self.fieldHeight)
+        .frame(width: Self.fieldWidth, height: Metrics.controlHeight)
         .background(Palette.surfaceSunken, in: RoundedRectangle(cornerRadius: Metrics.cornerSmall))
         // A hand-built field gets no focus ring from AppKit, and a text field that looks
         // identical whether or not it has the keyboard is the single most reliable way to make a
@@ -126,9 +126,6 @@ struct HomeBar: View {
     /// stroke reads as the same signal at this size.
     private static let focusRingWidth: CGFloat = 2
 
-    /// A small control's height, so the field sits inside the strip with the same clearance the
-    /// menu and the toggle beside it have rather than filling it edge to edge.
-    private static let fieldHeight: CGFloat = 22
     /// Enough for a branch name typed in full and no more. It was 360, which is not a control any
     /// more, it is a column.
     private static let fieldWidth: CGFloat = 220

--- a/Sources/BloomCore/System/BrowserAddress.swift
+++ b/Sources/BloomCore/System/BrowserAddress.swift
@@ -16,10 +16,19 @@ public enum BrowserAddress {
         if trimmed.contains("://") { return URL(string: trimmed) }
 
         let host = trimmed.split(separator: "/", maxSplits: 1).first.map(String.init) ?? trimmed
-        let isLocal = host.hasPrefix("localhost") || host.hasPrefix("127.0.0.1")
+        let local = isLocal(host: host)
+        guard local || host.contains(".") else { return nil }
+        return URL(string: (local ? "http://" : "https://") + trimmed)
+    }
+
+    /// A server on this Mac, with or without a port on the end.
+    ///
+    /// Read twice: here, to decide that a bare host gets `http` rather than `https`, and by
+    /// `BrowserAddressDisplay`, to decide that plain http is a dev server rather than something to
+    /// warn about. One policy, so the field cannot call an address local and the parser not.
+    public static func isLocal(host: String) -> Bool {
+        host.hasPrefix("localhost") || host.hasPrefix("127.0.0.1")
             || host.hasPrefix("0.0.0.0") || host.hasSuffix(".localhost")
-        guard isLocal || host.contains(".") else { return nil }
-        return URL(string: (isLocal ? "http://" : "https://") + trimmed)
     }
 
     /// Whether a browser of Bloom's own could show this address at all.

--- a/Sources/BloomCore/System/BrowserAddressDisplay.swift
+++ b/Sources/BloomCore/System/BrowserAddressDisplay.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// How the address field draws an address nobody is typing into: the host in reading ink, the rest
+/// a rung down, and a glyph for what the connection is.
+///
+/// **The host comes from the parser, never from a search through the string.**
+/// `https://spatie.be@evil.com/login` is served by evil.com, and anything that emphasised the
+/// first match for a familiar name would put the strong ink on what is really a username. Every
+/// part below is taken from `URLComponents` and reassembled in order, so the three runs still
+/// spell the address the page is at.
+public struct BrowserAddressDisplay: Equatable, Sendable {
+    /// The scheme, and any user and password, drawn a rung down.
+    public var leading: String
+    /// The host and port, in reading ink. Empty when the address has no host to speak of.
+    public var host: String
+    /// Path, query and fragment, a rung down.
+    public var trailing: String
+    public var security: Security
+
+    /// Nothing to draw, so the field shows its placeholder.
+    public var isEmpty: Bool { leading.isEmpty && host.isEmpty && trailing.isEmpty }
+
+    /// What the glyph at the left end of the field says about the connection.
+    public enum Security: Equatable, Sendable {
+        /// No address yet.
+        case none
+        /// A server on this Mac, which is what this pane is mostly pointed at.
+        case local
+        /// Plain http somewhere else.
+        case insecure
+        case secure
+
+        public var symbol: String? {
+            switch self {
+            case .none: nil
+            case .local: "desktopcomputer"
+            case .insecure: "globe"
+            case .secure: "lock.fill"
+            }
+        }
+
+        public var help: String? {
+            switch self {
+            case .none: nil
+            case .local: "A server on this Mac"
+            case .insecure: "This connection is not encrypted"
+            case .secure: "This connection is encrypted"
+            }
+        }
+    }
+
+    /// The most of an address anybody draws. URLs of several kilobytes exist, and one of them
+    /// would otherwise be laid out in full behind a field 300 points wide.
+    public static let limit = 512
+
+    public static func of(_ address: String) -> BrowserAddressDisplay {
+        let text = sanitised(address)
+        // `encodedHost` rather than the host itself, so a name written with percent escapes or in
+        // punycode is drawn as the parser sees it. Decoding is how two different hosts come to
+        // look like one.
+        guard let parts = URLComponents(string: text),
+              let host = parts.encodedHost, !host.isEmpty
+        else {
+            return BrowserAddressDisplay(leading: text, host: "", trailing: "", security: .none)
+        }
+
+        let scheme = parts.scheme?.lowercased()
+        var leading = scheme.map { $0 + "://" } ?? ""
+        if let user = parts.percentEncodedUser {
+            let password = parts.percentEncodedPassword.map { ":" + $0 } ?? ""
+            leading += user + password + "@"
+        }
+
+        var trailing = parts.percentEncodedPath
+        if let query = parts.percentEncodedQuery { trailing += "?" + query }
+        if let fragment = parts.percentEncodedFragment { trailing += "#" + fragment }
+
+        return BrowserAddressDisplay(
+            leading: leading,
+            host: host + (parts.port.map { ":\($0)" } ?? ""),
+            trailing: trailing,
+            security: security(scheme: scheme, host: host)
+        )
+    }
+
+    private static func security(scheme: String?, host: String) -> Security {
+        switch scheme {
+        case "https": .secure
+        case "http": BrowserAddress.isLocal(host: host) ? .local : .insecure
+        default: .none
+        }
+    }
+
+    /// Control characters and the bidirectional overrides, out.
+    ///
+    /// A right-to-left override in a path reverses what is drawn after it, which is how a file
+    /// ending `.exe` can be made to read as ending `.png`. The address is a string from the
+    /// network on its way onto screen, so it gets the treatment `BrowserTabTitle.tidy` gives a
+    /// title.
+    private static func sanitised(_ raw: String) -> String {
+        let kept = raw.unicodeScalars.filter { scalar in
+            switch scalar.value {
+            case 0..<0x20, 0x7F, 0x200E, 0x200F, 0x202A...0x202E, 0x2066...0x2069: false
+            default: true
+            }
+        }
+        let text = String(String.UnicodeScalarView(kept))
+        return text.count > limit ? String(text.prefix(limit)) + "…" : text
+    }
+}

--- a/Sources/BloomCore/System/BrowserAddressDisplay.swift
+++ b/Sources/BloomCore/System/BrowserAddressDisplay.swift
@@ -75,6 +75,14 @@ public struct BrowserAddressDisplay: Equatable, Sendable {
         if let query = parts.percentEncodedQuery { trailing += "?" + query }
         if let fragment = parts.percentEncodedFragment { trailing += "#" + fragment }
 
+        // Cut again, on the assembled parts. The cap in `sanitised` bounds what the parser is
+        // handed, and percent encoding then makes the pieces longer than the string they came
+        // from: one ellipsis goes in as three bytes and comes back out as `%E2%80%A6`.
+        let head = leading.count + host.count
+        if head + trailing.count > limit {
+            trailing = String(trailing.prefix(max(0, limit - head))) + "…"
+        }
+
         return BrowserAddressDisplay(
             leading: leading,
             host: host + (parts.port.map { ":\($0)" } ?? ""),

--- a/Sources/BloomCore/System/BrowserToolbar.swift
+++ b/Sources/BloomCore/System/BrowserToolbar.swift
@@ -11,18 +11,17 @@ import Foundation
 /// those two are the browser's other rules and a reader looking for what the browser decides
 /// should find the three of them together.
 ///
-/// ## There is no tab component to reach for
+/// ## There is no stock component for any of this
 ///
 /// The question comes back every time somebody looks at Safari beside this pane, so the answer is
-/// written down where they will be reading. **AppKit's only public tab bar is the window one.**
-/// `NSWindowTabGroup` gathers whole `NSWindow`s into one stack, and `NSWindowTab` describes one
-/// window's entry in it: neither can draw a strip inside a view, and there is no `NSTabBar`.
-/// `NSTabView` is a different control altogether, the one behind a preferences window's segments.
-/// Safari's tab bar is not shipped as a control at all.
+/// written where they will be reading. **Every AppKit component that draws browser chrome belongs
+/// to an `NSWindow`.** `NSToolbar` is a window's, and with it go `NSToolbarItemGroup`, which is
+/// what joins Safari's back and forward arrows, and `NSSearchToolbarItem`, which is its address
+/// field; `NSWindowTabGroup` gathers whole windows, and there is no `NSTabBar`. This bar is a pane
+/// inside a split inside a tab, so none of them can be reached from here. `NSToolbarDisplayMode`
+/// has no `unified` case in the macOS 26 SDK either, whatever memory says.
 ///
-/// It would be the wrong thing here in any case. A browser pane is already one tab of the centre
-/// column's strip, so a Safari strip inside it would be tabs inside tabs, and the tab the reader
-/// would reach for first is the one already at the top of the window.
+/// So the bar is drawn, out of `Palette` and `Capsule`. What that costs is written on the view.
 public struct BrowserToolbar: Equatable, Sendable {
     /// One button in the bar: what it draws, what it is called, and whether it can be pressed.
     public struct Control: Equatable, Sendable {
@@ -50,6 +49,8 @@ public struct BrowserToolbar: Equatable, Sendable {
     public var canGoBack: Bool
     public var canGoForward: Bool
     public var isLoading: Bool
+    /// What WebKit says of the fetch in flight, as `estimatedProgress` reports it.
+    public var loadProgress: Double
     /// A screenshot is already on its way to the composer, so the camera goes quiet rather than
     /// attaching the same page twice. See `BrowserTabView.capture`.
     public var isCapturing: Bool
@@ -59,13 +60,25 @@ public struct BrowserToolbar: Equatable, Sendable {
         canGoBack: Bool = false,
         canGoForward: Bool = false,
         isLoading: Bool = false,
+        loadProgress: Double = 0,
         isCapturing: Bool = false
     ) {
         self.page = page
         self.canGoBack = canGoBack
         self.canGoForward = canGoForward
         self.isLoading = isLoading
+        self.loadProgress = loadProgress
         self.isCapturing = isCapturing
+    }
+
+    /// How much of the field to fill behind the address, or nil for no fill at all.
+    ///
+    /// Nil rather than zero at both ends, so the field is a plain field before a load starts and
+    /// again the moment it finishes: a bar left sitting at 100 percent reads as still working. A
+    /// fetch that has not reported anything yet is nil for the same reason.
+    public var progress: Double? {
+        guard isLoading, loadProgress > 0, loadProgress < 1 else { return nil }
+        return loadProgress
     }
 
     /// Where the page is, as an address the rest of the app agrees is one. Nil for a pane split

--- a/Tests/BloomCoreTests/BrowserAddressDisplayTests.swift
+++ b/Tests/BloomCoreTests/BrowserAddressDisplayTests.swift
@@ -1,0 +1,99 @@
+import Testing
+@testable import BloomCore
+
+/// The split behind the two-tone address, which is the one thing in the browser bar that can be
+/// got dangerously wrong: the strong ink has to land on the host that is really serving the page.
+@Suite("Browser address display")
+struct BrowserAddressDisplayTests {
+    @Test("The host is the emphasised run, and the scheme and path are not")
+    func splitsAnOrdinaryAddress() {
+        let display = BrowserAddressDisplay.of("https://spatie.be/docs/laravel-medialibrary")
+        #expect(display.leading == "https://")
+        #expect(display.host == "spatie.be")
+        #expect(display.trailing == "/docs/laravel-medialibrary")
+    }
+
+    @Test("The port travels with the host, because a dev server IS its port")
+    func portIsPartOfTheHost() {
+        let display = BrowserAddressDisplay.of("http://localhost:3100/settings")
+        #expect(display.host == "localhost:3100")
+        #expect(display.trailing == "/settings")
+    }
+
+    @Test("Query and fragment stay in the quiet run")
+    func queryAndFragmentAreQuiet() {
+        let display = BrowserAddressDisplay.of("https://example.com/a?b=c#d")
+        #expect(display.host == "example.com")
+        #expect(display.trailing == "/a?b=c#d")
+    }
+
+    @Test("A username is not the host, however much it looks like one")
+    func userInfoIsNeverEmphasised() {
+        let display = BrowserAddressDisplay.of("https://spatie.be@evil.example/login")
+        #expect(display.host == "evil.example")
+        #expect(display.leading == "https://spatie.be@")
+        #expect(display.security == .secure)
+    }
+
+    @Test("The three runs still spell the address they were split from", arguments: [
+        "https://spatie.be/docs",
+        "http://localhost:3100/",
+        "https://example.com/a?b=c#d",
+        "https://user:secret@example.com/x",
+    ])
+    func runsRejoinIntoTheAddress(address: String) {
+        let display = BrowserAddressDisplay.of(address)
+        #expect(display.leading + display.host + display.trailing == address)
+    }
+
+    @Test("What the glyph says about the connection")
+    func securityIsReadOffTheScheme() {
+        #expect(BrowserAddressDisplay.of("https://example.com/").security == .secure)
+        #expect(BrowserAddressDisplay.of("http://localhost:3100/").security == .local)
+        #expect(BrowserAddressDisplay.of("http://127.0.0.1:8080/").security == .local)
+        #expect(BrowserAddressDisplay.of("http://myapp.localhost/").security == .local)
+        #expect(BrowserAddressDisplay.of("http://example.com/").security == .insecure)
+        #expect(BrowserAddressDisplay.of("").security == .none)
+        #expect(BrowserAddressDisplay.of("").symbolIsAbsent)
+    }
+
+    @Test("Anything that will not parse is drawn plainly rather than half emphasised")
+    func unparsedTextIsAllQuiet() {
+        let display = BrowserAddressDisplay.of("not an address")
+        #expect(display.host.isEmpty)
+        #expect(display.leading == "not an address")
+        #expect(display.security == .none)
+    }
+
+    @Test("An empty field has nothing to draw, so the placeholder is left to AppKit")
+    func emptyIsEmpty() {
+        #expect(BrowserAddressDisplay.of("").isEmpty)
+        #expect(!BrowserAddressDisplay.of("https://example.com/").isEmpty)
+    }
+
+    @Test("A right-to-left override cannot reverse what the field draws")
+    func bidiOverridesAreStripped() {
+        let display = BrowserAddressDisplay.of("https://example.com/\u{202E}gnp.exe")
+        #expect(display.trailing == "/gnp.exe")
+        #expect(!display.trailing.unicodeScalars.contains { $0.value == 0x202E })
+    }
+
+    @Test("A newline cannot draw a second line into the bar")
+    func controlCharactersAreStripped() {
+        let display = BrowserAddressDisplay.of("https://example.com/a\nb")
+        #expect(display.trailing == "/ab")
+    }
+
+    @Test("An address of several kilobytes is cut before anything tries to lay it out")
+    func absurdAddressesAreCapped() {
+        let long = "https://example.com/" + String(repeating: "a", count: 4000)
+        let display = BrowserAddressDisplay.of(long)
+        #expect(display.leading.count + display.host.count + display.trailing.count
+            <= BrowserAddressDisplay.limit + 1)
+    }
+}
+
+private extension BrowserAddressDisplay {
+    /// Nothing to certify, so nothing is drawn at the left end of the field.
+    var symbolIsAbsent: Bool { security.symbol == nil && security.help == nil }
+}

--- a/Tests/BloomCoreTests/BrowserToolbarTests.swift
+++ b/Tests/BloomCoreTests/BrowserToolbarTests.swift
@@ -171,4 +171,15 @@ struct BrowserToolbarTests {
         #expect(BrowserToolbar.backMenu([]).isEmpty)
         #expect(BrowserToolbar.forwardMenu([]).isEmpty)
     }
+
+    @Test("The fill behind the address is there only while a load is really under way")
+    func progressIsOnlyDrawnMidLoad() {
+        let page = Self.page("https://example.com/", "Example")
+        #expect(BrowserToolbar(page: page, isLoading: true, loadProgress: 0.4).progress == 0.4)
+        // Nothing before the first report, and nothing once it is done: a field left at full
+        // width reads as still working.
+        #expect(BrowserToolbar(page: page, isLoading: true, loadProgress: 0).progress == nil)
+        #expect(BrowserToolbar(page: page, isLoading: true, loadProgress: 1).progress == nil)
+        #expect(BrowserToolbar(page: page, isLoading: false, loadProgress: 0.4).progress == nil)
+    }
 }


### PR DESCRIPTION
Back and forward joined in one raised capsule with a hairline between them, the address in a capsule of its own with the connection glyph at its head and Reload at its tail, camera and Share bare at the trailing edge.

There is no stock component for this. Every AppKit control that draws browser chrome belongs to an `NSWindow`, and this bar is a pane inside a split inside a tab, so `NSToolbar`, `NSToolbarItemGroup` and `NSSearchToolbarItem` are all out. Read from the 26.5 SDK rather than recalled: `NSToolbarDisplayMode` has no `unified` case, and `NSSearchToolbarItem` declares `view` as unavailable, which rules out the favicon, the progress and the inline Reload. What macOS 26 gives us here is the shape language, not a component.

Glass is available and deliberately unused: it samples what is behind it, and behind this bar is an arbitrary web page. The palette already refused a material once for that reason, with the measurement in its doc comment.

`BrowserAddressDisplay` in the core, with tests, splits the address for the two-tone label. The host comes from `URLComponents.encodedHost` and never from a search through the string, so `https://spatie.be@evil.example/login` puts the strong ink on `evil.example`. Control characters and bidi overrides are stripped and the whole thing is capped.

The real `TextField` is always present with its text clear and the two-tone label drawn over it without hit testing, so caret placement, drag selection and select-all on focus all survive.