### PR TITLE
Put real glass in the browser bar

### DIFF
--- a/Sources/Bloom/Design/BrowserToolbarGallery.swift
+++ b/Sources/Bloom/Design/BrowserToolbarGallery.swift
@@ -12,6 +12,14 @@ import BloomCore
 /// split out: a pane needs a live `BrowserSession` behind it, and an offscreen render paints
 /// SwiftUI's yellow placeholder over the `WKWebView` under it in any case.
 ///
+/// **This page is an honest picture of the glass, and `--snapshot` would not be.** The bar's
+/// arrow capsule and address pill are `glassEffect`, and a material has to be composited by the
+/// window server to exist: `ImageRenderer` draws into a bitmap with no window behind it, so what
+/// it photographs is the opaque fallback rather than the thing. `--snapshot-gallery` does not use
+/// it. It builds a real `NSWindow`, orders it front and asks `screencapture -l<window>` for that
+/// window by number, so the two shapes are sampling their own bar the way they do in the pane.
+/// Nothing here samples outside the window, which is why capturing one window is enough.
+///
 /// `Bloom --snapshot-gallery <dir> --gallery browser-toolbar`.
 struct BrowserToolbarGallery: View {
     /// The width a browser pane sits at in one half of a split centre column, which is the

--- a/Sources/Bloom/Design/Theme.swift
+++ b/Sources/Bloom/Design/Theme.swift
@@ -145,6 +145,28 @@ enum Palette {
     /// the worst ground cleared AA. See `PaletteContrastTests`, which now says so on every build.
     static let textTertiary = dynamic(PaletteInk.textTertiary)
 
+    /// The tertiary rung where the ground under it is glass, which is a different rung in each
+    /// appearance because the ground moves in only one of them.
+    ///
+    /// `glassEffect` over a flat backdrop is that backdrop lifted toward white. In light the bar
+    /// it lifts is already all but white, so `#F7FAFA` becomes about `#F9FBFB` and `textTertiary`
+    /// holds 4.56 to 1 there: nothing has happened and the tuned ink is still the right one. In
+    /// dark the same lift is the whole story, because `#0C1E2A` has somewhere to go:
+    /// `textTertiary` measures 5.65 on the resting bar, crosses the 4.5 floor by an 8 percent lift
+    /// and reaches 2.98 by 20. `secondaryLabelColor` is 5.07 and 4.01 at those two, and AppKit
+    /// resolves it against the material's own effective appearance rather than against a number
+    /// tuned for an opaque page.
+    ///
+    /// **The two halves differ because the ground differs, and unifying them costs whichever half
+    /// is unified away.** Both land in the same place against their own ground, 4.56 in light and
+    /// 4.51 to 5.07 in dark, so it is one weight to look at and two colours only underneath.
+    /// See `PaletteContrastTests.aLiftedGroundCostsTheTertiaryInk` and `BrowserToolbarView`.
+    static let textTertiaryOnGlass = Color(nsColor: NSColor(name: nil) { appearance in
+        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            ? .secondaryLabelColor
+            : NSColor(rgb: PaletteInk.textTertiary.light)
+    })
+
     /// Ink on anything Bloom has filled with a colour of its own.
     ///
     /// Spelled as the selection's ink rather than built from the same `NSColor` a second time,

--- a/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
@@ -38,12 +38,15 @@ struct BrowserToolbarButton: View {
 /// no stock component for any of it, and `BrowserToolbar` says why: the toolbar, the joined pair
 /// and the search item are all `NSWindow`'s, and this is a pane inside a split inside a tab.
 ///
-/// Two notes this file used to carry are overturned by that, both knowingly. The pair had no
-/// plate, because `surfaceRaised` means *switched on* in this window and a fill round two of five
-/// glyphs would have read that way; it cannot now, since the pair and the field wear the same fill
-/// and the same radius, so the bar reads as two raised controls beside three bare glyphs. And the
-/// camera has crossed the field, because with Reload inside the field what is left on the right is
-/// the two controls that take this page elsewhere.
+/// **The pair and the field are real glass.** It was refused once on the grounds that glass
+/// samples an arbitrary web page, and that was wrong: `BrowserTabView` is a `VStack(spacing: 0)`,
+/// so this bar sits above the page rather than over it. What the two shapes sample is the bar's
+/// own `surfaceSunken`, which is ours.
+///
+/// The camera and Share stay `.accessoryBar` rather than taking `.buttonStyle(.glass)`. Four
+/// raised capsules in a row is a bar with no groups left in it, and Safari's own two are bare
+/// glyphs until the pointer is on them. The camera is on that side because with Reload inside the
+/// field, what is left on the right is the pair that takes this page elsewhere.
 struct BrowserToolbarView: View {
     var toolbar: BrowserToolbar
     /// What the field shows, which is not where the page is. See `BrowserTabView.address`.
@@ -76,14 +79,24 @@ struct BrowserToolbarView: View {
     private var display: BrowserAddressDisplay { .of(address) }
 
     var body: some View {
-        HStack(spacing: Metrics.spacingWide) {
-            navigation
-            addressField
-            BrowserToolbarButton(control: toolbar.screenshot, action: capture)
-            BrowserShareButton(control: toolbar.share, shareable: toolbar.shareable)
+        // One sampling pass for the two shapes rather than two, which is what the container is
+        // for. `spacing: 0` because the other thing it does is merge shapes that come within a
+        // distance of each other, and the capsule and the pill running together into one blob is
+        // exactly what the three groups above must not become.
+        GlassEffectContainer(spacing: 0) {
+            HStack(spacing: Metrics.spacingWide) {
+                navigation
+                addressField
+                BrowserToolbarButton(control: toolbar.screenshot, action: capture)
+                BrowserShareButton(control: toolbar.share, shareable: toolbar.shareable)
+            }
         }
         .padding(.horizontal, Metrics.spacingSmall)
         .frame(height: Metrics.barHeight)
+        // The bar itself is a colour and not glass. What is behind it is `Palette.surface`, one
+        // flat fill, so the material would resolve to a colour Bloom already has a name for, and
+        // it would lift the ground the two shapes above sample. Its bottom edge also meets the
+        // page's top edge, where a ground that moves reads as a seam rather than as material.
         .background(Palette.surfaceSunken)
     }
 
@@ -98,10 +111,15 @@ struct BrowserToolbarView: View {
                 .modifier(HistoryMenu(entries: forwardHistory, go: goToHistory))
         }
         .frame(height: Metrics.controlHeight)
-        .background(Palette.surfaceRaised)
-        // Before the border, so the clip takes the hover fills of the two buttons and not the
-        // stroke, which `strokeBorder` already draws inside the edge.
+        // Clipped before the glass, not after it. `glassEffect` shapes only its own background, so
+        // the two hover fills still need this to stop at the capsule.
         .clipShape(Capsule())
+        // `.interactive()` here and nowhere else in the bar: this shape is nothing but controls,
+        // and the material answering the pointer is what separates glass from a picture of it.
+        // Which arrow is under the pointer is still said by `.accessoryBar`'s own fill inside.
+        .glassEffect(.regular.interactive(), in: Capsule())
+        // The rim is drawn rather than left to the material's, because it is what still says where
+        // the capsule ends once Reduce Transparency has turned the glass opaque.
         .overlay { Capsule().strokeBorder(Palette.border, lineWidth: Metrics.hairline) }
     }
 
@@ -112,7 +130,7 @@ struct BrowserToolbarView: View {
             if !isEditing, let symbol = display.security.symbol {
                 Image(systemName: symbol)
                     .font(Typo.caption)
-                    .foregroundStyle(Palette.textTertiary)
+                    .foregroundStyle(Palette.textSecondary)
                     .help(display.security.help ?? "")
                     .accessibilityLabel(display.security.help ?? "")
             }
@@ -122,8 +140,12 @@ struct BrowserToolbarView: View {
         .padding(.leading, Metrics.spacing)
         .padding(.trailing, Metrics.spacingTight)
         .frame(height: Metrics.controlHeight)
-        .background(alignment: .leading) { fill }
+        .background(alignment: .leading) { load }
         .clipShape(Capsule())
+        // `.regular` and not `.interactive()`. This is where a caret is put, and a material that
+        // lifts and settles on the way to placing one reads as fidgety rather than alive. Both
+        // controls in the pill keep their own hover fills.
+        .glassEffect(.regular, in: Capsule())
         .overlay {
             Capsule().strokeBorder(
                 isRingVisible ? Palette.focusRing : Palette.border,
@@ -132,13 +154,15 @@ struct BrowserToolbarView: View {
         }
     }
 
-    /// The field's ground, with the load behind it.
+    /// How far the page has got, over the glass and under the address.
     ///
     /// `Palette.selected` rather than a tint: it is the step of Bloom's ramp meant to sit under
     /// content in a list that has not got the keyboard, which is exactly what is wanted behind a
     /// line of text, and it keeps the accent out of a bar that has nothing else tinted in it.
-    @ViewBuilder private var fill: some View {
-        Palette.surfaceRaised
+    ///
+    /// Opaque, so the material stops where the load has reached. A wash the glass carried through
+    /// would be a progress fill you have to look for, which is the one thing it must not be.
+    @ViewBuilder private var load: some View {
         if let progress = toolbar.progress {
             GeometryReader { proxy in
                 Palette.selected.frame(width: proxy.size.width * progress)
@@ -174,10 +198,19 @@ struct BrowserToolbarView: View {
         Text(string).foregroundStyle(colour)
     }
 
+    /// The dim runs are `textSecondary` and not `textTertiary`, and that is the glass rather than
+    /// a taste. Bloom's tertiary is tuned for opaque grounds: on the sunken bar in dark it measures
+    /// 5.65 to 1, and it crosses the 4.5 floor as soon as glass lifts that ground 8 percent toward
+    /// white, 2.98 by 20. Retuning it does not help, because an ink still clearing 4.5 at a quarter
+    /// lift stands only 1.32 to 1 off `labelColor` where the tertiary stands 2.21 today: the floor
+    /// is bought by deleting the two-tone. So the pair goes semantic, the way `QuotaPanel` did on
+    /// the menu's material, and AppKit resolves both against the glass's own effective appearance
+    /// with the vibrancy a flat composite cannot model. See
+    /// `PaletteContrastTests.aLiftedGroundCostsTheTertiaryInk`.
     private var addressLabel: some View {
         // Interpolated rather than concatenated: `Text.+` is deprecated in macOS 26 and the app
         // target builds with -warnings-as-errors.
-        Text("\(tinted(display.leading, Palette.textTertiary))\(tinted(display.host, Palette.textPrimary))\(tinted(display.trailing, Palette.textTertiary))")
+        Text("\(tinted(display.leading, Palette.textSecondary))\(tinted(display.host, Palette.textPrimary))\(tinted(display.trailing, Palette.textSecondary))")
             .lineLimit(1)
             // The tail, which is where a query string lives. The host is the part worth reading
             // and it is at the head, so it is the part that always survives the cut.

--- a/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
@@ -130,7 +130,7 @@ struct BrowserToolbarView: View {
             if !isEditing, let symbol = display.security.symbol {
                 Image(systemName: symbol)
                     .font(Typo.caption)
-                    .foregroundStyle(Palette.textSecondary)
+                    .foregroundStyle(Palette.textTertiaryOnGlass)
                     .help(display.security.help ?? "")
                     .accessibilityLabel(display.security.help ?? "")
             }
@@ -198,19 +198,25 @@ struct BrowserToolbarView: View {
         Text(string).foregroundStyle(colour)
     }
 
-    /// The dim runs are `textSecondary` and not `textTertiary`, and that is the glass rather than
-    /// a taste. Bloom's tertiary is tuned for opaque grounds: on the sunken bar in dark it measures
-    /// 5.65 to 1, and it crosses the 4.5 floor as soon as glass lifts that ground 8 percent toward
-    /// white, 2.98 by 20. Retuning it does not help, because an ink still clearing 4.5 at a quarter
-    /// lift stands only 1.32 to 1 off `labelColor` where the tertiary stands 2.21 today: the floor
-    /// is bought by deleting the two-tone. So the pair goes semantic, the way `QuotaPanel` did on
-    /// the menu's material, and AppKit resolves both against the glass's own effective appearance
-    /// with the vibrancy a flat composite cannot model. See
-    /// `PaletteContrastTests.aLiftedGroundCostsTheTertiaryInk`.
+    /// The dim half of the two-tone, named here only so the interpolation below fits on a line.
+    private var dim: Color { Palette.textTertiaryOnGlass }
+
+    /// The dim runs are `textTertiaryOnGlass`, which is Bloom's tertiary in light and AppKit's
+    /// secondary label in dark. **The two halves differ because the ground does.** Glass lifts a
+    /// flat backdrop toward white, and in light this bar is already all but white, so the tertiary
+    /// holds 4.56 to 1 and nothing is wrong; in dark the same lift takes it from 5.65 through the
+    /// 4.5 floor at 8 percent to 2.98 at 20. Retuning one pair cannot cover both, because an ink
+    /// still clearing 4.5 on a quarter-lifted dark ground stands 1.32 to 1 off `labelColor` where
+    /// the tertiary stands 2.21: the floor gets bought by deleting the two-tone. See
+    /// `Palette.textTertiaryOnGlass` and `PaletteContrastTests.aLiftedGroundCostsTheTertiaryInk`.
+    ///
+    /// The connection glyph takes the same ink rather than the bar's `textSecondary`, so the dim
+    /// half of the address stays one weight. Its floor is a glyph's 3, and the tertiary misses
+    /// even that in dark, at 2.98.
     private var addressLabel: some View {
         // Interpolated rather than concatenated: `Text.+` is deprecated in macOS 26 and the app
         // target builds with -warnings-as-errors.
-        Text("\(tinted(display.leading, Palette.textSecondary))\(tinted(display.host, Palette.textPrimary))\(tinted(display.trailing, Palette.textSecondary))")
+        Text("\(tinted(display.leading, dim))\(tinted(display.host, Palette.textPrimary))\(tinted(display.trailing, dim))")
             .lineLimit(1)
             // The tail, which is where a query string lives. The host is the part worth reading
             // and it is at the head, so it is the part that always survives the cut.

--- a/Sources/BloomCore/System/BrowserToolbar.swift
+++ b/Sources/BloomCore/System/BrowserToolbar.swift
@@ -21,7 +21,10 @@ import Foundation
 /// inside a split inside a tab, so none of them can be reached from here. `NSToolbarDisplayMode`
 /// has no `unified` case in the macOS 26 SDK either, whatever memory says.
 ///
-/// So the bar is drawn, out of `Palette` and `Capsule`. What that costs is written on the view.
+/// So the bar is drawn, out of glass and `Capsule`. Glass was refused here once because it
+/// "samples an arbitrary web page", which was never true: the pane stacks this bar above the web
+/// view rather than over it, so nothing in the bar ever samples the page. What the shapes sample,
+/// and what that costs the ink on them, is written on the view.
 public struct BrowserToolbar: Equatable, Sendable {
     /// One button in the bar: what it draws, what it is called, and whether it can be pressed.
     public struct Control: Equatable, Sendable {

--- a/Tests/BloomCoreTests/PaletteContrastTests.swift
+++ b/Tests/BloomCoreTests/PaletteContrastTests.swift
@@ -209,6 +209,49 @@ struct PaletteContrastTests {
         }
     }
 
+    /// Why the browser bar's address is not drawn in Bloom's own tertiary ink.
+    ///
+    /// The pane's toolbar puts its arrow capsule and its address pill in `Glass.regular`, and over
+    /// a flat backdrop that material is the backdrop lifted toward white. The backdrop is
+    /// `surfaceSunken`, so how far the ink can be trusted is a question about how far the lift
+    /// goes, and in dark the answer is: not far at all. The exact lift is the system's and cannot
+    /// be read from here, which is the point of asking it as a range.
+    ///
+    /// Retuning the pair is the obvious escape and it is closed: an ink that still clears the text
+    /// floor on a quarter-lifted ground is so near `labelColor` that the emphasised host and the
+    /// dim scheme stop being two tones. So the address goes to AppKit's semantic labels instead,
+    /// which resolve against the glass's own appearance. See `BrowserToolbarView.addressLabel`.
+    @Test("a translucent ground costs Bloom's tertiary ink its floor in dark")
+    func aLiftedGroundCostsTheTertiaryInk() {
+        let ground = PaletteInk.surfaceSunken.dark
+        let ink = PaletteInk.textTertiary.dark
+
+        // Resting, on the opaque bar it was tuned against, it is comfortable.
+        #expect(Contrast.ratio(ink, ground) >= Contrast.textFloor)
+
+        // A tenth of the way to white and it is under the floor for text.
+        let tenth = Contrast.composited(0xFFFFFF, over: ground, at: 0.10)
+        #expect(Contrast.ratio(ink, tenth) < Contrast.textFloor)
+
+        // A fifth, and it is under the floor a glyph holds, never mind a word.
+        let fifth = Contrast.composited(0xFFFFFF, over: ground, at: 0.20)
+        #expect(Contrast.ratio(ink, fifth) < Contrast.nonTextFloor)
+
+        // The escape, closed. `#BACCD4` is about the darkest ink that still clears the text floor
+        // a quarter of the way to white, and against the host beside it there is nothing left.
+        let quarter = Contrast.composited(0xFFFFFF, over: ground, at: 0.25)
+        let dim: UInt32 = 0xBACCD4
+        #expect(Contrast.ratio(dim, quarter) >= Contrast.textFloor)
+        let host = Contrast.composited(0xFFFFFF, over: ground, at: 0.85)
+        #expect(Contrast.ratio(dim, host) < 1.5)
+        #expect(Contrast.ratio(ink, host) > 2)
+
+        // Light is a different question and the answer there is yes: glass over a bar that is
+        // already all but white barely moves it, so the tertiary keeps its floor.
+        let lit = Contrast.composited(0xFFFFFF, over: PaletteInk.surfaceSunken.light, at: 0.25)
+        #expect(Contrast.ratio(PaletteInk.textTertiary.light, lit) >= Contrast.textFloor)
+    }
+
     /// A boundary is not read, so it holds the non-text floor rather than the text one. `border`
     /// is the case the window used to have none of: `separatorColor` composites to a 25 unit step
     /// on white, which the eye reads as nothing.

--- a/Tests/BloomCoreTests/PaletteContrastTests.swift
+++ b/Tests/BloomCoreTests/PaletteContrastTests.swift
@@ -246,10 +246,58 @@ struct PaletteContrastTests {
         #expect(Contrast.ratio(dim, host) < 1.5)
         #expect(Contrast.ratio(ink, host) > 2)
 
-        // Light is a different question and the answer there is yes: glass over a bar that is
-        // already all but white barely moves it, so the tertiary keeps its floor.
+        // Light is a different question and the answer there is the opposite: glass over a bar
+        // already all but white barely moves it, so the tuned ink keeps its floor and there is
+        // nothing here to fix. This is why `Palette.textTertiaryOnGlass` has two different halves.
         let lit = Contrast.composited(0xFFFFFF, over: PaletteInk.surfaceSunken.light, at: 0.25)
         #expect(Contrast.ratio(PaletteInk.textTertiary.light, lit) >= Contrast.textFloor)
+    }
+
+    /// What `Palette.textTertiaryOnGlass` resolves to, on both sides, and why it is not one colour.
+    ///
+    /// `secondaryLabelColor` is semantic and cannot be read from here, so it is stated as the
+    /// alphas AppKit composites it at: black at 50 percent in light, white at 55 in dark. Those
+    /// two numbers are the whole of it, and measuring the composite rather than the alpha is the
+    /// point `compositingIsTheThingMeasured` makes further up.
+    ///
+    /// The pair is asserted in both directions. In dark the semantic ink is the one that holds,
+    /// and in light it is the one that fails, which is the fact that stops the two halves being
+    /// tidied into one.
+    @Test("the ink on glass takes the better half in each appearance, and they are different halves")
+    func theInkOnGlassDiffersBecauseTheGroundDoes() {
+        let secondaryInLight = 0.50
+        let secondaryInDark = 0.55
+
+        // Light: the ground barely moves, Bloom's own ink clears the floor, and AppKit's does not.
+        let lit = Contrast.composited(0xFFFFFF, over: PaletteInk.surfaceSunken.light, at: 0.25)
+        let semanticInLight = Contrast.composited(0x000000, over: lit, at: secondaryInLight)
+        #expect(Contrast.ratio(PaletteInk.textTertiary.light, lit) >= Contrast.textFloor)
+        #expect(Contrast.ratio(semanticInLight, lit) < Contrast.textFloor)
+
+        // Dark: the ground moves a long way, and the two swap places. A 15 percent lift is the
+        // semantic ink's own edge rather than comfort, at 4.51, so this is the recorded limit of
+        // the arrangement: a `surfaceSunken` retuned any lighter and the browser bar says so here.
+        for lift in [0.10, 0.15] {
+            let ground = Contrast.composited(0xFFFFFF, over: PaletteInk.surfaceSunken.dark, at: lift)
+            let semantic = Contrast.composited(0xFFFFFF, over: ground, at: secondaryInDark)
+            #expect(Contrast.ratio(PaletteInk.textTertiary.dark, ground) < Contrast.textFloor)
+            #expect(
+                Contrast.ratio(semantic, ground) >= Contrast.textFloor,
+                "the semantic ink on a \(lift) lift: \(Contrast.ratio(semantic, ground).rounded(to: 2)) to 1"
+            )
+        }
+
+        // And it is one weight to look at, not two: each half lands in the same band against the
+        // ground it is drawn on, so switching appearance does not change how dim the run reads.
+        let inLight = Contrast.ratio(PaletteInk.textTertiary.light, lit)
+        let darkGround = Contrast.composited(0xFFFFFF, over: PaletteInk.surfaceSunken.dark, at: 0.15)
+        let inDark = Contrast.ratio(
+            Contrast.composited(0xFFFFFF, over: darkGround, at: secondaryInDark), darkGround
+        )
+        #expect(
+            abs(inLight - inDark) < 0.75,
+            "light reads at \(inLight.rounded(to: 2)) and dark at \(inDark.rounded(to: 2))"
+        )
     }
 
     /// A boundary is not read, so it holds the non-text floor rather than the text one. `border`


### PR DESCRIPTION
The arrow capsule and the address pill are glass, the capsule interactive. The reason they were not is that the commit said glass samples an arbitrary web page, and the layout says otherwise: the pane is a `VStack` with the bar above the web view, so the page abuts the bar rather than sitting behind it. Nothing here samples the page.

The bar itself stays opaque. Behind it is one flat fill, so glass would resolve to a colour Bloom already has a name for, and its bottom edge is the seam against the page, where a ground that shifts with the material reads as a joint. The camera and Share stay bare: four raised capsules in a five control bar leaves the three group anatomy with no groups. No `.interactive()` on the pill, because a material that lifts under the pointer on the way to placing a caret reads as fidgety.

`GlassEffectContainer` with `spacing: 0`, which takes the shared sampling pass and refuses the merge: the capsule and the pill are eight points apart and running them into one blob would destroy the grouping.

The two dim runs of the address and the connection glyph move to a light/dark pair. Glass lifts the ground toward white, and Bloom's tertiary crosses the 4.5 floor at an 8 percent lift in dark while light barely moves, so the ink differs by appearance because the ground does: the tuned tertiary in light at 4.56, AppKit's semantic secondary in dark at 4.51 to 5.07. Same band, so the run does not change weight when the appearance does. Retuning was closed: an ink clearing the floor at a realistic lift stands 1.32 to 1 off the host where the tertiary stands 2.21, which buys the floor by deleting the emphasis.

`PaletteContrastTests` pins both directions, including that the semantic ink fails in light and the tuned one fails in dark. One dark case lands six thousandths over the floor and is labelled as this arrangement's recorded edge, so a ground retuned lighter fails in the suite rather than in the pane.