### PR TITLE
Open the page a browser pane is showing in the real browser

### DIFF
--- a/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
@@ -189,48 +189,72 @@ struct BrowserTabView: View {
         }
     }
 
-    /// The pane's own menu with the screenshot on top of it, which is what a right click on the
-    /// page ends up showing under WebKit's Reload and Inspect Element.
+    /// The pane's own menu with what Bloom can do with this page on top of it, which is what a
+    /// right click on the page ends up showing under WebKit's Reload and Inspect Element.
     ///
-    /// The camera in the toolbar was the only way to reach this. A toolbar glyph with no word next
-    /// to it is discoverable by hovering it and reading the help tag, which is to say discoverable
-    /// by accident, and the right click is where a Mac user asks what can be done with the thing
-    /// under the pointer. It is not a menu bar item because it acts on one page in one pane, and
-    /// the menu bar cannot say which page.
+    /// The camera in the toolbar was the only way to reach the screenshot. A toolbar glyph with no
+    /// word next to it is discoverable by hovering it and reading the help tag, which is to say
+    /// discoverable by accident, and the right click is where a Mac user asks what can be done with
+    /// the thing under the pointer. Neither item is a menu bar item, because both act on one page
+    /// in one pane and the menu bar cannot say which page.
     ///
-    /// Built fresh on every click, like the pane menu it wraps, and dropped while a capture is
-    /// already running for the reason the toolbar button goes quiet: a second press in the middle
-    /// of the first would attach the same page twice.
+    /// **These two are one group, above the pane's own.** WebKit's items act on the page, these
+    /// act on the page, and Split Right and Close Pane act on the pane, so the separators the
+    /// reader ends up with divide it that way. Opening elsewhere leads, because it is the one item
+    /// here that hands the page to something outside Bloom.
+    ///
+    /// Built fresh on every click, like the pane menu it wraps. Either item is dropped rather than
+    /// greyed when it has nothing to act on, which is what Close Pane does one group down: no
+    /// address to open, no Open in External Browser, and a capture already running takes the
+    /// screenshot out for the reason the toolbar button goes quiet, which is that a second press
+    /// in the middle of the first would attach the same page twice.
+    private func pageMenu() -> NSMenu {
+        let menu = paneMenu?() ?? NSMenu()
+
+        var items: [NSMenuItem] = []
+        // Never the raw address. What may be handed to another application is `BrowserAddress`'s
+        // decision, because the string was written by the page.
+        if let url = BrowserAddress.external(from: session.displayAddress) {
+            // The same words the transcript's link menu uses for the same destination. See
+            // `TranscriptLinkMenu`.
+            items.append(item("Open in External Browser") { NSWorkspace.shared.open(url) })
+        }
+        if !isCapturing {
+            // The same words as the toolbar's own camera, taken from the one place that says them,
+            // so the glyph and the menu item cannot drift into naming the same thing two ways.
+            items.append(item(BrowserToolbar().screenshot.name, perform: capture))
+        }
+        guard !items.isEmpty else { return menu }
+
+        if !menu.items.isEmpty { menu.insertItem(.separator(), at: 0) }
+        for (offset, item) in items.enumerated() { menu.insertItem(item, at: offset) }
+        return menu
+    }
+
+    /// An item that runs a closure.
     ///
     /// The target is hung off the item's `representedObject` as well as its `target`, because
     /// `NSMenuItem` holds its target weakly and represented objects strongly, and the menu is the
     /// only thing alive by the time the item is clicked. See `BrowserPageWebView` for what happens
     /// to these items next.
-    private func pageMenu() -> NSMenu {
-        let menu = paneMenu?() ?? NSMenu()
-        guard !isCapturing else { return menu }
-
-        // The same words as the toolbar's own camera, taken from the one place that says them, so
-        // the glyph and the menu item cannot drift into naming the same thing two ways.
-        let title = BrowserToolbar().screenshot.name
-        let target = SnapshotMenuTarget(perform: capture)
+    private func item(
+        _ title: String, perform: @escaping @MainActor () -> Void
+    ) -> NSMenuItem {
+        let target = PageMenuTarget(perform: perform)
         let item = NSMenuItem(
-            title: title, action: #selector(SnapshotMenuTarget.fire), keyEquivalent: ""
+            title: title, action: #selector(PageMenuTarget.fire), keyEquivalent: ""
         )
         item.target = target
         item.representedObject = target
-
-        if !menu.items.isEmpty { menu.insertItem(.separator(), at: 0) }
-        menu.insertItem(item, at: 0)
-        return menu
+        return item
     }
 
 }
 
-/// What answers the page menu's screenshot item. A closure cannot be an `NSMenuItem` action, and
-/// the view that built the item is a struct that will not be there when the item is clicked.
+/// What answers an item of the page menu. A closure cannot be an `NSMenuItem` action, and the view
+/// that built the item is a struct that will not be there when the item is clicked.
 @MainActor
-final class SnapshotMenuTarget: NSObject {
+final class PageMenuTarget: NSObject {
     private let perform: @MainActor () -> Void
 
     init(perform: @escaping @MainActor () -> Void) {

--- a/Sources/BloomCore/System/BrowserAddress.swift
+++ b/Sources/BloomCore/System/BrowserAddress.swift
@@ -48,4 +48,29 @@ public enum BrowserAddress {
         }
         return self.url(from: url.absoluteString) != nil
     }
+
+    /// The page at this address, as something Bloom may hand to another application on this Mac.
+    ///
+    /// **The string is written by the page, and `NSWorkspace.open` sends a URL to whatever
+    /// application claims its scheme**, so this is a gate rather than a conversion. `file://`
+    /// would hand any path on this Mac to whatever opens it, up to a `.command` or an `.app`, and
+    /// `javascript:` is a line of script for the default browser to run: neither is a page, and
+    /// the answer for both is nil. So is `about:blank`, an address with no host in it, and a pane
+    /// that has been nowhere. Nil means the menu item is absent, not greyed.
+    ///
+    /// http and https only, which is the same door `shows` opens for a browser pane of Bloom's
+    /// own, plus a host to go to.
+    ///
+    /// The scheme has to be written down, which is the one place this asks less of `url(from:)`
+    /// than the field does. That parser completes a bare host, and a completed string is not the
+    /// address a page is on: `mailto:someone@example.com` carries no `://`, so it comes back as
+    /// `https://mailto:someone@example.com`, which is a third site with credentials on it. A page
+    /// always knows its own scheme, so nothing real is lost by insisting on one.
+    public static func external(from address: String) -> URL? {
+        let trimmed = address.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.contains("://"), let url = url(from: trimmed), shows(url),
+              url.host()?.isEmpty == false
+        else { return nil }
+        return url
+    }
 }

--- a/Tests/BloomCoreTests/BrowserAddressTests.swift
+++ b/Tests/BloomCoreTests/BrowserAddressTests.swift
@@ -40,3 +40,52 @@ struct BrowserAddressTests {
         #expect(BrowserAddress.url(from: text) == nil)
     }
 }
+
+/// What a browser pane will hand to the Mac's own browser, which is a security gate: the address
+/// comes off a page, and `NSWorkspace` opens whatever scheme it is given.
+@Suite("Opening a page outside Bloom")
+struct BrowserAddressExternalTests {
+    @Test("A page the pane is really on is handed over as it stands", arguments: [
+        "https://example.com/docs",
+        "http://localhost:3100/health",
+        "http://127.0.0.1:8080",
+        "https://example.com/a?b=c#d",
+    ])
+    func pagesOpen(address: String) {
+        #expect(BrowserAddress.external(from: address)?.absoluteString == address)
+    }
+
+    @Test("A scheme that is not the web is refused", arguments: [
+        "javascript://example.com/%0aalert(1)",
+        "javascript:alert(1)",
+        "file:///Applications/Calculator.app",
+        "file:///Users/someone/.zshrc",
+        "about:blank",
+        "data:text/html,<script>alert(1)</script>",
+        "mailto:someone@example.com",
+        "x-apple-something://run/this",
+    ])
+    func otherSchemesRefused(address: String) {
+        #expect(BrowserAddress.external(from: address) == nil)
+    }
+
+    @Test("A pane that has been nowhere has nothing to open", arguments: [
+        "", "   ", "http://", "https:///docs",
+    ])
+    func nothingToOpen(address: String) {
+        #expect(BrowserAddress.external(from: address) == nil)
+    }
+
+    @Test("A half-written address is not one, because a page always knows its own scheme", arguments: [
+        "example.com", "localhost:3100", "not an address",
+    ])
+    func nothingIsCompleted(address: String) {
+        #expect(BrowserAddress.external(from: address) == nil)
+    }
+
+    @Test("The host is the parser's, so a name before an @ is not mistaken for one")
+    func credentialsDoNotMoveTheHost() {
+        let url = BrowserAddress.external(from: "https://example.com@evil.example/login")
+        #expect(url?.host() == "evil.example")
+    }
+}


### PR DESCRIPTION
A browser pane's menu gains Open in External Browser, above Send a Screenshot to the Agent. It shares that group rather than getting one of its own: WebKit's own items and the screenshot act on the page, the split items act on the pane, and opening elsewhere leads the group because it is the one item that hands the page outside Bloom. Deliberately not in WebKit's group, where over a link the neighbours are Open Link and Copy Link and this would read as being about the link.

Absent rather than greyed when there is no address, matching the screenshot item and Close Pane in the same menu.

`BrowserAddress.external(from:)` in the core with a suite: http and https with a non-empty host, nothing else. `file://` is out because `NSWorkspace` hands a path to whatever claims it, up to a `.command` or an `.app`; `javascript:` is out because it is a line of script for the default browser to run and it parses as a URL.

It also refuses to complete a scheme rather than guessing one, which came out of a real finding: `BrowserAddress.url(from:)` completes a bare host, and `mailto:someone@example.com` has no `://`, so it came back as `https://mailto:someone@example.com`, a third site with an address attached as credentials. A page always knows its own scheme and the view only passes the page's own URL, so nothing real is lost.

Not in the menu bar: the item acts on one page in one pane and the menu bar cannot say which pane is showing what, which is the argument the screenshot item already records for itself.