### PR TITLE
One generation of menu in the composer

### DIFF
--- a/Sources/Bloom/Views/Center/Composer/MenuPanel.swift
+++ b/Sources/Bloom/Views/Center/Composer/MenuPanel.swift
@@ -13,11 +13,19 @@ struct MenuPanel<Content: View>: View {
         // The panel floats outside the composer, so it must size itself from its rows rather than
         // from the space the composer happens to occupy.
         .fixedSize(horizontal: false, vertical: true)
-        // The menu material, not the header material this used to borrow. `.headerView` is the
-        // vibrancy of a toolbar strip; a thing that floats over content is a menu and reads wrong
-        // in anything else.
-        .background(VisualEffectBackground(material: .menu, blending: .withinWindow))
+        // Clipped before the glass rather than after it. `glassEffect` shapes only its own
+        // background, so a selected row's fill and the scroll view still need this to stop at the
+        // corner.
         .clipShape(RoundedRectangle(cornerRadius: Metrics.corner))
+        // macOS 26's material, not `NSVisualEffectView(.menu)`. `ComposerOptionMenu` is a real
+        // `Menu` an inch away in the same footer and the system draws it in glass, so the footer
+        // was showing two menus in two generations of material.
+        //
+        // `.regular` and not `.clear`: this opens over the transcript, where a user bubble is
+        // `Palette.accentFill`, and clear glass carries that through. See `JumpToNewestPill`.
+        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Metrics.corner))
+        // The rim is drawn rather than left to glass's own, because it is what still says where
+        // the card ends once Reduce Transparency has turned the material opaque.
         .overlay {
             RoundedRectangle(cornerRadius: Metrics.corner)
                 .strokeBorder(Palette.border, lineWidth: Metrics.hairline)

--- a/Sources/Bloom/Views/Sidebar/WorkspaceHoverCardView.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspaceHoverCardView.swift
@@ -173,12 +173,12 @@ struct WorkspaceHoverCardView: View {
 
     /// The card's own ground.
     ///
-    /// `MenuPanel` is the app's floating card and this is deliberately not it. `MenuPanel` blends
-    /// `.withinWindow` and carries a SwiftUI shadow, both of which are right for something drawn
-    /// inside the composer's window and neither of which is right here: this card IS a window, so
-    /// the material has to blend with what is behind the window rather than with the window, and
-    /// the shadow is AppKit's to draw around the panel's alpha. What is kept is the shape and the
-    /// rim, so the two read as one family.
+    /// `MenuPanel` is the app's floating card and this is deliberately not it. `MenuPanel` samples
+    /// the window it is drawn in (glass since macOS 26, `.withinWindow` vibrancy before that) and
+    /// carries a SwiftUI shadow, both of which are right inside the composer's window and neither
+    /// of which is right here: this card IS a window, so the material has to blend with what is
+    /// behind the window rather than with the window, and the shadow is AppKit's to draw around
+    /// the panel's alpha. What is kept is the shape and the rim, so the two read as one family.
     private var cardBackground: some View {
         VisualEffectBackground(material: .menu, blending: .behindWindow)
             // Clipped rather than filled through a shape, because the material is a view rather


### PR DESCRIPTION
`MenuPanel` moves from the macOS 25 `.menu` material to `glassEffect(.regular)`.

The reason is not that glass is nicer. `ComposerOptionMenu` is a real SwiftUI `Menu` an inch away in the same composer footer, and macOS 26 draws that in the new material, so the composer was showing two kinds of menu side by side in two generations of material.

Safe here because of what is behind it: the composer box and the top of the transcript, never a web page, a terminal or a diff. Every surface where glass would sample something Bloom does not own was ruled out, and the palette carries the measurements saying why.

`.regular` rather than `.clear`, because one of the six users is the transcript's tool row card, which floats over the conversation and can sit over a user bubble in the accent colour.

The explicit border and shadow stay rather than trusting glass's own rim: that is what holds the shape when Reduce Transparency turns glass off. `.clipShape` moved above the glass, since `glassEffect` shapes only its own background and a selected row's fill still runs to the panel edge.

Nothing was re-tuned. Both selection fills are opaque so the ground never composites into them, and their ink is semantic: white on the accent is 5.24:1 whatever is behind the card.

Two things flagged and not fixed, both wanting a photograph: the emoji mark picker is now glass inside a popover macOS 26 also draws in glass, and that picker's search field is an opaque recessed plate on a now translucent card.