### PR TITLE
Give the inspector toggle the sidebar toggle's own button

### DIFF
--- a/Sources/Bloom/Design/PaneTabsGallery.swift
+++ b/Sources/Bloom/Design/PaneTabsGallery.swift
@@ -93,6 +93,21 @@ struct PaneTabsGallery: View {
                 ),
             ])
 
+            // The one thing on this page that is a question rather than a record. `.glass` is a
+            // system style, so what it draws for a `.button` toggle's ON state is Apple's decision
+            // and not ours, and the whole reason the control used to be `.accessoryBar` was to keep
+            // that state off the saturated accent. Both states, side by side, is the answer.
+            row(
+                "The inspector toggle, hidden and shown",
+                tabs: [fixture("Chat", PaneGlyph.chat, active: true), fixture("Terminal", PaneGlyph.terminal)],
+                inspectorVisible: false
+            )
+            row(
+                "The same strip with the inspector open",
+                tabs: [fixture("Chat", PaneGlyph.chat, active: true), fixture("Terminal", PaneGlyph.terminal)],
+                inspectorVisible: true
+            )
+
             VStack(alignment: .leading, spacing: 8) {
                 caption("The three glyphs at the size they are read at")
                 HStack(spacing: 20) {
@@ -118,10 +133,10 @@ struct PaneTabsGallery: View {
     private static let longTitle =
         "WKWebView | Apple Developer Documentation | Displaying web content in a view"
 
-    private func row(_ title: String, tabs: [Fixture]) -> some View {
+    private func row(_ title: String, tabs: [Fixture], inspectorVisible: Bool? = nil) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             caption(title)
-            StripRow(tabs: tabs)
+            StripRow(tabs: tabs, inspectorVisible: inspectorVisible)
         }
     }
 
@@ -143,6 +158,9 @@ struct PaneTabsGallery: View {
 /// and the other four reading as though nothing in them were selected.
 private struct StripRow: View {
     var tabs: [Fixture]
+    /// Whether the strip ends in the inspector's toggle, and which way it is thrown. Nil for the
+    /// rows that are about the tabs.
+    var inspectorVisible: Bool?
 
     @Namespace private var selection
 
@@ -162,7 +180,10 @@ private struct StripRow: View {
         } append: {
             EmptyView()
         } trailing: {
-            EmptyView()
+            if let inspectorVisible {
+                TabStripSeparator()
+                InspectorToggle(isVisible: .constant(inspectorVisible))
+            }
         }
         .frame(width: 620)
         .background(Palette.surface)
@@ -202,7 +223,7 @@ extension Gallery {
     static let paneTabs = Gallery(
         name: "pane-tabs",
         title: "Pane tabs",
-        size: CGSize(width: 700, height: 720),
+        size: CGSize(width: 700, height: 880),
         needsFocus: false,
         view: { app in AnyView(PaneTabsGallery(app: app)) }
     )

--- a/Sources/Bloom/Design/SystemAccentGallery.swift
+++ b/Sources/Bloom/Design/SystemAccentGallery.swift
@@ -28,9 +28,11 @@ import BloomCore
 /// four swatches on the right are what those three would be drawn in, which is the same question
 /// answered one step indirectly.
 ///
-/// The last row is the control that deliberately does not follow, and it is here so the next person
-/// does not read its absence as a bug. See `InspectorToolbar` and `SettingsView`: a segmented
-/// control's selected cell is a neutral capsule on this SDK, and it stays one.
+/// The last row is the segmented control, and it is the one thing on this page that this page
+/// cannot answer. It is drawn without the `controlActiveState` override the column beside it gets,
+/// so it is photographed in the inactive grey every accented control drops to, exactly as the
+/// switch above it is. In a key window it carries `controlAccentColor`, which this process resolves
+/// to Bloom's own `accentFill`. See `InspectorToolbar`, where the same correction is written down.
 struct SystemAccentGallery: View {
     var app: AppModel
 
@@ -98,7 +100,7 @@ struct SystemAccentGallery: View {
                     }
                 }
 
-                captioned("The one that stays neutral, and is meant to") {
+                captioned("The one this page cannot answer: grey here, accent in a key window") {
                     SystemAccentSegments()
                 }
 
@@ -182,8 +184,8 @@ private struct SystemAccentControls: View {
     }
 }
 
-/// The segmented control, alone, because the answer about it is "unchanged" and that is worth
-/// photographing next to everything that did change.
+/// The segmented control, alone. See the head of this file: what it draws here is the inactive
+/// grey, not the answer.
 private struct SystemAccentSegments: View {
     @State private var segment = 0
 

--- a/Sources/Bloom/Views/Center/Panes/InspectorToggle.swift
+++ b/Sources/Bloom/Views/Center/Panes/InspectorToggle.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// The right pane's control, at the trailing end of the tab strip that borders it.
+///
+/// Drawn as the sidebar's toggle is drawn, because the two do the same job to opposite edges of
+/// one window and were in two registers: the sidebar's is `NavigationSplitView`'s own toolbar
+/// item, which macOS 26 draws as a round glass button, and this was a flat plate that appeared
+/// only under the pointer. `.buttonStyle(.glass)` rather than a rim of our own, so it keeps
+/// tracking whatever the system does to that shape.
+///
+/// 28 points across, which is the strip's own control inset taken off its 32 point height. The
+/// toolbar's button is about 30 in a 52 point title bar, so this is the nearest the strip has room
+/// for rather than a match.
+///
+/// Still a `Toggle`, so VoiceOver reads it as one. `.accessoryBar` was here because macOS 26 fills
+/// a `.button` toggle's on state with the saturated accent, and a pane that is on almost all the
+/// time then shouts. What glass does with that state is the one thing here that has to be
+/// photographed rather than reasoned about: `PaneTabsGallery` draws both.
+///
+/// A binding rather than the app model, so the gallery can hold both states on one page.
+struct InspectorToggle: View {
+    @Binding var isVisible: Bool
+
+    /// The plate, inset from the strip's height by the daylight every control in the row keeps.
+    private static let diameter = Metrics.barHeight - 2 * Metrics.spacingTight
+
+    var body: some View {
+        Toggle(isOn: $isVisible) {
+            Label("Inspector", systemImage: "sidebar.right")
+                .labelStyle(.iconOnly)
+                .font(Typo.labelEmphasis)
+        }
+        .toggleStyle(.button)
+        .buttonStyle(.glass)
+        .buttonBorderShape(.circle)
+        .frame(width: Self.diameter, height: Self.diameter)
+        .frame(height: Metrics.barHeight)
+        .padding(.horizontal, Metrics.spacingTight)
+        .help(isVisible ? "Hide the changed files" : "Show the changed files")
+    }
+}

--- a/Sources/Bloom/Views/Center/Panes/SessionTabsView.swift
+++ b/Sources/Bloom/Views/Center/Panes/SessionTabsView.swift
@@ -360,24 +360,12 @@ struct SessionTabsView: View {
     /// about which of them it would move. On the boundary it opens, the target is the thing it is
     /// pointing at.
     ///
-    /// `.accessoryBar` rather than the default `.button` fill: on macOS 26 that fill is the
-    /// saturated accent colour, and a pane that is on almost all the time then shouts all the
-    /// time. `.accessoryBar` marks on with the same neutral raised capsule Finder gives its own
-    /// toolbar items, which is legible without being an alarm. It stays a `Toggle` so VoiceOver
-    /// still reads it as one and announces the on state without being told to.
+    /// What it looks like is `InspectorToggle`, which is a view of its own so that both of its
+    /// states can be photographed.
     private var inspectorToggle: some View {
         @Bindable var app = app
 
-        return Toggle(isOn: $app.isInspectorVisible) {
-            Label("Inspector", systemImage: "sidebar.right")
-                .labelStyle(.iconOnly)
-                .font(Typo.labelEmphasis)
-        }
-        .toggleStyle(.button)
-        .buttonStyle(.accessoryBar)
-        .padding(.horizontal, Metrics.spacing)
-        .frame(height: Metrics.barHeight)
-        .help(app.isInspectorVisible ? "Hide the changed files" : "Show the changed files")
+        return InspectorToggle(isVisible: $app.isInspectorVisible)
     }
 
     /// Whether this tab can be opened beside the one the user is in. The pair of menu items is

--- a/Sources/Bloom/Views/Inspector/InspectorToolbar.swift
+++ b/Sources/Bloom/Views/Inspector/InspectorToolbar.swift
@@ -133,11 +133,25 @@ struct InspectorToolbar: View {
     /// here. AppKit has no `appearance()` proxy to set it globally either.
     ///
     /// So the tint was a line of code that did nothing, sitting under a comment claiming a colour
-    /// decision that was never being made. What it wanted is what the system now does anyway: this
-    /// SDK draws the selected segment as a neutral capsule rather than in the accent colour, so
-    /// the tab row is already the quiet grey the pull request band above it needs it to be, and
-    /// there is nothing left for a tint to fix. If a future SDK puts the accent back in it, this is
-    /// the note to come back to, and the answer will be a control of our own rather than a tint.
+    /// decision that was never being made. That half is settled: `.tint` cannot reach this control
+    /// whatever it draws.
+    ///
+    /// **The colours above were measured in a window that was not key, and that is not the same
+    /// question.** They came off `--gallery system-accent`, which is captured with `needsFocus`
+    /// false, and every accented control on this platform drops to a neutral grey while its window
+    /// is inactive: that page says so itself about the switch beside it. `#CFCFCF` and `#4B4E54`
+    /// are those greys. In a key window `NSAccentColorName` in `Resources/Info.plist` makes this
+    /// process's `controlAccentColor` Bloom's own `accentFill`, and the owner's screenshot of a
+    /// live window shows the selected segment carrying it. Which is the right outcome and needs
+    /// nothing done to it: the accent it fills with is ours.
+    ///
+    /// Do not add glass here. `.glassEffect` shapes a view's own background, and this is one
+    /// `NSSegmentedControl` rather than three views, so a tinted glass segment means drawing the
+    /// strip by hand and freezing it at today's look. Measured for the record: white on
+    /// `.regular.tint(accentFill)` over this pane's light ground is 4.32 to 1 at a tint as strong
+    /// as nine tenths and 2.99 at seven tenths, against a floor of 4.5. Bloom's light surface is
+    /// pure white, so any translucency drags the fill towards the ink on it. Flat `accentFill` is
+    /// 5.24.
     private var tabPicker: some View {
         // Whichever tabs this workspace has, rather than all three. Checks is only offered when
         // GitHub has reported a run for the branch, so a workspace with no pull request draws two


### PR DESCRIPTION
The sidebar toggle is the system's round glass button in the title bar; the inspector toggle was a small flat plate at the end of the tab strip. Two buttons doing the same job to opposite edges of one window, drawn in two registers. It is now `.buttonStyle(.glass)` with `.buttonBorderShape(.circle)`, still a system style so it keeps tracking macOS 26, still a `Toggle` so VoiceOver still announces the on state. It fits: 28 points inside a 32 point strip, against about 30 in the title bar, and it takes no more room than the plate it replaces.

Nothing else in the inspector header changes, and that is the finding rather than a shortcut. Every control in that strip is already system drawn: the tab picker is a segmented `Picker`, the folder is a system button style, the filter and the ellipsis are borderless menus. They already track macOS 26 and hand rolling glass would freeze them. What is behind them is one flat opaque colour, so glass would sample nothing and say nothing.

Tinted glass does not rescue the selected segment either. Three segments are one `NSSegmentedControl`, so tinting one means drawing the control ourselves, and the numbers are against it anyway: white on tinted glass over Bloom's white light ground measures 4.32 at a very strong tint and 2.99 at a moderate one, against a 4.5 floor, where the flat accent measures 5.24. Dark goes the other way, and a control that passes in one appearance and fails in the other is not shippable.

The pull request band stays opaque: it is in the title bar accessory, so glass there samples the desktop, and carrying pull request state as colour is the whole of its job.

Two doc comments claiming the selected segment is a neutral grey are corrected. The measurement behind them was taken from a gallery page that photographs in a non key window, where every accented control drops to grey, and the key window override that page applies reaches only one of its two columns.