### PR TITLE
Let a row's detail sit next to its own label

### DIFF
--- a/Sources/Bloom/Design/Snapshot.swift
+++ b/Sources/Bloom/Design/Snapshot.swift
@@ -861,7 +861,7 @@ enum Snapshot {
             ("home", AnyView(HomeView().frame(width: 900, height: 620)), CGSize(width: 900, height: 620)),
             ("components", AnyView(ComponentGallery().frame(width: 640, height: 700)), CGSize(width: 640, height: 700)),
             ("permission", AnyView(PermissionSnapshotGallery().frame(width: 720, height: 1560)), CGSize(width: 720, height: 1560)),
-            ("tool-rows", AnyView(ToolRowSnapshotGallery().frame(width: 800, height: 900)), CGSize(width: 800, height: 900)),
+            ("tool-rows", AnyView(ToolRowSnapshotGallery().frame(width: 800, height: 1_020)), CGSize(width: 800, height: 1_020)),
             // Offscreen rather than through a window: no `CheckRunRow` holds a representable, so
             // `ImageRenderer` draws the real column here.
             ("check-runs", AnyView(CheckRunSnapshotGallery()), CGSize(width: 420, height: 1000)),

--- a/Sources/Bloom/Design/ToolRowSnapshotGallery.swift
+++ b/Sources/Bloom/Design/ToolRowSnapshotGallery.swift
@@ -15,6 +15,9 @@ import BloomCore
 /// shows fewer characters than it did, and a page that photographed a short command would hide
 /// exactly that.
 ///
+/// It is also where the label's width is judged, which is why the labels here run from four
+/// letters to a sentence: see `TranscriptLabelColumn`.
+///
 /// `Snapshot.render` picks this up as the "tool-rows" scene, light and dark.
 struct ToolRowSnapshotGallery: View {
     /// 154 characters, wrapped in nothing. This is the line from the screenshot.
@@ -144,6 +147,26 @@ struct ToolRowSnapshotGallery: View {
                     "description": .string("Find where the transcript decides which rows are code"),
                     "prompt": .string(Self.brief),
                 ], isExpanded: true)
+            }
+
+            // The label column was never the tool rows' alone, so the rows that share it are
+            // photographed beside them: a transcript running two habits would read worse than one
+            // running either. The last row is the pairing that is easiest to get wrong, a text
+            // detail and a chip on the same line behind a short label.
+            group("The other rows on the same ceiling") {
+                SessionStartRowView(info: AgentInit(
+                    sessionID: "s1",
+                    model: "opus-5-1m",
+                    permissionMode: "acceptEdits"
+                ))
+                ThinkingRowView(
+                    text: "The gap is the whole complaint: four letters of label, then a "
+                        + "hundred and forty seven points of nothing before its own detail."
+                )
+                row("s1", "Grep", [
+                    "pattern": .string("labelWidth|transcriptLabelColumn"),
+                    "path": .string("/tmp/app/src/WebhookCall.php"),
+                ])
             }
         }
         .frame(width: 760, alignment: .leading)

--- a/Sources/Bloom/Views/Transcript/AgentErrorRowView.swift
+++ b/Sources/Bloom/Views/Transcript/AgentErrorRowView.swift
@@ -37,7 +37,7 @@ struct AgentErrorRowView: View {
                 .foregroundStyle(Palette.negative)
                 .lineLimit(1)
                 .truncationMode(.tail)
-                .transcriptLabelColumn()
+                .transcriptLabelColumn(exit.title, font: Typo.label)
 
             Text(exit.summary)
                 .font(Typo.label)

--- a/Sources/Bloom/Views/Transcript/RateLimitRowView.swift
+++ b/Sources/Bloom/Views/Transcript/RateLimitRowView.swift
@@ -23,7 +23,7 @@ struct RateLimitRowView: View {
                 Text("Rate limit")
                     .font(Typo.label)
                     .foregroundStyle(Palette.textSecondary)
-                    .transcriptLabelColumn()
+                    .transcriptLabelColumn("Rate limit", font: Typo.label)
 
                 Text(sentence)
                     .font(Typo.label)

--- a/Sources/Bloom/Views/Transcript/SessionStartRowView.swift
+++ b/Sources/Bloom/Views/Transcript/SessionStartRowView.swift
@@ -24,7 +24,7 @@ struct SessionStartRowView: View {
             Text("Session started")
                 .font(Typo.label)
                 .foregroundStyle(Palette.textSecondary)
-                .transcriptLabelColumn()
+                .transcriptLabelColumn("Session started", font: Typo.label)
 
             if !info.model.isEmpty {
                 Chip(text: modelLabel)

--- a/Sources/Bloom/Views/Transcript/StreamingThinkingView.swift
+++ b/Sources/Bloom/Views/Transcript/StreamingThinkingView.swift
@@ -59,7 +59,7 @@ struct StreamingThinkingView: View {
                 .foregroundStyle(Palette.textSecondary)
                 .italic()
                 .lineLimit(1)
-                .transcriptLabelColumn()
+                .transcriptLabelColumn("Thinking", font: Typo.label)
 
             if tokens > 0 {
                 Text("\(tokens) tokens")

--- a/Sources/Bloom/Views/Transcript/ThinkingRowView.swift
+++ b/Sources/Bloom/Views/Transcript/ThinkingRowView.swift
@@ -45,7 +45,7 @@ struct ThinkingRowView: View {
                 .foregroundStyle(Palette.textSecondary)
                 .italic()
                 .lineLimit(1)
-                .transcriptLabelColumn()
+                .transcriptLabelColumn("Thinking", font: Typo.label)
 
             if !isExpanded {
                 Text(ToolPresenter.oneLine(text))

--- a/Sources/Bloom/Views/Transcript/ToolRowHeader.swift
+++ b/Sources/Bloom/Views/Transcript/ToolRowHeader.swift
@@ -150,7 +150,7 @@ struct ToolRowHeader: View {
                 .foregroundStyle(Palette.textSecondary)
                 .lineLimit(1)
                 .truncationMode(.tail)
-                .transcriptLabelColumn()
+                .transcriptLabelColumn(presentation.label, font: Typo.label)
                 .reportsTruncation(
                     of: presentation.label,
                     font: Typo.label,

--- a/Sources/Bloom/Views/Transcript/TranscriptLabelColumn.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptLabelColumn.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import AppKit
+
+/// The label at the head of a one line row: as wide as its own text, and never wider than
+/// `TranscriptLayout.labelCeiling`.
+///
+/// It was a fixed 176 point column, which started every detail on the same x. That reads well down
+/// a page of long labels and badly down a page of short ones, and short is what most of them are:
+/// `Read` measures 28 points, so 147 points of the column it sat in were empty and the eye crossed
+/// them to reach the file the row was about. Details no longer line up with each other, which is
+/// the trade, and it is the one that was asked for.
+///
+/// The ceiling is what the column was, so no row is drawn in less room than it had: a label that
+/// filled 176 points still fills it and is cut in the same place, and every shorter one hands the
+/// difference to its own detail rather than to the gap.
+///
+/// Measured rather than proposed, because SwiftUI has no "as wide as the text, up to N".
+/// `frame(maxWidth:)` fills whatever width it is offered, which is the fixed column again, and
+/// `fixedSize()` has no ceiling at all, which lets one long label push a command off the row.
+struct TranscriptLabelColumn: ViewModifier {
+    /// The same string the label draws, in the same rung it is set in, for the reason
+    /// `TruncationProbe` gives: a ruler laid against another face reports a width nothing has.
+    var text: String
+    var font: ScaledFont
+
+    /// Was a `@ScaledMetric`, which on macOS never moves because there is no Dynamic Type for it to
+    /// track, so the ceiling stayed at 176 however large the conversation was set.
+    @Environment(\.fontScale) private var fontScale
+    @Environment(\.chatFont) private var face
+
+    func body(content: Content) -> some View {
+        content.frame(
+            width: min(
+                TranscriptLabelWidth.of(text, font: font, scale: fontScale, face: face),
+                TranscriptLayout.labelCeiling * fontScale
+            ),
+            alignment: .leading
+        )
+    }
+}
+
+extension View {
+    func transcriptLabelColumn(_ text: String, font: ScaledFont) -> some View {
+        modifier(TranscriptLabelColumn(text: text, font: font))
+    }
+}
+
+/// What a label wants, measured once per string.
+///
+/// AppKit's ruler rather than a hidden `Text`: a second `Text` behind every row is a second layout
+/// pass per row per pass, which is the cost `TruncationProbe` goes to the trouble of building for
+/// the hovered row alone. This is one CoreText run, 6.6 microseconds measured, and the table means
+/// a transcript of four hundred `Read` rows pays for one of them.
+@MainActor
+enum TranscriptLabelWidth {
+    private struct Key: Hashable {
+        var text: String
+        var font: ScaledFont
+        var scale: CGFloat
+        var face: ChatFont
+    }
+
+    private static var widths: [Key: CGFloat] = [:]
+
+    /// A Bash row's label is the model's own sentence, so this is not a table of tool names and
+    /// cannot be left to grow for the life of a window.
+    private static let limit = 512
+
+    static func of(_ text: String, font: ScaledFont, scale: CGFloat, face: ChatFont) -> CGFloat {
+        let key = Key(text: text, font: font, scale: scale, face: face)
+        if let known = widths[key] { return known }
+
+        let measured = (text as NSString)
+            .size(withAttributes: [.font: font.resolvedNSFont(scale: scale, face: face)])
+            .width
+        // A point of slack, rounded up: the ruler is AppKit's and the label is SwiftUI's, and a
+        // frame a hair under what the text wants draws an ellipsis where nothing was cut.
+        let width = (measured + 1).rounded(.up)
+
+        if widths.count >= limit { widths.removeAll(keepingCapacity: true) }
+        widths[key] = width
+        return width
+    }
+}

--- a/Sources/Bloom/Views/Transcript/TranscriptLayout.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptLayout.swift
@@ -9,8 +9,8 @@ import SwiftUI
 ///
 /// The three spacings below are the window's scale rather than numbers of their own, so the
 /// transcript cannot drift a point away from the sidebar and the inspector the way it did when
-/// all three kept private copies. The column widths underneath them are genuinely the
-/// transcript's, because nothing else in the window has a glyph column or a label column.
+/// all three kept private copies. The widths underneath them are genuinely the transcript's,
+/// because nothing else in the window has a glyph column.
 enum TranscriptLayout {
     /// The gap between two things that belong to each other, such as a label and its counter.
     static let tight = Metrics.spacingTight
@@ -58,10 +58,13 @@ enum TranscriptLayout {
 
     static let glyphWidth: CGFloat = 16
     static let glyphGap: CGFloat = 8
-    /// The label column, at the default text size. Read through `transcriptLabelColumn()` rather
-    /// than directly, because it is the one column here that holds text of unknown length.
-    static let labelWidth: CGFloat = 176
-    /// Where an expanded body starts, lined up under the label column.
+    /// The widest a row's label may be drawn, at the default text size, which is not the width it
+    /// is drawn at. Read through `transcriptLabelColumn(_:font:)`, where a label's own width is
+    /// worked out and where the reason for the ceiling being this number is written down.
+    static let labelCeiling: CGFloat = 176
+    /// Where an expanded body starts, lined up under the label. Built from the glyph column and
+    /// not from the label's own width, which is why nothing below a row moved when that stopped
+    /// being a fixed number.
     static let detailIndent: CGFloat = glyphWidth + glyphGap + inset
     static let nestIndent: CGFloat = 16
     /// The coloured rule down the left of an error, a quote or a tool result.
@@ -92,26 +95,4 @@ enum TranscriptLayout {
     /// loses the start of the next line. Generous on purpose: at the sizes the window is usually
     /// dragged to this never bites, and it only ever stops prose running away.
     static let proseMeasure: CGFloat = 680
-}
-
-/// The label column of a row header.
-///
-/// Fixed columns are what make the transcript scan, but this one holds text nobody chose the
-/// length of ("Run Pint and the new test"), so it is the one that has to grow with the user's text
-/// size. The glyph and detail columns stay pinned, so an expanded body still lands under the label
-/// it belongs to whatever size the text is set at.
-struct TranscriptLabelColumn: ViewModifier {
-    /// Was a `@ScaledMetric`, which on macOS never moves because there is no Dynamic Type for it to
-    /// track, so the column stayed at 176 however large the conversation was set.
-    @Environment(\.fontScale) private var fontScale
-
-    func body(content: Content) -> some View {
-        content.frame(width: TranscriptLayout.labelWidth * fontScale, alignment: .leading)
-    }
-}
-
-extension View {
-    func transcriptLabelColumn() -> some View {
-        modifier(TranscriptLabelColumn())
-    }
 }


### PR DESCRIPTION
The label was a fixed 176 point column, so every short label left a wide gap before its own detail and the eye had to jump it on every row. The label is now measured and drawn at its own width, and 176 becomes a ceiling rather than a frame.

The ceiling is the same number on purpose: 176 was already a cap, because a label longer than it was already cut there. So the worst case row is drawn identically and no detail has less room than before, while every shorter label hands the difference straight to its own detail. `Read` is 28 points wide, so that row's chip moves 147 points to the left.

Measured rather than proposed, because SwiftUI has no "as wide as the text, up to N": `frame(maxWidth:)` fills what it is offered, which is the column again, and `fixedSize()` has no ceiling, so one long label pushes the command off the row. The measure is 6.6 microseconds per string and memoised; a hidden ruler view per row would be a second layout pass per row, which is the cost the truncation probe goes out of its way to pay only for the hovered row.

All six row kinds that used the modifier move together. Two habits in one transcript would read worse than either.

Nothing else read the number: the expanded body's indent is built from the glyph, not the label, and the trailing duration is still a column, because that one is read by scanning down.