### PR TITLE
File a height correction against the row, not against its number

### DIFF
--- a/Sources/Bloom/Design/ScrollProbe.swift
+++ b/Sources/Bloom/Design/ScrollProbe.swift
@@ -53,6 +53,11 @@ enum ScrollProbe {
         // Not brought to the front, for the reason at the head of `ProbeHarness.window`.
         let (window, contentView) = await harness.window()
 
+        // Before the conversation is opened, so the arrival is in the count. `uncorrectedRows` is
+        // the one to read: a row the table draws at a height the row did not report is the white
+        // gap between rows. See `TranscriptHoldCensus`.
+        TranscriptHoldCensus.reset()
+
         if let workspace {
             OpenWorkspaceNotification.post(WorkspaceID(workspace))
             // Long enough for the transcript to load every row and for the inspector to settle.
@@ -151,6 +156,7 @@ enum ScrollProbe {
             "didScroll": .bool((offsets.max() ?? 0) - (offsets.min() ?? 0) > 1),
             "step": .number(Double(step)),
             "sweeps": .integer(sweeps),
+            "transcriptHold": .map(TranscriptHoldCensus.summary()),
         ]
         // The probe's own keys win over both, so a report that has an opinion keeps it.
         return .object(

--- a/Sources/Bloom/Design/TranscriptHoldCensus.swift
+++ b/Sources/Bloom/Design/TranscriptHoldCensus.swift
@@ -28,6 +28,11 @@ enum TranscriptHoldCensus {
     private(set) static var measurements = 0
     /// Rows a reflow left holding an estimate rather than measuring. What the hold buys.
     private(set) static var estimatedRows = 0
+    /// **The check that a row is the height it draws at.** Rows that reported the height they
+    /// drew at, and how many of those the table was still drawing at another height a turn after
+    /// it was told. See `TranscriptTable.Coordinator.checkCorrected`, which carries the bug.
+    private(set) static var correctedRows = 0
+    private(set) static var uncorrectedRows = 0
 
     static func held(_ what: TranscriptPaneHold.PaneHeld, underAHand hand: Bool, liveResize: Bool) {
         switch what {
@@ -49,6 +54,12 @@ enum TranscriptHoldCensus {
 
     static func released(estimated: Int) { estimatedRows = estimated }
 
+    /// One batch of corrections, and the ones that did not take.
+    static func corrected(rows: Int, uncorrected: Int) {
+        correctedRows += rows
+        uncorrectedRows += uncorrected
+    }
+
     static func reset() {
         holds = 0
         underAHand = 0
@@ -58,6 +69,8 @@ enum TranscriptHoldCensus {
         reveals = 0
         measurements = 0
         estimatedRows = 0
+        correctedRows = 0
+        uncorrectedRows = 0
     }
 
     static func summary() -> [String: Double] {
@@ -70,6 +83,8 @@ enum TranscriptHoldCensus {
             "reveals": Double(reveals),
             "measurements": Double(measurements),
             "estimatedRows": Double(estimatedRows),
+            "correctedRows": Double(correctedRows),
+            "uncorrectedRows": Double(uncorrectedRows),
         ]
     }
 }

--- a/Sources/Bloom/Views/Transcript/TranscriptTable.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTable.swift
@@ -257,7 +257,13 @@ struct TranscriptTable: NSViewRepresentable {
         private var reaimWork: Task<Void, Never>?
         /// Rows whose height turned out to be wrong once they were drawn, batched so a pass over
         /// the visible rows costs one `noteHeightOfRows` rather than one each.
-        private var owedHeights = IndexSet()
+        ///
+        /// **By id, and it was by row index.** The batch is drained a turn after it is filled, and
+        /// a pass in between renumbers every row: an arrival draws the tail and puts the history
+        /// in above it a frame later, which moved every index in here by seventeen hundred. The
+        /// table was then told that seventeen hundred estimates had changed, and the rows that had
+        /// actually reported were never told again. See `noted`.
+        private var owedHeights: Set<TranscriptEntryID> = []
         private var owedWork: Task<Void, Never>?
 
         /// **A standing instruction to be at the end of the conversation.** See
@@ -442,6 +448,11 @@ struct TranscriptTable: NSViewRepresentable {
             if environmentMoved, change != .rebuilt { tableView.reloadData() }
 
             if remeasured {
+                // **The screen first, exactly.** A reset empties the cache under cells that are
+                // already drawn, and a cell holding the content it already holds never reports its
+                // height again, so those rows would be answered from the mean for ever. One screen,
+                // and none at all on the first pass of a pane, which has nothing laid out yet.
+                measureExactly(visibleRows)
                 noteHeights(IndexSet(integersIn: entries.indices))
             } else if !changed.isEmpty {
                 // The cells first, so that a row whose height is about to travel already holds
@@ -549,13 +560,16 @@ struct TranscriptTable: NSViewRepresentable {
             guard !isHeld else { return }
             guard let row = index[entryID], entries.indices.contains(row) else { return }
             guard heights.note(height, for: entries[row].contentKey) else { return }
-            owedHeights.insert(row)
+            owedHeights.insert(entryID)
             guard owedWork == nil else { return }
             owedWork = Task { @MainActor [weak self] in
                 guard let self else { return }
                 owedWork = nil
-                let rows = owedHeights
-                owedHeights = IndexSet()
+                let owed = owedHeights
+                owedHeights = []
+                // **Where each of them is NOW.** An id that has left the list is dropped, which is
+                // what a rebuilt list comes to. See `owedHeights`.
+                let rows = IndexSet(owed.compactMap(rowOf))
                 guard !rows.isEmpty else { return }
                 let wasAtEnd = isFollowingAlong
                 // **The row being corrected is usually above the reader.** Scrolling up brings
@@ -570,7 +584,47 @@ struct TranscriptTable: NSViewRepresentable {
                 // than it was measured at.
                 keepPlace(wasAtEnd: wasAtEnd, anchor: anchor)
                 reportGeometry()
+                // A turn later, because a table lays a height change out on the pass after it is
+                // told about it.
+                await Task.yield()
+                checkCorrected(owed)
             }
+        }
+
+        /// Where an entry is in the list now, or nothing if it has left it.
+        private func rowOf(_ entryID: TranscriptEntryID) -> Int? {
+            guard let row = index[entryID], entries.indices.contains(row) else { return nil }
+            return row
+        }
+
+        /// **A row is the height it draws at, and this is the thing that says so.**
+        ///
+        /// Nothing compared a row's estimate against the height it turned out to be, so a
+        /// correction that was filed against the wrong row shipped and was found by eye: a screen
+        /// of one line Bash rows with a hundred points of blank under each. A row that has
+        /// reported its drawn height and been corrected must be a row the table now draws at that
+        /// height, and a count of the ones that are not is the number to watch.
+        private func checkCorrected(_ owed: Set<TranscriptEntryID>) {
+            guard let tableView, !isHeld else { return }
+            var wrong = 0
+            // A row that has reported again since is owed another correction rather than missing
+            // this one, which is the streaming tail on every frame of a turn.
+            for id in owed where !owedHeights.contains(id) {
+                guard let row = rowOf(id),
+                      let measured = heights.height(for: entries[row].contentKey) else { continue }
+                let told = tableView.rect(ofRow: row).height
+                let drawn = max(Double(Self.hair), measured)
+                guard !TranscriptRowHeights.isSameHeight(Double(told), drawn) else { continue }
+                wrong += 1
+                #if DEBUG
+                // Said rather than trapped. A false positive is a row mid animation, and stopping
+                // the owner's build over one would be worse than the gap this is looking for.
+                FileHandle.standardError.write(Data(
+                    "transcript: row \(row) drew at \(drawn), the table says \(told)\n".utf8
+                ))
+                #endif
+            }
+            TranscriptHoldCensus.corrected(rows: owed.count, uncorrected: wrong)
         }
 
         /// Every height change in this file goes through here.
@@ -985,7 +1039,7 @@ struct TranscriptTable: NSViewRepresentable {
             resizeWork = nil
             owedWork?.cancel()
             owedWork = nil
-            owedHeights = IndexSet()
+            owedHeights = []
         }
 
         @discardableResult
@@ -1134,7 +1188,12 @@ struct TranscriptTable: NSViewRepresentable {
             let rect = CGRect(x: 0, y: max(0, y - viewport), width: 1, height: viewport * 3)
             let range = tableView.rows(in: rect)
             guard range.length > 0 else { return }
-            noteHeights(measureExactly(range.location..<(range.location + range.length)))
+            let rows = range.location..<(range.location + range.length)
+            measureExactly(rows)
+            // Every row of the landing, not only the ones this pass measured. A row whose height
+            // the cache already knows and the table does not is exactly the bug this file shipped,
+            // and re-asking sixty rows for a number they already have costs nothing.
+            noteHeights(IndexSet(integersIn: rows))
         }
 
         /// The rows the pane can see, in the entries' own indices.

--- a/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
+++ b/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
@@ -115,6 +115,15 @@ public struct TranscriptRowHeights: Equatable, Sendable {
     /// document several times the height of its content and a scroller to match.
     public static let assumedRowHeight: Double = 64
 
+    /// Whether a row is the height it drew at.
+    ///
+    /// The same half point `note` files a measurement under, so the check that a drawn row is the
+    /// height the table gives it cannot disagree with the cache about what counts as a change.
+    /// See `TranscriptTable.Coordinator.checkCorrected`.
+    public static func isSameHeight(_ one: Double, _ other: Double) -> Bool {
+        abs(one - other) <= 0.5
+    }
+
     /// The narrowest width worth measuring a row at.
     ///
     /// A table that has not been laid out yet reports a width of nought or one, and a row measured
@@ -236,7 +245,7 @@ public struct TranscriptRowHeights: Equatable, Sendable {
         // the old width still stops being owed a measurement.
         stale.remove(contentKey)
         let rounded = Self.rounded(height)
-        guard abs((heights[contentKey] ?? -1) - rounded) > 0.5 else { return false }
+        guard !Self.isSameHeight(heights[contentKey] ?? -1, rounded) else { return false }
         // See `mostRows`. Asked before the insert, so the cache never holds more than it says.
         if heights.count >= Self.mostRows, heights[contentKey] == nil { forget() }
         total += rounded - (heights[contentKey] ?? 0)

--- a/Tests/BloomCoreTests/TranscriptRowHeightsTests.swift
+++ b/Tests/BloomCoreTests/TranscriptRowHeightsTests.swift
@@ -346,6 +346,22 @@ struct TranscriptRowHeightsTests {
         #expect(heights.height(for: key("row.0")) == 999)
     }
 
+    /// The check that a row is the height it draws at asks this, and so does `note`. Two answers
+    /// would mean a height the cache calls unchanged being reported as a row drawn wrong.
+    @Test("half a point is the same height, and it is the slack a note is filed under")
+    func oneRuleAboutTheSameHeight() {
+        #expect(TranscriptRowHeights.isSameHeight(24, 24.4))
+        #expect(!TranscriptRowHeights.isSameHeight(24, 25))
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 800, scale: 1)
+        heights.note(24, for: key("row.1"))
+        // Rounded up to 25, which is a point away and therefore news.
+        let news = heights.note(24.4, for: key("row.1"))
+        #expect(news)
+        let again = heights.note(25, for: key("row.1"))
+        #expect(!again)
+    }
+
     @Test("half a point is the same width, and one answer says so")
     func oneRuleAboutTheSameWidth() {
         #expect(TranscriptRowHeights.isSameWidth(831.5, 831.75))


### PR DESCRIPTION
The transcript showed permanent gaps of a hundred points and more between one line rows, in the shipped build.

Corrections were batched as an `IndexSet` of row indices and drained a turn later. Arriving at a conversation draws the last eighty rows first and puts the history in above them a frame after, which renumbers every row by about 1,770 on a long session. So the drain told the table that 1,770 untouched estimates had changed, and the eighty rows that had actually reported were never told again.

Nothing could then recover. The cache holds the right number, so every path that measures skips those rows for ever; the cell holds the content it already holds, so the row never reports a second time; and the write would be a no-op anyway, the height not having moved. The cache is right, the table is wrong, and every mechanism that could reconcile them is short-circuited.

The bug is older than the estimating. Before rows carried an assumed height, a correction filed against the wrong row simply re-asked for a number that was already right. Not measuring up front is what made it visible.

Corrections are now keyed on `TranscriptEntryID` and resolved to indices when the batch drains, so a renumbering cannot misplace them and an id that has left the list is dropped. Two other permanent-estimate paths went with it: a placement now notes every row of its landing rather than only the ones it measured, and a cache emptied under cells that are already drawn measures the visible screen before answering from the mean.

And the check that was missing: a turn after each correction batch, every row in it is compared against the height it actually drew at, and disagreements are counted in the census where a probe can read them. The reason this shipped is that nothing compared those two numbers.