### PR TITLE
Prepare a transcript before the table asks for it

### DIFF
--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -276,9 +276,18 @@ final class TranscriptModel {
 
         rows = built.rows
         indexByRefID = built.index
-        // Stays on the main actor, because it reads `TranscriptEventCache` and that cache is the
-        // main actor's. It can afford to: it walks backwards and stops as soon as it has both
-        // numbers, which is within a few rows of the end whatever the session's length.
+
+        // The parsing every row of the window is about to want, done now and off this thread. See
+        // `TranscriptPrime`, which is where the whole argument for it is. Nothing cancels it: it
+        // is one window of a session that has just been asked for, at `.utility`, and a handle
+        // nobody would ever call `cancel` on is bookkeeping.
+        let unread = firstUnreadSeq
+        Task.detached(priority: .utility) { [rows = built.rows, worktree = workspace.path] in
+            await TranscriptPrime.run(rows: rows, worktree: worktree, unreadSeq: unread)
+        }
+
+        // Stays on the main actor, and can afford to: it walks backwards and stops as soon as it
+        // has both numbers, which is within a few rows of the end whatever the session's length.
         //
         // The one place the whole list is walked, because it is also the one place there is a
         // whole list to walk. Everything after this folds in what arrived. Nothing is held from

--- a/Sources/Bloom/Views/Markdown/CodeBlockView.swift
+++ b/Sources/Bloom/Views/Markdown/CodeBlockView.swift
@@ -149,11 +149,19 @@ private final class CodeBlockPreparation {
 ///
 /// Code and language are both exact key fields because either can change line boundaries and the
 /// lexer state carried into every following line.
-@MainActor
 private enum CodeBlockPreparationCache {
-    private static let values: NSCache<CodeBlockPreparationKey, CodeBlockPreparation> = {
+    /// **Bounded by bytes, not by fences**, which is the conclusion `TranscriptEventCache` reached
+    /// and this never revisited. It was 80, which is a screen of them rather than a session: one
+    /// scroll up a long transcript evicted every settled fence and re-split and re-carried all of
+    /// them on the way back. The eight megabytes below is what was already doing the bounding.
+    ///
+    /// `nonisolated(unsafe)` for `SyntaxCache`'s reason and on the same two legs: `NSCache` does
+    /// its own locking, and a `CodeBlockPreparation` is a `final class` holding two `let`s of
+    /// `Sendable` value types, so nothing a reader gets out of it can be written by anybody. The
+    /// key is immutable in the same way.
+    nonisolated(unsafe) private static let values: NSCache<CodeBlockPreparationKey, CodeBlockPreparation> = {
         let cache = NSCache<CodeBlockPreparationKey, CodeBlockPreparation>()
-        cache.countLimit = 80
+        cache.countLimit = 0
         cache.totalCostLimit = 8 * 1_024 * 1_024
         return cache
     }()
@@ -161,20 +169,26 @@ private enum CodeBlockPreparationCache {
     /// The live tail's fence gets a cache of exactly one entry rather than a share of the one
     /// above, for the reason `MarkdownParseCache` wrote down for prose: a growing fence is one
     /// new prefix per delta, each seen for milliseconds and never again, and put through
-    /// `values` a single streamed answer evicted every settled block's preparation, so the
-    /// visible finished fences re-split and re-ran `CarryPass` on their next redraw.
-    private static var streamed: (code: String, language: Language, value: CodeBlockPreparation)?
+    /// `values` a single streamed answer filled it with prefixes nobody will ask for again, so
+    /// the visible finished fences re-split and re-ran `CarryPass` on their next redraw.
+    ///
+    /// **The main actor's, and it stays there.** `values` is an `NSCache` and does its own
+    /// locking; this is a plain `var`, so it is the one thing here a preparation pass may not
+    /// touch. Nothing off the main actor has a live tail to draw anyway.
+    @MainActor private static var streamed: (code: String, language: Language, value: CodeBlockPreparation)?
 
-    static func prepared(code: String, language: Language, isStreaming: Bool) -> CodeBlockPreparation {
-        if isStreaming {
-            if let streamed, streamed.code == code, streamed.language == language {
-                return streamed.value
-            }
-            let value = compute(code: code, language: language)
-            streamed = (code, language, value)
-            return value
+    @MainActor static func prepared(code: String, language: Language, isStreaming: Bool) -> CodeBlockPreparation {
+        guard isStreaming else { return settled(code: code, language: language) }
+        if let streamed, streamed.code == code, streamed.language == language {
+            return streamed.value
         }
+        let value = compute(code: code, language: language)
+        streamed = (code, language, value)
+        return value
+    }
 
+    /// The settled cache alone, which is the half a preparation pass off the main actor may fill.
+    static func settled(code: String, language: Language) -> CodeBlockPreparation {
         let key = CodeBlockPreparationKey(code: code, language: language)
         if let cached = values.object(forKey: key) { return cached }
         let value = compute(code: code, language: language)
@@ -188,5 +202,15 @@ private enum CodeBlockPreparationCache {
             lines: lines,
             carries: CarryPass.states(for: lines, language: language)
         )
+    }
+}
+
+/// Splitting and carrying a settled fence before anything asks for it. See `TranscriptPrime`.
+///
+/// A function rather than the cache widened, for `MarkdownPrime`'s reason: what the cache holds is
+/// this file's own type and there is nothing to hand out.
+enum CodeBlockPrime {
+    static func prepare(code: String, language: Language) {
+        _ = CodeBlockPreparationCache.settled(code: code, language: language)
     }
 }

--- a/Sources/Bloom/Views/Markdown/MarkdownView.swift
+++ b/Sources/Bloom/Views/Markdown/MarkdownView.swift
@@ -26,15 +26,26 @@ private final class MarkdownBlockBox: NSObject {
     }
 }
 
-@MainActor
 private enum MarkdownParseCache {
-    static let values: NSCache<NSString, MarkdownBlockBox> = {
+    /// **Bounded by bytes, not by rows**, which is the conclusion `TranscriptEventCache` reached
+    /// and this never revisited. It was 160, and the workspace those measurements were taken
+    /// against holds 1,306 messages, so one scroll from the bottom to the top evicted every
+    /// answer in it and re-parsed all of them on the way back. The eight megabytes below is what
+    /// was already doing the bounding.
+    ///
+    /// `nonisolated(unsafe)` for `SyntaxCache`'s reason and on the same two legs: `NSCache` does
+    /// its own locking, and every value in it is a `final class` holding two `let`s of `Sendable`
+    /// value types, so nothing a reader gets out of it can be written by anybody. The keys are
+    /// bridged `NSString`s, which are immutable too.
+    nonisolated(unsafe) static let values: NSCache<NSString, MarkdownBlockBox> = {
         let cache = NSCache<NSString, MarkdownBlockBox>()
-        cache.countLimit = 160
+        cache.countLimit = 0
         cache.totalCostLimit = 8 * 1_024 * 1_024
         return cache
     }()
 
+    /// A settled answer, parsed once. Nonisolated so a preparation pass can fill this before the
+    /// table asks: see `MarkdownPrime`, and `TranscriptPrime` for why the values are safe to share.
     static func parsed(for text: String) -> MarkdownBlockBox {
         let key = text as NSString
         if let cached = values.object(forKey: key) { return cached }
@@ -46,21 +57,36 @@ private enum MarkdownParseCache {
     /// The live tail gets a cache of exactly one entry rather than a share of the one above.
     ///
     /// Streaming an answer produces one prefix per token, every one of them seen for a few
-    /// milliseconds and never again. Put through `values`, which holds 160 entries, a single
-    /// streamed answer would evict every finished row in it and leave the visible transcript
-    /// re-parsing settled prose on its next redraw. One entry is still worth keeping, because
-    /// SwiftUI is free to evaluate a body more than once for the same value.
+    /// milliseconds and never again. Put through `values` they would be eight megabytes of
+    /// prefixes nobody will ask for again, evicting every finished row and leaving the visible
+    /// transcript re-parsing settled prose on its next redraw. One entry is still worth keeping,
+    /// because SwiftUI is free to evaluate a body more than once for the same value.
+    ///
+    /// **The main actor's, and it stays there.** `values` is an `NSCache` and does its own
+    /// locking; this is a plain `var`, so it is the one thing here a preparation pass may not
+    /// touch. Nothing off the main actor has a live tail to draw anyway.
     ///
     /// The addresses in this one are always empty, and that is not an omission: a run that is
     /// still arriving offers none, so there is nothing for the walk to find and nothing yet worth
     /// finding. See `MarkdownView.body`.
-    private static var streamed: (text: String, box: MarkdownBlockBox)?
+    @MainActor private static var streamed: (text: String, box: MarkdownBlockBox)?
 
-    static func streamingParsed(for text: String) -> MarkdownBlockBox {
+    @MainActor static func streamingParsed(for text: String) -> MarkdownBlockBox {
         if let streamed, streamed.text == text { return streamed.box }
         let box = MarkdownBlockBox(MarkdownParser.parse(text), addresses: [])
         streamed = (text, box)
         return box
+    }
+}
+
+/// Parsing a settled answer before anything asks for it. See `TranscriptPrime`.
+///
+/// A function rather than the cache widened, because `MarkdownBlockBox` is this file's and the
+/// blocks inside it are the core's. The blocks come back so the caller can prime the fences in
+/// them.
+enum MarkdownPrime {
+    static func blocks(of text: String) -> [MarkdownBlock] {
+        MarkdownParseCache.parsed(for: text).blocks
     }
 }
 

--- a/Sources/Bloom/Views/Transcript/TranscriptEventCache.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptEventCache.swift
@@ -5,7 +5,6 @@ import BloomCore
 ///
 /// The payload bytes are part of the key alongside the row ID because an updated store row may
 /// retain its identity. Exact byte equality prevents a cached event from surviving that change.
-@MainActor
 enum TranscriptEventCache {
     /// **Bounded by bytes, not by rows.** `countLimit` was 256, and a real transcript is longer
     /// than that: the workspace this was measured against holds 1,306 messages, so one scroll from
@@ -31,14 +30,20 @@ enum TranscriptEventCache {
     private static let limit = 0
     private static let costLimit = 8 * 1_024 * 1_024
 
-    private static let events: NSCache<TranscriptPayloadKey, TranscriptEventBox> = {
+    /// **Both of these are shared, and both are safe to share.** `NSCache` does its own locking,
+    /// which is half of it; the other half is that a `TranscriptEventBox` and a
+    /// `TranscriptJSONBox` are `final class`es holding one `let` of a `Sendable` enum, and
+    /// `TranscriptPayloadKey` is immutable in the same way. Nothing a reader gets out of here can
+    /// be written by anybody, which is what lets `TranscriptPrime` fill them off the main actor
+    /// while the table reads them on it.
+    nonisolated(unsafe) private static let events: NSCache<TranscriptPayloadKey, TranscriptEventBox> = {
         let cache = NSCache<TranscriptPayloadKey, TranscriptEventBox>()
         cache.countLimit = limit
         cache.totalCostLimit = costLimit
         return cache
     }()
 
-    private static let jsonValues: NSCache<TranscriptPayloadKey, TranscriptJSONBox> = {
+    nonisolated(unsafe) private static let jsonValues: NSCache<TranscriptPayloadKey, TranscriptJSONBox> = {
         let cache = NSCache<TranscriptPayloadKey, TranscriptJSONBox>()
         cache.countLimit = limit
         cache.totalCostLimit = costLimit

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -308,11 +308,13 @@ struct TranscriptListView: View {
         var out: [TranscriptTableEntry] = []
         out.append(TranscriptTableEntry(
             id: .setup,
-            contentKey: "setup"
-                + ".\(workspace.id)"
-                + ".\(isRunningSetup)"
-                + ".\(transcript.hasNothingToShow)"
-                + ".\(Int(paneHeight))",
+            contentKey: TranscriptContentKey {
+                $0.combine("setup")
+                $0.combine(workspace.id)
+                $0.combine(isRunningSetup)
+                $0.combine(transcript.hasNothingToShow)
+                $0.combine(Int(paneHeight))
+            },
             content: {
                 AnyView(
                     WorkspaceEventsView(
@@ -344,12 +346,20 @@ struct TranscriptListView: View {
             // is built rather than baked in as this runs, and putting it in the key would rebuild
             // the cell again a fifth of a second later when the answer expired, throwing away the
             // settle it is meant to be showing. See `TranscriptArrivals`.
-            let key = [
-                "\(row.id)", "\(row.seq)", row.kind.rawValue, "\(row.isError)",
-                "\(row.durationMS ?? -1)", "\(row.resultPayload?.count ?? -1)",
-                row.permissionDecision ?? "", row.permissionNote, "\(isExpanded)",
-                row.parentToolUseID ?? "", "\(wasStopped)", "\(recovered != nil)",
-            ].joined(separator: "|")
+            let key = TranscriptContentKey {
+                $0.combine(row.id)
+                $0.combine(row.seq)
+                $0.combine(row.kind)
+                $0.combine(row.isError)
+                $0.combine(row.durationMS)
+                $0.combine(row.resultPayload?.count)
+                $0.combine(row.permissionDecision)
+                $0.combine(row.permissionNote)
+                $0.combine(isExpanded)
+                $0.combine(row.parentToolUseID)
+                $0.combine(wasStopped)
+                $0.combine(recovered != nil)
+            }
             // Free, and no for the two kinds that make up most of a long session, so it is asked
             // here rather than inside the closure that runs per cell.
             let settles = TranscriptMotion.fadesOnArrival(row.kind)
@@ -413,7 +423,11 @@ struct TranscriptListView: View {
             id: .sending,
             // The session is in the key for the reason `streaming` below carries: a pane visits
             // one conversation after another and the heights are remembered across the switch.
-            contentKey: "sending.\(transcript.session.id).\(sending?.id.rawValue ?? "none")",
+            contentKey: TranscriptContentKey {
+                $0.combine("sending")
+                $0.combine(transcript.session.id)
+                $0.combine(sending?.id)
+            },
             content: {
                 guard let sending else { return AnyView(EmptyView()) }
                 let review = ReviewTurn.split(sending.body)
@@ -451,7 +465,11 @@ struct TranscriptListView: View {
             // several hundred points of blank under the newest row, closing again the moment the
             // cell is drawn. Every stored row is keyed by a row id, which is unique across
             // sessions; these two are the only entries that are not.
-            id: .streaming, contentKey: "streaming.\(transcript.session.id)",
+            id: .streaming,
+            contentKey: TranscriptContentKey {
+                $0.combine("streaming")
+                $0.combine(transcript.session.id)
+            },
             content: {
                 AnyView(
                     StreamingTailView(transcript: transcript)
@@ -474,7 +492,11 @@ struct TranscriptListView: View {
             let hold = isLast ? transcript.deliveryHold : nil
             out.append(TranscriptTableEntry(
                 id: .pending(delivery.id),
-                contentKey: "pending.\(delivery.id).\(isLast)",
+                contentKey: TranscriptContentKey {
+                    $0.combine("pending")
+                    $0.combine(delivery.id)
+                    $0.combine(isLast)
+                },
                 content: {
                     AnyView(
                         PendingTurnRowView(

--- a/Sources/Bloom/Views/Transcript/TranscriptPresentationCache.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptPresentationCache.swift
@@ -17,7 +17,6 @@ import BloomCore
 /// The cost limit the event cache carries has no equivalent here. A `ToolPresentation` is a glyph
 /// name, two short strings and a handful of chips, all of them already truncated to a line, so the
 /// count is the whole of what needs bounding. Only the number was wrong.
-@MainActor
 enum TranscriptPresentationCache {
     /// **Every tool row a long session can hold, rather than a screen of them.**
     ///
@@ -35,7 +34,11 @@ enum TranscriptPresentationCache {
     /// thousand payloads would be the transcript itself.
     private static let limit = 8_192
 
-    private static let values: NSCache<NSNumber, ToolPresentationBox> = {
+    /// Shared, and safe to share for `TranscriptEventCache`'s reason: `NSCache` does its own
+    /// locking, a `ToolPresentationBox` is a `final class` holding one `let` of a `Sendable`
+    /// struct, and an `NSNumber` is immutable. `TranscriptPrime` fills this off the main actor
+    /// while the table reads it on it.
+    nonisolated(unsafe) private static let values: NSCache<NSNumber, ToolPresentationBox> = {
         let cache = NSCache<NSNumber, ToolPresentationBox>()
         cache.countLimit = limit
         return cache

--- a/Sources/Bloom/Views/Transcript/TranscriptPrime.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptPrime.swift
@@ -1,0 +1,122 @@
+import Foundation
+import BloomCore
+
+/// The transcript's caches, filled before the table asks them anything.
+///
+/// Every expensive thing a row does is already a pure function over `Sendable` values:
+/// `AgentEvent.decode`, `JSONValue.parse`, `TranscriptPresenter.present`, `MarkdownParser.parse`
+/// and `CarryPass.states`. Every one of them ran on the main actor all the same, on a cache miss,
+/// while the row it belonged to was being measured or drawn, and nothing filled them in advance.
+/// So the whole of a session's parsing sat on the one thread that also has to lay it out.
+///
+/// It is safe for the reason `DiffView.prime` gives for `SyntaxCache`: the caches are `NSCache`s,
+/// which do their own locking, and every value in them is a `final class` whose stored properties
+/// are `let`s of `Sendable` value types. Nothing a reader takes out can be written by anybody, so
+/// the second pass can happen before the first row is asked for.
+///
+/// **It moves no measuring.** An `NSHostingView` is laid out on the main thread by law, and that
+/// is about 2.1ms a row. This makes each of those cheaper, and there are exactly as many of them
+/// as there were.
+///
+/// It races the reader for the first screen and is meant to: both may compute the same row, and
+/// the loser's answer is dropped by whichever `setObject` lands second. That is a few rows of
+/// wasted microseconds once, and coalescing it would mean a lock the main thread has to take on
+/// every lookup to save them.
+enum TranscriptPrime {
+    /// How many rows are prepared at once.
+    ///
+    /// The pass exists to be finished before the reader scrolls, not to use the machine. The main
+    /// thread is measuring rows while it runs, every item allocates, and the caches take a lock
+    /// per write, so a fan-out over four hundred rows buys contention rather than throughput. Four
+    /// stays comfortably ahead of a reader and leaves the rest of the machine to the window.
+    static let width = 4
+
+    /// Fills the caches for the rows the list is about to draw.
+    ///
+    /// The same window the list will settle on, worked out with the same two functions it uses, so
+    /// this cannot prepare a different four hundred rows from the ones asked for. `unreadSeq` is
+    /// what moves that window off the live end, and it is also where the reader lands, which is
+    /// why it decides the order as well.
+    static func run(rows: [TranscriptRow], worktree: String, unreadSeq: Int?) async {
+        guard !rows.isEmpty else { return }
+        let unread = unreadSeq.flatMap {
+            TranscriptWindow.index(ofSeqAtOrAfter: $0, in: rows.lazy.map(\.seq))
+        }
+        let window = TranscriptWindow.settling(
+            from: .opening(
+                rowCount: rows.count,
+                tailStart: TranscriptTail.start(in: rows.lazy.map(\.kind)),
+                mustReach: unread
+            ),
+            rowCount: rows.count
+        )
+
+        await withTaskGroup(of: Void.self) { group in
+            var started = 0
+            for index in window.indices(outwardFrom: unread ?? rows.count - 1) {
+                if started >= width { _ = await group.next() }
+                let row = rows[index]
+                group.addTask { prime(row, worktree: worktree) }
+                started += 1
+            }
+        }
+    }
+
+    /// What one row costs the first time anybody looks at it, done here instead.
+    ///
+    /// The switch is `TranscriptRowView`'s own, and has to stay it: a kind prepared through the
+    /// wrong cache is work done twice rather than nought times. A notice is absent on purpose,
+    /// because it is drawn from the payload itself and goes through no cache at all.
+    private static func prime(_ row: TranscriptRow, worktree: String) {
+        switch row.kind {
+        // The bubble is read straight out of the stored request, and an error's exit out of the
+        // same tree, so both want the JSON rather than the decoded event.
+        case .user, .error:
+            _ = TranscriptEventCache.json(rowID: row.id, payload: row.payload)
+        case .notice:
+            break
+        default:
+            guard let event = TranscriptEventCache.event(rowID: row.id, payload: row.payload) else {
+                return
+            }
+            switch event {
+            case .assistantText(let block):
+                prose(block.text)
+            case .toolUse(let use):
+                _ = TranscriptPresentationCache.presentation(
+                    rowID: row.id, use: use, worktree: worktree
+                )
+            default:
+                break
+            }
+        }
+    }
+
+    /// An answer parsed, and the fences inside it split and carried.
+    ///
+    /// A thinking block is deliberately not here: it is one line until the reader opens it, so
+    /// parsing every one of them would be work for a row nobody has asked to see.
+    private static func prose(_ text: String) {
+        guard !text.isEmpty else { return }
+        fences(in: MarkdownPrime.blocks(of: text))
+    }
+
+    /// Every fence in a block tree, including the ones inside a list or a quote, which is where an
+    /// agent's longest ones usually are.
+    ///
+    /// Table cells hold inline runs rather than blocks, so there is nothing under them to walk.
+    private static func fences(in blocks: [MarkdownBlock]) {
+        for block in blocks {
+            switch block {
+            case .codeBlock(let code, let language, _):
+                CodeBlockPrime.prepare(code: code, language: language)
+            case .blockQuote(let inner):
+                fences(in: inner)
+            case .bulletList(let items, _), .numberedList(_, let items, _):
+                for item in items { fences(in: item) }
+            default:
+                break
+            }
+        }
+    }
+}

--- a/Sources/Bloom/Views/Transcript/TranscriptTable.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTable.swift
@@ -31,7 +31,7 @@ struct TranscriptTableEntry: Identifiable {
     /// be.** The streaming tail, the setup log and the delivery at the head of the queue watch
     /// their own state and redraw inside the cell they are in; handing them a new root view on
     /// every pass threw that state away and rebuilt the tail several times a second.
-    let contentKey: String
+    let contentKey: TranscriptContentKey
     /// Built on demand: when the row is measured, and when it is drawn. Nothing is built for a row
     /// that is neither, which is what keeps the pass that assembles these cheap.
     let content: @MainActor () -> AnyView
@@ -1218,7 +1218,7 @@ private struct HostedRow: View {
 /// the same layout that drew it.
 final class TranscriptTableCell: NSView {
     private let host: NSHostingView<AnyView>
-    private var appliedKey: String?
+    private var appliedKey: TranscriptContentKey?
     private var unclip: Task<Void, Never>?
     var onHeightChange: (@MainActor (TranscriptEntryID, CGFloat) -> Void)?
 

--- a/Sources/BloomCore/Transcript/TranscriptContentKey.swift
+++ b/Sources/BloomCore/Transcript/TranscriptContentKey.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Everything about a drawn transcript entry that can change what it draws, and therefore how tall
+/// it is, reduced to one number.
+///
+/// **A number rather than the string it was, because nothing ever reads it.** A stored row's key
+/// was twelve interpolations joined with a separator, built for every row in the window on every
+/// pass of the list, and that includes every 50ms flush of a streaming turn: four hundred rows is
+/// some five thousand allocations a pass, to make strings the table only compares for equality and
+/// then hashes again as a dictionary key. `Hasher` answers the same question and allocates
+/// nothing.
+///
+/// It is the trade `TranscriptPayloadKey` and `SyntaxKey` already make, one step further on: they
+/// keep a hash beside the fields and compare the fields behind it, and this keeps the hash and
+/// drops the fields. What it costs is that two different entries hashing alike would be a row told
+/// another row's height and never rebuilt. With the twenty thousand entries `TranscriptRowHeights`
+/// holds at most, the chance of any two colliding is about one in ninety thousand million, and the
+/// hand-built string prefixes it replaces were the likelier way to spell one entry into another.
+///
+/// The seed is per process, so a key is only ever comparable with another key from this launch.
+/// Nothing here is persisted, which is what makes that fine.
+public struct TranscriptContentKey: Hashable, Sendable {
+    public let value: UInt64
+
+    /// Built by combining every field that can change what the entry draws into a `Hasher`.
+    ///
+    /// The closure does not escape, so a key costs no allocation at all: the fields go into the
+    /// hasher and none of them is kept.
+    public init(_ combine: (inout Hasher) -> Void) {
+        var hasher = Hasher()
+        combine(&hasher)
+        value = UInt64(bitPattern: Int64(hasher.finalize()))
+    }
+}

--- a/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
+++ b/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
@@ -12,6 +12,9 @@ import Foundation
 ///
 /// ## The key is the content, and the width and the scale are the cache's
 ///
+/// The content is a `TranscriptContentKey`, which is a hash rather than the string it used to be:
+/// see that type for what building four hundred of those strings on every pass cost.
+///
 /// A row's height depends on three things: what it draws, how wide it is drawn, and the text size
 /// it is drawn at. The obvious spelling folds all three into one key, which is what the spike did,
 /// and it is wrong in a way that only shows up after a while: the pane is resized all day, so the
@@ -123,9 +126,9 @@ public struct TranscriptRowHeights: Equatable, Sendable {
     /// arrived. What a caller measures a fresh row against, so that it cannot measure at one width
     /// and file the answer under another.
     public private(set) var measure: Measure?
-    private var heights: [String: Double] = [:]
+    private var heights: [TranscriptContentKey: Double] = [:]
     /// The keys whose height was taken at a width that no longer holds. See `rewidth`.
-    private var stale: Set<String> = []
+    private var stale: Set<TranscriptContentKey> = []
     /// The sum of `heights`, kept in step on every write so the mean below costs nothing to ask.
     private var total: Double = 0
 
@@ -182,14 +185,14 @@ public struct TranscriptRowHeights: Equatable, Sendable {
     }
 
     /// Whether this height is owed a measurement at the width the cache is now for.
-    public func isStale(_ contentKey: String) -> Bool { stale.contains(contentKey) }
+    public func isStale(_ contentKey: TranscriptContentKey) -> Bool { stale.contains(contentKey) }
 
     /// How many heights are still estimates. For a probe: it is the count of rows a resize did
     /// NOT have to measure, which is the whole of what the hold buys.
     public var staleCount: Int { stale.count }
 
     /// The remembered height of this content, or nothing if it has never been measured.
-    public func height(for contentKey: String) -> Double? {
+    public func height(for contentKey: TranscriptContentKey) -> Double? {
         heights[contentKey]
     }
 
@@ -209,7 +212,7 @@ public struct TranscriptRowHeights: Equatable, Sendable {
     /// Never nil and never a measurement, so answering it for every row of a session costs a
     /// dictionary lookup each. See the header for why a table is answered rather than made to
     /// wait.
-    public func assumed(for contentKey: String) -> Double {
+    public func assumed(for contentKey: TranscriptContentKey) -> Double {
         heights[contentKey] ?? estimate
     }
 
@@ -227,7 +230,7 @@ public struct TranscriptRowHeights: Equatable, Sendable {
     /// False for a height that has not moved by half a point, which is what keeps a row that
     /// reports its size on every layout pass from telling the table to relayout on every one.
     @discardableResult
-    public mutating func note(_ height: Double, for contentKey: String) -> Bool {
+    public mutating func note(_ height: Double, for contentKey: TranscriptContentKey) -> Bool {
         guard measure != nil else { return false }
         // Before the news test below, so a row that turns out to be exactly as tall as it was at
         // the old width still stops being owed a measurement.

--- a/Sources/BloomCore/Transcript/TranscriptWindow.swift
+++ b/Sources/BloomCore/Transcript/TranscriptWindow.swift
@@ -114,6 +114,19 @@ public struct TranscriptWindow: Equatable, Sendable {
         Self(start: clamp(rowCount - settled, rowCount: rowCount), end: max(0, rowCount))
     }
 
+    /// The window's rows in the order a preparation pass should take them: nearest first to the
+    /// row the reader lands on.
+    ///
+    /// A pass that ran from `start` would prepare the reader's own screen last, which is the one
+    /// screen it exists to have ready before the table asks. The anchor is the row the list opens
+    /// on: the unread mark or the search result when there is one, and the live end otherwise.
+    /// An anchor outside the window is pulled to its nearer edge, so a caller never has to check.
+    public func indices(outwardFrom anchor: Int) -> [Int] {
+        guard count > 0 else { return [] }
+        let pinned = min(max(anchor, start), end - 1)
+        return (start..<end).sorted { abs($0 - pinned) < abs($1 - pinned) }
+    }
+
     /// Whether there is any history left above the window to grow into.
     public var canGrowUp: Bool { start > 0 }
 

--- a/Tests/BloomCoreTests/TranscriptContentKeyTests.swift
+++ b/Tests/BloomCoreTests/TranscriptContentKeyTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+@Suite("What a table compares to know a row's content moved")
+struct TranscriptContentKeyTests {
+    @Test("the same fields are the same key")
+    func isStableForTheSameFields() {
+        let one = TranscriptContentKey {
+            $0.combine(7)
+            $0.combine("assistantText")
+            $0.combine(false)
+        }
+        let other = TranscriptContentKey {
+            $0.combine(7)
+            $0.combine("assistantText")
+            $0.combine(false)
+        }
+        #expect(one == other)
+    }
+
+    /// A fold the reader just clicked is one field of twelve moving, and it has to be enough for
+    /// the table to rebuild the cell and remeasure the row.
+    @Test("one field moving is a different key")
+    func oneFieldIsEnough() {
+        let folded = TranscriptContentKey {
+            $0.combine(7)
+            $0.combine(false)
+        }
+        let unfolded = TranscriptContentKey {
+            $0.combine(7)
+            $0.combine(true)
+        }
+        #expect(folded != unfolded)
+    }
+
+    /// The separator the joined string carried is what this replaces, so the thing it was there to
+    /// prevent is worth a test: two entries whose fields run into each other are not one entry.
+    @Test("two fields cannot be spelled into each other")
+    func doesNotRunFieldsTogether() {
+        let one = TranscriptContentKey {
+            $0.combine("row")
+            $0.combine("12")
+        }
+        let other = TranscriptContentKey {
+            $0.combine("row1")
+            $0.combine("2")
+        }
+        #expect(one != other)
+    }
+
+    /// Which is the whole of what a height cache does with it.
+    @Test("a key is a dictionary key")
+    func worksAsADictionaryKey() {
+        let seven = TranscriptContentKey { $0.combine("row.7") }
+        let sevenAgain = TranscriptContentKey { $0.combine("row.7") }
+        let eight = TranscriptContentKey { $0.combine("row.8") }
+        var heights: [TranscriptContentKey: Double] = [:]
+        heights[seven] = 120
+        #expect(heights[sevenAgain] == 120)
+        #expect(heights[eight] == nil)
+    }
+}

--- a/Tests/BloomCoreTests/TranscriptRowHeightsTests.swift
+++ b/Tests/BloomCoreTests/TranscriptRowHeightsTests.swift
@@ -4,22 +4,28 @@ import Foundation
 
 @Suite("Remembering how tall a transcript row is")
 struct TranscriptRowHeightsTests {
+    /// A key from one string, which is all these tests need to tell two entries apart. The real
+    /// one combines a dozen fields: see `TranscriptContentKey`.
+    private func key(_ text: String) -> TranscriptContentKey {
+        TranscriptContentKey { $0.combine(text) }
+    }
+
     // MARK: - What the cache is keyed on
 
     @Test("a row measured once is not measured again")
     func remembersAHeight() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(120, for: "row.7|assistant")
-        #expect(heights.height(for: "row.7|assistant") == 120)
+        heights.note(120, for: key("row.7|assistant"))
+        #expect(heights.height(for: key("row.7|assistant")) == 120)
     }
 
     @Test("a row whose content moved is a different row")
     func contentIsPartOfTheKey() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(120, for: "row.7|folded")
-        #expect(heights.height(for: "row.7|unfolded") == nil)
+        heights.note(120, for: key("row.7|folded"))
+        #expect(heights.height(for: key("row.7|unfolded")) == nil)
     }
 
     /// The pane made narrower rewraps every paragraph in it, so nothing measured at the old width
@@ -28,12 +34,12 @@ struct TranscriptRowHeightsTests {
     func widthInvalidates() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(120, for: "row.7")
+        heights.note(120, for: key("row.7"))
         // Called before the expectation rather than inside it: `reset` is mutating, and `#expect`
         // rewrites its argument into a closure that takes the value immutably.
         let invalidated = heights.reset(width: 600, scale: 1)
         #expect(invalidated)
-        #expect(heights.height(for: "row.7") == nil)
+        #expect(heights.height(for: key("row.7")) == nil)
         #expect(heights.count == 0)
     }
 
@@ -41,10 +47,10 @@ struct TranscriptRowHeightsTests {
     func scaleInvalidates() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(120, for: "row.7")
+        heights.note(120, for: key("row.7"))
         let invalidated = heights.reset(width: 800, scale: 1.3)
         #expect(invalidated)
-        #expect(heights.height(for: "row.7") == nil)
+        #expect(heights.height(for: key("row.7")) == nil)
     }
 
     /// The width and the scale are the cache's rather than each key's, so the cache cannot grow one
@@ -54,9 +60,9 @@ struct TranscriptRowHeightsTests {
     func doesNotHoldEveryWidthItHasSeen() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(120, for: "row.7")
+        heights.note(120, for: key("row.7"))
         heights.reset(width: 600, scale: 1)
-        heights.note(180, for: "row.7")
+        heights.note(180, for: key("row.7"))
         heights.reset(width: 800, scale: 1)
         #expect(heights.count == 0)
     }
@@ -68,10 +74,10 @@ struct TranscriptRowHeightsTests {
     func toleratesAFraction() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 831.5, scale: 1)
-        heights.note(120, for: "row.7")
+        heights.note(120, for: key("row.7"))
         let invalidated = heights.reset(width: 831.75, scale: 1)
         #expect(!invalidated)
-        #expect(heights.height(for: "row.7") == 120)
+        #expect(heights.height(for: key("row.7")) == 120)
     }
 
     @Test("a pass that changes nothing says so")
@@ -101,9 +107,9 @@ struct TranscriptRowHeightsTests {
     @Test("nothing is remembered before a width has arrived")
     func refusesHeightsWithoutAWidth() {
         var heights = TranscriptRowHeights()
-        let changed = heights.note(120, for: "row.7")
+        let changed = heights.note(120, for: key("row.7"))
         #expect(!changed)
-        #expect(heights.height(for: "row.7") == nil)
+        #expect(heights.height(for: key("row.7")) == nil)
     }
 
     @Test("the first real width makes the cache ready")
@@ -124,10 +130,10 @@ struct TranscriptRowHeightsTests {
     func aDrawnRowWins() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(120, for: "row.7")
-        let changed = heights.note(340, for: "row.7")
+        heights.note(120, for: key("row.7"))
+        let changed = heights.note(340, for: key("row.7"))
         #expect(changed)
-        #expect(heights.height(for: "row.7") == 340)
+        #expect(heights.height(for: key("row.7")) == 340)
     }
 
     /// A row reports its size on every layout pass. Telling the table to relayout on every one of
@@ -136,12 +142,12 @@ struct TranscriptRowHeightsTests {
     func ignoresAnUnchangedHeight() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        let changed = heights.note(120, for: "row.7")
+        let changed = heights.note(120, for: key("row.7"))
         #expect(changed)
-        let changedAgain = heights.note(120, for: "row.7")
+        let changedAgain = heights.note(120, for: key("row.7"))
         #expect(!changedAgain)
         // Rounds up to the same 120, so a fraction of a point of drift says nothing either.
-        let changedByAFraction = heights.note(119.6, for: "row.7")
+        let changedByAFraction = heights.note(119.6, for: key("row.7"))
         #expect(!changedByAFraction)
     }
 
@@ -151,9 +157,9 @@ struct TranscriptRowHeightsTests {
     func nothingIsAnAnswer() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        let changed = heights.note(0, for: "row.7")
+        let changed = heights.note(0, for: key("row.7"))
         #expect(changed)
-        #expect(heights.height(for: "row.7") == 0)
+        #expect(heights.height(for: key("row.7")) == 0)
     }
 
     @Test("a height is rounded up, and never below nothing")
@@ -172,11 +178,11 @@ struct TranscriptRowHeightsTests {
     func rewidthEstimates() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(120, for: "row.7")
+        heights.note(120, for: key("row.7"))
         let moved = heights.rewidth(to: 600)
         #expect(moved)
-        #expect(heights.height(for: "row.7") == 120)
-        #expect(heights.isStale("row.7"))
+        #expect(heights.height(for: key("row.7")) == 120)
+        #expect(heights.isStale(key("row.7")))
         #expect(heights.measure?.width == 600)
         #expect(heights.staleCount == 1)
     }
@@ -185,10 +191,10 @@ struct TranscriptRowHeightsTests {
     func measuringClearsTheDebt() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(120, for: "row.7")
+        heights.note(120, for: key("row.7"))
         heights.rewidth(to: 600)
-        heights.note(180, for: "row.7")
-        #expect(!heights.isStale("row.7"))
+        heights.note(180, for: key("row.7"))
+        #expect(!heights.isStale(key("row.7")))
         #expect(heights.staleCount == 0)
     }
 
@@ -199,21 +205,21 @@ struct TranscriptRowHeightsTests {
     func anUnchangedHeightStillSettlesTheDebt() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(120, for: "row.7")
+        heights.note(120, for: key("row.7"))
         heights.rewidth(to: 600)
-        let changed = heights.note(120, for: "row.7")
+        let changed = heights.note(120, for: key("row.7"))
         #expect(!changed)
-        #expect(!heights.isStale("row.7"))
+        #expect(!heights.isStale(key("row.7")))
     }
 
     @Test("a resize to the same width changes nothing")
     func rewidthToTheSameWidth() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(120, for: "row.7")
+        heights.note(120, for: key("row.7"))
         let rewidened = heights.rewidth(to: 800.25)
         #expect(!rewidened)
-        #expect(!heights.isStale("row.7"))
+        #expect(!heights.isStale(key("row.7")))
     }
 
     /// A pane that has never been laid out has nothing to estimate from, so this is `reset`'s
@@ -234,22 +240,22 @@ struct TranscriptRowHeightsTests {
     func resetClearsTheDebt() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(120, for: "row.7")
+        heights.note(120, for: key("row.7"))
         heights.rewidth(to: 600)
         heights.reset(width: 600, scale: 1.3)
         #expect(heights.staleCount == 0)
-        #expect(heights.height(for: "row.7") == nil)
+        #expect(heights.height(for: key("row.7")) == nil)
     }
 
     @Test("forgetting settles every debt a resize left")
     func forgettingClearsTheDebt() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(120, for: "row.7")
+        heights.note(120, for: key("row.7"))
         heights.rewidth(to: 600)
         heights.forget()
         #expect(heights.staleCount == 0)
-        #expect(!heights.isStale("row.7"))
+        #expect(!heights.isStale(key("row.7")))
     }
 
     // MARK: - What an unmeasured row is worth
@@ -261,20 +267,20 @@ struct TranscriptRowHeightsTests {
     func assumesAnUnmeasuredRow() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        #expect(heights.height(for: "row.7") == nil)
-        #expect(heights.assumed(for: "row.7") == TranscriptRowHeights.assumedRowHeight)
+        #expect(heights.height(for: key("row.7")) == nil)
+        #expect(heights.assumed(for: key("row.7")) == TranscriptRowHeights.assumedRowHeight)
     }
 
     @Test("what has been measured is what the rest is assumed to be")
     func assumesTheMeanOfWhatIsKnown() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(100, for: "row.1")
-        heights.note(200, for: "row.2")
+        heights.note(100, for: key("row.1"))
+        heights.note(200, for: key("row.2"))
         #expect(heights.estimate == 150)
-        #expect(heights.assumed(for: "row.99") == 150)
+        #expect(heights.assumed(for: key("row.99")) == 150)
         // And the measured ones are still themselves.
-        #expect(heights.assumed(for: "row.1") == 100)
+        #expect(heights.assumed(for: key("row.1")) == 100)
     }
 
     /// The running total has to survive an overwrite, which is what every drawn row does to what
@@ -283,8 +289,8 @@ struct TranscriptRowHeightsTests {
     func meanFollowsAnOverwrite() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(100, for: "row.1")
-        heights.note(300, for: "row.1")
+        heights.note(100, for: key("row.1"))
+        heights.note(300, for: key("row.1"))
         #expect(heights.estimate == 300)
     }
 
@@ -292,7 +298,7 @@ struct TranscriptRowHeightsTests {
     func meanIsEmptiedWithTheCache() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(400, for: "row.1")
+        heights.note(400, for: key("row.1"))
         heights.forget()
         #expect(heights.estimate == TranscriptRowHeights.assumedRowHeight)
     }
@@ -303,8 +309,8 @@ struct TranscriptRowHeightsTests {
     func meanSurvivesAResize() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(100, for: "row.1")
-        heights.note(200, for: "row.2")
+        heights.note(100, for: key("row.1"))
+        heights.note(200, for: key("row.2"))
         heights.rewidth(to: 600)
         #expect(heights.estimate == 150)
     }
@@ -318,12 +324,12 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
         for row in 0..<TranscriptRowHeights.mostRows {
-            heights.note(Double(row % 400) + 1, for: "row.\(row)")
+            heights.note(Double(row % 400) + 1, for: key("row.\(row)"))
         }
         #expect(heights.count == TranscriptRowHeights.mostRows)
-        heights.note(120, for: "one.too.many")
+        heights.note(120, for: key("one.too.many"))
         #expect(heights.count == 1)
-        #expect(heights.height(for: "one.too.many") == 120)
+        #expect(heights.height(for: key("one.too.many")) == 120)
         // The width is kept, because the pane is still the width it was.
         #expect(heights.measure?.width == 800)
     }
@@ -333,11 +339,11 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
         for row in 0..<TranscriptRowHeights.mostRows {
-            heights.note(Double(row % 400) + 1, for: "row.\(row)")
+            heights.note(Double(row % 400) + 1, for: key("row.\(row)"))
         }
-        heights.note(999, for: "row.0")
+        heights.note(999, for: key("row.0"))
         #expect(heights.count == TranscriptRowHeights.mostRows)
-        #expect(heights.height(for: "row.0") == 999)
+        #expect(heights.height(for: key("row.0")) == 999)
     }
 
     @Test("half a point is the same width, and one answer says so")
@@ -352,9 +358,9 @@ struct TranscriptRowHeightsTests {
     func forgets() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1)
-        heights.note(120, for: "row.7")
+        heights.note(120, for: key("row.7"))
         heights.forget()
-        #expect(heights.height(for: "row.7") == nil)
+        #expect(heights.height(for: key("row.7")) == nil)
         #expect(heights.isReady)
         let invalidated = heights.reset(width: 800, scale: 1)
         #expect(!invalidated)

--- a/Tests/BloomCoreTests/TranscriptWindowTests.swift
+++ b/Tests/BloomCoreTests/TranscriptWindowTests.swift
@@ -175,4 +175,34 @@ struct TranscriptWindowTests {
         #expect(TranscriptWindow.index(ofSeqAtOrAfter: 1_500, in: seqs) == 500)
         #expect(TranscriptWindow.index(ofSeqAtOrAfter: 1_501, in: seqs) == 501)
     }
+
+    // MARK: The order a preparation pass takes the window in
+
+    /// A session opened on its live end is read from the bottom, so the bottom is what has to be
+    /// ready first. See `TranscriptPrime`.
+    @Test("a window anchored at its end is prepared from the end")
+    func preparesTheLiveEndFirst() {
+        let window = TranscriptWindow(start: 0, end: 5)
+        #expect(window.indices(outwardFrom: 4) == [4, 3, 2, 1, 0])
+    }
+
+    @Test("a window anchored on an unread row is prepared outwards from it")
+    func preparesAroundTheUnreadRow() {
+        let window = TranscriptWindow(start: 0, end: 5)
+        let order = window.indices(outwardFrom: 2)
+        #expect(order.first == 2)
+        #expect(Set(order.prefix(3)) == [1, 2, 3])
+        #expect(Set(order) == Set(0..<5))
+    }
+
+    @Test("an anchor outside the window is pulled to its nearer edge")
+    func clampsTheAnchor() {
+        #expect(TranscriptWindow(start: 10, end: 20).indices(outwardFrom: 0).first == 10)
+        #expect(TranscriptWindow(start: 10, end: 20).indices(outwardFrom: 99).first == 19)
+    }
+
+    @Test("an empty window is nothing to prepare")
+    func preparesNothingForAnEmptyWindow() {
+        #expect(TranscriptWindow(start: 0, end: 0).indices(outwardFrom: 0).isEmpty)
+    }
 }


### PR DESCRIPTION
Every expensive per-row function in the transcript is already a pure static over sendable values: decode, JSON parse, tool presentation, markdown parse, fence preparation. All of them ran on the main actor, on a cache miss, while a row was being measured or drawn, and nothing primed them.

After the rows are read, a detached task now primes the settled window four wide. Four because the main thread is measuring rows at the same time and every cache takes a lock per write, so a wider fan-out buys contention. Which rows, and in what order, is the testable half and went to the core: outward from the row the reader will land on, because a pass that ran from the start of the window would prepare their own screen last.

The four `NSCache` statics are `nonisolated(unsafe)`, the way `SyntaxCache` already is, and the argument is checked rather than assumed: every cached value is a final class whose stored properties are lets of sendable value types, and the keys are immutable too, which matters because `NSCache` retains keys rather than copying them. The genuinely mutable state, the one-entry streaming slots, stays on the main actor rather than taking a lock, because nothing off the main thread has a live tail to draw.

Two parse caches were sized 160 and 80 while carrying an 8MB cost limit that was already bounding them. The argument against that is written down twice in files next door: a count sized for a screen evicts the whole session on one scroll up and re-parses it on the way back.

The per-row content key built twelve interpolations, an array and a join for every row in the window on every pass, including every 50ms stream flush, to make a string only ever compared for equality. It is a hash now, and the height cache's suite moved with it.