### PR TITLE
Run the git a workspace click needs all at once

### DIFF
--- a/Sources/Bloom/Design/IdleProbe.swift
+++ b/Sources/Bloom/Design/IdleProbe.swift
@@ -150,15 +150,28 @@ enum IdleProbe {
     }
 
     /// One sweep of `Git.diffStat` over every worktree, exactly as `AppModel.refreshDiffStats`
-    /// runs it: one at a time, because that is what the loop does and a concurrent sweep would
-    /// measure how many cores this Mac has rather than what the loop costs.
+    /// runs it: `DiffRefreshSchedule.width` at a time, read from the same constant the loop reads
+    /// so the two cannot drift. It was one at a time here because the loop was one at a time; a
+    /// probe that keeps a width the loop no longer has measures a loop nobody runs.
     private static func pass(_ trees: [String]) async -> Pass {
         let spawnsBefore = Shell.spawnCount
         let cpuBefore = ProcessCPU.read()
         let wallBefore = CACurrentMediaTime()
 
-        for tree in trees {
-            _ = try? await Git.diffStat(worktree: tree, base: base)
+        let baseBranch = base
+        await withTaskGroup(of: Void.self) { group in
+            var next = trees.startIndex
+            var running = 0
+            while next < trees.endIndex || running > 0 {
+                while running < DiffRefreshSchedule.width, next < trees.endIndex {
+                    let tree = trees[next]
+                    next = trees.index(after: next)
+                    running += 1
+                    group.addTask { _ = try? await Git.diffStat(worktree: tree, base: baseBranch) }
+                }
+                guard await group.next() != nil else { break }
+                running -= 1
+            }
         }
 
         return Pass(

--- a/Sources/Bloom/State/AppModel.swift
+++ b/Sources/Bloom/State/AppModel.swift
@@ -764,23 +764,45 @@ final class AppModel {
         let present = Set(workspaces.map(\.id))
         lastDiffRefresh = lastDiffRefresh.filter { present.contains($0.key) }
 
-        var refreshed: Set<WorkspaceID> = []
-        for workspace in workspaces where due.contains(workspace.id) {
-            guard !Task.isCancelled else { return refreshed }
+        let pending = workspaces.filter {
             // A worktree that has been removed outside Bloom would make git walk up to the parent
             // repository and answer about the wrong tree.
-            guard FileManager.default.fileExists(atPath: workspace.path) else { continue }
-            await Self.withTimeLimit(.seconds(5)) {
-                await manager.refreshDiffStat(workspace: workspace)
+            due.contains($0.id) && FileManager.default.fileExists(atPath: $0.path)
+        }
+
+        var refreshed: Set<WorkspaceID> = []
+        await withTaskGroup(of: WorkspaceID.self) { group in
+            var next = pending.startIndex
+            var running = 0
+            while next < pending.endIndex || running > 0 {
+                while running < DiffRefreshSchedule.width, next < pending.endIndex {
+                    let workspace = pending[next]
+                    next = pending.index(after: next)
+                    running += 1
+                    // The deadline stays around each worktree rather than around the group, so one
+                    // git blocked on an `index.lock` costs its own slot and nobody else's.
+                    group.addTask {
+                        await Self.withTimeLimit(.seconds(5)) {
+                            await manager.refreshDiffStat(workspace: workspace)
+                        }
+                        return workspace.id
+                    }
+                }
+                guard let id = await group.next() else { break }
+                running -= 1
+                // After the pass rather than before it, so a workspace whose git call took four
+                // seconds is not immediately due again on the next tick.
+                lastDiffRefresh[id] = Date()
+                // And it has now been asked about, so the watcher's report is spent. Anything that
+                // happened WHILE the pass ran is a fresh event and lands back in here behind us,
+                // which is the right answer: the numbers this pass read are already a moment old.
+                changedWorkspaceIDs.remove(id)
+                refreshed.insert(id)
+                if Task.isCancelled {
+                    group.cancelAll()
+                    break
+                }
             }
-            // After the pass rather than before it, so a workspace whose git call took four
-            // seconds is not immediately due again on the next tick.
-            lastDiffRefresh[workspace.id] = Date()
-            // And it has now been asked about, so the watcher's report is spent. Anything that
-            // happened WHILE the pass ran is a fresh event and lands back in here behind us, which
-            // is the right answer: the numbers this pass read are already a moment old.
-            changedWorkspaceIDs.remove(workspace.id)
-            refreshed.insert(workspace.id)
         }
         // Nothing is read back here. `Store.updateDiffStat` only writes when one of the three
         // numbers has actually moved, and a write that happens publishes itself, so the sidebar is
@@ -794,7 +816,10 @@ final class AppModel {
     /// agent commits, would otherwise stall the refresh loop for every workspace forever.
     /// Cancellation reaches the subprocess itself: `Shell.run` terminates it when its task is
     /// cancelled.
-    private static func withTimeLimit(
+    ///
+    /// `nonisolated` because the pass calls it from a task group child now. Left on the main
+    /// actor it would hop back for the group's own bookkeeping, once per worktree, for nothing.
+    private nonisolated static func withTimeLimit(
         _ limit: Duration,
         _ work: @escaping @Sendable () async -> Void
     ) async {

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -903,22 +903,30 @@ final class WorkspaceModel {
 
         let task = Task.detached(priority: .userInitiated) { () -> Result<ChangesAnswer, GitFailure> in
             do {
-                let files = try await Git.changedFiles(worktree: path, base: base, scope: scope)
+                // All three together rather than one after another. They ask three different
+                // questions of the same worktree and none of them reads another's answer, so
+                // running them in sequence only ever made the switch longer. `Git.baseline`, which
+                // the first and the third both open with, coalesces so that starting them at once
+                // does not resolve the merge base twice. See `BaselineCache`.
+                //
                 // In the same task as the file list rather than on a cadence of its own. The one
                 // extra command is `status --porcelain -z --branch`, which answers uncommitted,
-                // untracked and unpushed at once, so the poll that already runs three git calls
-                // every six seconds runs four. Nothing stats the worktree on a redraw: the strip
-                // reads a value, and the value is only ever written here.
+                // untracked and unpushed at once. Nothing stats the worktree on a redraw: the
+                // strip reads a value, and the value is only ever written here.
                 //
                 // Failing to answer it is not a failure of the refresh. The file list is what the
                 // reader asked for; a missing local count means the strip says nothing extra,
-                // which is the right answer when we do not know.
-                let local = try? await Git.localWork(worktree: path)
-                // Same forgiveness as the local counts: failing to list the commits costs the
-                // menu its rows, not the reader their file list.
-                let commits = wantsCommits
-                    ? try? await Git.branchCommits(worktree: path, base: base)
+                // which is the right answer when we do not know. Same forgiveness for the commit
+                // list: failing to read it costs the menu its rows, not the reader their files.
+                async let filesRead = Git.changedFiles(worktree: path, base: base, scope: scope)
+                async let localRead = try? Git.localWork(worktree: path)
+                async let commitsRead: BranchCommitList? = wantsCommits
+                    ? try? Git.branchCommits(worktree: path, base: base)
                     : nil
+
+                let files = try await filesRead
+                let local = await localRead
+                let commits = await commitsRead
                 return .success(ChangesAnswer(files: files, local: local, commits: commits))
             } catch {
                 // Diagnosed rather than reported, in the register `WorkspaceStartFailure` set. A

--- a/Sources/Bloom/Views/Center/Panes/CenterTabStore.swift
+++ b/Sources/Bloom/Views/Center/Panes/CenterTabStore.swift
@@ -173,15 +173,24 @@ final class CenterTabStore {
     /// Nothing that is alive is dropped, and where that cannot be established the tab is kept. See
     /// `TerminalPersistence.sessions`.
     ///
-    /// It costs nothing on any launch after the first: with no rows left there is nothing to ask
-    /// tmux about, and the whole thing is one query that comes back empty.
+    /// It costs nothing on any launch after the first, and it is the first query that says so.
+    /// One `SELECT` over the whole table, grouped here: it used to ask once per workspace, which
+    /// on a table with no index on `workspace_id` was a full scan each, and the early-out that
+    /// was supposed to make this free came after the loop rather than before it.
     func adoptTerminalTabs(from store: Store?) async {
-        guard let store, let workspaces = try? await store.workspaces() else { return }
+        guard let store,
+              let rows = try? await store.terminalTabs(),
+              !rows.isEmpty,
+              let workspaces = try? await store.workspaces()
+        else { return }
 
+        // Rows for a workspace this app no longer has are dropped rather than adopted. The
+        // foreign key cascades, so there should be none; a tab nothing can open is not worth
+        // trusting that with.
+        let present = Set(workspaces.map(\.id))
         var rowsByWorkspace: [WorkspaceID: [TerminalTab]] = [:]
-        for workspace in workspaces {
-            let rows = (try? await store.terminalTabs(workspaceID: workspace.id)) ?? []
-            if !rows.isEmpty { rowsByWorkspace[workspace.id] = rows }
+        for row in rows where present.contains(row.workspaceID) {
+            rowsByWorkspace[row.workspaceID, default: []].append(row)
         }
         guard !rowsByWorkspace.isEmpty else { return }
 

--- a/Sources/BloomCore/Git/BaselineCache.swift
+++ b/Sources/BloomCore/Git/BaselineCache.swift
@@ -93,7 +93,16 @@ actor BaselineCache {
         var usedAt: UInt64
     }
 
+    /// The flights in progress, keyed on the fingerprint as well, because a resolve that started
+    /// before a ref moved is working out the merge base of a graph that no longer exists. Joining
+    /// it would hand back an answer for the old graph, which is the squash-merge bug again.
+    private struct Flight: Hashable {
+        let key: Key
+        let fingerprint: String
+    }
+
     private var entries: [Key: Entry] = [:]
+    private var inFlight: [Flight: Task<String, Error>] = [:]
 
     /// A counter rather than a clock, because `Date()` is not guaranteed to differ between two
     /// entries written in the same loop and an eviction that cannot order its candidates is one
@@ -122,6 +131,44 @@ actor BaselineCache {
         for (key, _) in oldest { entries[key] = nil }
     }
 
+    /// The remembered answer, or the one a caller that got here first is already working out.
+    ///
+    /// `changedFiles` and `branchCommits` both open with `baseline`, and they used to be ordered
+    /// so the second was always a hit. Run together they are two misses on a cold cache, which is
+    /// three extra processes on the workspace switch this coalescing exists to shorten.
+    ///
+    /// The task is detached rather than `Task {}`, which would inherit this actor and put the git
+    /// calls' home executor on the cache.
+    func baseline(
+        worktree: String,
+        base: String,
+        fingerprint: String,
+        resolve: @escaping @Sendable () async throws -> String
+    ) async throws -> String {
+        if let remembered = baseline(worktree: worktree, base: base, fingerprint: fingerprint) {
+            return remembered
+        }
+
+        let flight = Flight(key: Key(worktree: worktree, base: base), fingerprint: fingerprint)
+        // Nothing is awaited between the read and the write, so two callers cannot both find it
+        // empty and both start a resolve.
+        if let running = inFlight[flight] { return try await running.value }
+
+        let task = Task.detached(priority: Task.currentPriority) { try await resolve() }
+        inFlight[flight] = task
+        // Only the caller that started it clears it, and it clears it whether the resolve threw
+        // or not: an entry left behind is a worktree that can never be asked about again.
+        // Awaiting a task's value is not cancelled by the awaiting task, so this always runs.
+        defer { inFlight[flight] = nil }
+
+        let answer = try await task.value
+        remember(worktree: worktree, base: base, fingerprint: fingerprint, baseline: answer)
+        return answer
+    }
+
     /// Read by the suite, which is what pins the bound above.
     var count: Int { entries.count }
+
+    /// Read by the suite. A flight that outlives its resolve is a leak with no symptom.
+    var flights: Int { inFlight.count }
 }

--- a/Sources/BloomCore/Git/Git+Branches.swift
+++ b/Sources/BloomCore/Git/Git+Branches.swift
@@ -164,16 +164,19 @@ extension Git {
             "rebase-merge", "rebase-apply", "MERGE_HEAD",
             "CHERRY_PICK_HEAD", "REVERT_HEAD", "BISECT_LOG",
         ]
-        for marker in markers {
-            guard let result = try? await run(["rev-parse", "--git-path", marker], in: directory),
-                  result.ok else { continue }
-            let path = result.trimmed
-            guard !path.isEmpty else { continue }
+        // `rev-parse` takes `--git-path` as many times as it is given and prints one line per
+        // marker, in order, so six processes are one. It fails only for a directory that is not a
+        // repository, where all six failed anyway.
+        let arguments = ["rev-parse"] + markers.flatMap { ["--git-path", $0] }
+        guard let result = try? await run(arguments, in: directory), result.ok else { return false }
+
+        return result.lines.contains { line in
+            let path = line.trimmingCharacters(in: .whitespaces)
+            guard !path.isEmpty else { return false }
             let absolute = path.hasPrefix("/")
                 ? path
                 : (directory as NSString).appendingPathComponent(path)
-            if FileManager.default.fileExists(atPath: absolute) { return true }
+            return FileManager.default.fileExists(atPath: absolute)
         }
-        return false
     }
 }

--- a/Sources/BloomCore/Git/Git+Diffs.swift
+++ b/Sources/BloomCore/Git/Git+Diffs.swift
@@ -124,15 +124,23 @@ extension Git {
     ) async throws -> [ChangedFile] {
         let mergeBase = try await revision(for: scope, base: base, in: worktree)
 
-        let nameStatus = try await checkRaw(
+        // Three walks of the same worktree, none of which reads another's output, all three taking
+        // the merge base that is already resolved. Replaying these commands on this machine:
+        // 50.7ms serial to 18.8ms together on a fresh worktree, 99.4ms to 47.6ms on a real one.
+        // `GIT_OPTIONAL_LOCKS=0` is set on every one of them, so nothing here wants `index.lock`.
+        async let nameStatusRead = checkRaw(
             ["diff", "--name-status", "-M", "-z", mergeBase, "--"], in: worktree
         )
-        let numstat = try await checkRaw(
+        async let numstatRead = checkRaw(
             ["diff", "--numstat", "-M", "-z", mergeBase, "--"], in: worktree
         )
-        let untracked = try await checkRaw(
+        async let untrackedRead = checkRaw(
             ["ls-files", "--others", "--exclude-standard", "-z"], in: worktree
         )
+
+        let nameStatus = try await nameStatusRead
+        let numstat = try await numstatRead
+        let untracked = try await untrackedRead
 
         let changeByPath = parseNameStatus(nameStatus.stdout)
         var byPath = parseNumstat(numstat.stdout, changes: changeByPath)

--- a/Sources/BloomCore/Git/Git+Repository.swift
+++ b/Sources/BloomCore/Git/Git+Repository.swift
@@ -30,14 +30,22 @@ public extension Git {
     /// The name and address git would put on a commit made here. Either can be missing, and a
     /// commit with neither fails with a page of advice, so this is asked before anything is done.
     static func commitIdentity(in path: String) async -> (name: String?, email: String?) {
-        func value(_ key: String) async -> String? {
-            guard let result = try? await run(["config", "--get", key], in: path), result.ok else {
-                return nil
-            }
-            let trimmed = result.trimmed
-            return trimmed.isEmpty ? nil : trimmed
+        // One process rather than a `--get` each. `--get-regexp` prints `user.name <value>` per
+        // match and exits 1 when nothing matches, which is the same nothing two failed `--get`s
+        // said.
+        guard let result = try? await run(
+            ["config", "--get-regexp", "^user\\.(name|email)$"], in: path
+        ), result.ok else { return (nil, nil) }
+
+        var values: [String: String] = [:]
+        for line in result.lines {
+            guard let space = line.firstIndex(of: " ") else { continue }
+            let value = line[line.index(after: space)...]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !value.isEmpty else { continue }
+            values[String(line[..<space])] = value
         }
-        return await (value("user.name"), value("user.email"))
+        return (values["user.name"], values["user.email"])
     }
 
     /// The repository this folder sits inside, if any, found by walking up rather than by asking
@@ -67,6 +75,27 @@ public extension Git {
     static func isIgnored(_ relativePath: String, in repo: String) async -> Bool {
         let result = try? await run(["check-ignore", "--quiet", "--", relativePath], in: repo)
         return result?.ok ?? false
+    }
+
+    /// Which of these paths the repository's own ignore rules already cover.
+    ///
+    /// `check-ignore -z --stdin` takes the whole list at once and prints back the ones that match,
+    /// so a folder with thirty candidates costs one process instead of thirty. On stdin rather
+    /// than as arguments for the reason `safetyReport` feeds refs the same way: a long list would
+    /// pass the argument limit, and a name beginning with a dash cannot be read as an option.
+    ///
+    /// Exit 1 is "none matched" rather than a failure. Anything else is git failing to answer,
+    /// and that reads as not ignored, which is the same way round `isIgnored` had it: Bloom writes
+    /// the rule rather than assuming a file it cannot check is already covered.
+    static func ignoredPaths(among paths: [String], in repo: String) async -> Set<String> {
+        guard !paths.isEmpty else { return [] }
+        guard let result = try? await run(
+            ["check-ignore", "-z", "--stdin"],
+            in: repo,
+            stdin: paths.joined(separator: "\0") + "\0"
+        ), result.status == 0 || result.status == 1 else { return [] }
+
+        return Set(result.stdout.split(separator: "\0").map(String.init))
     }
 
     static func stageAll(in repo: String) async throws {

--- a/Sources/BloomCore/Git/Git+Safety.swift
+++ b/Sources/BloomCore/Git/Git+Safety.swift
@@ -274,6 +274,7 @@ extension Git {
         // entirely: git could not be asked, and every field below would be a zero standing in for
         // an answer nobody has. `isSafeToDiscard` would read that as "nothing at stake" and let
         // the worktree be deleted, so it throws instead, and the caller shows the reason.
+        var isDetached = false
         if FileManager.default.fileExists(atPath: worktree) {
             guard await isRepository(worktree) else {
                 throw ShellError(
@@ -285,15 +286,22 @@ extension Git {
             let status = try await checkRaw(["status", "--porcelain", "-z"], in: worktree)
             (report.hasUncommittedChanges, report.untrackedFiles) = parseStatus(status.stdout)
             report.modifiedIgnoredFiles = try await divergentIgnoredFiles(worktree: worktree, repo: repo)
-            report.detachedCommits = try await detachedCommitCount(worktree: worktree, repo: repo)
+            isDetached = try await isDetachedHead(worktree: worktree)
         }
 
-        guard await branchExists(branch, in: repo) else { return report }
+        let branchIsThere = await branchExists(branch, in: repo)
+        guard isDetached || branchIsThere else { return report }
 
-        let refs = try await check(
-            ["for-each-ref", "--format=%(refname)", "refs/heads", "refs/remotes", "refs/tags"],
-            in: repo
-        ).lines
+        // One ref walk for both counts. A detached worktree used to walk every head, remote and
+        // tag here and again inside `detachedCommitCount`, which on a repository with thousands
+        // of tags is the expensive call in this whole report.
+        let refs = try await allRefs(in: repo)
+
+        if isDetached {
+            report.detachedCommits = try await detachedCommitCount(worktree: worktree, excluding: refs)
+        }
+        guard branchIsThere else { return report }
+
         // Feeding the other refs in on stdin rather than as arguments, because a repository with
         // thousands of tags would otherwise blow past the argument limit.
         let negated = refs
@@ -439,19 +447,27 @@ extension Git {
         return false
     }
 
-    /// Commits reachable from the worktree's own HEAD and from no ref anywhere.
-    ///
-    /// Zero unless HEAD is detached, which is what happens when an agent runs `git checkout` in
-    /// its worktree. Those commits are held only by the per-worktree reflog, which
-    /// `git worktree remove` deletes.
-    static func detachedCommitCount(worktree: String, repo: String) async throws -> Int {
+    /// Whether HEAD here is a commit rather than a branch, which is what an agent running
+    /// `git checkout` in its worktree leaves behind.
+    static func isDetachedHead(worktree: String) async throws -> Bool {
         let head = try await run(["symbolic-ref", "--quiet", "HEAD"], in: worktree)
-        guard !head.ok else { return 0 }
+        return !head.ok
+    }
 
-        let refs = try await check(
+    /// Every ref in the repository, which is the walk `safetyReport` pays for once and hands to
+    /// both counts below.
+    static func allRefs(in repo: String) async throws -> [String] {
+        try await check(
             ["for-each-ref", "--format=%(refname)", "refs/heads", "refs/remotes", "refs/tags"],
             in: repo
         ).lines
+    }
+
+    /// Commits reachable from the worktree's own detached HEAD and from no ref anywhere. Those
+    /// commits are held only by the per-worktree reflog, which `git worktree remove` deletes.
+    ///
+    /// Only ever asked of a detached HEAD: on a branch the answer is zero by construction.
+    static func detachedCommitCount(worktree: String, excluding refs: [String]) async throws -> Int {
         let negated = refs.map { "^\($0)" }.joined(separator: "\n")
         let unique = try await run(
             ["rev-list", "--count", "--stdin", "HEAD"],

--- a/Sources/BloomCore/Git/Git.swift
+++ b/Sources/BloomCore/Git/Git.swift
@@ -303,21 +303,17 @@ public enum Git {
     public static func baseline(_ base: String, in worktree: String) async throws -> String {
         try validate(ref: base, label: "base branch")
 
-        let refs = await refPositions(base, in: worktree)
-        if let refs,
-           let remembered = await BaselineCache.shared.baseline(
-               worktree: worktree, base: base, fingerprint: refs
-           ) {
-            return remembered
+        // No fingerprint means git could not be asked, so there is nothing to remember it under
+        // and nothing to join: every such call resolves on its own.
+        guard let refs = await refPositions(base, in: worktree) else {
+            return try await resolveBaseline(base, in: worktree)
         }
 
-        let answer = try await resolveBaseline(base, in: worktree)
-        if let refs {
-            await BaselineCache.shared.remember(
-                worktree: worktree, base: base, fingerprint: refs, baseline: answer
-            )
+        return try await BaselineCache.shared.baseline(
+            worktree: worktree, base: base, fingerprint: refs
+        ) {
+            try await resolveBaseline(base, in: worktree)
         }
-        return answer
     }
 
     /// Where the three refs are now, as one string. Nil when git could not be asked at all, which

--- a/Sources/BloomCore/GitHub/GitHub.swift
+++ b/Sources/BloomCore/GitHub/GitHub.swift
@@ -101,7 +101,9 @@ private struct CheckPayload: Decodable {
     }
 }
 
-private struct PullRequestSnapshot: Sendable {
+/// Internal rather than private: the pull request and its check runs come out of one
+/// `gh pr view`, and `GitHub.checks(for:)` next door needs both halves of the same payload.
+struct PullRequestSnapshot: Sendable {
     let pullRequest: PullRequest
     let runs: [CheckRun]
 }
@@ -182,14 +184,6 @@ public enum GitHub {
         maxAge: Duration = .zero
     ) async throws -> PullRequest? {
         try await snapshot(forBranch: branch, worktree: worktree, maxAge: maxAge)?.pullRequest
-    }
-
-    public static func checks(
-        forBranch branch: String,
-        worktree: String,
-        maxAge: Duration = .zero
-    ) async throws -> [CheckRun] {
-        try await snapshot(forBranch: branch, worktree: worktree, maxAge: maxAge)?.runs ?? []
     }
 
     /// This seam makes gh version differences testable without a repository or network access.
@@ -347,7 +341,7 @@ public enum GitHub {
         stderr.localizedCaseInsensitiveContains("no pull requests found")
     }
 
-    private static func snapshot(
+    static func snapshot(
         forBranch branch: String,
         worktree: String,
         maxAge: Duration

--- a/Sources/BloomCore/GitHub/PullRequestOwnership.swift
+++ b/Sources/BloomCore/GitHub/PullRequestOwnership.swift
@@ -97,17 +97,10 @@ public extension GitHub {
     private static func pullRequest(
         for workspace: Workspace, onBranch head: String, maxAge: Duration
     ) async throws -> PullRequest? {
-        guard let found = try await pullRequest(
+        guard let found = try await snapshot(
             forBranch: head, worktree: workspace.path, maxAge: maxAge
-        ) else { return nil }
-
-        let checkedOut = await Git.checkedOutPullRequest(
-            branch: head, worktree: workspace.path
-        )
-        guard PullRequestOwnership.belongs(
-            found, toWorkspaceStartedAt: workspace.createdAt, checkedOutAs: checkedOut
-        ) else { return nil }
-        return found
+        ), await owns(found.pullRequest, workspace: workspace, onBranch: head) else { return nil }
+        return found.pullRequest
     }
 
     /// This workspace's checks, which are the checks of this workspace's pull request.
@@ -115,12 +108,27 @@ public extension GitHub {
     /// The same gate, because they come out of the same `gh pr view`: a rollup drawn for a pull
     /// request that merged before this workspace existed is a green tick over work nobody has run
     /// anything against.
+    ///
+    /// One snapshot, not two. Asking for the pull request and then for the checks landed on the
+    /// same cache key, and `maxAge` is zero for the only caller, which never hits, so the Checks
+    /// tab made two identical `gh pr view` round trips every twenty seconds and threw one payload
+    /// away.
     static func checks(for workspace: Workspace, maxAge: Duration = .zero) async throws -> [CheckRun] {
         // The same branch both times, or the rollup is read for one branch and gated on another.
         let head = await headBranch(of: workspace)
-        guard try await pullRequest(for: workspace, onBranch: head, maxAge: maxAge) != nil else {
-            return []
-        }
-        return try await checks(forBranch: head, worktree: workspace.path, maxAge: maxAge)
+        guard let found = try await snapshot(
+            forBranch: head, worktree: workspace.path, maxAge: maxAge
+        ), await owns(found.pullRequest, workspace: workspace, onBranch: head) else { return [] }
+        return found.runs
+    }
+
+    /// Whether the pull request gh found under this branch name is this workspace's.
+    private static func owns(
+        _ pullRequest: PullRequest, workspace: Workspace, onBranch head: String
+    ) async -> Bool {
+        let checkedOut = await Git.checkedOutPullRequest(branch: head, worktree: workspace.path)
+        return PullRequestOwnership.belongs(
+            pullRequest, toWorkspaceStartedAt: workspace.createdAt, checkedOutAs: checkedOut
+        )
     }
 }

--- a/Sources/BloomCore/Persistence/Store.swift
+++ b/Sources/BloomCore/Persistence/Store.swift
@@ -2511,10 +2511,13 @@ public actor Store {
 
     // MARK: - Terminal tabs
 
-    public func terminalTabs(workspaceID: WorkspaceID) throws -> [TerminalTab] {
+    /// Every row, because the one caller left is the migration that drains the table and it wants
+    /// all of them. Per workspace, it was a query each and `terminal_tabs` has no index on
+    /// `workspace_id`, so each was a full scan. Nothing is indexed instead: after the migration
+    /// the table is empty, and the only other statement here is keyed on the primary key.
+    public func terminalTabs() throws -> [TerminalTab] {
         try db.query(
-            "SELECT * FROM terminal_tabs WHERE workspace_id = ? ORDER BY sort_order",
-            [.text(workspaceID)]
+            "SELECT * FROM terminal_tabs ORDER BY workspace_id, sort_order"
         ).map {
             TerminalTab(
                 id: TerminalTabID($0.string("id") ?? newID()),

--- a/Sources/BloomCore/Presentation/DiffRefreshSchedule.swift
+++ b/Sources/BloomCore/Presentation/DiffRefreshSchedule.swift
@@ -42,6 +42,19 @@ public enum DiffRefreshSchedule {
     /// How often the loop wakes.
     public static let tick: TimeInterval = 6
 
+    /// How many worktrees a pass asks git about at once.
+    ///
+    /// The pass used to be strictly one at a time, over worktrees that share no state until the
+    /// `Store` write and that `GIT_OPTIONAL_LOCKS=0` keeps out of each other's `index.lock`. What
+    /// this moves is the wall time of a pass, not the 651ms of process time above: the same trade
+    /// `changedFiles` makes with its three reads inside one worktree.
+    ///
+    /// Capped rather than unbounded because `Shell.run` puts two reader threads with 512KB stacks
+    /// behind every process, so fanning out over a 27 project sidebar would be around 200 blocked
+    /// threads. It is here rather than in the loop so `IdleProbe` measures the width the loop
+    /// actually uses.
+    public static let width = 4
+
     /// How stale a workspace nothing is writing to is allowed to get.
     ///
     /// **Five minutes rather than one, because this is no longer how a change is noticed.**

--- a/Sources/BloomCore/Workspace/RepositoryStarter.swift
+++ b/Sources/BloomCore/Workspace/RepositoryStarter.swift
@@ -595,13 +595,13 @@ public enum RepositoryStarter {
     ) async throws -> (files: Int, excluded: [ExcludedPath], unsigned: Bool) {
         let contents = scan(folder)
 
-        var written: [ExcludedPath] = []
-        for candidate in contents.excluded {
-            // Already covered by a `.gitignore` the user wrote. Adding a duplicate line would be
-            // Bloom editing a file it had no reason to touch.
-            if await Git.isIgnored(candidate.path, in: folder) { continue }
-            written.append(candidate)
-        }
+        // What a `.gitignore` the user wrote already covers, asked for all of them in one
+        // `check-ignore` rather than one process per candidate. Adding a duplicate line would be
+        // Bloom editing a file it had no reason to touch.
+        let alreadyIgnored = await Git.ignoredPaths(
+            among: contents.excluded.map(\.path), in: folder
+        )
+        let written = contents.excluded.filter { !alreadyIgnored.contains($0.path) }
         if !written.isEmpty { try appendGitignore(written, in: folder) }
 
         try await Git.stageAll(in: folder)

--- a/Tests/BloomCoreTests/BaselineCacheTests.swift
+++ b/Tests/BloomCoreTests/BaselineCacheTests.swift
@@ -8,7 +8,8 @@ import Testing
 /// remembered one moment too long is the squash-merge bug in `BaselineTests` all over again, with
 /// every merged file shown as this workspace's work. So the two things worth pinning are that the
 /// key changes whenever any ref moves, and that an answer is only ever handed back for a key that
-/// matched exactly.
+/// matched exactly. The third is the coalescing: two callers arriving together resolve once, and
+/// a caller whose refs have moved does not join the flight it invalidated.
 @Suite("The remembered base of a workspace diff")
 struct BaselineCacheTests {
     private let head = "1111111111111111111111111111111111111111"
@@ -83,6 +84,181 @@ struct BaselineCacheTests {
         #expect(await cache.baseline(worktree: "/w", base: "main", fingerprint: "a") == nil)
         #expect(await cache.baseline(worktree: "/w", base: "main", fingerprint: "b") == remote)
     }
+
+    // MARK: - One resolve at a time
+
+    /// Two callers arriving together used to be two misses and two merge-base resolves, which is
+    /// three extra git processes on the workspace switch. `changedFiles` and `branchCommits` are
+    /// exactly that pair now that they run together.
+    @Test("callers arriving together resolve once")
+    func joinsOneFlight() async throws {
+        let cache = BaselineCache()
+        let gate = Gate()
+
+        async let first = cache.baseline(worktree: "/w", base: "main", fingerprint: "a") {
+            await gate.arrive()
+            return self.local
+        }
+        // Held inside its resolve, so the flight is registered and cannot have finished.
+        await gate.waitForArrivals(1)
+
+        async let second = cache.baseline(worktree: "/w", base: "main", fingerprint: "a") {
+            await gate.arrive()
+            return self.remote
+        }
+        await gate.open()
+
+        let firstAnswer = try await first
+        let secondAnswer = try await second
+        #expect(firstAnswer == local)
+        #expect(secondAnswer == local)
+        #expect(await gate.calls == 1)
+    }
+
+    /// The flight is keyed on the fingerprint as well as the worktree, because a resolve that
+    /// started before a ref moved is answering about a graph that no longer exists. Joining it
+    /// would be the squash-merge bug arriving through the back door.
+    @Test("a ref that moves mid-flight does not join the flight it invalidated", .timeLimit(.minutes(1)))
+    func doesNotJoinAStaleFlight() async throws {
+        let cache = BaselineCache()
+        let gate = Gate()
+
+        async let before = cache.baseline(worktree: "/w", base: "main", fingerprint: "a") {
+            await gate.arrive()
+            return self.local
+        }
+        async let after = cache.baseline(worktree: "/w", base: "main", fingerprint: "b") {
+            await gate.arrive()
+            return self.remote
+        }
+        // Both resolves have to run, or the second is being handed the first one's answer.
+        await gate.waitForArrivals(2)
+        await gate.open()
+
+        let beforeAnswer = try await before
+        let afterAnswer = try await after
+        #expect(beforeAnswer == local)
+        #expect(afterAnswer == remote)
+        #expect(await gate.calls == 2)
+    }
+
+    @Test("an answer already remembered is not resolved again")
+    func hitSkipsTheResolve() async throws {
+        let cache = BaselineCache()
+        let gate = Gate()
+        await gate.open()
+        await cache.remember(worktree: "/w", base: "main", fingerprint: "a", baseline: local)
+
+        let answer = try await cache.baseline(worktree: "/w", base: "main", fingerprint: "a") {
+            await gate.arrive()
+            return self.remote
+        }
+
+        #expect(answer == local)
+        #expect(await gate.calls == 0)
+    }
+
+    @Test("what a flight resolved is remembered for the next caller")
+    func remembersWhatItResolved() async throws {
+        let cache = BaselineCache()
+        let gate = Gate()
+        await gate.open()
+
+        _ = try await cache.baseline(worktree: "/w", base: "main", fingerprint: "a") {
+            await gate.arrive()
+            return self.local
+        }
+        let again = try await cache.baseline(worktree: "/w", base: "main", fingerprint: "a") {
+            await gate.arrive()
+            return self.remote
+        }
+
+        #expect(again == local)
+        #expect(await gate.calls == 1)
+    }
+
+    /// An entry left behind is a worktree that can never be asked about again, and nothing would
+    /// report it: the app would simply stop noticing that one workspace's diff had changed.
+    @Test("a finished flight leaves nothing behind")
+    func clearsTheFlight() async throws {
+        let cache = BaselineCache()
+        let gate = Gate()
+        await gate.open()
+
+        _ = try await cache.baseline(worktree: "/w", base: "main", fingerprint: "a") {
+            await gate.arrive()
+            return self.local
+        }
+
+        #expect(await cache.flights == 0)
+    }
+
+    @Test("a resolve that throws is not remembered and leaves nothing behind")
+    func doesNotRememberAFailure() async throws {
+        let cache = BaselineCache()
+        let gate = Gate()
+        await gate.open()
+
+        await #expect(throws: Boom.self) {
+            _ = try await cache.baseline(worktree: "/w", base: "main", fingerprint: "a") {
+                await gate.arrive()
+                throw Boom()
+            }
+        }
+
+        #expect(await cache.flights == 0)
+        #expect(await cache.baseline(worktree: "/w", base: "main", fingerprint: "a") == nil)
+
+        let answer = try await cache.baseline(worktree: "/w", base: "main", fingerprint: "a") {
+            await gate.arrive()
+            return self.local
+        }
+        #expect(answer == local)
+        #expect(await gate.calls == 2)
+    }
+
+    private struct Boom: Error {}
+
+    /// A resolve that can be held open, so a second caller can be let in while the first is still
+    /// running. Counting alone would not do it: a caller that arrives after the first has finished
+    /// is a cache hit, which looks exactly like a caller that joined.
+    private actor Gate {
+        private(set) var calls = 0
+        private var isOpen = false
+        private var held: [CheckedContinuation<Void, Never>] = []
+        private var watchers: [(needed: Int, continuation: CheckedContinuation<Void, Never>)] = []
+
+        /// One run of the resolve: counted, then held until `open`.
+        func arrive() async {
+            calls += 1
+            let reached = calls
+            watchers.removeAll { watcher in
+                guard reached >= watcher.needed else { return false }
+                watcher.continuation.resume()
+                return true
+            }
+            guard !isOpen else { return }
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                held.append(continuation)
+            }
+        }
+
+        func waitForArrivals(_ needed: Int) async {
+            guard calls < needed else { return }
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                watchers.append((needed: needed, continuation: continuation))
+            }
+        }
+
+        func open() {
+            isOpen = true
+            let waiting = held
+            held = []
+            for continuation in waiting { continuation.resume() }
+        }
+    }
+
+    // MARK: - The bound
 
     /// Keyed on a path, and paths are created and archived all day. Unbounded would be a leak
     /// with a slow fuse rather than a bug anybody would notice.


### PR DESCRIPTION
Every workspace click ran five independent git processes one after another: three inside `Git.changedFiles` and then `localWork` and `branchCommits`. None reads another's output and all take the already-resolved merge base. Replaying the exact commands on this machine: 50.7ms to 18.8ms on one worktree, 99.4ms to 47.6ms on a real one.

The trap in doing that is the merge base. `branchCommits` resolves it again, and today it hits the cache because it runs second, so running them together would miss twice and put three extra processes on the path being shortened. `BaselineCache` now coalesces in flight, with the fingerprint in the flight key: a resolve that started before a ref moved is computing the merge base of a graph that no longer exists, and joining it would be the squash-merge bug through the back door. Six tests, including one with a time limit so a regression fails rather than hangs.

The diff stat refresh ran its worktrees one at a time. It is a task group four wide now, with the cap deliberate: the shell spawns two threads per process, so unbounded fan-out over a 27 project sidebar is about 200 blocked threads. The five second limit stays around each child, not the group. The width lives in `DiffRefreshSchedule` because `IdleProbe` documents itself as running the pass exactly as the app does, and leaving it serial would have made the probe measure a loop nobody runs.

The Checks tab made two identical `gh pr view` calls every twenty seconds and threw one payload away, because the cache returns nil for a zero max age and both halves ask for the same snapshot on the same key. One call now.

Adopting terminal tabs was one query per workspace against a table with no index on the column, every launch, awaited before the window was usable, under a comment claiming it was a single query. One query, grouped in memory. No index: the migration drains that table, so it is empty after the first launch.

Three loops became one process each: `rev-parse` takes repeated `--git-path`, `check-ignore` takes every path on stdin, and `config --get-regexp` takes both keys. All three verified against real git on this machine.