### PR TITLE
Take the inspector toggle's on state off, the way the sidebar has none

### DIFF
--- a/Sources/Bloom/Design/PaneTabsGallery.swift
+++ b/Sources/Bloom/Design/PaneTabsGallery.swift
@@ -93,18 +93,24 @@ struct PaneTabsGallery: View {
                 ),
             ])
 
-            // The one thing on this page that is a question rather than a record. `.glass` is a
-            // system style, so what it draws for a `.button` toggle's ON state is Apple's decision
-            // and not ours, and the whole reason the control used to be `.accessoryBar` was to keep
-            // that state off the saturated accent. Both states, side by side, is the answer.
+            // Two rows that have to come out identical, which is the whole reason they are both
+            // here. The control is a `Button` and has no on state to draw, the way the sidebar's
+            // own toolbar item has none: see `InspectorToggle`. A filled plate in the second row
+            // is the bug this page exists to catch.
             row(
-                "The inspector toggle, hidden and shown",
-                tabs: [fixture("Chat", PaneGlyph.chat, active: true), fixture("Terminal", PaneGlyph.terminal)],
+                "The inspector toggle, inspector hidden",
+                tabs: [
+                    fixture("Chat", PaneGlyph.chat, active: true),
+                    fixture("Terminal", PaneGlyph.terminal),
+                ],
                 inspectorVisible: false
             )
             row(
-                "The same strip with the inspector open",
-                tabs: [fixture("Chat", PaneGlyph.chat, active: true), fixture("Terminal", PaneGlyph.terminal)],
+                "The same strip, inspector shown. Identical, and that is the point",
+                tabs: [
+                    fixture("Chat", PaneGlyph.chat, active: true),
+                    fixture("Terminal", PaneGlyph.terminal),
+                ],
                 inspectorVisible: true
             )
 
@@ -158,8 +164,8 @@ struct PaneTabsGallery: View {
 /// and the other four reading as though nothing in them were selected.
 private struct StripRow: View {
     var tabs: [Fixture]
-    /// Whether the strip ends in the inspector's toggle, and which way it is thrown. Nil for the
-    /// rows that are about the tabs.
+    /// Whether the strip ends in the inspector's control, and which way the inspector is. Nil for
+    /// the rows that are about the tabs. Both values must draw the same button.
     var inspectorVisible: Bool?
 
     @Namespace private var selection

--- a/Sources/Bloom/Views/Center/Panes/InspectorToggle.swift
+++ b/Sources/Bloom/Views/Center/Panes/InspectorToggle.swift
@@ -2,20 +2,24 @@ import SwiftUI
 
 /// The right pane's control, at the trailing end of the tab strip that borders it.
 ///
-/// Drawn as the sidebar's toggle is drawn, because the two do the same job to opposite edges of
-/// one window and were in two registers: the sidebar's is `NavigationSplitView`'s own toolbar
-/// item, which macOS 26 draws as a round glass button, and this was a flat plate that appeared
-/// only under the pointer. `.buttonStyle(.glass)` rather than a rim of our own, so it keeps
-/// tracking whatever the system does to that shape.
+/// Drawn as the sidebar's control is drawn, because the two do the same job to opposite edges of
+/// one window. That reference is `NSToolbarToggleSidebarItemIdentifier`, which the SDK describes
+/// as "a standard item configured to send -toggleSidebar: to the firstResponder": a plain action
+/// item. `NSSplitViewController` validates it, but validation answers enabled or disabled, so
+/// **AppKit gives that control no on state at all.** It is the same quiet round button whether the
+/// sidebar is open or shut, and what answers "is the pane there" is the pane, a whole column wide.
 ///
-/// 28 points across, which is the strip's own control inset taken off its 32 point height. The
-/// toolbar's button is about 30 in a 52 point title bar, so this is the nearest the strip has room
-/// for rather than a match.
+/// So this is a `Button` rather than a `Toggle`. `.buttonStyle(.glass)` is right for the resting
+/// shape and wrong the moment a toggle is on: `GlassButtonStyle` takes a
+/// `PrimitiveButtonStyleConfiguration`, which carries no on state, so the accent plate came from
+/// `.toggleStyle(.button)` wrapping it, and no button style can reach that. A `Button` has no such
+/// wrapper and cannot acquire one.
 ///
-/// Still a `Toggle`, so VoiceOver reads it as one. `.accessoryBar` was here because macOS 26 fills
-/// a `.button` toggle's on state with the saturated accent, and a pane that is on almost all the
-/// time then shouts. What glass does with that state is the one thing here that has to be
-/// photographed rather than reasoned about: `PaneTabsGallery` draws both.
+/// 28 points across, the strip's own control inset taken off its 32 point height, against about 30
+/// in a 52 point title bar. The nearest the strip has room for.
+///
+/// The state a `Toggle` used to announce is put back by hand below, because it has to be: a sighted
+/// reader has the pane itself, and a VoiceOver user has nothing unless this says so.
 ///
 /// A binding rather than the app model, so the gallery can hold both states on one page.
 struct InspectorToggle: View {
@@ -25,17 +29,21 @@ struct InspectorToggle: View {
     private static let diameter = Metrics.barHeight - 2 * Metrics.spacingTight
 
     var body: some View {
-        Toggle(isOn: $isVisible) {
+        Button { isVisible.toggle() } label: {
             Label("Inspector", systemImage: "sidebar.right")
                 .labelStyle(.iconOnly)
                 .font(Typo.labelEmphasis)
         }
-        .toggleStyle(.button)
         .buttonStyle(.glass)
         .buttonBorderShape(.circle)
         .frame(width: Self.diameter, height: Self.diameter)
         .frame(height: Metrics.barHeight)
         .padding(.horizontal, Metrics.spacingTight)
+        // A stable name with a spoken state, rather than a name that changes under the reader: a
+        // control called "Show the changed files" one moment and "Hide" the next is a different
+        // control every time it is found. The direction is in `help`, which is also the tooltip.
+        .accessibilityLabel("Inspector")
+        .accessibilityValue(isVisible ? "Shown" : "Hidden")
         .help(isVisible ? "Hide the changed files" : "Show the changed files")
     }
 }

--- a/Sources/Bloom/Views/Center/Panes/SessionTabsView.swift
+++ b/Sources/Bloom/Views/Center/Panes/SessionTabsView.swift
@@ -360,8 +360,8 @@ struct SessionTabsView: View {
     /// about which of them it would move. On the boundary it opens, the target is the thing it is
     /// pointing at.
     ///
-    /// What it looks like is `InspectorToggle`, which is a view of its own so that both of its
-    /// states can be photographed.
+    /// What it looks like is `InspectorToggle`, which is a view of its own so that the gallery can
+    /// draw it with the inspector both ways and show they come out the same.
     private var inspectorToggle: some View {
         @Bindable var app = app
 


### PR DESCRIPTION
The inspector toggle was drawing its on state as a filled accent plate beside a sidebar toggle that has no on state at all, so the two matched less than before.

The fill was not the button style's. `GlassButtonStyle` is a `PrimitiveButtonStyle` whose configuration carries no on state, so no button style could have drawn it or suppressed it. It came from `.toggleStyle(.button)`, which paints the selected state itself.

The reference has no on state, from the SDK rather than by eye: the system's sidebar toggle is a plain action item sending `toggleSidebar:`, and `NSToolbarItem` has no selection API. It looks the same whether the sidebar is open or shut, because the open pane is the feedback.

So this is a plain `Button` now, drawn identically both ways, in the same round glass style and the same 28 point slot. The loud state is gone by construction rather than by tuning.

The accessibility did not go with the toggle: a stable `Inspector` label with a spoken value of Shown or Hidden, rather than a control that renames itself. That matters more now that nothing is drawn: a sighted reader has the pane as feedback and a VoiceOver user has only this.

Apple ships `NSToolbarToggleInspectorItemIdentifier` for exactly this control. Bloom cannot take it without undoing the decision that moved both pane toggles out of the toolbar, where an item sits above all three columns and says nothing about which one it moves. It is named in the code so nobody has to find it twice.