### PR TITLE
Measure nothing a reader will not look at

### DIFF
--- a/Sources/Bloom/Design/TabProbe.swift
+++ b/Sources/Bloom/Design/TabProbe.swift
@@ -147,6 +147,11 @@ enum TabProbe {
         ticker.beginRun()
         PaneLayoutTiming.reset()
         PaneLayoutTiming.isEnabled = true
+        // **The number this probe is read for.** A tab switch through a tool tab tears the chat
+        // pane down and builds it again, so this is the case a coordinator's own height cache
+        // cannot help with and the one that says whether measuring nothing up front worked. See
+        // `TranscriptHoldCensus`.
+        TranscriptHoldCensus.reset()
         // The same timeline `SwitchProbe` reads, begun by hand: the app itself only begins one
         // when the SIDEBAR selection changes, and nothing about a tab switch moves that.
         SwitchTrace.begin(workspaceID: workspace.workspace.id)
@@ -167,6 +172,7 @@ enum TabProbe {
             "blocks": .numbers(ticker.blocksMs),
             "paneLayout": .map(PaneLayoutTiming.summary()),
             "panePasses": .map(PaneLayoutTiming.timeline()),
+            "transcriptHold": .map(TranscriptHoldCensus.summary()),
             "worstFrameMs": .number(ticker.intervalsMs.max() ?? 0),
         ]
     }

--- a/Sources/Bloom/Design/TranscriptHoldCensus.swift
+++ b/Sources/Bloom/Design/TranscriptHoldCensus.swift
@@ -1,3 +1,4 @@
+import BloomCore
 import Foundation
 
 /// What a transcript's holds did, for a probe to read. See `TranscriptHoldView`.
@@ -28,15 +29,18 @@ enum TranscriptHoldCensus {
     /// Rows a reflow left holding an estimate rather than measuring. What the hold buys.
     private(set) static var estimatedRows = 0
 
-    static func held(underAHand hand: Bool, liveResize: Bool) {
-        holds += 1
-        if hand { underAHand += 1 }
-        if liveResize { underLiveResize += 1 }
+    static func held(_ what: TranscriptPaneHold.PaneHeld, underAHand hand: Bool, liveResize: Bool) {
+        switch what {
+        case .whatIsDrawn:
+            holds += 1
+            if hand { underAHand += 1 }
+            if liveResize { underLiveResize += 1 }
+        case .nothing:
+            arrivals += 1
+        }
     }
 
     static func liveResizeBegan() { liveResizes += 1 }
-
-    static func arriving() { arrivals += 1 }
 
     static func revealed() { reveals += 1 }
 

--- a/Sources/Bloom/Views/Transcript/TranscriptHoldView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptHoldView.swift
@@ -15,20 +15,31 @@ extension Notification.Name {
 /// What a held transcript is asked to do. `TranscriptTable.Coordinator` is the only one.
 @MainActor
 protocol TranscriptHoldDelegate: AnyObject {
-    /// Stop applying anything: nothing is remeasured, nothing is reloaded, no row lands.
-    func holdBegan()
-    /// Lay out at the new width. True when anything actually moved.
-    func holdEnded() -> Bool
+    /// A hold has begun. What it is holding is the whole of the difference between the two.
+    func holdBegan(_ held: TranscriptHoldView.Held)
+    /// The pane may be drawn again. True when there was anything to show for the wait, which is
+    /// what decides whether the fade is worth playing.
+    func holdEnded(_ held: TranscriptHoldView.Held) -> Bool
     /// Stop being held, and lay out nothing: what was held belongs to a conversation the pane has
-    /// already left. See `holdForArrival`.
+    /// already left. See `hold(_:)`.
     func holdCancelled()
     var reducesMotion: Bool { get }
 }
 
-/// Holds a transcript back while the pane it is in is not ready to show it, and fades to it when
-/// it is. Twice: a pane being resized, and a pane being pointed at another conversation.
+/// **Holds a transcript back while its pane is not ready to show it, and fades to it when it is.**
 ///
-/// ## A resize
+/// One mechanism, one way in and one way out, asked by three triggers that differ in one thing
+/// only: what there is to hold. `hold(_:)` takes that as `Held` and `ready()` ends every one of
+/// them the same way.
+///
+/// - **A drag** halves or widens the pane under the reader's hand: `.whatIsDrawn`.
+/// - **A split** halves it too, but the pane is rebuilt rather than resized (see `CenterPanesView`,
+///   whose `ForEach` identity deliberately changes when a tab goes from one pane to two), so the
+///   arriving pane has no pixels of its own to keep: `.nothing`.
+/// - **An arrival**, which is a workspace switch, a tab switch and the pane's first conversation:
+///   `.nothing`, because what is on screen belongs to the conversation being left.
+///
+/// ## What `.whatIsDrawn` does
 ///
 /// **The trick is Safari's**, in the owner's words: dragging its sidebar does not redraw the page,
 /// the page appears beside the new edge at the size it already had, and the reflowed one is faded
@@ -39,34 +50,50 @@ protocol TranscriptHoldDelegate: AnyObject {
 /// own background, so the content neither stretches nor distorts: it is exactly the pixels that
 /// were there, in the place they were.
 ///
-/// **The fade is a `CATransition` rather than a picture we take.** `Snapshot` records the
-/// measurement: `cacheDisplay` misses anything whose content lives in a layer rather than in
-/// `draw(_:)`, and `layer.render(in:)` misses whole view controller hierarchies, so a bitmap of
-/// this pane is not something to build a crossfade on. A transition on this view's layer makes the
-/// render server crossfade what it already has against the next commit, and the reflow happens in
-/// that same commit, so the new layout is complete before a frame of the fade is drawn.
+/// ## What `.nothing` does
+///
+/// It draws the pane's own background and takes no clicks. A pane is NOT torn down by a workspace
+/// switch: the centre column hands the same view a different model and a different session, so
+/// without this the rows on screen for the moment after the switch are the conversation being
+/// left, then the tail lands at the top of the pane, then the view jumps to the live end. Three of
+/// those four states are a transcript nobody asked to see.
+///
+/// A picture of the pane's own last frame would be better than nothing here and is not available:
+/// `Snapshot` records the measurement that `cacheDisplay` misses anything whose content lives in a
+/// layer, and `layer.render(in:)` misses whole view controller hierarchies. What makes the blank
+/// acceptable is that it is short: nothing is measured up front any more, so a pane arrives in the
+/// time it takes to read its rows and measure one screen of them.
+///
+/// ## The fade, and letting go
+///
+/// The fade is a `CATransition` on this view's layer, for the same measurement: the render server
+/// crossfades what it already has against the next commit, and everything the reveal does happens
+/// in that commit, so the new layout is complete before a frame of the fade is drawn.
 ///
 /// **Every hold is armed to let go by itself.** A drag that is interrupted, a window zoomed or
-/// tiled, a display change, `--window-size`, and a pane taken off screen all end at
-/// `TranscriptPaneHold.quiet` after the last width change, which is 200ms. Nothing here needs an
-/// end event to arrive, which is why it is safe to hold for gestures that do not send one.
-///
-/// ## An arrival
-///
-/// The second thing this pane does that takes longer than a frame: see `holdForArrival`. The two
-/// holds cannot both be running, because a pane that has just been pointed at another conversation
-/// has nothing worth freezing, and `holdForArrival` ends a resize hold that was.
+/// tiled, a display change, `--window-size`, a pane taken off screen, a conversation that never
+/// loads: all of them end at a deadline in `TranscriptPaneHold`, without anything having to
+/// arrive. Nothing here needs an end event, which is why it is safe to hold for gestures and
+/// arrivals that do not send one.
 ///
 /// **Nothing held here can belong to another pane.** The frozen thing is this view's own scroll
-/// view, in place, and an arrival is drawn as nothing at all. There is no store of pictures to
-/// look a pane up in and therefore no way to reach the wrong one: the guarantee is the shape of
+/// view, in place, and everything else is drawn as nothing at all. There is no store of pictures
+/// to look a pane up in and therefore no way to reach the wrong one: the guarantee is the shape of
 /// the mechanism rather than a rule somebody has to keep.
 final class TranscriptHoldView: NSView {
+    /// What a hold is holding, which is the whole of the difference between the three triggers.
+    ///
+    /// The core's, under a shorter name. The deadline each kind is armed with is a decision and
+    /// lives with the other decisions; this is the mechanism, and the two must not be able to
+    /// disagree about what the kinds are.
+    typealias Held = TranscriptPaneHold.PaneHeld
+
     let scroll: NSScrollView
     weak var delegate: TranscriptHoldDelegate?
 
-    /// The frame the scroll view keeps for as long as the transcript is held, and nil when it is
-    /// following this view again.
+    /// What this pane is holding, and nil when it is drawing itself normally.
+    private(set) var held: Held?
+    /// The frame the scroll view keeps while `.whatIsDrawn` is on.
     private var frozen: NSRect?
     /// Whether a divider is known to be under a hand. See `bloomPaneResizeBegan`.
     private var isUnderAHand = false
@@ -74,10 +101,6 @@ final class TranscriptHoldView: NSView {
     /// SwiftUI happen to deliver it.
     private var lastWidth: CGFloat = 0
     private var letGo: Task<Void, Never>?
-    /// Whether this pane is waiting for the conversation it has been pointed at. See
-    /// `holdForArrival`.
-    private var isArriving = false
-    private var reveal: Task<Void, Never>?
 
     private static let fadeKey = "bloom.transcript.reveal"
 
@@ -109,7 +132,7 @@ final class TranscriptHoldView: NSView {
     /// the standing instruction to be at the live end off a transcript nobody can see yet, and the
     /// reader would be somewhere they never scrolled to when it fades in.
     override func hitTest(_ point: NSPoint) -> NSView? {
-        isArriving ? nil : super.hitTest(point)
+        held == .nothing ? nil : super.hitTest(point)
     }
 
     // MARK: - Layout
@@ -129,44 +152,72 @@ final class TranscriptHoldView: NSView {
         scroll.frame = frozen ?? bounds
     }
 
-    // MARK: - Holding
+    // MARK: - The one way in
 
-    private func noteWidth(_ width: CGFloat) {
-        guard width != lastWidth else { return }
-        let before = lastWidth
-        lastWidth = width
-        guard window != nil, !isArriving else { return }
-        guard TranscriptPaneHold.holds(from: Double(before), to: Double(width)) else { return }
-        if frozen == nil {
+    /// **This pane is about to be laid out differently. Hold what is drawn, let the work happen,
+    /// and fade the result in.**
+    ///
+    /// Idempotent per kind: a drag that goes on changing the width re-arms the deadline rather
+    /// than starting a second hold. An arrival outranks a resize, because the pixels a resize was
+    /// keeping belong to a conversation this pane has just left.
+    func hold(_ what: Held) {
+        if held == what {
+            armLetGo()
+            return
+        }
+
+        if what == .nothing, frozen != nil {
+            // Cancelled rather than ENDED, and laid out on the next pass rather than this one,
+            // because an arrival is announced from inside `updateNSView` and a reflow reports
+            // geometry, which writes SwiftUI state.
+            frozen = nil
+            needsLayout = true
+            delegate?.holdCancelled()
+        }
+
+        held = what
+        switch what {
+        case .whatIsDrawn:
             // The frame the scroll view has NOW, which is the one it was laid out at.
             frozen = scroll.frame
-            TranscriptHoldCensus.held(underAHand: isUnderAHand, liveResize: inLiveResize)
-            delegate?.holdBegan()
+        case .nothing:
+            scroll.alphaValue = 0
         }
+        TranscriptHoldCensus.held(what, underAHand: isUnderAHand, liveResize: inLiveResize)
+        delegate?.holdBegan(what)
         armLetGo()
     }
 
-    private func armLetGo() {
-        letGo?.cancel()
-        let deadline = TranscriptPaneHold.letsGo(underAHand: isUnderAHand || inLiveResize)
-        letGo = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: deadline)
-            guard !Task.isCancelled else { return }
-            self?.release()
-        }
-    }
-
-    /// Lets the transcript out at the width the pane is now, and crossfades to it.
-    private func release() {
+    /// **The one way out.** The pane may be drawn again: reflow if the hold owes one, and fade to
+    /// whatever that leaves.
+    func ready() {
         letGo?.cancel()
         letGo = nil
-        guard frozen != nil else { return }
+        guard let what = held else { return }
+        held = nil
         frozen = nil
         fading {
             needsLayout = true
             // The scroll view takes the pane's width here, which is what tells the table it moved.
             layoutSubtreeIfNeeded()
-            return delegate?.holdEnded() ?? false
+            scroll.alphaValue = 1
+            // A reflow that finds nothing to do is a drag that ended where it started, and there
+            // is nothing to crossfade. An arrival always has something: the conversation.
+            let moved = delegate?.holdEnded(what) ?? false
+            return what == .nothing || moved
+        }
+        TranscriptHoldCensus.revealed()
+    }
+
+    private func armLetGo() {
+        letGo?.cancel()
+        let deadline = TranscriptPaneHold.letsGo(
+            of: held ?? .whatIsDrawn, underAHand: isUnderAHand || inLiveResize
+        )
+        letGo = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: deadline)
+            guard !Task.isCancelled else { return }
+            self?.ready()
         }
     }
 
@@ -174,8 +225,7 @@ final class TranscriptHoldView: NSView {
     ///
     /// The transition goes on BEFORE the change it covers and comes off again if the change turns
     /// out to have been nothing: an animation added and removed inside one run loop turn never
-    /// reaches a frame. Everything `change` does happens in that same commit, which is what makes
-    /// "the new layout is complete before the fade starts" true rather than hoped for.
+    /// reaches a frame.
     private func fading(_ change: () -> Bool) {
         let seconds = delegate?.reducesMotion == true ? 0 : Motion.revealSeconds
         if seconds > 0 {
@@ -187,66 +237,30 @@ final class TranscriptHoldView: NSView {
         if !change() { layer?.removeAnimation(forKey: Self.fadeKey) }
     }
 
-    // MARK: - Arriving at another conversation
+    // MARK: - What asks for a hold
 
-    /// **This pane has been pointed at another conversation, so it draws nothing until that one is
-    /// ready.**
-    ///
-    /// The pane is not torn down by a workspace switch: the centre column hands the same view a
-    /// different model and a different session, so without this the rows on screen for the moment
-    /// after the switch are the conversation being left. Then the tail lands at the top of the
-    /// pane, then the view jumps to the live end, then the history goes in behind it. Four states,
-    /// three of which are a transcript nobody asked to see.
-    ///
-    /// So it is hidden until `arrived`, and what it shows meanwhile is its own background. Never
-    /// the outgoing conversation, and never a picture of anything: an empty pane is honest, and it
-    /// is the only thing that cannot be the wrong workspace's.
-    func holdForArrival() {
-        guard !isArriving else { return }
-        // A resize hold has nothing left to protect, because the rows it was holding still belong
-        // to the conversation being left. Cancelled rather than dropped: the table is held by a
-        // flag of its own, and dropping this would leave it held for ever. Cancelled rather than
-        // ENDED, and laid out on the next pass rather than this one, because this is called from
-        // inside `updateNSView` and a reflow reports geometry, which writes SwiftUI state.
-        if frozen != nil {
-            frozen = nil
-            letGo?.cancel()
-            letGo = nil
-            needsLayout = true
-            delegate?.holdCancelled()
-        }
-        isArriving = true
-        scroll.alphaValue = 0
-        reveal = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: TranscriptPaneHold.arrival)
-            guard !Task.isCancelled else { return }
-            self?.arrived()
-        }
+    /// A width change, however it was produced: a divider under a hand, a window edge, a zoom, a
+    /// tiling, a display change, the inspector collapsing, or a probe driving any of them.
+    private func noteWidth(_ width: CGFloat) {
+        guard width != lastWidth else { return }
+        let before = lastWidth
+        lastWidth = width
+        // A pane that is not drawing anything has nothing to freeze, and the reflow a freeze would
+        // owe is the one the arrival is about to do anyway.
+        guard window != nil, held != .nothing else { return }
+        guard TranscriptPaneHold.holds(from: Double(before), to: Double(width)) else { return }
+        hold(.whatIsDrawn)
     }
-
-    /// The conversation is in, and in the place the reader left it. See `TranscriptResume`.
-    func arrived() {
-        reveal?.cancel()
-        reveal = nil
-        guard isArriving else { return }
-        isArriving = false
-        fading {
-            scroll.alphaValue = 1
-            return true
-        }
-        TranscriptHoldCensus.revealed()
-    }
-
-    // MARK: - What says a gesture is running
 
     @objc private func handTookHold() {
         isUnderAHand = true
-        if frozen != nil { armLetGo() }
+        if held != nil { armLetGo() }
     }
 
     @objc private func handLetGo() {
         isUnderAHand = false
-        release()
+        guard held == .whatIsDrawn else { return }
+        ready()
     }
 
     /// The window's own edge, and any divider AppKit resizes panes for. Nothing is held here: the
@@ -254,18 +268,20 @@ final class TranscriptHoldView: NSView {
     override func viewWillStartLiveResize() {
         super.viewWillStartLiveResize()
         TranscriptHoldCensus.liveResizeBegan()
-        if frozen != nil { armLetGo() }
+        if held != nil { armLetGo() }
     }
 
     override func viewDidEndLiveResize() {
         super.viewDidEndLiveResize()
-        release()
+        guard held == .whatIsDrawn else { return }
+        ready()
     }
 
     /// A pane put away mid drag must not come back holding a picture of the width it used to be.
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         needsLayout = true
-        release()
+        guard held == .whatIsDrawn else { return }
+        ready()
     }
 }

--- a/Sources/Bloom/Views/Transcript/TranscriptTable.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTable.swift
@@ -99,7 +99,7 @@ final class TranscriptTableController {
     /// Said by the pane rather than worked out here, because the only thing that knows a
     /// transcript is where it belongs is whatever put it there: the rows have loaded, the window
     /// has been chosen and `TranscriptResume`'s placement has been applied. Until this arrives the
-    /// pane draws nothing. See `TranscriptHoldView.holdForArrival`.
+    /// pane draws nothing. See `TranscriptHoldView.hold(_:)`.
     func arrived() { coordinator?.arrived() }
 
     /// The entry at the top of the pane, which is the place a reader is put back at.
@@ -131,7 +131,7 @@ struct TranscriptTable: NSViewRepresentable {
     let entries: [TranscriptTableEntry]
     /// Which conversation these entries are. A pane is handed a different one by every workspace
     /// switch, and what it draws until that one is ready is nothing at all: see
-    /// `TranscriptHoldView.holdForArrival`.
+    /// `TranscriptHoldView.hold(_:)`.
     let session: SessionID
     let controller: TranscriptTableController
     /// The text scale the rows are drawn at. Part of what the height cache is keyed on, because
@@ -250,6 +250,8 @@ struct TranscriptTable: NSViewRepresentable {
         /// `TranscriptRowHeights`.
         private var heights = TranscriptRowHeights()
         private var settleWork: Task<Void, Never>?
+        /// A reflow saying its placement a second time. See `rewidth`.
+        private var placeWork: Task<Void, Never>?
         private var resizeWork: Task<Void, Never>?
         private var endWork: Task<Void, Never>?
         private var reaimWork: Task<Void, Never>?
@@ -489,20 +491,21 @@ struct TranscriptTable: NSViewRepresentable {
 
         // MARK: Heights
 
-        /// The cache, and a fresh measurement when it misses.
+        /// What the table is told a row is, which is never a measurement.
         ///
-        /// The three entries that re-render themselves read the cache like everything else. They
-        /// used to be measured on every call, which is a whole hosting view per layout pass for
-        /// the streaming tail; what keeps them right instead is `noted` below, which is
-        /// authoritative and which the tail triggers itself as it grows.
+        /// **This used to measure on a miss, and that was the whole of "opening a workspace or a
+        /// tab with a chat in it is slow".** A table asks for every row it holds, so a pane
+        /// arriving at a conversation built an `NSHostingView` for each of the four hundred rows
+        /// in its window, none of which anybody saw. Now an unmeasured row is answered with
+        /// `TranscriptRowHeights.assumed` and put right when it is drawn, or when a placement is
+        /// about to show it: see `measureLanding`.
+        ///
+        /// The three entries that re-render themselves are answered the same way. What keeps them
+        /// right is `noted` below, which is authoritative and which the tail triggers itself as it
+        /// grows.
         private func height(of entry: TranscriptTableEntry) -> CGFloat {
-            guard let sizing = heights.measure else { return Self.hair }
-            if let cached = heights.height(for: entry.contentKey) { return CGFloat(cached) }
-            let measured = CGFloat(
-                TranscriptRowHeights.rounded(measure(entry, at: CGFloat(sizing.width)))
-            )
-            heights.note(measured, for: entry.contentKey)
-            return measured
+            guard heights.isReady else { return Self.hair }
+            return CGFloat(heights.assumed(for: entry.contentKey))
         }
 
         /// A fresh `NSHostingView` per measurement, at the exact width the cell is laid out at.
@@ -737,6 +740,20 @@ struct TranscriptTable: NSViewRepresentable {
 
         private func putEnd() {
             guard let scrollView else { return }
+            // The last screen, measured before the end is claimed to be anywhere. Read again
+            // afterwards, because measuring it is what moves the end: an estimate for a row nobody
+            // has drawn is what the sum said, and the sum is where the scroller stops.
+            //
+            // **This is the reachable end.** Reported as "when I'm at the bottom of a chat and it
+            // gets resized, sometimes I get placed a little higher and can't reach the bottom
+            // anymore": the rows at the end were short by whatever the estimate was out by, so the
+            // document ended above the content and the scroller could not travel to it.
+            //
+            // Twice at most, because measuring the last screen is what moves the end and the
+            // screen at the moved end can hold a row the first pass did not reach. The second
+            // round costs nothing once the rows are measured, which is every return to a
+            // conversation this pane has already drawn.
+            for _ in 0..<2 { measureLanding(at: scrollView.endOffset) }
             // The only number that means the end. A row being *visible* is not it: the last row of
             // a transcript is often taller than the pane. See `NSScrollView.endOffset`.
             put(scrollView.endOffset, in: scrollView)
@@ -761,21 +778,25 @@ struct TranscriptTable: NSViewRepresentable {
 
         private func put(at entryID: TranscriptEntryID, anchor: UnitPoint) {
             guard let tableView, let scrollView, let row = index[entryID] else { return }
-            let rect = tableView.rect(ofRow: row)
-            put(
-                TranscriptAnchor.offset(
+            func target() -> CGFloat {
+                let rect = tableView.rect(ofRow: row)
+                return TranscriptAnchor.offset(
                     rowTop: rect.minY,
                     rowHeight: rect.height,
                     viewportHeight: scrollView.contentView.bounds.height,
                     anchor: anchor.y
-                ),
-                in: scrollView
-            )
+                )
+            }
+            // Aimed at where the estimates say the row is, measured there, and then aimed again at
+            // where it turned out to be: measuring the screen is what moves it.
+            measureLanding(at: target())
+            put(target(), in: scrollView)
         }
 
         func scroll(toY y: CGFloat) {
             aimingElsewhere()
             guard let scrollView else { return }
+            measureLanding(at: y)
             put(y, in: scrollView)
         }
 
@@ -943,8 +964,13 @@ struct TranscriptTable: NSViewRepresentable {
 
         // MARK: - Being held while a pane is resized
 
-        /// Everything stops. See `TranscriptHoldView`, and `TranscriptPaneHold` for the rule.
-        func holdBegan() {
+        /// A hold has begun. What it is holding is the whole of the difference.
+        ///
+        /// **An arrival stops nothing**, because the work it is waiting for is this pane's own
+        /// rows landing: stashing those would be holding out for the thing being held for. What it
+        /// holds is the drawing, which is `TranscriptHoldView`'s alone.
+        func holdBegan(_ held: TranscriptHoldView.Held) {
+            guard held == .whatIsDrawn else { return }
             isHeld = true
             // **Where the reader is, read now rather than when the hold lets go.**
             //
@@ -963,8 +989,12 @@ struct TranscriptTable: NSViewRepresentable {
         }
 
         @discardableResult
-        func holdEnded() -> Bool {
+        func holdEnded(_ held: TranscriptHoldView.Held) -> Bool {
             isHeld = false
+            // A reflow either way. An arrival has usually not changed the width and finds nothing
+            // to do, which is what makes it honest to run the same line for both: the question
+            // "is this pane a different width from the one these heights were taken at" has one
+            // answer wherever it is asked.
             let moved = rewidth()
             // After the width, so this pass finds the cache already declared for the new one and
             // deals with the rows that changed rather than with all of them.
@@ -993,21 +1023,22 @@ struct TranscriptTable: NSViewRepresentable {
         // MARK: - Being pointed at another conversation
 
         /// **The pane has a different conversation in it, so it draws nothing until that one is
-        /// ready.** See `TranscriptHoldView.holdForArrival`, and `arrived` for what ends it.
+        /// ready.** See `TranscriptHoldView.hold(_:)`, and `arrived` for what ends it.
+        ///
+        /// The pane's FIRST conversation is held too, and that is what covers a split: splitting a
+        /// tab rebuilds both panes (see `CenterPanesView`), so the chat arrives in a pane that has
+        /// never drawn anything, exactly as it does in a window that has only just opened. Holding
+        /// it means the split itself is drawn on the frame it was asked for and the conversation
+        /// fades in behind it, rather than the whole column waiting for a transcript to lay out.
         func showing(session: SessionID, in view: TranscriptHoldView) {
             holdView = view
             guard shownSession != session else { return }
-            let isFirst = shownSession == nil
             shownSession = session
-            // Not the pane's first conversation. There is nothing on screen to hide, and hiding it
-            // would blank a window that has only just been opened.
-            guard !isFirst else { return }
-            TranscriptHoldCensus.arriving()
-            view.holdForArrival()
+            view.hold(.nothing)
         }
 
         /// The conversation is in and in the right place. See `TranscriptTableController.arrived`.
-        func arrived() { holdView?.arrived() }
+        func arrived() { holdView?.ready() }
 
         /// **The transcript, laid out at the width the drag left the pane at.**
         ///
@@ -1042,20 +1073,68 @@ struct TranscriptTable: NSViewRepresentable {
             let eager = TranscriptPaneHold.eager(visible: visibleRows, count: entries.count)
             measureExactly(eager)
             noteHeights(IndexSet(integersIn: entries.indices))
+            // **The standing instruction rather than a movement, for a reader who was at the end.**
+            //
+            // A movement is short of the end the moment anything below it changes size, and a
+            // reflow is followed by a burst of exactly that: every cell it redraws reports its own
+            // height a turn or two later. Reported as "sometimes I get placed a little higher and
+            // can't reach the bottom anymore". The instruction is self-releasing, so a reader who
+            // scrolls away in the next moment is not pinned: see `clipMoved`.
+            if wasAtEnd, !isFollowerDriving, !isLiveScrolling { holdsEnd = true }
             keepPlace(wasAtEnd: wasAtEnd, anchor: anchor)
             reportGeometry()
+            // And once more on the next turn, for the reason `goToEnd` says the end twice: a table
+            // lays out a height change on the pass after it is told about it, so a placement made
+            // on this one is resolved against numbers that are still moving.
+            placeWork?.cancel()
+            placeWork = Task { @MainActor [weak self] in
+                await Task.yield()
+                guard !Task.isCancelled, let self, !isLiveScrolling else { return }
+                placeWork = nil
+                keepPlace(wasAtEnd: wasAtEnd, anchor: anchor)
+                reportGeometry()
+            }
             TranscriptHoldCensus.released(estimated: heights.staleCount)
             return true
         }
 
-        /// Measures these rows now, at the width the cache is for, and files the answers.
-        private func measureExactly(_ rows: Range<Int>) {
-            guard let sizing = heights.measure else { return }
+        /// Measures these rows now, at the width the cache is for, and says which of them moved.
+        ///
+        /// A row is measured here if nobody has measured it at all, or if what is held for it was
+        /// taken at another width. Everything else is already the answer.
+        @discardableResult
+        private func measureExactly(_ rows: Range<Int>) -> IndexSet {
+            guard let sizing = heights.measure else { return IndexSet() }
+            var moved = IndexSet()
             for row in rows where entries.indices.contains(row) {
-                let entry = entries[row]
-                guard heights.isStale(entry.contentKey) else { continue }
-                heights.note(measure(entry, at: CGFloat(sizing.width)), for: entry.contentKey)
+                let key = entries[row].contentKey
+                guard heights.height(for: key) == nil || heights.isStale(key) else { continue }
+                if heights.note(measure(entries[row], at: CGFloat(sizing.width)), for: key) {
+                    moved.insert(row)
+                }
             }
+            return moved
+        }
+
+        /// **The screen a placement is about to show, measured exactly before it is shown.**
+        ///
+        /// Nothing is measured up front, so the table's idea of where a row is comes from an
+        /// estimate until somebody looks at it. That is safe for the rows above the reader, which
+        /// are corrected as they are drawn and anchored while they are; it is not safe for the
+        /// screen the reader is being put on, because a placement resolved against an estimate
+        /// lands where the estimate said rather than where the row is. So every placement measures
+        /// its own landing first.
+        ///
+        /// A screen either side of it as well, so that a small scroll after arriving does not land
+        /// on an estimate either.
+        private func measureLanding(at y: CGFloat) {
+            guard let tableView, let scrollView, heights.isReady else { return }
+            let viewport = scrollView.contentView.bounds.height
+            guard viewport > 1 else { return }
+            let rect = CGRect(x: 0, y: max(0, y - viewport), width: 1, height: viewport * 3)
+            let range = tableView.rows(in: rect)
+            guard range.length > 0 else { return }
+            noteHeights(measureExactly(range.location..<(range.location + range.length)))
         }
 
         /// The rows the pane can see, in the entries' own indices.

--- a/Sources/BloomCore/Presentation/TranscriptPaneHold.swift
+++ b/Sources/BloomCore/Presentation/TranscriptPaneHold.swift
@@ -12,12 +12,18 @@ import Foundation
 /// and the transcript keeps the size it had, the way Safari keeps a page while its sidebar moves,
 /// and the reflow happens once when the hand comes off.
 ///
-/// **An arrival.** Pointing a pane at another conversation measures the tail of it, and a beat
-/// later the four hundred rows behind that. Until both have landed the pane is a transcript in
-/// pieces: rows at the top, then a jump to the live end. So it is not drawn at all until it is in
-/// the place it belongs, and then it is faded in.
+/// **An arrival.** Pointing a pane at another conversation used to measure the whole window it
+/// opened: the tail, and a beat later the four hundred rows behind it. None of that is measured up
+/// front any more (see `TranscriptRowHeights.assumed`), so what is left is reading the rows and
+/// measuring the one screen the reader actually lands on. Until that has happened the pane is a
+/// transcript in pieces, so it is not drawn at all until it is in the place it belongs, and then
+/// it is faded in.
 ///
-/// One rule for both: hold, do the expensive thing, fade to it. `TranscriptHoldView` is the
+/// **A split** is the third, and it is an arrival: `CenterPanesView` deliberately changes a pane's
+/// `ForEach` identity when a tab goes from one pane to two, so the chat is rebuilt rather than
+/// resized and has no pixels of its own to keep.
+///
+/// One rule for all three: hold, do the expensive thing, fade to it. `TranscriptHoldView` is the
 /// mechanism, and this is the part that can be tested.
 public enum TranscriptPaneHold {
     /// Whether a width change is worth holding the transcript for.
@@ -45,8 +51,13 @@ public enum TranscriptPaneHold {
     /// unfreezes anyway.
     public static let quietUnderAHand: Duration = .seconds(2)
 
-    public static func letsGo(underAHand: Bool) -> Duration {
-        underAHand ? quietUnderAHand : quiet
+    /// The deadline a hold of this kind is armed with, so that nothing has to arrive for it to
+    /// end. See `TranscriptHoldView.hold(_:)`, which arms one for every hold it takes.
+    public static func letsGo(of held: PaneHeld, underAHand: Bool) -> Duration {
+        switch held {
+        case .whatIsDrawn: underAHand ? quietUnderAHand : quiet
+        case .nothing: arrival
+        }
     }
 
     /// The longest a pane stays blank waiting for the conversation it has been pointed at.
@@ -57,6 +68,19 @@ public enum TranscriptPaneHold {
     /// measuring away. This is what covers a load that never returns, a task cancelled on its way
     /// there, and a session with nothing in it at all.
     public static let arrival: Duration = .seconds(1)
+
+    /// What a hold is holding, which is the whole of the difference between the triggers.
+    ///
+    /// Here rather than in the view, because the deadline and the rule above are decisions and a
+    /// decision taken inside a view is a decision nothing can test.
+    /// `TranscriptHoldView.Held` is this, spelled where the mechanism is.
+    public enum PaneHeld: Equatable, Sendable {
+        /// The pixels a pane already has, at the size it had them. A resize.
+        case whatIsDrawn
+        /// Nothing: the pane draws its own ground until it is ready. An arrival, and a split,
+        /// which is an arrival in a pane that has just been built.
+        case nothing
+    }
 
     /// The most rows measured either side of the ones on screen.
     ///

--- a/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
+++ b/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
@@ -20,6 +20,19 @@ import Foundation
 /// changing either empties it. That is also the truthful shape, because there is never more than
 /// one width in play.
 ///
+/// ## Nothing is measured up front
+///
+/// A row nobody has measured is not a question the table can be made to wait for: it is told
+/// `estimate`, drawn if the reader ever looks at it, and corrected by `note` the moment it is.
+/// **This is what makes arriving at a conversation cost one screen rather than a window of rows.**
+/// Building the four hundred `NSHostingView`s a window used to open with was the whole of "opening
+/// a workspace or a tab with a chat in it is slow", and none of them was for a row anybody saw.
+///
+/// The estimate is the running mean of what HAS been measured here, which after one screen of a
+/// real conversation is a better number than any constant, and `assumedRowHeight` until then. What
+/// keeps this honest is that no placement is ever resolved against an estimate: the caller
+/// measures the screen it is about to show, exactly, before it shows it.
+///
 /// ## It outlives the conversation it was filled for
 ///
 /// A pane is pointed at one conversation after another, and the heights of the one being left are
@@ -90,6 +103,15 @@ public struct TranscriptRowHeights: Equatable, Sendable {
     /// cost of hitting this is one conversation measured again.
     public static let mostRows = 20_000
 
+    /// What a row is worth before anything at all has been measured here.
+    ///
+    /// The one number in this file nothing measured, and it is only ever the answer for the first
+    /// screen of the first conversation a pane draws: one measured row replaces it with the mean
+    /// below. A tool row is about thirty points and a paragraph of prose several hundred, so this
+    /// is deliberately nearer the short end. Guessing high would open every conversation with a
+    /// document several times the height of its content and a scroller to match.
+    public static let assumedRowHeight: Double = 64
+
     /// The narrowest width worth measuring a row at.
     ///
     /// A table that has not been laid out yet reports a width of nought or one, and a row measured
@@ -104,6 +126,8 @@ public struct TranscriptRowHeights: Equatable, Sendable {
     private var heights: [String: Double] = [:]
     /// The keys whose height was taken at a width that no longer holds. See `rewidth`.
     private var stale: Set<String> = []
+    /// The sum of `heights`, kept in step on every write so the mean below costs nothing to ask.
+    private var total: Double = 0
 
     public init() {}
 
@@ -129,6 +153,7 @@ public struct TranscriptRowHeights: Equatable, Sendable {
         measure = wanted
         heights.removeAll()
         stale.removeAll()
+        total = 0
         return true
     }
 
@@ -168,6 +193,26 @@ public struct TranscriptRowHeights: Equatable, Sendable {
         heights[contentKey]
     }
 
+    /// What an unmeasured row is worth: the mean of everything measured here, or
+    /// `assumedRowHeight` before there is one.
+    ///
+    /// A mean rather than a median, because it is kept as a running total and a median would mean
+    /// holding the numbers sorted for an answer that is corrected the moment the row is drawn.
+    /// Rows that draw nothing are in it and should be: a conversation with a run of empty rows in
+    /// it really is shorter per row than one without.
+    public var estimate: Double {
+        heights.isEmpty ? Self.assumedRowHeight : total / Double(heights.count)
+    }
+
+    /// **The number to tell a table**: what is known, or what is assumed.
+    ///
+    /// Never nil and never a measurement, so answering it for every row of a session costs a
+    /// dictionary lookup each. See the header for why a table is answered rather than made to
+    /// wait.
+    public func assumed(for contentKey: String) -> Double {
+        heights[contentKey] ?? estimate
+    }
+
     /// Remembers a height, and says whether it is news.
     ///
     /// **A report from a row that has actually been drawn outranks anything measured off screen,
@@ -191,6 +236,7 @@ public struct TranscriptRowHeights: Equatable, Sendable {
         guard abs((heights[contentKey] ?? -1) - rounded) > 0.5 else { return false }
         // See `mostRows`. Asked before the insert, so the cache never holds more than it says.
         if heights.count >= Self.mostRows, heights[contentKey] == nil { forget() }
+        total += rounded - (heights[contentKey] ?? 0)
         heights[contentKey] = rounded
         return true
     }
@@ -209,5 +255,6 @@ public struct TranscriptRowHeights: Equatable, Sendable {
     public mutating func forget() {
         heights.removeAll()
         stale.removeAll()
+        total = 0
     }
 }

--- a/Tests/BloomCoreTests/TranscriptPaneHoldTests.swift
+++ b/Tests/BloomCoreTests/TranscriptPaneHoldTests.swift
@@ -36,16 +36,31 @@ struct TranscriptPaneHoldTests {
     /// a frozen picture on screen.
     @Test("a hold with no hand on it lets go quickly")
     func letsGoOnItsOwn() {
-        #expect(TranscriptPaneHold.letsGo(underAHand: false) == TranscriptPaneHold.quiet)
+        #expect(
+            TranscriptPaneHold.letsGo(of: .whatIsDrawn, underAHand: false)
+                == TranscriptPaneHold.quiet
+        )
         #expect(TranscriptPaneHold.quiet < .seconds(1))
     }
 
     @Test("a hold under a hand waits longer, and still ends")
     func waitsForAHand() {
-        let held = TranscriptPaneHold.letsGo(underAHand: true)
+        let held = TranscriptPaneHold.letsGo(of: .whatIsDrawn, underAHand: true)
         #expect(held == TranscriptPaneHold.quietUnderAHand)
         #expect(held > TranscriptPaneHold.quiet)
         #expect(held < .seconds(30))
+    }
+
+    /// A pane waiting for a conversation is waiting for a read and one screen of measuring, not
+    /// for a hand, so the hand makes no difference to it.
+    @Test("a pane holding nothing waits for its conversation and no longer")
+    func waitsForAnArrival() {
+        #expect(
+            TranscriptPaneHold.letsGo(of: .nothing, underAHand: true) == TranscriptPaneHold.arrival
+        )
+        #expect(
+            TranscriptPaneHold.letsGo(of: .nothing, underAHand: false) == TranscriptPaneHold.arrival
+        )
     }
 
     // MARK: - Arriving at another conversation

--- a/Tests/BloomCoreTests/TranscriptRowHeightsTests.swift
+++ b/Tests/BloomCoreTests/TranscriptRowHeightsTests.swift
@@ -252,6 +252,63 @@ struct TranscriptRowHeightsTests {
         #expect(!heights.isStale("row.7"))
     }
 
+    // MARK: - What an unmeasured row is worth
+
+    /// **Nothing is measured up front.** A table asks for every row it holds, so a pane arriving
+    /// at a conversation used to build an `NSHostingView` for each of the four hundred rows in its
+    /// window, none of which anybody saw.
+    @Test("a row nobody has measured is assumed rather than refused")
+    func assumesAnUnmeasuredRow() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 800, scale: 1)
+        #expect(heights.height(for: "row.7") == nil)
+        #expect(heights.assumed(for: "row.7") == TranscriptRowHeights.assumedRowHeight)
+    }
+
+    @Test("what has been measured is what the rest is assumed to be")
+    func assumesTheMeanOfWhatIsKnown() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 800, scale: 1)
+        heights.note(100, for: "row.1")
+        heights.note(200, for: "row.2")
+        #expect(heights.estimate == 150)
+        #expect(heights.assumed(for: "row.99") == 150)
+        // And the measured ones are still themselves.
+        #expect(heights.assumed(for: "row.1") == 100)
+    }
+
+    /// The running total has to survive an overwrite, which is what every drawn row does to what
+    /// was measured for it off screen.
+    @Test("a row measured again does not count twice")
+    func meanFollowsAnOverwrite() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 800, scale: 1)
+        heights.note(100, for: "row.1")
+        heights.note(300, for: "row.1")
+        #expect(heights.estimate == 300)
+    }
+
+    @Test("a cache that has been emptied assumes nothing it used to know")
+    func meanIsEmptiedWithTheCache() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 800, scale: 1)
+        heights.note(400, for: "row.1")
+        heights.forget()
+        #expect(heights.estimate == TranscriptRowHeights.assumedRowHeight)
+    }
+
+    /// A resize keeps its numbers, so it keeps the estimate they make up: the rows it has not
+    /// measured yet are still better guessed at from this conversation than from a constant.
+    @Test("a resize keeps the estimate as well as the heights")
+    func meanSurvivesAResize() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 800, scale: 1)
+        heights.note(100, for: "row.1")
+        heights.note(200, for: "row.2")
+        heights.rewidth(to: 600)
+        #expect(heights.estimate == 150)
+    }
+
     // MARK: - The bound
 
     /// A pane keeps the heights of every conversation it draws, and one pane visits a great many.


### PR DESCRIPTION
Switching to a workspace or a tab with a chat, and splitting beside one, were all slow for one reason: the table measured a row on every cache miss, by building an `NSHostingView`, at about 2ms each. A table asks its delegate for the height of every row it holds, so arriving at a conversation paid for roughly 400 of them and nobody ever saw more than a screen.

The earlier fix did not move it, and this says why. Keeping the cache from being emptied on a workspace switch was real, but the workspace you switch to has rows that were never in it, so every one was a miss. That fix only ever helped returning to a session the same pane had already drawn at the same width.

Nothing is measured up front now. An unmeasured row is assumed from the running mean of what has been measured in that pane, and is put right the moment it is drawn, which was already anchored. Arriving costs one screen, whatever the size of the session.

That is also the reachable-end bug. The rows at the end were short by however far their estimates were out, so the document ended above its own content and the scroller could not travel to it: being placed a little higher and not being able to reach the bottom are the same fact. No placement is resolved against an estimate any more (the screen it is about to show is measured first, and the end is measured twice), and a reader who was at the end keeps a standing instruction to be there through the corrections that follow a reflow, released the moment they scroll.

One mechanism, three triggers, per the owner's constraint. `TranscriptHoldView` has one way in and one way out. A drag passes "keep what is drawn". An arrival and a split pass "nothing to keep", because a split rebuilds the pane and genuinely has no pixels of its own: that is the honest difference rather than a shared thing that lies. The deadline, the crossfade, the census and the reflow are shared.