### PR TITLE
Give a browser tab the page's own icon

### DIFF
--- a/Sources/Bloom/Design/PaneTabsGallery.swift
+++ b/Sources/Bloom/Design/PaneTabsGallery.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import BloomCore
 
@@ -93,6 +94,37 @@ struct PaneTabsGallery: View {
                 ),
             ])
 
+            // The two states a browser tab has. A page that declared an icon wears it; a dev
+            // server that declared none and a tab at no address keep the globe. Both are drawn in
+            // the same box at the same width, so nothing moves when an icon lands.
+            row("Browser tabs, wearing what the page gave them", tabs: [
+                page(
+                    BrowserTabTitle.title(
+                        page: "Spatie", address: "https://spatie.be/", fallback: "Browser"
+                    ),
+                    Self.redMark,
+                    active: true
+                ),
+                page(
+                    BrowserTabTitle.title(
+                        page: "spatie/laravel-backup",
+                        address: "https://github.com/spatie/laravel-backup",
+                        fallback: "Browser 2"
+                    ),
+                    Self.darkMark
+                ),
+                page(
+                    BrowserTabTitle.title(
+                        page: "", address: "http://localhost:3000/", fallback: "Browser 3"
+                    ),
+                    nil
+                ),
+                page(
+                    BrowserTabTitle.title(page: "", address: "about:blank", fallback: "Browser 4"),
+                    nil
+                ),
+            ])
+
             // Two rows that have to come out identical, which is the whole reason they are both
             // here. The control is a `Button` and has no on state to draw, the way the sidebar's
             // own toolbar item has none: see `InspectorToggle`. A filled plate in the second row
@@ -153,7 +185,38 @@ struct PaneTabsGallery: View {
     }
 
     private func fixture(_ title: String, _ icon: String, active: Bool = false) -> Fixture {
-        Fixture(title: title, icon: icon, isActive: active)
+        Fixture(title: title, icon: .symbol(icon), isActive: active)
+    }
+
+    private func page(_ title: String, _ favicon: NSImage?, active: Bool = false) -> Fixture {
+        Fixture(title: title, icon: .page(favicon), isActive: active)
+    }
+
+    /// Stand-ins for a real page's icon, drawn here because a gallery has no network and a capture
+    /// must not depend on one. Built once rather than per draw: this page redraws.
+    private static let redMark = mark(.systemRed, "S")
+    private static let darkMark = mark(.black, "G")
+
+    /// At `BrowserFavicon.pixels` square, which is what the page is asked to draw into, so the
+    /// strip is shown resampling exactly what it resamples.
+    private static func mark(_ colour: NSColor, _ letter: String) -> NSImage {
+        let side = CGFloat(BrowserFavicon.pixels)
+        return NSImage(size: NSSize(width: side, height: side), flipped: false) { rect in
+            colour.setFill()
+            NSBezierPath(roundedRect: rect, xRadius: side / 5, yRadius: side / 5).fill()
+
+            let text = letter as NSString
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: NSFont.systemFont(ofSize: side * 0.62, weight: .bold),
+                .foregroundColor: NSColor.white,
+            ]
+            let drawn = text.size(withAttributes: attributes)
+            text.draw(
+                at: NSPoint(x: (rect.width - drawn.width) / 2, y: (rect.height - drawn.height) / 2),
+                withAttributes: attributes
+            )
+            return true
+        }
     }
 }
 
@@ -218,7 +281,7 @@ private struct StripRow: View {
 
 private struct Fixture {
     var title: String
-    var icon: String
+    var icon: TabItemIcon
     var isActive: Bool
 }
 

--- a/Sources/Bloom/Views/Center/Browser/BrowserFaviconStore.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserFaviconStore.swift
@@ -1,0 +1,183 @@
+import AppKit
+import Foundation
+import Observation
+import BloomCore
+
+/// Every site's icon this Mac has seen, by origin, for as long as the app is open and across the
+/// next launch.
+///
+/// **By origin rather than by tab, because a site has one icon.** A reader walking twenty pages of
+/// one host asks once, four tabs on the same dev server share the answer, and a tab navigating
+/// within its host keeps the icon it has while the next page loads. That last one is not a rule
+/// written anywhere: the key does not change, so the lookup does not miss, so nothing flickers.
+///
+/// **A failure is remembered too.** A page declaring no icon would otherwise be asked again on
+/// every navigation for as long as the tab is open. `claim` hands out permission to ask once per
+/// origin per launch, and `BrowserSession.reload` gives it back, so pressing reload is how a
+/// reader gets a second try at a dev server that has since grown one.
+///
+/// The cache on disk is `RepoIconImage`'s argument at a longer range: a strip redraws for reasons
+/// that have nothing to do with icons, so each is decoded once. It lives in the app's own
+/// Application Support directory, which is the dev build's separately from the owner's, and is
+/// better lost than migrated.
+@MainActor
+@Observable
+final class BrowserFaviconStore {
+    static let shared = BrowserFaviconStore()
+
+    /// What the strip draws. Observed, so an icon landing redraws the tabs and nothing else has to
+    /// be told.
+    private(set) var icons: [String: NSImage] = [:]
+
+    /// The same icons as bytes, which is what is written back to disk.
+    ///
+    /// It can hold fewer than `icons` does, deliberately: the file is capped and its oldest
+    /// entries fall out, while a site whose tab is on screen keeps its picture for as long as the
+    /// app runs. A visible tab must not lose its icon because a hundred and twenty-ninth site was
+    /// visited.
+    @ObservationIgnored private var entries: [String: Entry] = [:]
+
+    /// Origins already asked about this launch, answered or not. See `claim`.
+    @ObservationIgnored private var asked: Set<String> = []
+
+    @ObservationIgnored private var hasWarmed = false
+
+    /// The write in flight, so a run of navigations that each land an icon costs one file write.
+    @ObservationIgnored private var writer: Task<Void, Never>?
+
+    private struct Entry: Codable, Sendable {
+        var png: Data
+        var seen: Date
+    }
+
+    private nonisolated static let fileName = "Favicons.plist"
+
+    /// How long a burst of new icons gathers before the file is written.
+    private static let writeDelay = Duration.seconds(1)
+
+    private init() {}
+
+    // MARK: - Reading
+
+    /// The icon for whatever page a tab is on, or nil for the globe.
+    ///
+    /// A dictionary lookup behind one `URL` parse, because it is asked from a tab's body and a
+    /// strip redraws on everything: a resize, a hover, a turn arriving three tabs along.
+    func icon(for address: String) -> NSImage? {
+        guard let origin = BrowserFavicon.origin(of: address) else { return nil }
+        return icons[origin]
+    }
+
+    // MARK: - Writing
+
+    /// Whether this origin may be asked, and takes the permission if so.
+    ///
+    /// A page with no icon, a host that will not share one across origins and a server that was
+    /// down are all failures that would otherwise repeat on every navigation, at two round trips
+    /// into the page each.
+    func claim(_ origin: String) -> Bool {
+        guard icons[origin] == nil, !asked.contains(origin) else { return false }
+        asked.insert(origin)
+        return true
+    }
+
+    /// Gives an origin its one question back, which is what a reader pressing reload is asking for.
+    func forget(_ origin: String) {
+        asked.remove(origin)
+    }
+
+    /// The bytes of an icon, already through `BrowserFavicon.read`.
+    ///
+    /// Refused rather than stored if `NSImage` will not have them, or if they draw larger than the
+    /// square the page was asked for. Both are impossible from a canvas Bloom sized and both are
+    /// checked, because this is the last point before a picture from the network is drawn inside
+    /// the app's own chrome.
+    func adopt(_ png: Data, for origin: String) {
+        guard let image = Self.image(from: png) else { return }
+        icons[origin] = image
+        entries[origin] = Entry(png: png, seen: Date())
+        save()
+    }
+
+    /// Reads the cache off disk, once.
+    ///
+    /// From the strip's own task rather than from launch, because the strip is what needs it: a
+    /// workspace reopening on a browser tab should draw its icon on the first frame instead of
+    /// asking the page for something this Mac already has. Anything already in hand wins, since an
+    /// icon can land while the file is being read.
+    func warm() async {
+        guard !hasWarmed else { return }
+        hasWarmed = true
+
+        let stored = await Task.detached(priority: .utility) { Self.read() }.value
+        for (origin, entry) in stored where entries[origin] == nil {
+            entries[origin] = entry
+            guard icons[origin] == nil, let image = Self.image(from: entry.png) else { continue }
+            icons[origin] = image
+        }
+    }
+
+    // MARK: - The file
+
+    /// Trims the cache to its cap and writes it, after a pause long enough to swallow a burst.
+    ///
+    /// Oldest by when they were adopted, because there is nothing better to go on: recording a
+    /// read would mean writing on every draw.
+    private func save() {
+        if entries.count > BrowserFavicon.cacheLimit {
+            let doomed = entries.sorted { $0.value.seen < $1.value.seen }
+                .prefix(entries.count - BrowserFavicon.cacheLimit)
+            for (origin, _) in doomed { entries[origin] = nil }
+        }
+
+        let snapshot = entries
+        writer?.cancel()
+        writer = Task {
+            try? await Task.sleep(for: Self.writeDelay)
+            guard !Task.isCancelled else { return }
+            await Task.detached(priority: .utility) { Self.write(snapshot) }.value
+        }
+    }
+
+    private nonisolated static func read() -> [String: Entry] {
+        let url = Store.defaultDirectory.appendingPathComponent(fileName)
+        guard let data = try? Data(contentsOf: url) else { return [:] }
+        // Our own file in our own container, and still bounded: a decoder handed a file that has
+        // been replaced is a decoder that can be made to work for a long time.
+        guard data.count <= BrowserFavicon.cacheLimit * (BrowserFavicon.byteLimit + 256) else {
+            return [:]
+        }
+        return (try? PropertyListDecoder().decode([String: Entry].self, from: data)) ?? [:]
+    }
+
+    private nonisolated static func write(_ entries: [String: Entry]) {
+        let directory = Store.defaultDirectory
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let encoder = PropertyListEncoder()
+        // Binary, so the bytes go in as bytes. XML would base64 every icon and make the file a
+        // third again as big for nothing.
+        encoder.outputFormat = .binary
+        guard let data = try? encoder.encode(entries) else { return }
+        try? data.write(to: directory.appendingPathComponent(fileName), options: .atomic)
+    }
+
+    /// A picture from the network, made into something the strip can draw.
+    private static func image(from png: Data) -> NSImage? {
+        guard png.count <= BrowserFavicon.byteLimit,
+              let image = NSImage(data: png), image.isValid
+        else { return nil }
+
+        let ceiling = CGFloat(BrowserFavicon.pixels)
+        let size = image.size
+        guard size.width > 0, size.height > 0, size.width <= ceiling, size.height <= ceiling else {
+            return nil
+        }
+
+        // Never a template, and this is the line here with an attacker on the other end of it. A
+        // black on transparent icon drawn as one takes the tab's own ink, at which point a page
+        // can put something indistinguishable from a control Bloom drew into Bloom's own strip.
+        image.isTemplate = false
+        return image
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
@@ -85,6 +85,10 @@ final class BrowserSession {
     /// are `BrowserFind` in the core.
     private(set) var find = BrowserFind()
 
+    /// The question in flight about this page's icon, so a tab that navigates twice does not leave
+    /// two of them racing to file an answer against two different origins.
+    @ObservationIgnored private var iconRequest: Task<Void, Never>?
+
     /// KVO on everything the toolbar reads, because the navigation delegate does not see every
     /// navigation.
     ///
@@ -195,6 +199,12 @@ final class BrowserSession {
     }
 
     func reload() {
+        // A reader pressing reload is asking for this page again, icon included. It is the only
+        // way to get a second look at an origin that had no icon the first time, which a dev
+        // server that has since grown one is exactly. See `BrowserFaviconStore.claim`.
+        if let origin = BrowserFavicon.origin(of: displayAddress) {
+            BrowserFaviconStore.shared.forget(origin)
+        }
         // A dev server that was not up when the tab opened has no page to reload, so an empty
         // view reloads the address instead of reloading nothing.
         if webView.url == nil, let url = currentURL {
@@ -297,6 +307,87 @@ final class BrowserSession {
                 }
             }
         }
+    }
+
+    // MARK: - The page's own icon
+
+    /// Asks the page what its icon is, unless this origin has been asked already.
+    ///
+    /// Off the navigation delegate rather than off the title observation, because this is a
+    /// question about a document and `didFinish` is the one callback that means one has arrived. A
+    /// `pushState` inside a single page app fires none of it and needs none: the origin has not
+    /// moved, so the store already holds the answer and the tab is already wearing it.
+    fileprivate func findIcon() {
+        guard let origin = BrowserFavicon.origin(of: displayAddress),
+              BrowserFaviconStore.shared.claim(origin)
+        else { return }
+
+        iconRequest?.cancel()
+        iconRequest = Task { [weak self] in await self?.findIcon(for: origin) }
+    }
+
+    /// Two questions and then silence, which is `BrowserFavicon.attempts`.
+    ///
+    /// **None of this costs the strip anything.** Both calls are asynchronous, the fetching and
+    /// the drawing happen inside the page, and what crosses back is a few kilobytes of PNG. There
+    /// is nothing here a tab being laid out can wait on, and the one write at the end lands in
+    /// `BrowserFaviconStore`, which the strip reads from a dictionary.
+    private func findIcon(for origin: String) async {
+        for delay in BrowserFavicon.attempts {
+            try? await Task.sleep(for: .milliseconds(delay))
+            guard !Task.isCancelled else { return }
+            // The page moved off this origin while Bloom was waiting, so any answer now would be
+            // filed against a site the tab has left.
+            guard BrowserFavicon.origin(of: displayAddress) == origin else { return }
+
+            let links = await iconLinks()
+            // Nothing declared yet. A framework that writes its `<link rel=icon>` from script has
+            // not necessarily written it by the time the page finishes loading, which is the whole
+            // reason there is a second attempt.
+            guard let choice = BrowserFavicon.choose(from: links) else { continue }
+
+            guard let answer = await iconImage(at: choice.index),
+                  // The list is read again inside the page, so a document that rewrote its
+                  // `<link>` elements in between would be handing back a different icon from the
+                  // one that was chosen. The same href or nothing.
+                  answer.href == links[choice.index].href,
+                  let png = BrowserFavicon.read(answer.dataURL)
+            else { return }
+
+            BrowserFaviconStore.shared.adopt(png, for: origin)
+            return
+        }
+    }
+
+    /// What the page says its icons are. See `BrowserFaviconScript`, which is where the argument
+    /// about the isolated content world and the numbers passed as numbers lives.
+    private func iconLinks() async -> [BrowserFaviconLink] {
+        let value: Any? = try? await webView.callAsyncJavaScript(
+            BrowserFaviconScript.links,
+            arguments: [
+                "limit": BrowserFavicon.linkLimit,
+                "chars": BrowserFavicon.textLimit,
+            ],
+            contentWorld: .defaultClient
+        )
+        return BrowserFavicon.links(from: value as? [String] ?? [])
+    }
+
+    /// One of them, named by its place in that list rather than by its address, drawn into a square
+    /// the page is told the size of and handed back as a PNG.
+    private func iconImage(at index: Int) async -> (href: String, dataURL: String)? {
+        let value: Any? = try? await webView.callAsyncJavaScript(
+            BrowserFaviconScript.image,
+            arguments: [
+                "index": index,
+                "size": BrowserFavicon.pixels,
+                "chars": BrowserFavicon.textLimit,
+                "timeout": BrowserFavicon.loadTimeout,
+            ],
+            contentWorld: .defaultClient
+        )
+        guard let pair = value as? [String], pair.count == 2 else { return nil }
+        return (href: pair[0], dataURL: pair[1])
     }
 
     /// The page asked for a window of its own, through `target="_blank"` or `window.open`.
@@ -429,6 +520,10 @@ final class BrowserSession {
 
     func stop() {
         observations = []
+        // A question put to a page whose tab has gone. Nothing would come back through it, and a
+        // sleeping task holding this session is one more thing keeping a closed web view alive.
+        iconRequest?.cancel()
+        iconRequest = nil
         // Before the web view is let go, so a page waiting on an answer gets one. Never calling
         // WebKit's completion handler hangs that page for ever, and a closing tab must not leave a
         // sheet standing on the window either. See `BrowserDialogPresenter`.
@@ -570,6 +665,7 @@ private final class NavigationObserver: NSObject, WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         owner?.refresh()
+        owner?.findIcon()
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: any Error) {

--- a/Sources/Bloom/Views/Center/Panes/SessionTabView.swift
+++ b/Sources/Bloom/Views/Center/Panes/SessionTabView.swift
@@ -34,7 +34,7 @@ struct SessionTabView: View {
     var body: some View {
         TabItemView(
             title: session.title.isEmpty ? PaneNaming.untitledChat : session.title,
-            icon: PaneGlyph.chatTab(agentMark: agentGlyph),
+            icon: .symbol(PaneGlyph.chatTab(agentMark: agentGlyph)),
             isActive: isActive,
             isRunning: isRunning,
             isAtPaneEdge: isAtPaneEdge,

--- a/Sources/Bloom/Views/Center/Panes/SessionTabsView.swift
+++ b/Sources/Bloom/Views/Center/Panes/SessionTabsView.swift
@@ -192,6 +192,11 @@ struct SessionTabsView: View {
         // an empty session list. It is `CenterColumnView`'s task now, after `onAppear`.
         .task(id: model.workspace.id) {
             tabs.load(workspaceID: model.workspace.id)
+            // The icons this Mac has already seen, read back once per launch. Here rather than at
+            // startup because this is what needs them: a workspace reopening on a browser tab
+            // should draw its icon on the first frame instead of asking the page for something
+            // that is already on disk.
+            await BrowserFaviconStore.shared.warm()
         }
     }
 
@@ -269,7 +274,7 @@ struct SessionTabsView: View {
     ) -> some View {
         TabItemView(
             title: tabs.displayTitle(of: tab, in: model),
-            icon: tab.icon,
+            icon: icon(for: tab),
             isActive: selected == .tool(tab.id),
             isAtPaneEdge: isAtPaneEdge,
             surface: Self.pane.surface,
@@ -302,6 +307,16 @@ struct SessionTabsView: View {
             onBegin: { begin(.tool(tab.id)) },
             onEnd: { finish(taken: $0) }
         ))
+    }
+
+    /// What a tool tab wears. Three of the four kinds have a glyph of Bloom's own; a browser wears
+    /// the page's own favicon, or the globe until one arrives and for ever if none does.
+    ///
+    /// A dictionary lookup behind one address parse, which is what it costs to ask this from a
+    /// body that redraws on a window resize. See `BrowserFaviconStore`.
+    private func icon(for tab: CenterTab) -> TabItemIcon {
+        guard tab.kind == .browser else { return .symbol(tab.icon) }
+        return .page(BrowserFaviconStore.shared.icon(for: tab.url))
     }
 
     private func closeTitle(for tab: CenterTab) -> String {

--- a/Sources/Bloom/Views/Tabs/TabItemIcon.swift
+++ b/Sources/Bloom/Views/Tabs/TabItemIcon.swift
@@ -1,0 +1,65 @@
+import AppKit
+import SwiftUI
+import BloomCore
+
+/// What a tab wears in front of its title.
+///
+/// Two cases, because a web page is the only tab whose mark is not Bloom's to choose. A
+/// conversation, a shell, a review and a note are named by `PaneGlyph`; a page brings its own, the
+/// way it does in every browser, and it is a picture from the network rather than a system glyph.
+///
+/// **The distinction is in the type because it is in the layout.** A page's icon arrives a second
+/// or so after the tab does, and a slot that is a symbol's intrinsic width one moment and a
+/// picture's the next is a tab whose title moves as the page loads. So `page` gets a fixed square
+/// whether it holds the icon or the globe standing in for it, and `symbol` is left exactly as it
+/// was, which is what keeps a chat tab measuring what it has always measured.
+enum TabItemIcon: Equatable {
+    /// A name from `PaneGlyph`.
+    case symbol(String)
+    /// A web page: its own icon once there is one, and the globe until then, or for ever.
+    case page(NSImage?)
+}
+
+/// The icon slot itself.
+///
+/// A favicon is content from the page drawn inside Bloom's own chrome, so it is given a box and
+/// clipped to it rather than allowed to say how big it is. `BrowserFaviconStore` has already
+/// refused anything decoding larger than the square the page was asked for, and has already said
+/// it is not a template image, which is the difference between a picture in a tab and a mark
+/// wearing the tab's own ink.
+struct TabItemIconView: View {
+    var icon: TabItemIcon
+    var ink: Color
+
+    /// The square a page's mark is drawn in, and the square the globe is centred in. A point over
+    /// `Metrics.glyph`: an icon with a ground of its own needs slightly more room than a stroked
+    /// glyph before the two read as the same size.
+    static let pageSize: CGFloat = 14
+
+    var body: some View {
+        switch icon {
+        case .symbol(let name):
+            Image(systemName: name)
+                .imageScale(.small)
+                .foregroundStyle(ink)
+        case .page(let image):
+            Group {
+                if let image {
+                    Image(nsImage: image)
+                        .resizable()
+                        .interpolation(.high)
+                        .aspectRatio(contentMode: .fit)
+                } else {
+                    Image(systemName: PaneGlyph.browser)
+                        .imageScale(.small)
+                        .foregroundStyle(ink)
+                }
+            }
+            .frame(width: Self.pageSize, height: Self.pageSize)
+            .clipped()
+            // One crossfade in a box that does not move, rather than a tab that relays out around
+            // the icon landing.
+            .animation(.easeInOut(duration: 0.12), value: image != nil)
+        }
+    }
+}

--- a/Sources/Bloom/Views/Tabs/TabItemIcon.swift
+++ b/Sources/Bloom/Views/Tabs/TabItemIcon.swift
@@ -48,7 +48,7 @@ struct TabItemIconView: View {
                     Image(nsImage: image)
                         .resizable()
                         .interpolation(.high)
-                        .aspectRatio(contentMode: .fit)
+                        .scaledToFit()
                 } else {
                     Image(systemName: PaneGlyph.browser)
                         .imageScale(.small)

--- a/Sources/Bloom/Views/Tabs/TabItemView.swift
+++ b/Sources/Bloom/Views/Tabs/TabItemView.swift
@@ -16,7 +16,10 @@ struct TabItemView: View {
     /// Every kind carries one, including a chat: a strip with a glyph on two tabs of three reads
     /// as a row that has lost an icon. Still optional, because the bottom panel's setup log and
     /// run scripts are named after the script and have nothing to add.
-    var icon: String?
+    ///
+    /// A `TabItemIcon` rather than a symbol name, because a browser tab wears the page's own
+    /// favicon and that is a picture rather than a glyph. See `TabItemIcon`.
+    var icon: TabItemIcon?
     var isActive: Bool
     var isRunning = false
     /// Whether this tab's leading edge is the leading edge of the pane itself, which is true of
@@ -102,9 +105,9 @@ struct TabItemView: View {
             }
 
             if let icon {
-                Image(systemName: icon)
-                    .imageScale(.small)
-                    .foregroundStyle(isActive ? surface.ink : Palette.textSecondary)
+                TabItemIconView(
+                    icon: icon, ink: isActive ? surface.ink : Palette.textSecondary
+                )
             }
 
             if isRenaming {

--- a/Sources/BloomCore/System/BrowserFavicon.swift
+++ b/Sources/BloomCore/System/BrowserFavicon.swift
@@ -1,0 +1,269 @@
+import CryptoKit
+import Foundation
+
+/// One `<link>` a page declares that might be its icon, as the document reported it.
+///
+/// `href` is `link.href`, which the document has already resolved against its own base. It is
+/// still a string from the network, so nothing here believes it until `URL` has parsed it.
+public struct BrowserFaviconLink: Equatable, Sendable {
+    public var rel: String
+    public var sizes: String
+    public var type: String
+    public var href: String
+
+    public init(rel: String, sizes: String = "", type: String = "", href: String) {
+        self.rel = rel
+        self.sizes = sizes
+        self.type = type
+        self.href = href
+    }
+}
+
+/// Which icon a browser tab wears, and what Bloom will accept as one.
+///
+/// **`WKWebView` has no favicon.** All of WebKit's public icon surface is on `WebView`, the
+/// framework it replaced: `mainFrameIcon` and `webView:didReceiveIcon:forFrame:`, both deprecated
+/// and neither reachable from a `WKWebView`. Measured rather than assumed, the only match for
+/// "favicon" under the macOS 26 SDK's `WebKit.framework/Headers` is a comment in
+/// `WebFrameLoadDelegate.h`. Safari uses `_WKIconLoadingDelegate`, which is in no public header.
+/// So the page is asked instead, and `BrowserFaviconScript` is what it is asked.
+///
+/// **There is no guess at `/favicon.ico`.** Most sites of the last decade declare their icon and
+/// serve something stale or nothing at that path, so the guess is wrong exactly where it matters,
+/// and it is Bloom opening a connection to whichever host a page happens to be on for a file
+/// nobody asked for. An icon a page does not declare is one Bloom does not go looking for.
+///
+/// **What comes back is never the page's own bytes.** The page rasterises its icon into a canvas
+/// Bloom sized and hands back a PNG of that, so no ICO parser, no SVG renderer and no image of a
+/// page's choosing runs in this process. `read` is the gate on the way in.
+public enum BrowserFavicon {
+    /// The square the page draws into, in device pixels. The strip draws the result at 14 points,
+    /// so 28 is what a two times display asks for and this is the next power of two up.
+    public static let pixels = 32
+
+    /// How many declarations are considered. A page with more than this many is not a page with a
+    /// better icon further down.
+    public static let linkLimit = 16
+
+    /// The most of any one attribute that crosses back. A `sizes` attribute is normally five
+    /// characters and a page is free to make it five megabytes.
+    public static let textLimit = 2_048
+
+    /// How long the page may spend loading its own icon, in milliseconds. An image element that
+    /// fires neither event otherwise leaves the call outstanding for as long as the tab is open.
+    public static let loadTimeout = 5_000
+
+    /// When the page is asked, in milliseconds after it finishes loading, and then again.
+    ///
+    /// Twice, because a framework that writes its `<link rel=icon>` from script has not written it
+    /// by `didFinish`. The alternative is a `MutationObserver` living in the page for as long as
+    /// the tab is open, and this pane deliberately has no injected script.
+    public static let attempts = [250, 1_500]
+
+    /// The most bytes a decoded icon may be. Well past anything the canvas can produce.
+    public static let byteLimit = 24 * 1_024
+
+    /// The only thing `read` will look at.
+    public static let dataPrefix = "data:image/png;base64,"
+
+    /// The longest data URL worth reading: the byte cap through base64, plus the prefix.
+    public static let dataLimit = dataPrefix.count + ((byteLimit + 2) / 3) * 4
+
+    /// How many origins are kept on disk. Losing the file costs one globe per site until each is
+    /// next visited.
+    public static let cacheLimit = 128
+
+    /// The eight bytes every PNG starts with.
+    private static let signature: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+
+    /// How many strings the script sends per declaration.
+    private static let fields = 4
+
+    // MARK: - Which page an icon belongs to
+
+    /// What an icon is filed under: scheme, host and port, with the port filled in.
+    ///
+    /// **The origin rather than the page**, because a site has one icon and a tab walking twenty
+    /// of its pages should ask once. It is also what stops the strip flickering, for free: a link
+    /// followed inside a host keeps the key, so the lookup keeps hitting and the icon stays up
+    /// while the next page loads. That is the rule `BrowserTabTitle.survives` applies to the name
+    /// beside it.
+    ///
+    /// Nil for anything that is not http or https, which is `about:blank`, a `file:` page and the
+    /// empty address a pane split open on nothing carries. All three are the globe, decided here
+    /// rather than in three places.
+    public static func origin(of address: String) -> String? {
+        let trimmed = address.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = url.host()?.lowercased(),
+              !host.isEmpty
+        else { return nil }
+
+        let port = url.port ?? (scheme == "https" ? 443 : 80)
+        return "\(scheme)://\(host):\(port)"
+    }
+
+    /// The file one origin's icon is cached in.
+    ///
+    /// A digest rather than the origin, so nothing a host is called can become a path: a host may
+    /// hold a dot, a colon and, through percent escapes, a slash.
+    public static func fileName(for origin: String) -> String {
+        let digest = SHA256.hash(data: Data(origin.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined() + ".png"
+    }
+
+    // MARK: - Which declaration is asked for
+
+    /// What the page said, read back out of the flat list the script sends.
+    ///
+    /// Flat because `callAsyncJavaScript` marshals arrays of strings and not objects worth
+    /// trusting the shape of. A length that is not a multiple of four is not an answer to this
+    /// question, and is dropped whole rather than read as far as it goes.
+    public static func links(from values: [String]) -> [BrowserFaviconLink] {
+        guard !values.isEmpty, values.count % fields == 0 else { return [] }
+        return stride(from: 0, to: values.count, by: fields).map { start in
+            BrowserFaviconLink(
+                rel: values[start],
+                sizes: values[start + 1],
+                type: values[start + 2],
+                href: values[start + 3]
+            )
+        }
+    }
+
+    /// The one declaration worth asking for, and where it is in the list.
+    ///
+    /// **The index is the answer, not a detail of it.** The bytes are fetched by a second call
+    /// naming the declaration by position rather than by address, so no string from the network
+    /// travels back into a script. See `BrowserFaviconScript`.
+    ///
+    /// The order is what a browser picks by. An icon at least as big as the square it will be
+    /// drawn in comes first, smallest such first, because it needs the least resampling. An icon
+    /// declaring no size comes next: `<link rel=icon href=/favicon.ico>` on its own is the most
+    /// common declaration there is, and ranking it under a declared 16x16 would pick the blurry
+    /// one on most of the web. A size too small comes last, largest first. Within a tier, `icon`
+    /// beats `apple-touch-icon`, which is a home screen tile with its own padding rather than a
+    /// mark for a 14 point row, and after that the page's own order decides.
+    public static func choose(from links: [BrowserFaviconLink]) -> Choice? {
+        let ranked = links.prefix(linkLimit).enumerated().compactMap { index, link in
+            Ranked(index: index, link: link)
+        }
+        guard let best = ranked.min(by: Ranked.precedes) else { return nil }
+        return Choice(index: best.index, url: best.url)
+    }
+
+    /// Which declaration the page is asked for, and what it said that was.
+    public struct Choice: Equatable, Sendable {
+        /// Its position in the list the page reported, which is how the page is asked for it.
+        public var index: Int
+        /// Where it says the icon is. Only http and https get this far.
+        public var url: URL
+
+        public init(index: Int, url: URL) {
+            self.index = index
+            self.url = url
+        }
+    }
+
+    /// One declaration with everything the ordering needs read out of it.
+    private struct Ranked {
+        var index: Int
+        var url: URL
+        var kind: Kind
+        /// The largest square it claims, or nil for one that claims nothing and for `sizes="any"`,
+        /// which is a vector saying it will draw at whatever size is asked.
+        var size: Int?
+
+        enum Kind: Int {
+            case icon
+            case appleTouch
+        }
+
+        /// Nil for a declaration Bloom will not ask for: a `rel` naming no icon, an href that will
+        /// not parse, and any scheme but http and https. That last is what keeps `data:` and
+        /// `javascript:` out, and it is a filter rather than an oversight.
+        init?(index: Int, link: BrowserFaviconLink) {
+            let tokens = Set(
+                link.rel.lowercased().components(separatedBy: .whitespacesAndNewlines)
+                    .filter { !$0.isEmpty }
+            )
+            if tokens.contains("icon") {
+                kind = .icon
+            } else if tokens.contains("apple-touch-icon")
+                || tokens.contains("apple-touch-icon-precomposed") {
+                kind = .appleTouch
+            } else {
+                return nil
+            }
+
+            guard let url = URL(string: link.href.trimmingCharacters(in: .whitespacesAndNewlines)),
+                  let scheme = url.scheme?.lowercased(),
+                  scheme == "http" || scheme == "https",
+                  url.host()?.isEmpty == false
+            else { return nil }
+
+            self.index = index
+            self.url = url
+            size = BrowserFavicon.square(in: link.sizes)
+        }
+
+        /// Which tier the ordering puts it in. See `choose` for the argument.
+        var tier: Int {
+            guard let size else { return 1 }
+            return size >= BrowserFavicon.pixels ? 0 : 2
+        }
+
+        static func precedes(_ one: Ranked, _ other: Ranked) -> Bool {
+            if one.tier != other.tier { return one.tier < other.tier }
+            if let mine = one.size, let theirs = other.size, mine != theirs {
+                // Above the square, the smallest that still covers it. Below it, the largest there
+                // is.
+                return one.tier == 0 ? mine < theirs : mine > theirs
+            }
+            if one.kind != other.kind { return one.kind.rawValue < other.kind.rawValue }
+            return one.index < other.index
+        }
+    }
+
+    /// The largest square a `sizes` attribute claims.
+    ///
+    /// `any` is a vector and claims nothing, which is not the same as claiming zero. Anything
+    /// unparseable is read the same way: a page writing nonsense here has told us nothing, not
+    /// told us it is small.
+    private static func square(in sizes: String) -> Int? {
+        let tokens = sizes.lowercased().components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+        guard !tokens.isEmpty, !tokens.contains("any") else { return nil }
+
+        let squares = tokens.compactMap { token -> Int? in
+            let parts = token.components(separatedBy: "x")
+            guard parts.count == 2,
+                  let width = Int(parts[0]), let height = Int(parts[1]),
+                  width > 0, height > 0
+            else { return nil }
+            // The short side, because that is what has to cover the square it is drawn in.
+            return min(width, height)
+        }
+        return squares.max()
+    }
+
+    // MARK: - What is accepted as an icon
+
+    /// The bytes of an icon, out of the data URL the page's canvas produced.
+    ///
+    /// Four things have to be true. The prefix is compared whole, so `data:image/svg+xml,` and a
+    /// `;charset=` slipped into the middle are refused rather than parsed leniently. The length is
+    /// capped before any decoding, so a page cannot make Bloom allocate its way through a
+    /// megabyte. And the decoded bytes have to open with the PNG signature, because the label on a
+    /// data URL is written by whoever wrote the URL.
+    public static func read(_ dataURL: String) -> Data? {
+        guard dataURL.count <= dataLimit, dataURL.hasPrefix(dataPrefix) else { return nil }
+
+        let encoded = String(dataURL.dropFirst(dataPrefix.count))
+        guard !encoded.isEmpty, let data = Data(base64Encoded: encoded) else { return nil }
+        guard data.count <= byteLimit, data.starts(with: signature) else { return nil }
+        return data
+    }
+}

--- a/Sources/BloomCore/System/BrowserFaviconScript.swift
+++ b/Sources/BloomCore/System/BrowserFaviconScript.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// The two things Bloom asks a page about its own icon.
+///
+/// **Nothing from outside this file is ever put into either string.** They are function bodies for
+/// `callAsyncJavaScript`, which passes named arguments as real JavaScript values rather than
+/// splicing characters into source, so the numbers arrive as numbers and the address of the icon
+/// never travels back in at all: the second call names the declaration by its position in the
+/// first call's list. `BrowserPageScript` keeps the same promise by having no case that carries a
+/// string, and the argument at the head of that file is the argument for this one.
+///
+/// **They run in `WKContentWorld.defaultClient`, not the page's own world.** A content world
+/// shares the DOM and not the globals, so the `<link>` read is the real one while
+/// `document.querySelectorAll`, `Image` and `HTMLCanvasElement.prototype.toDataURL` are the ones
+/// WebKit shipped. In the page's world a site is free to replace all three and answer with
+/// whatever it likes, and the answer ends up drawn inside Bloom's own chrome.
+///
+/// **The page rasterises, Bloom does not decode.** `image` draws the icon into a canvas Bloom
+/// sized and hands back a PNG of that, so the file the server sent is decoded by WebKit in
+/// WebKit's own sandbox and never by this process. An `.ico` with a hostile header, an SVG with a
+/// script in it and a two hundred megapixel PNG are all somebody else's problem, and the bytes
+/// that arrive are always a small PNG whatever the site serves.
+public enum BrowserFaviconScript {
+    /// Which elements count, in CSS's own words. `~=` is a whitespace token match, so
+    /// `rel="shortcut icon"` is found and `rel="mask-icon"`, a pinned tab silhouette rather than a
+    /// mark, is not.
+    ///
+    /// Shared, because the second script indexes into the list the first produced and two
+    /// selectors that drifted apart would fetch a different element from the one chosen.
+    private static let selector = """
+        link[rel~='icon'], link[rel~='apple-touch-icon'], link[rel~='apple-touch-icon-precomposed']
+        """
+
+    /// Every icon the page declares, four strings each: rel, sizes, type, and the resolved href.
+    ///
+    /// Which of them is worth having is `BrowserFavicon.choose`, in Swift, where it is a rule with
+    /// cases and a test rather than a sort buried in a string.
+    public static let links = """
+        const found = document.querySelectorAll("\(selector)");
+        const out = [];
+        for (let i = 0; i < found.length && out.length < limit * 4; i += 1) {
+          const link = found[i];
+          out.push(
+            String(link.rel || "").slice(0, chars),
+            String(link.getAttribute("sizes") || "").slice(0, chars),
+            String(link.type || "").slice(0, chars),
+            String(link.href || "").slice(0, chars)
+          );
+        }
+        return out;
+        """
+
+    /// One of those icons, drawn into a square canvas and handed back as a PNG data URL, with the
+    /// href it was taken from so the caller can check it against the one it chose.
+    ///
+    /// `crossOrigin = "anonymous"` is the line with a consequence. A same origin request still
+    /// carries the page's cookies, so an icon behind a login loads as it does for the page itself;
+    /// a request to another host is sent without them, so looking at a page never sends the
+    /// owner's session to a third party for a picture. The cost is that a host serving its icons
+    /// from a CDN with no `Access-Control-Allow-Origin` header cannot be read: the canvas is
+    /// tainted, `toDataURL` throws, and the tab keeps its globe.
+    public static let image = """
+        const found = document.querySelectorAll("\(selector)");
+        const link = found[index];
+        if (!link) { return null; }
+        const href = String(link.href || "").slice(0, chars);
+        if (!href) { return null; }
+
+        const image = new Image();
+        image.crossOrigin = "anonymous";
+        const loaded = await new Promise((resolve) => {
+          image.onload = () => resolve(true);
+          image.onerror = () => resolve(false);
+          setTimeout(() => resolve(false), timeout);
+          image.src = href;
+        });
+        if (!loaded) { return null; }
+
+        let width = image.naturalWidth || image.width || 0;
+        let height = image.naturalHeight || image.height || 0;
+        // An SVG with no width and no height of its own measures zero, and something zero wide
+        // draws nothing. It scales to whatever it is asked for, so it is asked for all of it.
+        if (width <= 0 || height <= 0) { width = size; height = size; }
+
+        const canvas = document.createElement("canvas");
+        canvas.width = size;
+        canvas.height = size;
+        const context = canvas.getContext("2d");
+        if (!context) { return null; }
+
+        // Letterboxed rather than stretched. A wordmark four times as wide as it is tall is a real
+        // thing to find in a `<link rel=icon>`, and squashing it would put a distorted picture in
+        // the strip instead of a small one.
+        const scale = Math.min(size / width, size / height);
+        const drawnWidth = Math.max(1, Math.round(width * scale));
+        const drawnHeight = Math.max(1, Math.round(height * scale));
+        context.drawImage(
+          image,
+          Math.round((size - drawnWidth) / 2),
+          Math.round((size - drawnHeight) / 2),
+          drawnWidth,
+          drawnHeight
+        );
+
+        let encoded = "";
+        try {
+          encoded = canvas.toDataURL("image/png");
+        } catch (error) {
+          return null;
+        }
+        return [href, encoded];
+        """
+}

--- a/Tests/BloomCoreTests/BrowserFaviconTests.swift
+++ b/Tests/BloomCoreTests/BrowserFaviconTests.swift
@@ -1,0 +1,303 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// What a browser tab wears: which of a page's declarations Bloom asks for, what it files the
+/// answer under, and what it refuses to draw.
+///
+/// The last of those is the half with consequences. A favicon is a picture from the network drawn
+/// at 14 points inside Bloom's own chrome, so `read` is the gate, and every case here is a way a
+/// data URL can claim to be something it is not.
+@Suite("Browser favicon")
+struct BrowserFaviconTests {
+    /// The smallest legal PNG: signature, IHDR, IDAT, IEND. Only the signature matters to `read`,
+    /// but a fixture that is a real file is one nobody has to wonder about.
+    private static let png = Data([
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+        0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+        0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+        0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+        0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+        0x42, 0x60, 0x82,
+    ])
+
+    private static var dataURL: String {
+        BrowserFavicon.dataPrefix + png.base64EncodedString()
+    }
+
+    private func link(
+        _ rel: String, _ href: String, sizes: String = "", type: String = ""
+    ) -> BrowserFaviconLink {
+        BrowserFaviconLink(rel: rel, sizes: sizes, type: type, href: href)
+    }
+
+    // MARK: - Which page an icon belongs to
+
+    @Test("An icon is filed under the origin, so every page of a site shares one")
+    func originIgnoresThePath() {
+        #expect(BrowserFavicon.origin(of: "https://spatie.be/open-source")
+            == BrowserFavicon.origin(of: "https://spatie.be/docs/laravel-backup"))
+    }
+
+    @Test("The port is filled in, so the same site written two ways is one key")
+    func defaultPortIsExplicit() {
+        #expect(BrowserFavicon.origin(of: "https://spatie.be/") == "https://spatie.be:443")
+        #expect(BrowserFavicon.origin(of: "https://spatie.be:443/") == "https://spatie.be:443")
+        #expect(BrowserFavicon.origin(of: "http://example.com/") == "http://example.com:80")
+    }
+
+    @Test("A dev server IS its port, so two of them are two origins")
+    func portsSeparateDevServers() {
+        #expect(BrowserFavicon.origin(of: "http://localhost:3000/") == "http://localhost:3000")
+        #expect(BrowserFavicon.origin(of: "http://localhost:3000/")
+            != BrowserFavicon.origin(of: "http://localhost:5173/"))
+    }
+
+    @Test("The host is compared in one case", arguments: [
+        "https://Spatie.BE/", "https://spatie.be/",
+    ])
+    func hostIsLowercased(address: String) {
+        #expect(BrowserFavicon.origin(of: address) == "https://spatie.be:443")
+    }
+
+    /// Every one of these is a tab that has to show the globe, and they are the globe here rather
+    /// than in three places further up.
+    @Test("Nothing but http and https has an origin", arguments: [
+        "about:blank",
+        "file:///Users/freek/notes.html",
+        "",
+        "   ",
+        "data:text/html,<h1>hi</h1>",
+        "javascript:alert(1)",
+        "https://",
+    ])
+    func nonPagesHaveNoOrigin(address: String) {
+        #expect(BrowserFavicon.origin(of: address) == nil)
+    }
+
+    @Test("A cache file is named by a digest, so nothing a host is called becomes a path")
+    func fileNameCarriesNoHostCharacters() {
+        let name = BrowserFavicon.fileName(for: "https://evil..%2f..%2fetc:443")
+        #expect(!name.contains("/"))
+        #expect(!name.contains(":"))
+        #expect(name.hasSuffix(".png"))
+        #expect(name.count == 64 + ".png".count)
+        #expect(name == BrowserFavicon.fileName(for: "https://evil..%2f..%2fetc:443"))
+        #expect(name != BrowserFavicon.fileName(for: "https://spatie.be:443"))
+    }
+
+    // MARK: - Reading what the page said
+
+    @Test("The flat list the script sends is read back four at a time")
+    func linksAreReadInFours() {
+        let links = BrowserFavicon.links(from: [
+            "icon", "32x32", "image/png", "https://spatie.be/icon.png",
+            "apple-touch-icon", "", "", "https://spatie.be/touch.png",
+        ])
+        #expect(links.count == 2)
+        #expect(links[0] == link("icon", "https://spatie.be/icon.png", sizes: "32x32", type: "image/png"))
+        #expect(links[1].rel == "apple-touch-icon")
+    }
+
+    @Test("A list that is not a multiple of four is not an answer, and is dropped whole")
+    func raggedListIsRefused() {
+        #expect(BrowserFavicon.links(from: ["icon", "32x32", "image/png"]).isEmpty)
+        #expect(BrowserFavicon.links(from: []).isEmpty)
+    }
+
+    // MARK: - Which declaration is asked for
+
+    @Test("A page that declares nothing gets no request at all")
+    func nothingDeclaredIsNothingFetched() {
+        #expect(BrowserFavicon.choose(from: []) == nil)
+    }
+
+    /// The whole of the argument against guessing at `/favicon.ico`: a page with no declaration is
+    /// a page Bloom does not go looking at.
+    @Test("A rel that names no icon is not an icon", arguments: [
+        "stylesheet", "preload", "mask-icon", "manifest", "canonical", "",
+    ])
+    func otherRelsAreIgnored(rel: String) {
+        #expect(BrowserFavicon.choose(from: [link(rel, "https://spatie.be/icon.png")]) == nil)
+    }
+
+    @Test("rel is a list of tokens, so `shortcut icon` is an icon and `iconography` is not")
+    func relIsMatchedByToken() {
+        #expect(BrowserFavicon.choose(from: [link("shortcut icon", "https://a.example/i.png")]) != nil)
+        #expect(BrowserFavicon.choose(from: [link("iconography", "https://a.example/i.png")]) == nil)
+    }
+
+    /// A declaration is a string from the network naming somewhere to make a request. Only two
+    /// schemes ever get one.
+    @Test("Only http and https are ever asked for", arguments: [
+        "javascript:alert(1)",
+        "data:image/svg+xml,<svg onload='alert(1)'/>",
+        "file:///etc/passwd",
+        "bloom://workspace/1",
+        "",
+        "not a url at all",
+    ])
+    func hostileSchemesAreRefused(href: String) {
+        #expect(BrowserFavicon.choose(from: [link("icon", href)]) == nil)
+    }
+
+    @Test("The smallest icon that still covers the square wins")
+    func smallestSufficientWins() {
+        let links = [
+            link("icon", "https://a.example/16.png", sizes: "16x16"),
+            link("icon", "https://a.example/180.png", sizes: "180x180"),
+            link("icon", "https://a.example/32.png", sizes: "32x32"),
+        ]
+        #expect(BrowserFavicon.choose(from: links)?.url.absoluteString == "https://a.example/32.png")
+    }
+
+    /// `<link rel=icon href=/favicon.ico>` on its own is the most common declaration on the web,
+    /// and ranking it under a declared 16x16 would pick the blurry one nearly everywhere.
+    @Test("An icon that declares no size beats one that declares too small a size")
+    func unsizedBeatsUndersized() {
+        let links = [
+            link("icon", "https://a.example/16.png", sizes: "16x16"),
+            link("icon", "https://a.example/favicon.ico"),
+        ]
+        #expect(BrowserFavicon.choose(from: links)?.url.absoluteString
+            == "https://a.example/favicon.ico")
+    }
+
+    @Test("`sizes=any` is a vector claiming nothing, not a claim of zero")
+    func anyIsUnsized() {
+        let links = [
+            link("icon", "https://a.example/16.png", sizes: "16x16"),
+            link("icon", "https://a.example/icon.svg", sizes: "any", type: "image/svg+xml"),
+        ]
+        #expect(BrowserFavicon.choose(from: links)?.url.absoluteString
+            == "https://a.example/icon.svg")
+    }
+
+    @Test("With nothing big enough, the biggest there is")
+    func largestOfTheSmallWins() {
+        let links = [
+            link("icon", "https://a.example/8.png", sizes: "8x8"),
+            link("icon", "https://a.example/24.png", sizes: "24x24"),
+            link("icon", "https://a.example/16.png", sizes: "16x16"),
+        ]
+        #expect(BrowserFavicon.choose(from: links)?.url.absoluteString == "https://a.example/24.png")
+    }
+
+    @Test("A multi size file is worth its biggest size")
+    func multipleSizesTakeTheLargest() {
+        let links = [
+            link("icon", "https://a.example/multi.ico", sizes: "16x16 32x32 48x48"),
+            link("icon", "https://a.example/16.png", sizes: "16x16"),
+        ]
+        #expect(BrowserFavicon.choose(from: links)?.url.absoluteString
+            == "https://a.example/multi.ico")
+    }
+
+    @Test("A home screen tile loses to a real icon of the same standing")
+    func iconBeatsAppleTouch() {
+        let links = [
+            link("apple-touch-icon", "https://a.example/touch.png"),
+            link("icon", "https://a.example/icon.png"),
+        ]
+        #expect(BrowserFavicon.choose(from: links)?.url.absoluteString
+            == "https://a.example/icon.png")
+    }
+
+    @Test("A tile is still better than nothing")
+    func appleTouchIsTakenWhenItIsAllThereIs() {
+        let links = [link("apple-touch-icon-precomposed", "https://a.example/touch.png", sizes: "180x180")]
+        #expect(BrowserFavicon.choose(from: links)?.url.absoluteString
+            == "https://a.example/touch.png")
+    }
+
+    @Test("Nonsense in `sizes` says nothing rather than says small", arguments: [
+        "banana", "32", "xx", "0x0", "-32x-32",
+    ])
+    func unparseableSizesAreUnknown(sizes: String) {
+        let links = [
+            link("icon", "https://a.example/16.png", sizes: "16x16"),
+            link("icon", "https://a.example/odd.png", sizes: sizes),
+        ]
+        #expect(BrowserFavicon.choose(from: links)?.url.absoluteString == "https://a.example/odd.png")
+    }
+
+    /// The bytes are asked for by position rather than by address, so the index has to point at
+    /// the declaration that was chosen and be counted over the list exactly as the page sent it,
+    /// including the entries that were skipped.
+    @Test("The index counts over the page's own list, skipped entries included")
+    func indexIsIntoTheReportedList() {
+        let links = [
+            link("stylesheet", "https://a.example/site.css"),
+            link("icon", "javascript:alert(1)"),
+            link("icon", "https://a.example/icon.png", sizes: "32x32"),
+        ]
+        let choice = BrowserFavicon.choose(from: links)
+        #expect(choice?.index == 2)
+        #expect(choice?.url.absoluteString == links[2].href)
+    }
+
+    @Test("The page's own order settles a tie")
+    func documentOrderBreaksTies() {
+        let links = [
+            link("icon", "https://a.example/first.png", sizes: "32x32"),
+            link("icon", "https://a.example/second.png", sizes: "32x32"),
+        ]
+        #expect(BrowserFavicon.choose(from: links)?.index == 0)
+    }
+
+    @Test("A page cannot bury the list under declarations nobody will read")
+    func onlyTheFirstFewAreConsidered() {
+        let padding = (0..<BrowserFavicon.linkLimit).map {
+            link("icon", "https://a.example/pad\($0).png", sizes: "8x8")
+        }
+        let links = padding + [link("icon", "https://a.example/perfect.png", sizes: "32x32")]
+        #expect(BrowserFavicon.choose(from: links)?.url.absoluteString.contains("perfect") == false)
+    }
+
+    // MARK: - What is accepted as an icon
+
+    @Test("A PNG data URL from the page's own canvas is read")
+    func aRealAnswerIsAccepted() {
+        #expect(BrowserFavicon.read(Self.dataURL) == Self.png)
+    }
+
+    /// The label on a data URL is written by whoever wrote the URL, so the prefix is compared
+    /// whole and the decoded bytes still have to open like a PNG.
+    @Test("Anything that is not exactly a base64 PNG data URL is refused", arguments: [
+        "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=",
+        "data:image/png,notbase64",
+        "data:image/png;charset=utf-8;base64,",
+        "data:text/html;base64,PGgxPmhpPC9oMT4=",
+        "https://a.example/icon.png",
+        "",
+        "data:image/png;base64,",
+    ])
+    func aLabelIsNotABitmap(dataURL: String) {
+        #expect(BrowserFavicon.read(dataURL) == nil)
+    }
+
+    @Test("Base64 that decodes to something that is not a PNG is refused")
+    func theSignatureIsChecked() {
+        let gif = Data("GIF89a".utf8)
+        #expect(BrowserFavicon.read(BrowserFavicon.dataPrefix + gif.base64EncodedString()) == nil)
+    }
+
+    @Test("The length is capped before any decoding happens")
+    func oversizedIsRefusedWithoutDecoding() {
+        let huge = BrowserFavicon.dataPrefix
+            + String(repeating: "A", count: BrowserFavicon.dataLimit)
+        #expect(BrowserFavicon.read(huge) == nil)
+    }
+
+    @Test("The cap is wide enough for what a canvas of that square can actually produce")
+    func theCapFitsTheCanvas() {
+        // Four bytes a pixel, uncompressed, is the worst a 32 point square can come to, and the
+        // cap has to be past it or the feature refuses its own output.
+        let worst = BrowserFavicon.pixels * BrowserFavicon.pixels * 4
+        #expect(BrowserFavicon.byteLimit > worst)
+        #expect(BrowserFavicon.dataLimit > BrowserFavicon.byteLimit)
+    }
+}


### PR DESCRIPTION
A browser tab in the centre strip showed a globe. It now shows the page's favicon, with the globe as the fallback.

`WKWebView` has no favicon API. All of WebKit's public icon surface is on the deprecated `WebView` (`mainFrameIcon`, `didReceiveIcon:forFrame:`), and Safari uses `_WKIconLoadingDelegate`, which is in no public header. Checked against the macOS 26 SDK rather than assumed.

So the page is asked, in two `callAsyncJavaScript` calls run in `WKContentWorld.defaultClient`: one for its `<link rel=icon>` declarations, one that draws the chosen icon into a 32 pixel canvas and hands back a PNG. Bloom never decodes the site's own bytes, and no string ever travels into the script (the second call names the declaration by index). There is no `/favicon.ico` guess: a page that declares nothing is a page Bloom does not go looking at.

Requests: one image load per origin, from inside the page, `crossOrigin="anonymous"`, so a same origin icon carries the page's cookies and a cross origin one does not. No `URLSession` anywhere.

`BrowserFavicon` in the core holds the ranking, the origin key, the byte and dimension caps and the data URL gate, with a suite. Cached by origin, in memory and in a binary plist under the app's own Application Support directory.

Untouched: the address bar's security glyph (it means something, and a favicon there would be the wrong thing to trust) and `pane_list`.