### PR TITLE
Draw the window's name once

### DIFF
--- a/Sources/Bloom/Views/Chrome/Window/WindowChrome.swift
+++ b/Sources/Bloom/Views/Chrome/Window/WindowChrome.swift
@@ -44,13 +44,17 @@ struct WindowChrome: ViewModifier {
         // so that a double click on the NAME can start a rename without taking the double click on
         // the BAR that Desktop & Dock has already spent on Zoom or Minimise.
         //
+        // **This is only half of it, and the half that shipped alone drew the name twice.** A
+        // window can carry two titles by two different routes: the one AppKit draws, which this
+        // governs, and a title item SwiftUI contributes to the toolbar from `navigationTitle`,
+        // which it owns and re-resolves and which nothing set on the window from the side can
+        // touch. That second one is `RootView`'s `.toolbar(removing: .title)`. Neither line makes
+        // the other redundant.
+        //
         // Here rather than in `WindowTitle`, which owns the title's words, because `addStrip`
         // below measures the title bar and the measurement has to be taken with this already
         // applied. Two sibling modifiers attach to the window in no defined order, so the
-        // measurement and the setting belong in one place. `NSWindowTitleHidden` "moves the
-        // toolbar up into the area previously occupied by the title", which is a no-op for a
-        // `.unified` toolbar whose title was already inline with it, but this is not a thing to
-        // depend on the ordering of.
+        // measurement and the setting belong in one place.
         window.titleVisibility = .hidden
         addStrip(to: window)
     }

--- a/Sources/Bloom/Views/Chrome/Window/WindowTitleControl.swift
+++ b/Sources/Bloom/Views/Chrome/Window/WindowTitleControl.swift
@@ -29,8 +29,12 @@ import BloomCore
 /// Desktop & Dock has "Double-click a window's title bar to", set to Zoom or Minimise, and a title
 /// bar that started a rename instead would be a system preference quietly broken. That is why the
 /// title is drawn as a view of ours at all: the gesture is attached to the text's own shape, so
-/// every other point of the bar is untouched AppKit and keeps whatever the user set. `WindowChrome`
-/// hides AppKit's own title so there are not two.
+/// every other point of the bar is untouched AppKit and keeps whatever the user set.
+///
+/// **Two titles have to be turned off for this to be the only one, not one.** `WindowChrome` sets
+/// `NSWindow.titleVisibility`, which governs the title AppKit draws; `RootView` says
+/// `.toolbar(removing: .title)`, which governs the title item SwiftUI contributes from
+/// `navigationTitle`. The first shipped without the second and the window wore its name twice.
 struct WindowTitleControl: View {
     /// Handed in rather than read from the environment, as `BloomWindowToolbar` takes it, because
     /// a `contextMenu`'s content is built in a detached context that observable values in the

--- a/Sources/Bloom/Views/RootView.swift
+++ b/Sources/Bloom/Views/RootView.swift
@@ -84,6 +84,13 @@ struct RootView: View {
                         app: app, isSidebarCollapsed: columnVisibility == .detailOnly
                     )
                 }
+                // Said here as well as under `navigationTitle` below, and deliberately.
+                //
+                // The title is declared on the split view and the toolbar is declared on this
+                // column, so the two are not the same view, and which of them resolves the default
+                // title item is not a thing reading the interface settles. The window came up
+                // wearing its name twice once already. Both, until a picture says which one did it.
+                .toolbar(removing: .title)
         }
         // As well as heading the toolbar (see BloomApp), the title names the window in the
         // Window menu and in Mission Control, so it is worth setting.
@@ -96,6 +103,20 @@ struct RootView: View {
         // names the window as well. It is still not what the inspector keys on, below: naming a
         // window costs nothing, and showing a diff for a worktree that is gone does not.
         .navigationTitle(app.menuWorkspace?.name ?? "Bloom")
+
+        // And then removed from the toolbar again, because `WindowTitleControl` draws the name
+        // itself and the window came up wearing it twice.
+        //
+        // The two titles are not one title drawn twice, they are two different mechanisms, which
+        // is why hiding one did not hide the other. `NSWindow.titleVisibility`, which `WindowChrome`
+        // sets, governs the title AppKit draws. The line above contributes a title item of
+        // SwiftUI's own to the window toolbar, and SwiftUI owns that one: it re-resolves it with
+        // the toolbar, so nothing set on the window from the side can take it away.
+        // `ToolbarDefaultItemKind.title` is the switch for it, and it is the only one.
+        //
+        // The title itself stays. It is what the Window menu, Mission Control and the Dock read,
+        // and the comment above is the reason it is set at all.
+        .toolbar(removing: .title)
 
         // Marks this scene as the main window, so the menu items that act on a workspace grey out
         // while Settings or a project settings window is key. See `MainWindowFocus`.


### PR DESCRIPTION
A window can wear its title by two routes and only one of them was turned off. `NSWindow.titleVisibility` governs the title AppKit draws. `navigationTitle` contributes a title item of SwiftUI's own to the toolbar, and SwiftUI owns that one: it re-resolves it with the toolbar, so nothing set on the window from the side ever reached it. Hence the name drawn twice, in the same weight and truncated the same way, because both copies were in SwiftUI's toolbar.

`ToolbarDefaultItemKind.title` is the switch for the second one. It is said at both levels, because the title is declared on the split view and the toolbar on the detail column, and reading does not settle which of them resolves the default item.

Not photographed: confirming it needs a window on screen.