### PR TITLE
Hide the cd every Bash row opened with

### DIFF
--- a/Sources/Bloom/Design/Snapshot.swift
+++ b/Sources/Bloom/Design/Snapshot.swift
@@ -861,7 +861,7 @@ enum Snapshot {
             ("home", AnyView(HomeView().frame(width: 900, height: 620)), CGSize(width: 900, height: 620)),
             ("components", AnyView(ComponentGallery().frame(width: 640, height: 700)), CGSize(width: 640, height: 700)),
             ("permission", AnyView(PermissionSnapshotGallery().frame(width: 720, height: 1560)), CGSize(width: 720, height: 1560)),
-            ("tool-rows", AnyView(ToolRowSnapshotGallery().frame(width: 800, height: 720)), CGSize(width: 800, height: 720)),
+            ("tool-rows", AnyView(ToolRowSnapshotGallery().frame(width: 800, height: 900)), CGSize(width: 800, height: 900)),
             // Offscreen rather than through a window: no `CheckRunRow` holds a representable, so
             // `ImageRenderer` draws the real column here.
             ("check-runs", AnyView(CheckRunSnapshotGallery()), CGSize(width: 420, height: 1000)),

--- a/Sources/Bloom/Design/ToolRowSnapshotGallery.swift
+++ b/Sources/Bloom/Design/ToolRowSnapshotGallery.swift
@@ -32,10 +32,14 @@ struct ToolRowSnapshotGallery: View {
         Do not change anything. This is a question, not a task.
         """
 
+    /// A real worktree path, at a real length, because the rows below are about what happens to
+    /// one. See `CommandDisplay`.
+    private static let worktree = "/Users/freek/bloom/workspaces/there-there/freekmurze-hibiki-sea"
+
     private var workspace: Workspace {
         Workspace(
             repoID: RepoID("r1"), name: "laravel-webhook-server", branch: "main",
-            path: "/tmp/nowhere", baseBranch: "main"
+            path: Self.worktree, baseBranch: "main"
         )
     }
 
@@ -48,7 +52,7 @@ struct ToolRowSnapshotGallery: View {
         let use = AgentToolUse(id: id, name: name, input: .object(input))
         return ToolRowView(
             use: use,
-            presentation: TranscriptPresenter.present(use),
+            presentation: TranscriptPresenter.present(use, worktree: workspace.path),
             workspace: workspace,
             result: nil,
             isError: false,
@@ -88,6 +92,28 @@ struct ToolRowSnapshotGallery: View {
                 ])])
                 row("p4", "AskUserQuestion", [
                     "question": .string("Should the copy button sit on the row or on the panel?"),
+                ])
+            }
+
+            // The four answers `CommandDisplay` gives, in the order a reader meets them. The
+            // first two are the point of the change and the third is what it must not break: a
+            // command that ran outside the workspace keeps its path, in the warning ink.
+            group("Where a command ran") {
+                row("c1", "Bash", [
+                    "description": .string("List admin tests"),
+                    "command": .string("cd \(Self.worktree)\nls tests/Http/Admin"),
+                ])
+                row("c2", "Bash", [
+                    "description": .string("Run the api package tests"),
+                    "command": .string("cd \(Self.worktree)/packages/api && npm test -- --runInBand"),
+                ])
+                row("c3", "Bash", [
+                    "description": .string("Check the other worktree"),
+                    "command": .string("cd /Users/freek/bloom/workspaces/bloom/main && git log --oneline -5"),
+                ])
+                row("c4", "Bash", [
+                    "description": .string("Show the current diff"),
+                    "command": .string("git diff --stat"),
                 ])
             }
 

--- a/Sources/Bloom/Design/ToolRowSnapshotGallery.swift
+++ b/Sources/Bloom/Design/ToolRowSnapshotGallery.swift
@@ -95,9 +95,9 @@ struct ToolRowSnapshotGallery: View {
                 ])
             }
 
-            // The four answers `CommandDisplay` gives, in the order a reader meets them. The
-            // first two are the point of the change and the third is what it must not break: a
-            // command that ran outside the workspace keeps its path, in the warning ink.
+            // Every answer `CommandDisplay` gives, in the order a reader meets them. The first two
+            // are the point of the change and the rest are what it must not break: a command that
+            // left the workspace keeps its path, and says so on the glyph.
             group("Where a command ran") {
                 row("c1", "Bash", [
                     "description": .string("List admin tests"),
@@ -114,6 +114,18 @@ struct ToolRowSnapshotGallery: View {
                 row("c4", "Bash", [
                     "description": .string("Show the current diff"),
                     "command": .string("git diff --stat"),
+                ])
+                // The two that were drawn wrongly once. A newline separated chain put a newline
+                // in the middle of a row that is one line tall and swallowed the command after
+                // it; a destination only a shell could work out went unmarked while a resolved
+                // one did not.
+                row("c5", "Bash", [
+                    "description": .string("Read the system log"),
+                    "command": .string("cd /tmp\ncd /var/log\ntail -n 20 system.log"),
+                ])
+                row("c6", "Bash", [
+                    "description": .string("List the home checkout"),
+                    "command": .string("cd ~/bloom && ls"),
                 ])
             }
 

--- a/Sources/Bloom/Views/Transcript/CodexItemPresenter.swift
+++ b/Sources/Bloom/Views/Transcript/CodexItemPresenter.swift
@@ -70,11 +70,18 @@ enum CodexItemPresenter {
         if let code = run.exitCode, code != 0 { chips.append(.code("exit \(code)")) }
         if run.status == .declined { chips.append(.code("declined")) }
 
+        // Failure first: a command that went wrong is more urgent than one that went elsewhere.
+        let tint: ToolTint = switch (run.status, display.leftTheWorkspace) {
+        case (.failed, _): .negative
+        case (_, true): .warning
+        default: .neutral
+        }
+
         return ToolPresentation(
             glyph: "terminal",
             label: "Shell",
             detail: command,
-            tint: run.status == .failed ? .negative : .neutral,
+            tint: tint,
             chips: chips,
             detailLead: display.lead
         )

--- a/Sources/Bloom/Views/Transcript/CodexItemPresenter.swift
+++ b/Sources/Bloom/Views/Transcript/CodexItemPresenter.swift
@@ -19,23 +19,23 @@ enum CodexItemPresenter {
     /// Read off the payload rather than off the session, deliberately: a transcript drawn from the
     /// database alone still knows which vocabulary each row is in, with no join and no column that
     /// did not exist when the row was written.
-    static func present(_ use: AgentToolUse) -> ToolPresentation? {
+    static func present(_ use: AgentToolUse, worktree: String = "") -> ToolPresentation? {
         guard let item = CodexTranslation.item(in: use.input) else { return nil }
-        return present(item)
+        return present(item, worktree: worktree)
     }
 
     /// The row, and then the same core question a Claude row asks: what the argument literally is.
     /// A Codex command must read as a command in exactly the face a Claude one does, or the two
     /// backends stop looking like one transcript.
-    static func present(_ item: CodexItem) -> ToolPresentation {
-        var presentation = shape(item)
+    static func present(_ item: CodexItem, worktree: String = "") -> ToolPresentation {
+        var presentation = shape(item, worktree: worktree)
         presentation.literal = ToolLiteral.of(codex: item)
         return presentation
     }
 
-    private static func shape(_ item: CodexItem) -> ToolPresentation {
+    private static func shape(_ item: CodexItem, worktree: String) -> ToolPresentation {
         switch item {
-        case .commandExecution(let run): command(run)
+        case .commandExecution(let run): command(run, worktree: worktree)
         case .fileChange(let change): fileChange(change)
         case .mcpToolCall(let call): mcp(call)
         case .webSearch(let search): webSearch(search)
@@ -60,8 +60,11 @@ enum CodexItemPresenter {
     /// Codex wraps everything in the login shell, so the command as sent reads
     /// `/bin/zsh -lc 'git status'`. What the user asked for is inside the quotes, and that is what
     /// the row shows: the wrapper is the same on every line and says nothing.
-    private static func command(_ run: CodexCommandExecution) -> ToolPresentation {
-        let command = ToolPresenter.oneLine(ToolLiteral.unwrapShell(run.command))
+    private static func command(_ run: CodexCommandExecution, worktree: String) -> ToolPresentation {
+        // Codex opens its commands with the same `cd` a Claude row does, so it is hidden by the
+        // same rule. Asked before the one line collapse; see `CommandDisplay`.
+        let display = CommandDisplay.of(ToolLiteral.unwrapShell(run.command), worktree: worktree)
+        let command = ToolPresenter.oneLine(display.command)
 
         var chips: [ToolChip] = []
         if let code = run.exitCode, code != 0 { chips.append(.code("exit \(code)")) }
@@ -72,7 +75,8 @@ enum CodexItemPresenter {
             label: "Shell",
             detail: command,
             tint: run.status == .failed ? .negative : .neutral,
-            chips: chips
+            chips: chips,
+            detailLead: display.lead
         )
     }
 
@@ -240,14 +244,14 @@ enum CodexItemPresenter {
 /// `DetailCodeBlock` and `ToolResultView` all draw a `ToolPresentation` and do not care where it
 /// came from.
 enum TranscriptPresenter {
-    static func present(_ use: AgentToolUse) -> ToolPresentation {
-        CodexItemPresenter.present(use) ?? ToolPresenter.present(use)
+    static func present(_ use: AgentToolUse, worktree: String = "") -> ToolPresentation {
+        CodexItemPresenter.present(use, worktree: worktree) ?? ToolPresenter.present(use, worktree: worktree)
     }
 
-    static func present(name: String, input: JSONValue) -> ToolPresentation {
+    static func present(name: String, input: JSONValue, worktree: String = "") -> ToolPresentation {
         if let item = CodexTranslation.item(in: input) {
-            return CodexItemPresenter.present(item)
+            return CodexItemPresenter.present(item, worktree: worktree)
         }
-        return ToolPresenter.present(name: name, input: input)
+        return ToolPresenter.present(name: name, input: input, worktree: worktree)
     }
 }

--- a/Sources/Bloom/Views/Transcript/ToolRowHeader.swift
+++ b/Sources/Bloom/Views/Transcript/ToolRowHeader.swift
@@ -60,6 +60,21 @@ struct ToolRowHeader: View {
             && !presentation.chips.contains { $0.text == presentation.detail }
     }
 
+    /// The detail, in one or two inks.
+    ///
+    /// A shell row whose command opened with `cd <worktree>` has had that prefix taken off by
+    /// `CommandDisplay`, because the sidebar and the title bar already say which workspace this
+    /// is. What is left in front is a directory below the worktree, or the `cd` that left the
+    /// worktree altogether, and those are the two the reader has to see: one `Text` for it, one
+    /// for the command, concatenated so the pair still truncates as a single line.
+    private var detailText: Text {
+        let lead = presentation.detailLead
+        guard !lead.text.isEmpty else { return Text(presentation.detail) }
+        return Text(lead.text).foregroundStyle(lead.tint.colour)
+            + Text(lead.joiner)
+            + Text(presentation.detail)
+    }
+
     /// The face the detail is set in.
     ///
     /// A shell command was set in the proportional face while the permission panel four points
@@ -143,14 +158,14 @@ struct ToolRowHeader: View {
                 )
 
             if showsDetail {
-                Text(presentation.detail)
+                detailText
                     .font(detailFont)
                     .foregroundStyle(Palette.textTertiary)
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .layoutPriority(1)
                     .reportsTruncation(
-                        of: presentation.detail,
+                        of: presentation.detailLine,
                         font: detailFont,
                         isActive: wantsMeasuring,
                         into: $detailIsCut
@@ -244,7 +259,7 @@ struct ToolRowHeader: View {
     private var card: TranscriptHoverCard {
         .row(
             title: presentation.label,
-            detail: showsDetail ? presentation.detail : "",
+            detail: showsDetail ? presentation.detailLine : "",
             isCode: presentation.detailIsCode
         )
     }

--- a/Sources/Bloom/Views/Transcript/ToolRowHeader.swift
+++ b/Sources/Bloom/Views/Transcript/ToolRowHeader.swift
@@ -70,9 +70,10 @@ struct ToolRowHeader: View {
     private var detailText: Text {
         let lead = presentation.detailLead
         guard !lead.text.isEmpty else { return Text(presentation.detail) }
-        return Text(lead.text).foregroundStyle(lead.tint.colour)
-            + Text(lead.joiner)
-            + Text(presentation.detail)
+        // Interpolated rather than concatenated: `Text.+` is deprecated in macOS 26 and the app
+        // target builds with -warnings-as-errors.
+        let tinted = Text(lead.text).foregroundStyle(lead.tint.colour)
+        return Text("\(tinted)\(lead.joiner)\(presentation.detail)")
     }
 
     /// The face the detail is set in.

--- a/Sources/Bloom/Views/Transcript/TranscriptPresentationCache.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptPresentationCache.swift
@@ -41,8 +41,10 @@ enum TranscriptPresentationCache {
         return cache
     }()
 
-    /// The worktree is not part of the key, and does not need to be: a row id belongs to one
-    /// workspace, and a workspace's worktree does not move under it.
+    /// The worktree is not part of the key, and does not need to be. A row id is a `messages`
+    /// rowid, `AUTOINCREMENT` so it is never reused, so it belongs to one workspace for good. The
+    /// worktree does move, on `Workspace.restore(to:)`, and a row stripped against the worktree it
+    /// actually ran in is the answer we want anyway.
     static func presentation(rowID: Int64, use: AgentToolUse, worktree: String) -> ToolPresentation {
         let key = NSNumber(value: rowID)
         if let cached = values.object(forKey: key) { return cached.value }

--- a/Sources/Bloom/Views/Transcript/TranscriptPresentationCache.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptPresentationCache.swift
@@ -41,11 +41,13 @@ enum TranscriptPresentationCache {
         return cache
     }()
 
-    static func presentation(rowID: Int64, use: AgentToolUse) -> ToolPresentation {
+    /// The worktree is not part of the key, and does not need to be: a row id belongs to one
+    /// workspace, and a workspace's worktree does not move under it.
+    static func presentation(rowID: Int64, use: AgentToolUse, worktree: String) -> ToolPresentation {
         let key = NSNumber(value: rowID)
         if let cached = values.object(forKey: key) { return cached.value }
 
-        let value = TranscriptPresenter.present(use)
+        let value = TranscriptPresenter.present(use, worktree: worktree)
         values.setObject(ToolPresentationBox(value), forKey: key)
         return value
     }

--- a/Sources/Bloom/Views/Transcript/TranscriptRowView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptRowView.swift
@@ -125,7 +125,11 @@ struct TranscriptRowView: View, Equatable {
             if let use = toolUse {
                 ToolRowView(
                     use: use,
-                    presentation: TranscriptPresentationCache.presentation(rowID: row.id, use: use),
+                    presentation: TranscriptPresentationCache.presentation(
+                        rowID: row.id,
+                        use: use,
+                        worktree: workspace.path
+                    ),
                     workspace: workspace,
                     result: toolResult,
                     isError: row.isError,

--- a/Sources/BloomCore/Agent/ToolPresentation.swift
+++ b/Sources/BloomCore/Agent/ToolPresentation.swift
@@ -20,6 +20,10 @@ public struct ToolPresentation: Equatable, Sendable {
     /// drawing, in one place, so a new tool cannot invent a sixth colour by accident.
     public var tint: ToolTint
     public var chips: [ToolChip] = []
+    /// Drawn ahead of `detail` in its own ink, and `.none` for every row that is not a shell
+    /// command whose `cd` has been read. See `CommandDisplay`: which prefix a row may hide is
+    /// decided there, and this is what it left behind.
+    public var detailLead: CommandDisplay.Lead = .none
     /// The whole of what `detail` was cut down from, and nil when the row's argument is prose.
     ///
     /// One field answering both of the questions a row asks about its own argument, because they
@@ -36,6 +40,13 @@ public struct ToolPresentation: Equatable, Sendable {
     /// proportional face, which is most of them.
     public var detailIsCode: Bool { literal != nil }
 
+    /// The detail as one string, lead and all: what a row measures itself against and what it
+    /// reads as to VoiceOver. Nothing draws it, because the two halves are drawn in two inks.
+    public var detailLine: String {
+        let lead = detailLead
+        return lead.text.isEmpty ? detail : lead.text + lead.joiner + detail
+    }
+
     /// Written out because a memberwise initialiser on a public struct is internal.
     public init(
         glyph: String,
@@ -43,6 +54,7 @@ public struct ToolPresentation: Equatable, Sendable {
         detail: String,
         tint: ToolTint,
         chips: [ToolChip] = [],
+        detailLead: CommandDisplay.Lead = .none,
         literal: String? = nil
     ) {
         self.glyph = glyph
@@ -50,6 +62,7 @@ public struct ToolPresentation: Equatable, Sendable {
         self.detail = detail
         self.tint = tint
         self.chips = chips
+        self.detailLead = detailLead
         self.literal = literal
     }
 }

--- a/Sources/BloomCore/Agent/ToolPresenter.swift
+++ b/Sources/BloomCore/Agent/ToolPresenter.swift
@@ -13,20 +13,24 @@ import Foundation
 /// actually sends (see docs/PROTOCOL.md and Tests/fixtures/session-basic.jsonl), and anything unrecognised
 /// still lands on a sensible line rather than nothing, because new tools ship constantly.
 public enum ToolPresenter {
-    public static func present(_ use: AgentToolUse) -> ToolPresentation {
-        present(name: use.name, input: use.input)
+    public static func present(_ use: AgentToolUse, worktree: String = "") -> ToolPresentation {
+        present(name: use.name, input: use.input, worktree: worktree)
     }
 
     /// The row, and then the one thing about it that is decided in the core: what the argument
     /// literally is. `ToolLiteral` is asked once here rather than per case, so the presenter cannot
     /// answer differently from the permission panel below it, which reads the same type.
-    public static func present(name: String, input: JSONValue) -> ToolPresentation {
-        var presentation = shape(name: name, input: input)
+    ///
+    /// `worktree` is the workspace this call ran in, and the only thing it decides is which
+    /// leading `cd` a shell row may hide. Empty hides nothing, which is what every caller with no
+    /// workspace to hand wants.
+    public static func present(name: String, input: JSONValue, worktree: String = "") -> ToolPresentation {
+        var presentation = shape(name: name, input: input, worktree: worktree)
         presentation.literal = ToolLiteral.of(name: name, input: input)
         return presentation
     }
 
-    private static func shape(name: String, input: JSONValue) -> ToolPresentation {
+    private static func shape(name: String, input: JSONValue, worktree: String) -> ToolPresentation {
         if name.hasPrefix("mcp__") { return mcp(name: name, input: input) }
 
         switch name {
@@ -35,7 +39,7 @@ public enum ToolPresenter {
         case "Edit": return edit(input)
         case "MultiEdit": return multiEdit(input)
         case "NotebookEdit": return notebookEdit(input)
-        case "Bash": return bash(input)
+        case "Bash": return bash(input, worktree: worktree)
         case "BashOutput": return bashOutput(input)
         case "KillShell", "KillBash": return killShell(input)
         case "Glob": return glob(input)
@@ -152,8 +156,12 @@ public enum ToolPresenter {
 
     // MARK: Shell
 
-    private static func bash(_ input: JSONValue) -> ToolPresentation {
-        let command = oneLine(input["command"]?.stringValue ?? "")
+    private static func bash(_ input: JSONValue, worktree: String) -> ToolPresentation {
+        // Before the one line collapse, not after: a newline is one of the separators a `cd`
+        // prefix ends with, and collapsing it first leaves a space nothing can tell from an
+        // argument. See `CommandDisplay`.
+        let display = CommandDisplay.of(input["command"]?.stringValue ?? "", worktree: worktree)
+        let command = oneLine(display.command)
         // Claude writes a short description of every command it runs, and that reads far better
         // as the label than the word "Bash" repeated forty times down the transcript.
         let label = input["description"]?.stringValue.map { oneLine($0) } ?? "Bash"
@@ -169,7 +177,8 @@ public enum ToolPresenter {
             label: label.isEmpty ? "Bash" : label,
             detail: command,
             tint: .neutral,
-            chips: chips
+            chips: chips,
+            detailLead: display.lead
         )
     }
 

--- a/Sources/BloomCore/Agent/ToolPresenter.swift
+++ b/Sources/BloomCore/Agent/ToolPresenter.swift
@@ -176,7 +176,11 @@ public enum ToolPresenter {
             glyph: "terminal",
             label: label.isEmpty ? "Bash" : label,
             detail: command,
-            tint: .neutral,
+            // The mark for a command that left the workspace goes on the glyph, at the left edge
+            // where a reader's eye runs down, rather than on a hue in the middle of the line. Every
+            // `.elsewhere` gets it, the ones whose destination could not be read included: "this
+            // went somewhere and I cannot tell where" is as worth seeing as a resolved path.
+            tint: display.leftTheWorkspace ? .warning : .neutral,
             chips: chips,
             detailLead: display.lead
         )

--- a/Sources/BloomCore/Transcript/CommandDisplay.swift
+++ b/Sources/BloomCore/Transcript/CommandDisplay.swift
@@ -19,6 +19,11 @@ import Foundation
 ///
 /// Nothing here touches the disk: no symlinks resolved, no `~` expanded, no variable substituted.
 /// A destination it cannot resolve is `elsewhere`, which shows more rather than less.
+///
+/// **Only the drawing is stripped.** `TranscriptSearchText` indexes the stored payload, an open
+/// row prints the command from that payload, and `ToolPresentation.literal` is read off the tool's
+/// input rather than off this. So a worktree path still finds the row, and a copy still gives a
+/// command that runs.
 public struct CommandDisplay: Equatable, Sendable {
     /// Where the command ran, as far as its own text says.
     public enum Place: Equatable, Sendable {
@@ -26,8 +31,9 @@ public struct CommandDisplay: Equatable, Sendable {
         case workspace
         /// A directory below the worktree, named by the path below it.
         case subdirectory(String)
-        /// Outside the worktree, or somewhere this cannot name. Nothing is dropped. The prefix is
-        /// the `cd` that left, and is empty where the text could not be split into one.
+        /// Outside the worktree, or somewhere this cannot name. Nothing is dropped, and the row
+        /// says so on its glyph. The prefix is the `cd` that left, and is empty where the text
+        /// could not be split into one.
         case elsewhere(prefix: String)
         /// No `cd` to read. Nothing is dropped.
         case unstated
@@ -38,7 +44,9 @@ public struct CommandDisplay: Equatable, Sendable {
         case none
         /// A directory below the worktree. The command ran there rather than at the root.
         case location(String)
-        /// The `cd` that left the worktree, kept whole. Its ink is what makes the row stand out.
+        /// The `cd` that left the worktree, kept whole and collapsed to one line by
+        /// `ToolPresenter.oneLine`. A chain separated by newlines put a newline in the middle of
+        /// a row that is one line tall, and everything after it was swallowed.
         case prefix(String)
 
         public var text: String {
@@ -115,8 +123,8 @@ public struct CommandDisplay: Equatable, Sendable {
             case .notMoved:
                 break loop
             case .opaque:
-                // Nothing is hidden and nothing is marked: there is no prefix this could honestly
-                // point at.
+                // No prefix, because there is none this could honestly point at. Still
+                // `.elsewhere`, so the glyph still says the row went somewhere.
                 return CommandDisplay(place: .elsewhere(prefix: ""), command: command)
             case .moved(let destination, let remainder):
                 directory = destination
@@ -126,13 +134,21 @@ public struct CommandDisplay: Equatable, Sendable {
         }
 
         guard moved else { return untouched }
-        // A row is never left blank, so a bare `cd somewhere` keeps its own text.
-        guard !rest.isEmpty else { return untouched }
 
         guard let below = relation(of: directory, to: root) else {
-            let consumed = command[..<rest.startIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+            // A bare `cd elsewhere` keeps its own text, because a row is never left blank, and it
+            // is still `.elsewhere`: Claude Code's Bash tool holds one shell across calls, so a
+            // bare `cd` moves the directory for every row after it. That is the last row to leave
+            // quiet.
+            guard !rest.isEmpty else {
+                return CommandDisplay(place: .elsewhere(prefix: ""), command: command)
+            }
+            let consumed = ToolPresenter.oneLine(String(command[..<rest.startIndex]))
             return CommandDisplay(place: .elsewhere(prefix: consumed), command: String(rest))
         }
+        // A bare `cd` to the worktree keeps its own text, for the same reason and with nothing to
+        // say about it.
+        guard !rest.isEmpty else { return untouched }
         return CommandDisplay(
             place: below.isEmpty ? .workspace : .subdirectory(below),
             command: String(rest)

--- a/Sources/BloomCore/Transcript/CommandDisplay.swift
+++ b/Sources/BloomCore/Transcript/CommandDisplay.swift
@@ -10,8 +10,8 @@ import Foundation
 /// What may be hidden is a decision about what a person is shown, so it is here rather than in the
 /// view. The rule: a `cd` to the worktree itself is dropped, because a row with no `cd` at all
 /// already means "ran in the worktree" and both are the same fact; a `cd` below the worktree keeps
-/// the part below; and a `cd` anywhere else is left exactly as the agent wrote it, because a
-/// command that ran outside this workspace is the thing a reader most needs to notice.
+/// the part below; and a `cd` anywhere else is left whole and marked, because a command that ran
+/// outside this workspace is the thing a reader most needs to notice.
 ///
 /// **Ask this before `ToolPresenter.oneLine`, not after.** A newline is one of the separators a
 /// `cd` can end with, and the collapse turns it into a space, which is indistinguishable from a
@@ -24,12 +24,48 @@ public struct CommandDisplay: Equatable, Sendable {
     public enum Place: Equatable, Sendable {
         /// The workspace's own worktree. The prefix is dropped.
         case workspace
-        /// A directory below the worktree, named by `location`.
+        /// A directory below the worktree, named by the path below it.
         case subdirectory(String)
-        /// Outside the worktree, or somewhere this cannot name. Nothing is dropped.
-        case elsewhere
+        /// Outside the worktree, or somewhere this cannot name. Nothing is dropped. The prefix is
+        /// the `cd` that left, and is empty where the text could not be split into one.
+        case elsewhere(prefix: String)
         /// No `cd` to read. Nothing is dropped.
         case unstated
+    }
+
+    /// What a row draws ahead of the command, in its own ink.
+    public enum Lead: Equatable, Sendable {
+        case none
+        /// A directory below the worktree. The command ran there rather than at the root.
+        case location(String)
+        /// The `cd` that left the worktree, kept whole. Its ink is what makes the row stand out.
+        case prefix(String)
+
+        public var text: String {
+            switch self {
+            case .none: ""
+            case .location(let path): path
+            case .prefix(let text): text
+            }
+        }
+
+        /// Between the lead and the command. A location is a tag on the row and gets a mark of its
+        /// own; a prefix is part of the command and keeps the space it had.
+        public var joiner: String {
+            switch self {
+            case .none: ""
+            case .location: " \u{203A} "
+            case .prefix: " "
+            }
+        }
+
+        public var tint: ToolTint {
+            switch self {
+            case .none: .neutral
+            case .location: .accent
+            case .prefix: .warning
+            }
+        }
     }
 
     public var place: Place
@@ -37,16 +73,30 @@ public struct CommandDisplay: Equatable, Sendable {
     /// original where nothing may be removed.
     public var command: String
 
-    /// The path below the worktree, and empty for every other place. The view draws this ahead of
-    /// `command`, in its own ink.
-    public var location: String {
-        guard case .subdirectory(let path) = place else { return "" }
-        return path
-    }
-
     public init(place: Place, command: String) {
         self.place = place
         self.command = command
+    }
+
+    /// Derived from `place` rather than stored beside it, so the two cannot disagree.
+    public var lead: Lead {
+        switch place {
+        case .workspace, .unstated: .none
+        case .subdirectory(let path): .location(path)
+        case .elsewhere(let prefix): prefix.isEmpty ? .none : .prefix(prefix)
+        }
+    }
+
+    /// True where the command left the workspace, however that was spelled.
+    public var leftTheWorkspace: Bool {
+        if case .elsewhere = place { return true }
+        return false
+    }
+
+    /// The whole detail as one string, lead and all: what a row measures and what it reads as.
+    public var line: String {
+        let lead = lead
+        return lead.text.isEmpty ? command : lead.text + lead.joiner + command
     }
 
     public static func of(_ command: String, worktree: String) -> CommandDisplay {
@@ -65,7 +115,9 @@ public struct CommandDisplay: Equatable, Sendable {
             case .notMoved:
                 break loop
             case .opaque:
-                return CommandDisplay(place: .elsewhere, command: command)
+                // Nothing is hidden and nothing is marked: there is no prefix this could honestly
+                // point at.
+                return CommandDisplay(place: .elsewhere(prefix: ""), command: command)
             case .moved(let destination, let remainder):
                 directory = destination
                 rest = remainder
@@ -74,13 +126,17 @@ public struct CommandDisplay: Equatable, Sendable {
         }
 
         guard moved else { return untouched }
-        guard let below = relation(of: directory, to: root) else {
-            return CommandDisplay(place: .elsewhere, command: command)
-        }
         // A row is never left blank, so a bare `cd somewhere` keeps its own text.
         guard !rest.isEmpty else { return untouched }
 
-        return CommandDisplay(place: below.isEmpty ? .workspace : .subdirectory(below), command: String(rest))
+        guard let below = relation(of: directory, to: root) else {
+            let consumed = command[..<rest.startIndex].trimmingCharacters(in: .whitespacesAndNewlines)
+            return CommandDisplay(place: .elsewhere(prefix: consumed), command: String(rest))
+        }
+        return CommandDisplay(
+            place: below.isEmpty ? .workspace : .subdirectory(below),
+            command: String(rest)
+        )
     }
 
     // MARK: Reading one `cd`
@@ -102,8 +158,8 @@ public struct CommandDisplay: Equatable, Sendable {
         scan = scan.drop(while: { $0 == " " || $0 == "\t" })
 
         guard let word = word(&scan) else { return .opaque }
-        // A word Bloom would have to run a shell to understand, and `cd -`, which is a
-        // destination only the shell's own history knows.
+        // A word Bloom would have to run a shell to understand, and `cd -`, whose destination only
+        // the shell's own history knows.
         let readable = !word.contains("$") && !word.contains("`") && !word.hasPrefix("~") && word != "-"
         guard readable else { return .opaque }
 

--- a/Sources/BloomCore/Transcript/CommandDisplay.swift
+++ b/Sources/BloomCore/Transcript/CommandDisplay.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+/// Which of a shell command's leading `cd` a transcript row may hide, and what has to survive it.
+///
+/// Every Bash row in a workspace opened with the same sixty odd characters of worktree path, in a
+/// column that holds about eighty, so the part that differed was off the right edge on every row.
+/// The workspace is named in the sidebar and in the title bar; the row does not have to say it a
+/// third time.
+///
+/// What may be hidden is a decision about what a person is shown, so it is here rather than in the
+/// view. The rule: a `cd` to the worktree itself is dropped, because a row with no `cd` at all
+/// already means "ran in the worktree" and both are the same fact; a `cd` below the worktree keeps
+/// the part below; and a `cd` anywhere else is left exactly as the agent wrote it, because a
+/// command that ran outside this workspace is the thing a reader most needs to notice.
+///
+/// **Ask this before `ToolPresenter.oneLine`, not after.** A newline is one of the separators a
+/// `cd` can end with, and the collapse turns it into a space, which is indistinguishable from a
+/// `cd` with two arguments.
+///
+/// Nothing here touches the disk: no symlinks resolved, no `~` expanded, no variable substituted.
+/// A destination it cannot resolve is `elsewhere`, which shows more rather than less.
+public struct CommandDisplay: Equatable, Sendable {
+    /// Where the command ran, as far as its own text says.
+    public enum Place: Equatable, Sendable {
+        /// The workspace's own worktree. The prefix is dropped.
+        case workspace
+        /// A directory below the worktree, named by `location`.
+        case subdirectory(String)
+        /// Outside the worktree, or somewhere this cannot name. Nothing is dropped.
+        case elsewhere
+        /// No `cd` to read. Nothing is dropped.
+        case unstated
+    }
+
+    public var place: Place
+    /// What the row draws: the command with the consumed `cd` chain removed, or the whole of the
+    /// original where nothing may be removed.
+    public var command: String
+
+    /// The path below the worktree, and empty for every other place. The view draws this ahead of
+    /// `command`, in its own ink.
+    public var location: String {
+        guard case .subdirectory(let path) = place else { return "" }
+        return path
+    }
+
+    public init(place: Place, command: String) {
+        self.place = place
+        self.command = command
+    }
+
+    public static func of(_ command: String, worktree: String) -> CommandDisplay {
+        let untouched = CommandDisplay(place: .unstated, command: command)
+        // A worktree that is not an absolute path is not one this can compare against.
+        guard worktree.hasPrefix("/") else { return untouched }
+        let root = normalise(worktree)
+        guard root != "/" else { return untouched }
+
+        var rest = Substring(command)
+        var directory = root
+        var moved = false
+
+        loop: while true {
+            switch step(rest, from: directory) {
+            case .notMoved:
+                break loop
+            case .opaque:
+                return CommandDisplay(place: .elsewhere, command: command)
+            case .moved(let destination, let remainder):
+                directory = destination
+                rest = remainder
+                moved = true
+            }
+        }
+
+        guard moved else { return untouched }
+        guard let below = relation(of: directory, to: root) else {
+            return CommandDisplay(place: .elsewhere, command: command)
+        }
+        // A row is never left blank, so a bare `cd somewhere` keeps its own text.
+        guard !rest.isEmpty else { return untouched }
+
+        return CommandDisplay(place: below.isEmpty ? .workspace : .subdirectory(below), command: String(rest))
+    }
+
+    // MARK: Reading one `cd`
+
+    private enum Step {
+        /// Not a `cd`, so the walk stops here.
+        case notMoved
+        /// A `cd` whose destination cannot be worked out from the text: `~`, `$TMPDIR`, a
+        /// substitution, an unbalanced quote.
+        case opaque
+        case moved(String, Substring)
+    }
+
+    private static func step(_ text: Substring, from directory: String) -> Step {
+        var scan = text.drop(while: \.isWhitespace)
+        guard scan.hasPrefix("cd") else { return .notMoved }
+        scan = scan.dropFirst(2)
+        guard let next = scan.first, next == " " || next == "\t" else { return .notMoved }
+        scan = scan.drop(while: { $0 == " " || $0 == "\t" })
+
+        guard let word = word(&scan) else { return .opaque }
+        // A word Bloom would have to run a shell to understand, and `cd -`, which is a
+        // destination only the shell's own history knows.
+        let readable = !word.contains("$") && !word.contains("`") && !word.hasPrefix("~") && word != "-"
+        guard readable else { return .opaque }
+
+        var after = scan.drop(while: { $0 == " " || $0 == "\t" })
+        if after.hasPrefix("&&") {
+            after = after.dropFirst(2)
+        } else if after.hasPrefix(";") {
+            after = after.dropFirst()
+        } else if let first = after.first, !first.isNewline {
+            // `cd a b`, `cd a || b`, `cd a & b`: the `cd` is not simply a prefix, so leave it all.
+            return .notMoved
+        }
+
+        return .moved(resolve(word, against: directory), after.drop(while: \.isWhitespace))
+    }
+
+    /// One shell word, unquoted. Nil for an unbalanced quote, which is a command this should not
+    /// be guessing at.
+    private static func word(_ scan: inout Substring) -> String? {
+        var out = ""
+        var quote: Character?
+
+        while let character = scan.first {
+            if let open = quote {
+                scan = scan.dropFirst()
+                if character == open { quote = nil } else { out.append(character) }
+                continue
+            }
+            if character == "'" || character == "\"" {
+                quote = character
+                scan = scan.dropFirst()
+                continue
+            }
+            if character == "\\" {
+                scan = scan.dropFirst()
+                guard let escaped = scan.first else { return nil }
+                out.append(escaped)
+                scan = scan.dropFirst()
+                continue
+            }
+            if character.isWhitespace || character == ";" || character == "&" || character == "|" { break }
+            out.append(character)
+            scan = scan.dropFirst()
+        }
+
+        guard quote == nil, !out.isEmpty else { return nil }
+        return out
+    }
+
+    // MARK: Paths
+
+    /// Relative resolves against the worktree, because that is the directory every agent Bloom
+    /// runs is spawned in.
+    private static func resolve(_ path: String, against directory: String) -> String {
+        path.hasPrefix("/") ? normalise(path) : normalise(directory + "/" + path)
+    }
+
+    /// Absolute, no trailing slash, `.` and `..` applied. Textual only.
+    private static func normalise(_ path: String) -> String {
+        var components: [Substring] = []
+        for part in path.split(separator: "/") {
+            if part == "." { continue }
+            if part == ".." { _ = components.popLast(); continue }
+            components.append(part)
+        }
+        return "/" + components.joined(separator: "/")
+    }
+
+    /// The part of `path` below `root`, empty where they are the same, and nil for anything
+    /// outside. `/a/bc` is not inside `/a/b`, which is what the separator is for.
+    private static func relation(of path: String, to root: String) -> String? {
+        if path == root { return "" }
+        guard path.hasPrefix(root + "/") else { return nil }
+        return String(path.dropFirst(root.count + 1))
+    }
+}

--- a/Tests/BloomCoreTests/CommandDisplayTests.swift
+++ b/Tests/BloomCoreTests/CommandDisplayTests.swift
@@ -1,0 +1,234 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+/// Which `cd` a Bash row may hide, and the three that it may not.
+///
+/// The suite is organised by the case that decides the design rather than by the method: the
+/// dangerous answer here is not a wrong string, it is a command that ran outside the workspace and
+/// was drawn as though it ran inside it.
+@Suite("Command display")
+struct CommandDisplayTests {
+    private static let worktree = "/Users/freek/bloom/workspaces/there-there/freekmurze-hibiki-sea"
+
+    private static func of(_ command: String) -> CommandDisplay {
+        CommandDisplay.of(command, worktree: worktree)
+    }
+
+    // MARK: 1. The worktree itself
+
+    @Test("a cd to the worktree is dropped")
+    func worktreeRoot() {
+        let display = Self.of("cd \(Self.worktree) && ls tests/Http/Admin")
+        #expect(display.place == .workspace)
+        #expect(display.command == "ls tests/Http/Admin")
+        #expect(display.location.isEmpty)
+    }
+
+    @Test("a trailing slash on the cd is still the worktree")
+    func trailingSlash() {
+        #expect(Self.of("cd \(Self.worktree)/ && ls").place == .workspace)
+    }
+
+    @Test("a dot component in the cd is still the worktree")
+    func dotComponent() {
+        #expect(Self.of("cd \(Self.worktree)/./packages/../ && ls").place == .workspace)
+    }
+
+    @Test("a cd out and back again is where it ended up")
+    func chain() {
+        let display = Self.of("cd /tmp && cd \(Self.worktree) && composer test")
+        #expect(display.place == .workspace)
+        #expect(display.command == "composer test")
+    }
+
+    // MARK: 2. Inside the worktree
+
+    @Test("a directory below the worktree keeps the part below")
+    func subdirectory() {
+        let display = Self.of("cd \(Self.worktree)/packages/api && npm test -- --runInBand")
+        #expect(display.place == .subdirectory("packages/api"))
+        #expect(display.location == "packages/api")
+        #expect(display.command == "npm test -- --runInBand")
+    }
+
+    @Test("a relative cd resolves against the worktree, because that is where an agent stands")
+    func relativeSubdirectory() {
+        let display = Self.of("cd packages/api/src && rg --no-heading 'palette' -n")
+        #expect(display.place == .subdirectory("packages/api/src"))
+        #expect(display.command == "rg --no-heading 'palette' -n")
+    }
+
+    @Test("a chain of relative cds ends where the command ran")
+    func relativeChain() {
+        let display = Self.of("cd packages; cd api && npm test")
+        #expect(display.place == .subdirectory("packages/api"))
+        #expect(display.command == "npm test")
+    }
+
+    // MARK: 3. Somewhere else, which must stay obvious
+
+    @Test("another workspace is left whole")
+    func anotherWorkspace() {
+        let command = "cd /Users/freek/bloom/workspaces/bloom/main && git log --oneline -5"
+        let display = Self.of(command)
+        #expect(display.place == .elsewhere)
+        #expect(display.command == command)
+    }
+
+    @Test("a system path is left whole")
+    func systemPath() {
+        let command = "cd /tmp/build-cache && rm -rf artefacts"
+        #expect(Self.of(command) == CommandDisplay(place: .elsewhere, command: command))
+    }
+
+    @Test("a sibling whose name merely starts with the worktree's is outside it")
+    func siblingPrefix() {
+        let command = "cd \(Self.worktree)-old && ls"
+        #expect(Self.of(command).place == .elsewhere)
+    }
+
+    @Test("a relative cd above the worktree is outside it")
+    func relativeAbove() {
+        let command = "cd ../other && ls"
+        #expect(Self.of(command) == CommandDisplay(place: .elsewhere, command: command))
+    }
+
+    @Test("a destination only a shell could work out is outside it")
+    func unresolvableDestinations() {
+        for command in [
+            "cd ~/bloom && ls",
+            "cd $TMPDIR && ls",
+            "cd \"$(git rev-parse --show-toplevel)\" && ls",
+            "cd `pwd`/build && ls",
+            "cd - && ls",
+        ] {
+            #expect(Self.of(command) == CommandDisplay(place: .elsewhere, command: command), "\(command)")
+        }
+    }
+
+    @Test("a cd out and then deeper is outside, however far it walks")
+    func chainLeavingTheWorktree() {
+        let command = "cd \(Self.worktree) && cd /var/log && tail -n 20 system.log"
+        #expect(Self.of(command).place == .elsewhere)
+    }
+
+    // MARK: 4. No cd at all
+
+    @Test("a command with no cd is untouched")
+    func noPrefix() {
+        let display = Self.of("git diff --stat")
+        #expect(display.place == .unstated)
+        #expect(display.command == "git diff --stat")
+        #expect(display.location.isEmpty)
+    }
+
+    @Test("a command that merely mentions cd is untouched")
+    func mentionsCD() {
+        for command in ["echo cd /tmp", "cdk deploy", "cd", "git cd-log"] {
+            #expect(Self.of(command).place == .unstated, "\(command)")
+        }
+    }
+
+    @Test("a bare cd to the worktree keeps its own text, because a row is never blank")
+    func nothingAfterTheCD() {
+        let command = "cd \(Self.worktree)"
+        #expect(Self.of(command) == CommandDisplay(place: .unstated, command: command))
+    }
+
+    // MARK: 5. Separators and quoting
+
+    @Test("and, semicolon and newline all end the prefix")
+    func separators() {
+        for separator in [" && ", "; ", "\n", " ;\n", "&&\n  "] {
+            let display = Self.of("cd \(Self.worktree)\(separator)php artisan tinker")
+            #expect(display.place == .workspace, "\(separator.debugDescription)")
+            #expect(display.command == "php artisan tinker", "\(separator.debugDescription)")
+        }
+    }
+
+    @Test("a heredoc after a newline keeps every line of itself")
+    func heredoc() {
+        let body = "python3 - <<'PYEOF'\nimport json\nPYEOF"
+        let display = Self.of("cd \(Self.worktree)\n\(body)")
+        #expect(display.place == .workspace)
+        #expect(display.command == body)
+    }
+
+    @Test("a quoted path is unquoted before it is compared")
+    func quoted() {
+        for command in [
+            "cd '\(Self.worktree)' && composer test",
+            "cd \"\(Self.worktree)\" && composer test",
+        ] {
+            let display = Self.of(command)
+            #expect(display.place == .workspace, "\(command)")
+            #expect(display.command == "composer test", "\(command)")
+        }
+    }
+
+    @Test("a path with a space in it is read, quoted or escaped")
+    func spaces() {
+        let spaced = "/Users/freek/bloom/workspaces/there there/hibiki sea"
+        for command in [
+            "cd '\(spaced)' && ls",
+            "cd \"\(spaced)\" && ls",
+            "cd /Users/freek/bloom/workspaces/there\\ there/hibiki\\ sea && ls",
+        ] {
+            let display = CommandDisplay.of(command, worktree: spaced)
+            #expect(display.place == .workspace, "\(command)")
+            #expect(display.command == "ls", "\(command)")
+        }
+    }
+
+    @Test("a quoted subdirectory keeps the part below the worktree")
+    func quotedSubdirectory() {
+        let display = Self.of("cd \"\(Self.worktree)/packages/api\" && npm test")
+        #expect(display.place == .subdirectory("packages/api"))
+    }
+
+    @Test("an unbalanced quote is not guessed at")
+    func unbalancedQuote() {
+        let command = "cd '\(Self.worktree) && ls"
+        #expect(Self.of(command) == CommandDisplay(place: .elsewhere, command: command))
+    }
+
+    @Test("a cd this cannot treat as a prefix is left alone")
+    func notAPrefix() {
+        // `||` means the cd may have failed, `&` backgrounds it, and a second argument is not a
+        // path at all.
+        for command in [
+            "cd \(Self.worktree) || echo missing",
+            "cd \(Self.worktree) & ls",
+            "cd \(Self.worktree) extra && ls",
+        ] {
+            #expect(Self.of(command).place == .unstated, "\(command)")
+            #expect(Self.of(command).command == command, "\(command)")
+        }
+    }
+
+    // MARK: The worktree itself
+
+    @Test("no worktree to compare against means nothing is hidden")
+    func noWorktree() {
+        for worktree in ["", "relative/path", "/"] {
+            let command = "cd /anywhere && ls"
+            let display = CommandDisplay.of(command, worktree: worktree)
+            #expect(display == CommandDisplay(place: .unstated, command: command), "\(worktree)")
+        }
+    }
+
+    @Test("a worktree written with a trailing slash still matches")
+    func worktreeTrailingSlash() {
+        let display = CommandDisplay.of("cd \(Self.worktree) && ls", worktree: Self.worktree + "/")
+        #expect(display.place == .workspace)
+    }
+
+    // MARK: What the row is left with
+
+    @Test("the command keeps its own leading whitespace off, and nothing else is trimmed")
+    func remainderIsTrimmedOnce() {
+        let display = Self.of("  cd \(Self.worktree)   &&    ls -la   ")
+        #expect(display.command == "ls -la   ")
+    }
+}

--- a/Tests/BloomCoreTests/CommandDisplayTests.swift
+++ b/Tests/BloomCoreTests/CommandDisplayTests.swift
@@ -22,7 +22,8 @@ struct CommandDisplayTests {
         let display = Self.of("cd \(Self.worktree) && ls tests/Http/Admin")
         #expect(display.place == .workspace)
         #expect(display.command == "ls tests/Http/Admin")
-        #expect(display.location.isEmpty)
+        #expect(display.lead == .none)
+        #expect(display.line == "ls tests/Http/Admin")
     }
 
     @Test("a trailing slash on the cd is still the worktree")
@@ -48,8 +49,9 @@ struct CommandDisplayTests {
     func subdirectory() {
         let display = Self.of("cd \(Self.worktree)/packages/api && npm test -- --runInBand")
         #expect(display.place == .subdirectory("packages/api"))
-        #expect(display.location == "packages/api")
+        #expect(display.lead == .location("packages/api"))
         #expect(display.command == "npm test -- --runInBand")
+        #expect(display.leftTheWorkspace == false)
     }
 
     @Test("a relative cd resolves against the worktree, because that is where an agent stands")
@@ -68,33 +70,36 @@ struct CommandDisplayTests {
 
     // MARK: 3. Somewhere else, which must stay obvious
 
-    @Test("another workspace is left whole")
+    @Test("another workspace keeps its whole path, marked")
     func anotherWorkspace() {
         let command = "cd /Users/freek/bloom/workspaces/bloom/main && git log --oneline -5"
         let display = Self.of(command)
-        #expect(display.place == .elsewhere)
-        #expect(display.command == command)
+        #expect(display.leftTheWorkspace)
+        #expect(display.lead == .prefix("cd /Users/freek/bloom/workspaces/bloom/main &&"))
+        #expect(display.command == "git log --oneline -5")
+        #expect(display.line == command)
     }
 
-    @Test("a system path is left whole")
+    @Test("a system path keeps its whole path, marked")
     func systemPath() {
-        let command = "cd /tmp/build-cache && rm -rf artefacts"
-        #expect(Self.of(command) == CommandDisplay(place: .elsewhere, command: command))
+        let display = Self.of("cd /tmp/build-cache && rm -rf artefacts")
+        #expect(display.place == .elsewhere(prefix: "cd /tmp/build-cache &&"))
+        #expect(display.command == "rm -rf artefacts")
     }
 
     @Test("a sibling whose name merely starts with the worktree's is outside it")
     func siblingPrefix() {
-        let command = "cd \(Self.worktree)-old && ls"
-        #expect(Self.of(command).place == .elsewhere)
+        #expect(Self.of("cd \(Self.worktree)-old && ls").leftTheWorkspace)
     }
 
     @Test("a relative cd above the worktree is outside it")
     func relativeAbove() {
-        let command = "cd ../other && ls"
-        #expect(Self.of(command) == CommandDisplay(place: .elsewhere, command: command))
+        let display = Self.of("cd ../other && ls")
+        #expect(display.place == .elsewhere(prefix: "cd ../other &&"))
+        #expect(display.command == "ls")
     }
 
-    @Test("a destination only a shell could work out is outside it")
+    @Test("a destination only a shell could work out is outside it, and nothing is hidden")
     func unresolvableDestinations() {
         for command in [
             "cd ~/bloom && ls",
@@ -103,14 +108,20 @@ struct CommandDisplayTests {
             "cd `pwd`/build && ls",
             "cd - && ls",
         ] {
-            #expect(Self.of(command) == CommandDisplay(place: .elsewhere, command: command), "\(command)")
+            let display = Self.of(command)
+            #expect(display.leftTheWorkspace, "\(command)")
+            // No prefix, because there is none this could honestly point at.
+            #expect(display.lead == .none, "\(command)")
+            #expect(display.command == command, "\(command)")
         }
     }
 
     @Test("a cd out and then deeper is outside, however far it walks")
     func chainLeavingTheWorktree() {
-        let command = "cd \(Self.worktree) && cd /var/log && tail -n 20 system.log"
-        #expect(Self.of(command).place == .elsewhere)
+        let display = Self.of("cd \(Self.worktree) && cd /var/log && tail -n 20 system.log")
+        #expect(display.leftTheWorkspace)
+        #expect(display.command == "tail -n 20 system.log")
+        #expect(display.lead == .prefix("cd \(Self.worktree) && cd /var/log &&"))
     }
 
     // MARK: 4. No cd at all
@@ -120,7 +131,7 @@ struct CommandDisplayTests {
         let display = Self.of("git diff --stat")
         #expect(display.place == .unstated)
         #expect(display.command == "git diff --stat")
-        #expect(display.location.isEmpty)
+        #expect(display.lead == .none)
     }
 
     @Test("a command that merely mentions cd is untouched")
@@ -130,10 +141,11 @@ struct CommandDisplayTests {
         }
     }
 
-    @Test("a bare cd to the worktree keeps its own text, because a row is never blank")
+    @Test("a bare cd keeps its own text, because a row is never blank")
     func nothingAfterTheCD() {
-        let command = "cd \(Self.worktree)"
-        #expect(Self.of(command) == CommandDisplay(place: .unstated, command: command))
+        for command in ["cd \(Self.worktree)", "cd /tmp"] {
+            #expect(Self.of(command) == CommandDisplay(place: .unstated, command: command), "\(command)")
+        }
     }
 
     // MARK: 5. Separators and quoting
@@ -190,7 +202,9 @@ struct CommandDisplayTests {
     @Test("an unbalanced quote is not guessed at")
     func unbalancedQuote() {
         let command = "cd '\(Self.worktree) && ls"
-        #expect(Self.of(command) == CommandDisplay(place: .elsewhere, command: command))
+        let display = Self.of(command)
+        #expect(display.leftTheWorkspace)
+        #expect(display.command == command)
     }
 
     @Test("a cd this cannot treat as a prefix is left alone")
@@ -202,8 +216,9 @@ struct CommandDisplayTests {
             "cd \(Self.worktree) & ls",
             "cd \(Self.worktree) extra && ls",
         ] {
-            #expect(Self.of(command).place == .unstated, "\(command)")
-            #expect(Self.of(command).command == command, "\(command)")
+            let display = Self.of(command)
+            #expect(display.place == .unstated, "\(command)")
+            #expect(display.command == command, "\(command)")
         }
     }
 
@@ -230,5 +245,56 @@ struct CommandDisplayTests {
     func remainderIsTrimmedOnce() {
         let display = Self.of("  cd \(Self.worktree)   &&    ls -la   ")
         #expect(display.command == "ls -la   ")
+    }
+
+    // MARK: What a Bash row is built from
+
+    @Test("a Bash row hides the prefix and still copies the whole command")
+    func bashRow() {
+        let input = JSONValue.object([
+            "description": .string("List admin tests"),
+            "command": .string("cd \(Self.worktree)\nls tests/Http/Admin"),
+        ])
+        let row = ToolPresenter.present(name: "Bash", input: input, worktree: Self.worktree)
+        #expect(row.label == "List admin tests")
+        #expect(row.detail == "ls tests/Http/Admin")
+        #expect(row.detailLead == .none)
+        // The copy and the expanded body are the record, so they keep the `cd`.
+        #expect(row.literal == "cd \(Self.worktree)\nls tests/Http/Admin")
+    }
+
+    @Test("a Bash row that ran elsewhere keeps its path and says so")
+    func bashRowElsewhere() {
+        let command = "cd /tmp/build-cache && rm -rf artefacts"
+        let input = JSONValue.object(["command": .string(command)])
+        let row = ToolPresenter.present(name: "Bash", input: input, worktree: Self.worktree)
+        #expect(row.detailLead == .prefix("cd /tmp/build-cache &&"))
+        #expect(row.detail == "rm -rf artefacts")
+        #expect(row.detailLine == command)
+    }
+
+    @Test("a Bash row below the worktree keeps the part below")
+    func bashRowSubdirectory() {
+        let input = JSONValue.object(["command": .string("cd \(Self.worktree)/packages/api && npm test")])
+        let row = ToolPresenter.present(name: "Bash", input: input, worktree: Self.worktree)
+        #expect(row.detailLead == .location("packages/api"))
+        #expect(row.detail == "npm test")
+    }
+
+    @Test("with no worktree to compare against a Bash row is what it always was")
+    func bashRowWithoutAWorkspace() {
+        let command = "cd \(Self.worktree) && ls"
+        let row = ToolPresenter.present(name: "Bash", input: .object(["command": .string(command)]))
+        #expect(row.detail == command)
+        #expect(row.detailLead == .none)
+    }
+
+    @Test("a location is drawn as a tag and a prefix as part of the command")
+    func leads() {
+        #expect(CommandDisplay.Lead.none.text.isEmpty)
+        #expect(CommandDisplay.Lead.location("packages/api").tint == .accent)
+        #expect(CommandDisplay.Lead.prefix("cd /tmp &&").tint == .warning)
+        #expect(CommandDisplay.Lead.prefix("cd /tmp &&").joiner == " ")
+        #expect(CommandDisplay.Lead.location("packages/api").joiner.contains("\u{203A}"))
     }
 }

--- a/Tests/BloomCoreTests/CommandDisplayTests.swift
+++ b/Tests/BloomCoreTests/CommandDisplayTests.swift
@@ -124,6 +124,22 @@ struct CommandDisplayTests {
         #expect(display.lead == .prefix("cd \(Self.worktree) && cd /var/log &&"))
     }
 
+    @Test("a chain separated by newlines keeps its command, because a row is one line tall")
+    func chainOverNewlines() {
+        let display = Self.of("cd /tmp\ncd /var/log\ntail -n 20 system.log")
+        #expect(display.command == "tail -n 20 system.log")
+        // Collapsed, not raw. Drawn raw, the newline in the middle of it took the command with it.
+        #expect(display.lead == .prefix("cd /tmp cd /var/log"))
+        #expect(!display.line.contains("\n"))
+    }
+
+    @Test("a prefix nobody could read is cut, the way a command is")
+    func absurdPrefix() {
+        let display = Self.of("cd /" + String(repeating: "a", count: 400) + " && ls")
+        #expect(display.lead.text.count <= 301)
+        #expect(display.command == "ls")
+    }
+
     // MARK: 4. No cd at all
 
     @Test("a command with no cd is untouched")
@@ -141,11 +157,20 @@ struct CommandDisplayTests {
         }
     }
 
-    @Test("a bare cd keeps its own text, because a row is never blank")
+    @Test("a bare cd to the worktree keeps its own text, because a row is never blank")
     func nothingAfterTheCD() {
-        for command in ["cd \(Self.worktree)", "cd /tmp"] {
-            #expect(Self.of(command) == CommandDisplay(place: .unstated, command: command), "\(command)")
-        }
+        let command = "cd \(Self.worktree)"
+        #expect(Self.of(command) == CommandDisplay(place: .unstated, command: command))
+    }
+
+    @Test("a bare cd away keeps its own text and is still outside")
+    func bareCDAway() {
+        // Not quiet, and this is why: the Bash tool holds one shell across calls, so this moves
+        // the directory for every row after it.
+        let display = Self.of("cd /tmp")
+        #expect(display.place == .elsewhere(prefix: ""))
+        #expect(display.command == "cd /tmp")
+        #expect(display.lead == .none)
     }
 
     // MARK: 5. Separators and quoting
@@ -259,6 +284,7 @@ struct CommandDisplayTests {
         #expect(row.label == "List admin tests")
         #expect(row.detail == "ls tests/Http/Admin")
         #expect(row.detailLead == .none)
+        #expect(row.tint == .neutral)
         // The copy and the expanded body are the record, so they keep the `cd`.
         #expect(row.literal == "cd \(Self.worktree)\nls tests/Http/Admin")
     }
@@ -271,6 +297,19 @@ struct CommandDisplayTests {
         #expect(row.detailLead == .prefix("cd /tmp/build-cache &&"))
         #expect(row.detail == "rm -rf artefacts")
         #expect(row.detailLine == command)
+        // On the glyph, at the left edge, which is the column a reader scans.
+        #expect(row.tint == .warning)
+    }
+
+    @Test("a Bash row whose destination could not be read is marked too")
+    func bashRowOpaque() {
+        for command in ["cd ~/bloom && ls", "cd $TMPDIR && ls", "cd /tmp"] {
+            let input = JSONValue.object(["command": .string(command)])
+            let row = ToolPresenter.present(name: "Bash", input: input, worktree: Self.worktree)
+            #expect(row.tint == .warning, "\(command)")
+            #expect(row.detail == command, "\(command)")
+            #expect(row.detailLead == .none, "\(command)")
+        }
     }
 
     @Test("a Bash row below the worktree keeps the part below")


### PR DESCRIPTION
Every Bash row began with sixty characters of the same worktree path, so the part that differed was pushed off the right edge. A `cd` to the workspace's own worktree is now hidden.

No stand-in marks where it was. A row with no `cd` at all already means "ran in the worktree", because that is where Bloom spawns every agent, so a marker would spell one fact two ways.

A `cd` below the worktree keeps the path below it, in the accent ink, including a relative `cd packages/api` and a chain. A `cd` outside the worktree keeps every character and is tinted with the warning colour: a command that ran somewhere else is the thing a reader most needs to notice, and it is the whole safety argument for hiding the others. Anything the parser cannot resolve with certainty (`~`, `$VAR`, a subshell, `cd -`, an unbalanced quote, a sibling whose name merely starts with the worktree's) hides nothing.

The expanded row, the copy button and the permission panel keep the full command: they are the record, and nobody can paste a stripped command into a shell. There is a test pinning that.

`CommandDisplay` in the core holds the rule with 25 tests. Codex shell rows go through it too, since Codex writes the same prefixes. `ToolRowSnapshotGallery` gained a group with all four cases, so it has a picture.