### PR TITLE
Ask before running a project's setup script

### DIFF
--- a/Sources/Bloom/Design/WorkspaceMenuItems.swift
+++ b/Sources/Bloom/Design/WorkspaceMenuItems.swift
@@ -106,7 +106,8 @@ struct WorkspaceMenuItems: View {
     /// Running this repository's setup script in this worktree, worded and gated by
     /// `SetupRunOffer`, which is also what the menu bar's Workspace menu draws. Absent when the
     /// repository has no setup script, greyed while a run is going, and "Run Setup" rather than
-    /// "Run Setup Again" on a workspace where it has never run.
+    /// "Run Setup Again" on a workspace where it has never run. It asks before it runs, through
+    /// the same `SetupRunAlert` the other two controls go through.
     ///
     /// **Nothing is offered for a workspace with no live `WorkspaceModel`, and that is not a
     /// no-op waiting to happen.** Two of the three facts the item is made of are the model's:
@@ -128,7 +129,7 @@ struct WorkspaceMenuItems: View {
     @ViewBuilder
     private var setupItem: some View {
         if let model = app.existingModel(for: workspace.id), let offer = model.setupRunOffer {
-            Button(offer.title) { model.runSetupAgain() }
+            Button(offer.title) { SetupRunAlert.shared.ask(model) }
                 .disabled(!offer.isEnabled)
         }
     }

--- a/Sources/Bloom/State/SetupRunAlert.swift
+++ b/Sources/Bloom/State/SetupRunAlert.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Observation
+import BloomCore
+
+/// The question asked before a workspace's setup script runs, and the one place that asks it.
+///
+/// Its own type because three controls offer the run: the Workspace menu, a workspace row's own
+/// menu, and the "Run setup again" link on a failed setup row in the transcript. A confirmation
+/// only one of them raised would be a confirmation the other two walk straight past, which is the
+/// argument `CloseSessionAlert` was written on and this follows.
+///
+/// WHAT it asks is `BloomCore.SetupRunConfirmation`, because a sentence decided inside a view is a
+/// sentence nothing can test, and the line about an agent mid turn is a claim about what the run
+/// does to a turn in flight.
+///
+/// A shared presenter rather than an `NSAlert`, for the reason `CloseSessionAlert` gives: a modal
+/// run loop stops every other workspace's transcript streaming for as long as the question is up.
+/// `RootView` presents `request`.
+@MainActor
+@Observable
+final class SetupRunAlert {
+    static let shared = SetupRunAlert()
+
+    /// A run waiting on an answer.
+    struct Request: Identifiable, Equatable {
+        let id = UUID()
+        var model: WorkspaceModel
+        var question: SetupRunConfirmation.Question
+
+        static func == (lhs: Request, rhs: Request) -> Bool { lhs.id == rhs.id }
+    }
+
+    /// Non-nil while the dialog is up.
+    var request: Request?
+
+    /// Asks about a run, having read the workspace's state at the moment the item was pressed.
+    ///
+    /// The facts are captured here rather than read again when the sheet draws, so the question
+    /// describes the workspace the reader was looking at. `runSetupAgain` keeps its own guard for
+    /// the other half of that gap: a run that started while the question was on screen refuses the
+    /// second one rather than doubling it.
+    func ask(_ model: WorkspaceModel) {
+        guard model.canRunSetup else { return }
+        request = Request(
+            model: model,
+            question: SetupRunConfirmation.question(
+                hasRunSetup: model.hasRunSetup, isAgentRunning: model.isRunning
+            )
+        )
+    }
+}

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -813,7 +813,8 @@ final class WorkspaceModel {
         workspace.setupState != .pending || !setupOutput.isEmpty
     }
 
-    /// Runs the setup script in this worktree again.
+    /// Runs the setup script in this worktree again. Called only once the reader has said yes:
+    /// see `SetupRunAlert`.
     ///
     /// A recovery rather than a first run, which is why it sends no prompt and reloads no
     /// sessions: the script failed, or it was edited, and it is being run once more. A workspace

--- a/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
+++ b/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
@@ -516,10 +516,13 @@ struct BloomCommands: Commands {
     /// having gone away. That, and the absent case beside it, are `SetupRunOffer` now: the same
     /// item is on a workspace row's own menu, and the two must not word it differently or disagree
     /// about when it can be pressed.
+    ///
+    /// It asks before it runs, and every control that offers the run asks the same question. See
+    /// `SetupRunAlert`.
     @ViewBuilder
     private var setupItem: some View {
         if let workspace = model.selectedModel, let offer = workspace.setupRunOffer {
-            Button(offer.title) { workspace.runSetupAgain() }
+            Button(offer.title) { SetupRunAlert.shared.ask(workspace) }
                 .disabled(!offer.isEnabled)
         }
     }

--- a/Sources/Bloom/Views/RootView.swift
+++ b/Sources/Bloom/Views/RootView.swift
@@ -20,6 +20,7 @@ struct RootView: View {
 
     @Bindable private var projectSetup = ProjectSetup.shared
     @Bindable private var closeSession = CloseSessionAlert.shared
+    @Bindable private var setupRun = SetupRunAlert.shared
     /// The two Help menu sheets, and the drafts typed into them. See `FeedbackPresenter`.
     @Bindable private var feedback = FeedbackPresenter.shared
 
@@ -215,6 +216,19 @@ struct RootView: View {
             Button(request.cost.cancelTitle, role: .cancel) { closeSession.cancel() }
         } message: { request in
             Text(request.message)
+        }
+        // The question asked before a setup script runs. On the window because the three controls
+        // that raise it are two menus and a transcript row, and a `Commands` body is not a view
+        // and can present nothing. See `SetupRunAlert`.
+        .confirmation($setupRun.request) { request in
+            Confirmation(
+                title: request.question.title,
+                message: request.question.message,
+                confirmLabel: request.question.confirmLabel,
+                cancelLabel: request.question.cancelLabel
+            )
+        } onConfirm: { request in
+            request.model.runSetupAgain()
         }
         // A single OK that does nothing but dismiss is the system default, so the actions builder
         // is deliberately empty rather than spelling one out.

--- a/Sources/Bloom/Views/Transcript/WorkspaceEventsView.swift
+++ b/Sources/Bloom/Views/Transcript/WorkspaceEventsView.swift
@@ -477,10 +477,10 @@ struct WorkspaceEventRow: View {
                     // Not hidden from accessibility the way its neighbour is. Nothing else on this
                     // row does what it does, so there is no second announcement of it to prefer.
                     if showsRunSetupAgain, let model {
-                        Button("Run setup again") { model.runSetupAgain() }
+                        Button("Run setup again") { SetupRunAlert.shared.ask(model) }
                             .linkButton()
                             .font(Typo.caption)
-                            .help("Runs this repository's setup script in this workspace again")
+                            .help("Asks, then runs this repository's setup script in this workspace again")
                     }
                 }
                 .padding(.leading, TranscriptLayout.block)

--- a/Sources/BloomCore/Workspace/SetupRunConfirmation.swift
+++ b/Sources/BloomCore/Workspace/SetupRunConfirmation.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// What to ask before a workspace's setup script is run, in the words the dialog uses.
+///
+/// It is asked at all because the run is not cheap and is not Bloom's to undo. The script is
+/// whatever the project's settings file names, it is launched with the worktree as its working
+/// directory, and the two things it is written to do are install dependencies and write files.
+/// `WorkspaceManager.runSetup` streams its output for as long as it takes, which for a cold
+/// checkout is minutes, and `Workspace.setupLogLimit` exists because one of them printed tens of
+/// megabytes.
+///
+/// Here rather than at any of the three controls that offer the run, for the reason `SetupRunOffer`
+/// is here: there are three of them, and three copies of a sentence are three sentences waiting to
+/// disagree.
+public enum SetupRunConfirmation {
+    /// One confirmation's worth of words. The app owns the dialog; these are the sentences in it.
+    public struct Question: Equatable, Sendable {
+        public var title: String
+        public var message: String
+        public var confirmLabel: String
+        public var cancelLabel: String
+
+        public init(title: String, message: String, confirmLabel: String, cancelLabel: String) {
+            self.title = title
+            self.message = message
+            self.confirmLabel = confirmLabel
+            self.cancelLabel = cancelLabel
+        }
+    }
+
+    /// What to ask before running setup in a workspace.
+    ///
+    /// **One question with a conditional line, rather than two questions.** The action, its cost
+    /// and its confirm button are the same whether or not an agent is working: a turn in flight
+    /// adds a fact to weigh, not a different decision to take. Two questions would mean two titles
+    /// and two confirm labels for one menu item, which is the drift `SetupRunOffer` was written to
+    /// stop one layer up.
+    ///
+    /// **What the agent line says is that nothing stops.** Setup is a child process of this app
+    /// and the agent is another, so the script does not interrupt the turn, and the reader's
+    /// worry is the opposite one: two writers in one worktree. Warning that the agent would be
+    /// cancelled would be warning about something that does not happen.
+    ///
+    /// The title follows the item that was pressed, which says "again" only when there was a first
+    /// time. See `WorkspaceModel.hasRunSetup`.
+    public static func question(hasRunSetup: Bool, isAgentRunning: Bool) -> Question {
+        var message = "This project\u{2019}s setup script runs in the worktree. It can take "
+            + "minutes, and Bloom cannot undo what it writes."
+
+        if isAgentRunning {
+            message += "\n\nAn agent is mid turn here. The script does not stop it, so both "
+                + "write to this worktree at once."
+        }
+
+        return Question(
+            title: hasRunSetup ? "Run the setup script again?" : "Run the setup script?",
+            message: message,
+            confirmLabel: hasRunSetup ? "Run Setup Again" : "Run Setup",
+            cancelLabel: "Don\u{2019}t Run"
+        )
+    }
+}

--- a/Sources/BloomCore/Workspace/SetupRunOffer.swift
+++ b/Sources/BloomCore/Workspace/SetupRunOffer.swift
@@ -28,6 +28,8 @@ import Foundation
 /// contradicting itself an inch apart, and that is a sentence somebody read before it was fixed.
 /// See `WorkspaceModel.hasRunSetup` for what counts as a first time, which includes a run this app
 /// was killed in the middle of.
+///
+/// Pressing the item asks before it runs. See `SetupRunConfirmation`.
 public struct SetupRunOffer: Sendable, Hashable {
     /// What the item says.
     public let title: String

--- a/Tests/BloomCoreTests/SetupRunConfirmationTests.swift
+++ b/Tests/BloomCoreTests/SetupRunConfirmationTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+/// The question asked before setup runs, and the one line that moves with the workspace's state.
+///
+/// Settled here because the three controls that raise it are all places nothing can reach, and
+/// because the sentence about an agent mid turn is the only thing in this app that says what a
+/// setup run does to one.
+@Suite("The setup run confirmation")
+struct SetupRunConfirmationTests {
+    @Test("the confirm button says what it will do rather than OK")
+    func theConfirmButtonNamesTheAction() {
+        let again = SetupRunConfirmation.question(hasRunSetup: true, isAgentRunning: false)
+        #expect(again.confirmLabel == "Run Setup Again")
+
+        let first = SetupRunConfirmation.question(hasRunSetup: false, isAgentRunning: false)
+        #expect(first.confirmLabel == "Run Setup")
+    }
+
+    /// The dialog echoes the item that was pressed, and `SetupRunOffer` says "again" only when
+    /// there was a first time. A title that disagreed with the row above it is the bug that
+    /// wording rule already exists for.
+    @Test("the title says again exactly when the item does")
+    func theTitleFollowsTheItem() {
+        #expect(
+            SetupRunConfirmation.question(hasRunSetup: true, isAgentRunning: false).title
+                == "Run the setup script again?"
+        )
+        #expect(
+            SetupRunConfirmation.question(hasRunSetup: false, isAgentRunning: false).title
+                == "Run the setup script?"
+        )
+    }
+
+    /// The two facts that make the run worth asking about: it is long, and nothing here reverses
+    /// it. Both are in the message on every workspace, whatever else is going on.
+    @Test("the message always says what the run costs")
+    func theMessageAlwaysSaysTheCost() {
+        for hasRunSetup in [true, false] {
+            for isAgentRunning in [true, false] {
+                let question = SetupRunConfirmation.question(
+                    hasRunSetup: hasRunSetup, isAgentRunning: isAgentRunning
+                )
+                #expect(question.message.contains("runs in the worktree"))
+                #expect(question.message.contains("can take minutes"))
+                #expect(question.message.contains("cannot undo"))
+            }
+        }
+    }
+
+    @Test("an idle workspace is told nothing about an agent")
+    func anIdleWorkspaceSaysNothingAboutAnAgent() {
+        let question = SetupRunConfirmation.question(hasRunSetup: true, isAgentRunning: false)
+        #expect(!question.message.contains("agent"))
+    }
+
+    /// The line exists to answer "will this interrupt what is running", and the true answer is no,
+    /// which is worse rather than better: the script and the agent write to one worktree at the
+    /// same time. A dialog that said the turn would be cancelled would be warning about something
+    /// that cannot happen.
+    @Test("a workspace with an agent mid turn is told the script does not stop it")
+    func aRunningAgentGetsTheCollisionLine() {
+        let question = SetupRunConfirmation.question(hasRunSetup: true, isAgentRunning: true)
+        #expect(question.message.contains("An agent is mid turn here"))
+        #expect(question.message.contains("does not stop it"))
+    }
+
+    /// One question, not two: the agent adds a paragraph and changes nothing else, because the
+    /// action and its cost are the same either way.
+    @Test("an agent mid turn adds a line and moves nothing else")
+    func theAgentOnlyAddsALine() {
+        let idle = SetupRunConfirmation.question(hasRunSetup: true, isAgentRunning: false)
+        let busy = SetupRunConfirmation.question(hasRunSetup: true, isAgentRunning: true)
+
+        #expect(busy.title == idle.title)
+        #expect(busy.confirmLabel == idle.confirmLabel)
+        #expect(busy.cancelLabel == idle.cancelLabel)
+        #expect(busy.message.hasPrefix(idle.message))
+    }
+
+    /// Escape's answer, and the one that has to read as doing nothing.
+    @Test("the cancel button promises nothing happens")
+    func theCancelButtonIsPlain() {
+        #expect(
+            SetupRunConfirmation.question(hasRunSetup: true, isAgentRunning: true).cancelLabel
+                == "Don\u{2019}t Run"
+        )
+    }
+}


### PR DESCRIPTION
Run Setup Again fired straight from the menu. It runs the project's own shell script in the worktree, for as long as that script takes, and Bloom cannot undo what it writes. The codebase's own evidence that this is not small: the setup log limit is 200,000 characters because a cold `swift build` prints tens of megabytes, and the re-run race is described in terms of a `composer install` still going.

Three facts, one each: what it touches, how long it can take, and that nothing here reverses it. Nothing about losing commits or stopping the agent, because neither happens.

One of those is worth knowing on its own: **the script does not stop the agent.** They are two child processes of the app, so a re-run means the script and a running turn write to the same worktree at once. The dialog says so, but only when a turn is actually in flight. That is one question with a conditional paragraph rather than two questions: the action, its cost and its confirm button are identical either way, and a turn in flight adds a fact to weigh rather than a different decision. A test asserts the busy message is the idle message plus that line, with the title and both labels unmoved.

It asks on the first run too, not only the re-run. Same script, same minutes, same overwrite, and one question rather than one control that asks and one that does not. The title follows `hasRunSetup` so the dialog cannot say "again" over an item that says "Run Setup".

The action is reachable from three places (the Workspace menu, the workspace row's menu, and the link on a failed setup row) and all three now route through one presenter, so `runSetupAgain` has exactly one caller.