### PR TITLE
Take four full defaults snapshots off the launch path

### DIFF
--- a/Sources/Bloom/Design/RepoIcon.swift
+++ b/Sources/Bloom/Design/RepoIcon.swift
@@ -127,7 +127,8 @@ struct RepoIcon: View {
     }
 
     private var tint: Color {
-        accent.map(Color.init(hexString:)) ?? Palette.textTertiary
+        guard let accent else { return Palette.textTertiary }
+        return RepoAccent.tint(for: accent)
     }
 
     /// On the emphasized selection the tile becomes the translucent white a `Chip` becomes there,
@@ -150,19 +151,46 @@ struct RepoIcon: View {
     /// draws (a Reminders list mark, a Finder tag), and only the genuinely pale colours flip.
     private var contrastingInk: Color {
         guard let accent else { return Palette.textPrimary }
-        guard let color = NSColor(Color(hexString: accent)).usingColorSpace(.sRGB) else {
-            return .white
-        }
-        let luminance = 0.2126 * linear(color.redComponent)
-            + 0.7152 * linear(color.greenComponent)
-            + 0.0722 * linear(color.blueComponent)
-        return luminance > 0.35 ? .black : .white
+        return RepoAccent.ink(for: accent)
+    }
+}
+
+/// The two colours a project's accent hex resolves to, worked out once per hex.
+///
+/// Both used to be worked out on every body pass of every project mark, artwork included: the
+/// monogram sits in the stack at zero opacity so that a found icon arriving is a crossfade rather
+/// than a relayout. That was two hex parses, three `NSColor`s, a SwiftUI to AppKit bridge, a
+/// colour space conversion and three `pow()` calls per mark per pass, for an answer that depends
+/// on nothing but the string. The zero-opacity monogram stays, because gating it on `artwork`
+/// would make the arrival an insertion again; it is the arithmetic behind it that goes.
+///
+/// The luminance is `Contrast`'s, which is WCAG's and is unit tested, rather than a second copy
+/// here. The two agreed already: the branch constants (0.03928 against 0.04045) are the two
+/// spellings of the same crossover and meet to five decimal places at the one byte value between
+/// them.
+///
+/// No eviction. The keys are the accents of the projects in the sidebar, so the table is bounded
+/// by how many projects the owner has.
+@MainActor
+private enum RepoAccent {
+    private static var inks: [String: Color] = [:]
+    private static var tints: [String: Color] = [:]
+
+    static func tint(for hex: String) -> Color {
+        if let known = tints[hex] { return known }
+        let tint = Color(hexString: hex)
+        tints[hex] = tint
+        return tint
     }
 
-    /// sRGB is gamma encoded, so its components have to be linearised before they mean anything
-    /// as a brightness. Averaging the raw bytes instead is what makes a mid blue look as bright
-    /// as a mid yellow to the arithmetic and to nothing else.
-    private func linear(_ component: CGFloat) -> CGFloat {
-        component <= 0.04045 ? component / 12.92 : pow((component + 0.055) / 1.055, 2.4)
+    static func ink(for hex: String) -> Color {
+        if let known = inks[hex] { return known }
+        // The same fallback `Color(hexString:)` makes, so an unreadable accent is measured as the
+        // colour it is actually drawn in rather than as nothing.
+        let parsed = HexColor(hex: hex) ?? HexColor(red: 0x4C, green: 0x8D, blue: 0xF6)
+        let packed = UInt32(parsed.red) << 16 | UInt32(parsed.green) << 8 | UInt32(parsed.blue)
+        let ink: Color = Contrast.relativeLuminance(of: packed) > 0.35 ? .black : .white
+        inks[hex] = ink
+        return ink
     }
 }

--- a/Sources/Bloom/State/AppModel.swift
+++ b/Sources/Bloom/State/AppModel.swift
@@ -306,6 +306,7 @@ final class AppModel {
     func bootstrap() async {
         Self.probeInstance = self
         guard store == nil else { return }
+        let began = Date()
         do {
             // Off the main actor. Opening the database creates directories, opens the file and
             // runs every migration, and one of those migrations walks the whole messages table.
@@ -360,6 +361,8 @@ final class AppModel {
             // jumps to the workspace.
             restoreLastSelection()
             isLoaded = true
+            let blocking = Int(Date().timeIntervalSince(began) * 1000)
+            Log.launch.info("window usable after \(blocking, privacy: .public)ms")
             reportFailedDatabaseMigration()
         } catch {
             // `TranscriptStanding.complaint` rather than `readableMessage`: a `SQLiteError`

--- a/Sources/Bloom/State/Log.swift
+++ b/Sources/Bloom/State/Log.swift
@@ -40,6 +40,11 @@ enum Log {
     /// Permission questions: what was granted, and what a crash left unanswered.
     static let permissions = Logger(subsystem: subsystem, category: "permissions")
 
+    /// The blocking half of `bootstrap`, which is how long the window sits on `LoadingView`.
+    /// Nothing outside the process can see the moment `isLoaded` is set, so a sampler cannot
+    /// answer this and a probe would have to be told when to start.
+    static let launch = Logger(subsystem: subsystem, category: "launch")
+
     /// The workspace bridge: the socket it bound, the handshakes it refused, and the sessions it
     /// could not register. Every one of those is a tool the agent silently does not have, which is
     /// invisible from inside a transcript.

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -1098,7 +1098,11 @@ final class TranscriptModel {
         // still on its way in, and the read ends by putting the whole list on the model in one go:
         // a row appended here in the meantime would simply be overwritten.
         await loader.wait()
-        let after = rows.map(\.seq).max() ?? -1
+        // `lazy`, because this runs on every assistant text, tool use and tool result event and the
+        // eager map allocated an array the length of the whole transcript each time. Not
+        // `rows.last?.seq`: a tool result folds onto a row that is already there rather than
+        // appending, so the last row is not reliably the highest sequence.
+        let after = rows.lazy.map(\.seq).max() ?? -1
         let fresh = (try? await store.messages(sessionID: session.id, afterSeq: after)) ?? []
         guard !fresh.isEmpty else { return }
         let appendedFrom = rows.count

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -1268,7 +1268,16 @@ final class WorkspaceModel {
 
     /// Full contents of a file in the worktree, for the All files tab.
     func contents(of relativePath: String) -> String? {
-        let full = (workspace.path as NSString).appendingPathComponent(relativePath)
+        Self.contents(of: relativePath, in: workspace.path)
+    }
+
+    /// The same read with the worktree named, for a caller that is off the main actor.
+    ///
+    /// `DiffView.present` does the first read of a clicked file beside `DiffDocument.prepare` in
+    /// the same detached task, and this is what lets it: everything else in that function had
+    /// already been moved off the main actor and the file read had been left behind on it.
+    nonisolated static func contents(of relativePath: String, in worktree: String) -> String? {
+        let full = (worktree as NSString).appendingPathComponent(relativePath)
         return try? String(contentsOfFile: full, encoding: .utf8)
     }
 

--- a/Sources/Bloom/Views/Center/Panes/WorkspaceTabsStore.swift
+++ b/Sources/Bloom/Views/Center/Panes/WorkspaceTabsStore.swift
@@ -110,11 +110,23 @@ final class WorkspaceTabsStore {
     /// 2e3d6e3 written down: the sweep kills every tmux session whose pane id nothing can
     /// enumerate, there is no way to get a killed shell back, and the next phase does rewrite a
     /// key the census reads.
+    ///
+    /// One snapshot of the app's own domain feeds all three scans below, because
+    /// `dictionaryRepresentation()` materialises the merged search list and this ran it three
+    /// times on the main actor before the window was usable. See `DefaultsSnapshot`.
     private init() {
         let defaults = UserDefaults.standard
-        TabMigration.migrateAll(in: defaults)
+        var snapshot = DefaultsSnapshot.own(defaults, name: Bundle.main.bundleIdentifier)
 
-        for (key, value) in defaults.dictionaryRepresentation()
+        for tab in TabMigration.migrateAll(in: defaults, keys: snapshot.keys) {
+            // Phase A's own writes, folded back in. The scan below reads the snapshot rather than
+            // defaults, so without this a launch that migrated would file no tab at all and show
+            // every migrated workspace unsplit.
+            guard let data = defaults.data(forKey: tab.key) else { continue }
+            snapshot[tab.key] = data
+        }
+
+        for (key, value) in snapshot
         where key.hasPrefix(TabDefaults.tabPrefix) {
             let rootID = String(key.dropFirst(TabDefaults.tabPrefix.count))
             guard let data = value as? Data,
@@ -141,7 +153,7 @@ final class WorkspaceTabsStore {
             arrangements[rootID] = arrangement
         }
 
-        for (key, value) in defaults.dictionaryRepresentation()
+        for (key, value) in snapshot
         where key.hasPrefix(TabDefaults.stripPrefix) {
             let workspaceID = WorkspaceID(String(key.dropFirst(TabDefaults.stripPrefix.count)))
             guard let data = value as? Data,

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -291,19 +291,28 @@ struct DiffView: View {
 
     private func present(_ fileDiff: FileDiff) async {
         let path = file.path
-        let document = await Task.detached(priority: .userInitiated) {
-            DiffDocument.prepare(file: fileDiff, path: path)
-        }.value
-
-        guard !Task.isCancelled else { return }
-
-        // The worktree copy is what the between-hunks expanders reveal. A file git deleted, or one
-        // that is not text, simply has no expanders. Split by the anchor's own rule rather than
+        let worktree = model.workspace.path
+        // The worktree copy is read here rather than after the await, which is where it used to be
+        // and where it read and split a whole file on the main actor on every file click.
+        //
+        // It is what the between-hunks expanders reveal. A file git deleted, or one that is not
+        // text, simply has no expanders. Split by the anchor's own rule rather than
         // `components(separatedBy:)`, which counts a phantom last line on a file ending in a
         // newline: the review payload resolves against `ReviewCommentAnchor.split`, and the bands
         // resolve against these lines, so the two splits disagreeing at the end of the file is
         // exactly the band-versus-payload disagreement `ReviewCommentRender` warns against.
-        fileLines = model.contents(of: path).map(ReviewCommentAnchor.split)
+        let prepared = await Task.detached(priority: .userInitiated) {
+            (
+                document: DiffDocument.prepare(file: fileDiff, path: path),
+                lines: WorkspaceModel.contents(of: path, in: worktree)
+                    .map(ReviewCommentAnchor.split)
+            )
+        }.value
+
+        guard !Task.isCancelled else { return }
+
+        let document = prepared.document
+        fileLines = prepared.lines
         phase = .ready(document)
         rebuild()
         prime(document)

--- a/Sources/Bloom/Views/Sidebar/RepoHeaderRow.swift
+++ b/Sources/Bloom/Views/Sidebar/RepoHeaderRow.swift
@@ -44,6 +44,8 @@ struct RepoHeaderRow: View {
     @FocusState private var repoFieldFocused: Bool
 
     @State private var isConfirmingRemove = false
+    /// What the dialog says, from the moment the menu item was pressed. See `askAboutRemoving`.
+    @State private var removal: Confirmation?
     /// Lights the `+` and swaps the project's mark for its settings gear. It belongs to this row
     /// rather than to a hover id shared across the whole list, so crossing the pane lights one
     /// project at a time.
@@ -157,17 +159,18 @@ struct RepoHeaderRow: View {
                 repo: repo,
                 onCreateWorkspace: onCreateWorkspace,
                 onRename: beginRepoRename,
-                onRemove: { isConfirmingRemove = true }
+                onRemove: askAboutRemoving
             )
         }
         .confirmationDialog(
-            removal.title,
+            removal?.title ?? "",
             isPresented: $isConfirmingRemove,
-            titleVisibility: .visible
-        ) {
+            titleVisibility: .visible,
+            presenting: removal
+        ) { removal in
             Button(removal.confirmLabel, role: .destructive, action: removeRepo)
             Button(removal.cancelLabel, role: .cancel) {}
-        } message: {
+        } message: { removal in
             Text(removal.message)
         }
     }
@@ -397,8 +400,17 @@ struct RepoHeaderRow: View {
     // MARK: - Actions
 
     /// The one question, asked here and in both settings panes. See `ProjectRemoval`.
-    private var removal: Confirmation {
-        app.projectRemoval(repo)
+    ///
+    /// Built when the menu item is pressed and held, rather than computed in `body`. It used to be
+    /// a computed property read as `confirmationDialog`'s positional title, which is a plain
+    /// argument rather than one of the lazy `@ViewBuilder` closures under it, so it was evaluated
+    /// on every pass whether or not the dialog was open. `AppModel.projectRemoval` filters the
+    /// whole workspace list, which made every project header depend on that list, and `reload()`
+    /// reassigns it whenever any diff stat moves: the same observation edge `DetailColumn` names
+    /// in its own doc, one pane over.
+    private func askAboutRemoving() {
+        removal = app.projectRemoval(repo)
+        isConfirmingRemove = true
     }
 
     private func removeRepo() {

--- a/Sources/Bloom/Views/Sidebar/WorkspaceRow.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspaceRow.swift
@@ -71,6 +71,19 @@ struct WorkspaceRow: View {
     private var isEmphasized: Bool { backgroundProminence == .increased }
 
     var body: some View {
+        // Bound once. `status` was resolved three times a pass and the pull request dictionary read
+        // five, because the sentence reaches both and is asked for twice, by the tooltip and by
+        // VoiceOver, which get the same words on purpose. GitHub's answer is read straight from the
+        // shared store rather than passed in, because the sidebar's row builder cannot reach it.
+        let pullRequest = WorkspacePullRequests.shared.pullRequest(for: workspace.id)
+        let status = WorkspaceStatus.resolve(
+            workspace: workspace,
+            isRunning: isRunning,
+            pullRequest: pullRequest,
+            isAwaitingPermission: isAwaitingPermission
+        )
+        let statusDescription = status.summary(pullRequest: pullRequest)
+
         Label {
             HStack(spacing: Metrics.spacing) {
                 if isRenaming {
@@ -176,7 +189,9 @@ struct WorkspaceRow: View {
         .onHover { isHovered = $0 }
         // Only rows that exist ask GitHub anything, and the id carries the branch and whether
         // there is any work at all, because both change what is worth asking about.
-        .task(id: "\(workspace.id)|\(workspace.branch)|\(workspace.hasDiff)") {
+        .task(id: PullRequestQuestion(
+            workspace: workspace.id, branch: workspace.branch, hasDiff: workspace.hasDiff
+        )) {
             await WorkspacePullRequests.shared.track(workspace)
         }
         // The list inverts the row's text for us, but a label that carries its own colour, such as
@@ -367,30 +382,6 @@ struct WorkspaceRow: View {
         .accessibilityLabel("Archive \(workspace.name)")
     }
 
-    // MARK: - Status
-
-    /// GitHub's answer for this branch, if anything has asked yet. Read straight from the shared
-    /// store rather than passed in, because the sidebar's row builder has no way to reach it.
-    private var pullRequest: PullRequest? {
-        WorkspacePullRequests.shared.pullRequest(for: workspace.id)
-    }
-
-    private var status: WorkspaceStatus {
-        WorkspaceStatus.resolve(
-            workspace: workspace,
-            isRunning: isRunning,
-            pullRequest: pullRequest,
-            isAwaitingPermission: isAwaitingPermission
-        )
-    }
-
-    /// What the mark means, in one sentence, for the tooltip and for VoiceOver. Both get the same
-    /// words on purpose: a sighted user hovering and a VoiceOver user landing on the row are
-    /// asking the identical question.
-    private var statusDescription: String {
-        status.summary(pullRequest: pullRequest)
-    }
-
     // MARK: - Renaming
 
     /// One door out of the field, for all four ways of leaving it.
@@ -411,6 +402,15 @@ struct WorkspaceRow: View {
         ) else { return }
         Task { await app.rename(workspace, to: name) }
     }
+}
+
+/// What is worth asking GitHub about again, as a value rather than as the interpolated string this
+/// used to be: that string was built on every pass of every row and never read, because a `.task`
+/// id is only ever compared.
+private struct PullRequestQuestion: Hashable, Sendable {
+    var workspace: WorkspaceID
+    var branch: String
+    var hasDiff: Bool
 }
 
 /// The cross and its count, set tight so the pair reads as one mark rather than as an icon beside

--- a/Sources/Bloom/Views/Terminal/TerminalSplitStore.swift
+++ b/Sources/Bloom/Views/Terminal/TerminalSplitStore.swift
@@ -31,9 +31,16 @@ final class TerminalSplitStore {
     /// Read in one pass at launch rather than lazily per tab. A getter may not mutate, and loading
     /// from a task instead would leave the first frame showing a single pane, which is long enough
     /// to fork a shell for a pane the restored layout does not have.
+    ///
+    /// The app's own domain rather than `dictionaryRepresentation()`, which merges the whole
+    /// search list in to answer about one prefix. See `DefaultsSnapshot`. Its own snapshot rather
+    /// than one shared with `WorkspaceTabsStore`, because these two are reached from different
+    /// call sites in `bootstrap` and a snapshot handed across them would be a cache with a
+    /// lifetime nobody owns, for a domain of 87 entries.
     private init() {
         let defaults = UserDefaults.standard
-        for (key, value) in defaults.dictionaryRepresentation() where key.hasPrefix(Self.keyPrefix) {
+        let snapshot = DefaultsSnapshot.own(defaults, name: Bundle.main.bundleIdentifier)
+        for (key, value) in snapshot where key.hasPrefix(Self.keyPrefix) {
             guard let encoded = value as? String, let layout = SplitLayout(encoded: encoded) else {
                 continue
             }

--- a/Sources/BloomCore/Persistence/DefaultsSnapshot.swift
+++ b/Sources/BloomCore/Persistence/DefaultsSnapshot.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// The app's own defaults, for the readers that have to scan for a key prefix.
+///
+/// `UserDefaults.dictionaryRepresentation()` materialises the whole merged search list and bridges
+/// every value to Swift. Measured on this Mac: `NSGlobalDomain` holds 7,514 entries and 344KB
+/// where Bloom's own domain holds 87, so a scan for one prefix bridged about 7,600 values to find
+/// keys among 87. Launch did that four times on the main actor before `isLoaded` was set.
+///
+/// **Only safe for keys written with `set(_:forKey:)`.** A key supplied through
+/// `register(defaults:)` lives in the registration domain, which is not a persistent domain and is
+/// not here, so a scan over this would silently miss it. The tab and split prefixes qualify:
+/// `SystemDefaults` is the only `register(defaults:)` in the app and it registers three switches.
+public enum DefaultsSnapshot {
+    /// - Parameter name: the persistent domain, which is the bundle id for `UserDefaults.standard`
+    ///   and the suite name for a suite. Nil, or a domain the store cannot answer for, falls back
+    ///   to the merged representation, which is what an unbundled binary gets.
+    public static func own(_ defaults: UserDefaults, name: String?) -> [String: Any] {
+        guard let name, let domain = defaults.persistentDomain(forName: name) else {
+            return defaults.dictionaryRepresentation()
+        }
+        return domain
+    }
+}

--- a/Sources/BloomCore/Persistence/DefaultsSnapshot.swift
+++ b/Sources/BloomCore/Persistence/DefaultsSnapshot.swift
@@ -13,12 +13,14 @@ import Foundation
 /// `SystemDefaults` is the only `register(defaults:)` in the app and it registers three switches.
 public enum DefaultsSnapshot {
     /// - Parameter name: the persistent domain, which is the bundle id for `UserDefaults.standard`
-    ///   and the suite name for a suite. Nil, or a domain the store cannot answer for, falls back
-    ///   to the merged representation, which is what an unbundled binary gets.
+    ///   and the suite name for a suite. Nil falls back to the merged representation, which is
+    ///   what an unbundled binary gets.
     public static func own(_ defaults: UserDefaults, name: String?) -> [String: Any] {
-        guard let name, let domain = defaults.persistentDomain(forName: name) else {
-            return defaults.dictionaryRepresentation()
-        }
-        return domain
+        // A named domain with nothing written to it answers nil, and that is an empty answer
+        // rather than an unanswerable one. Falling back there would take the whole merged list on
+        // every launch until the first tab is stored, and would put the registration domain back
+        // in the scan, which is the one thing this type exists to keep out.
+        guard let name else { return defaults.dictionaryRepresentation() }
+        return defaults.persistentDomain(forName: name) ?? [:]
     }
 }

--- a/Sources/BloomCore/Presentation/TabMigration.swift
+++ b/Sources/BloomCore/Presentation/TabMigration.swift
@@ -94,12 +94,19 @@ public enum TabMigration {
 
     /// Runs phase A over a whole defaults domain, and returns what it made.
     ///
+    /// The keys are handed in rather than read here, because the caller is already holding a
+    /// snapshot of the app's own domain and `dictionaryRepresentation()` would materialise the
+    /// merged search list a second time. See `DefaultsSnapshot`. A key in the list that has since
+    /// gone simply reads as nothing, so a stale list costs a lookup and no correctness.
+    ///
     /// Sorted, so two runs over the same domain do the same writes in the same sequence. Nothing
     /// depends on that today, but a migration whose behaviour turns on a dictionary's iteration
     /// order cannot be reproduced from a bug report.
     @discardableResult
-    public static func migrateAll(in defaults: UserDefaults) -> [CompositeTab] {
-        defaults.dictionaryRepresentation().keys
+    public static func migrateAll(
+        in defaults: UserDefaults, keys: some Sequence<String>
+    ) -> [CompositeTab] {
+        keys
             .filter { $0.hasPrefix(TabDefaults.legacyCentrePrefix) }
             .sorted()
             .compactMap { migrate(legacyKey: $0, in: defaults) }

--- a/Sources/BloomCore/System/Shell.swift
+++ b/Sources/BloomCore/System/Shell.swift
@@ -85,12 +85,24 @@ public enum Shell {
         spawns.load(ordering: .relaxed)
     }
 
-    public static func environment(extra: [String: String] = [:]) -> [String: String] {
+    /// This process's environment with the PATH above merged in, worked out once.
+    ///
+    /// It used to be rebuilt per spawn: the whole process environment copied, PATH split, about 45
+    /// entries deduped through a `Set`, and `which` asks for it before every subprocess as well.
+    /// Nothing in Bloom calls `setenv`, so the base cannot move under this, and the two callers
+    /// that pass an overlay get a copy-on-write copy of it rather than a rebuild.
+    private static let base: [String: String] = {
         var env = ProcessInfo.processInfo.environment
         let existing = env["PATH"]?.components(separatedBy: ":") ?? []
         var seen = Set<String>()
         let merged = (existing + extraPaths).filter { seen.insert($0).inserted }
         env["PATH"] = merged.joined(separator: ":")
+        return env
+    }()
+
+    public static func environment(extra: [String: String] = [:]) -> [String: String] {
+        guard !extra.isEmpty else { return base }
+        var env = base
         for (key, value) in extra { env[key] = value }
         return env
     }

--- a/Tests/BloomCoreTests/DefaultsSnapshotTests.swift
+++ b/Tests/BloomCoreTests/DefaultsSnapshotTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// The launch scans read this instead of `dictionaryRepresentation()`, so the two things that
+/// would make that swap wrong are written down: a written key must be in it, and a registered key
+/// must be known to be missing from it.
+@Suite("DefaultsSnapshot")
+struct DefaultsSnapshotTests {
+    private func domain() -> (name: String, defaults: UserDefaults) {
+        let name = "bloom.test.snapshot.\(UUID().uuidString)"
+        return (name, UserDefaults(suiteName: name)!)
+    }
+
+    private func clean(_ name: String) {
+        UserDefaults.standard.removePersistentDomain(forName: name)
+    }
+
+    @Test("a written key is in the snapshot and the global domain is not")
+    func ownKeysOnly() {
+        let (name, defaults) = domain()
+        defer { clean(name) }
+        defaults.set("v", forKey: "center.tab.s1")
+
+        let snapshot = DefaultsSnapshot.own(defaults, name: name)
+
+        #expect(snapshot["center.tab.s1"] as? String == "v")
+        // The whole point of the swap. `AppleLanguages` is in `dictionaryRepresentation()` for any
+        // domain, because that merges `NSGlobalDomain` in, and it is not in this one.
+        #expect(defaults.dictionaryRepresentation()["AppleLanguages"] != nil)
+        #expect(snapshot["AppleLanguages"] == nil)
+    }
+
+    /// The trap the swap could have walked into: a registration domain is not a persistent one, so
+    /// a key supplied that way is invisible here and a prefix scan would silently drop it.
+    @Test("a registered key is not in the snapshot")
+    func registeredKeysAreAbsent() {
+        let (name, defaults) = domain()
+        defer { clean(name) }
+        defaults.register(defaults: ["center.tab.registered": "v"])
+
+        #expect(defaults.string(forKey: "center.tab.registered") == "v")
+        #expect(DefaultsSnapshot.own(defaults, name: name)["center.tab.registered"] == nil)
+    }
+
+    /// An unbundled binary has no domain name to ask for, and it still has to see its own keys.
+    @Test("no domain name falls back to the merged representation")
+    func namelessFallsBack() {
+        let (name, defaults) = domain()
+        defer { clean(name) }
+        defaults.set("v", forKey: "center.tab.s1")
+
+        #expect(DefaultsSnapshot.own(defaults, name: nil)["center.tab.s1"] as? String == "v")
+    }
+}

--- a/Tests/BloomCoreTests/TabMigrationTests.swift
+++ b/Tests/BloomCoreTests/TabMigrationTests.swift
@@ -394,7 +394,9 @@ struct TabMigrationDefaultsTests {
         let second = try #require(other.encoded)
         defaults.set(second, forKey: "center.panes.w2")
 
-        let tabs = TabMigration.migrateAll(in: defaults)
+        let tabs = TabMigration.migrateAll(
+            in: defaults, keys: DefaultsSnapshot.own(defaults, name: name).keys
+        )
 
         #expect(tabs.map(\.key) == ["center.tab.s1", "center.tab.s2"])
         #expect(defaults.data(forKey: "center.panes.w1") == nil)

--- a/Tests/BloomCoreTests/TerminalPaneCensusTests.swift
+++ b/Tests/BloomCoreTests/TerminalPaneCensusTests.swift
@@ -213,7 +213,9 @@ struct TerminalPaneCensusTests {
         let before = TerminalPaneCensus.census(of: [workspace], in: defaults)
         #expect(before == .init(panes: ["t1", "x1", "t3"]))
 
-        let migrated = TabMigration.migrateAll(in: defaults)
+        let migrated = TabMigration.migrateAll(
+            in: defaults, keys: DefaultsSnapshot.own(defaults, name: name).keys
+        )
 
         #expect(migrated.count == 1)
         #expect(TerminalPaneCensus.census(of: [workspace], in: defaults) == before)
@@ -241,7 +243,7 @@ struct TerminalPaneCensusTests {
         defaults.set(panes, forKey: "center.panes.w1")
 
         let before = try #require(UserDefaults.standard.persistentDomain(forName: name))
-        TabMigration.migrateAll(in: defaults)
+        TabMigration.migrateAll(in: defaults, keys: before.keys)
         let after = try #require(UserDefaults.standard.persistentDomain(forName: name))
 
         #expect(Set(before.keys) == ["center.tabs.w1", "terminal.split.t1", "center.panes.w1"])


### PR DESCRIPTION
Launch materialised the whole merged defaults search list four times on the main actor, before the window was usable, to filter one key prefix. Measured on this Mac: `NSGlobalDomain` holds 7,514 entries and 344KB where Bloom's own domain holds 87, so each call bridged about 7,600 values to find keys among 87. It now takes the app's own persistent domain instead.

The trap that would have made that wrong is pinned by a test: a key supplied through `register(defaults:)` lives in the registration domain, which is not a persistent one, so a prefix scan over the snapshot would silently drop it. There is exactly one `register(defaults:)` in the tree and it registers three switches, none of them a tab key.

A project header no longer observes the whole workspace list. The removal dialog's title was read as a positional argument, so it was built on every body pass whether or not the dialog was open, and building it read `app.workspaces`, which is reassigned whenever any diff stat moves. Same fix as `DetailColumn`. Its text is now a snapshot taken when the menu item is pressed, so a count can be one turn stale; the alternative is the bug.

Clicking a file no longer reads and splits the whole file on the main actor. Everything around that line had already been moved off it.

Smaller: the whole transcript is no longer allocated as an array on every streamed event, a sidebar row no longer builds a throwaway interpolated task id per body, a project icon's colour work is a dictionary lookup rather than two hex parses and three `pow()` calls per body, and the shell's environment base is built once rather than per spawn.