### PR TITLE
Let the merge button say which merge it will do

### DIFF
--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -145,6 +145,14 @@ final class WorkspaceModel {
     }
 
     var isLoadingPullRequest = false
+
+    /// How this project's branches land, which is what the band's split button promises.
+    ///
+    /// Kept here so the band can read it synchronously while it draws, and read back from the
+    /// store on every arrival, because the choice belongs to the PROJECT: two workspaces cut from
+    /// the same repository are two copies of this property and the store is the one answer between
+    /// them. See `MergeMethodChoice`, which holds the scope argument and the key.
+    private(set) var mergeMethod = MergeMethodChoice.fallback
     /// What the last press on the pull request strip left to say, drawn at the top of the
     /// inspector column.
     ///
@@ -1304,6 +1312,28 @@ final class WorkspaceModel {
     /// changed asks again with no age at all: a finished turn, the bar's own poll, and the button
     /// that creates one.
     static let pullRequestArrivalMaxAge = Duration.seconds(30)
+
+    /// Reads this project's merge method back, for the band that is about to draw it.
+    ///
+    /// Nothing here talks to GitHub or to git: it is one row of the store's key value table, so it
+    /// costs nothing to ask again every time a workspace is arrived at, and asking again is what
+    /// keeps two worktrees of one project from disagreeing about their project's convention.
+    func loadMergeMethod() async {
+        guard let store else { return }
+        mergeMethod = await MergeMethodChoice.load(repoID: workspace.repoID, from: store)
+    }
+
+    /// Changes the method in force, and merges nothing.
+    ///
+    /// The property moves first so the button's label changes with the press that changed it,
+    /// rather than a beat later when SQLite has answered. A write that fails leaves the choice
+    /// standing for this launch, which is the right way round: the alternative is a menu that
+    /// appears to ignore the tick.
+    func chooseMergeMethod(_ method: GitHub.MergeMethod) async {
+        mergeMethod = method
+        guard let store else { return }
+        await MergeMethodChoice.save(method, repoID: workspace.repoID, to: store)
+    }
 
     /// - Parameter maxAge: how old a cached answer may be. Zero always asks GitHub.
     func refreshPullRequest(maxAge: Duration = .zero) async {

--- a/Sources/Bloom/Views/Inspector/MergeSplitButton.swift
+++ b/Sources/Bloom/Views/Inspector/MergeSplitButton.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+import BloomCore
+
+/// Merge, and the chevron that says which merge.
+///
+/// One control rather than two, which is the whole point of it. The chevron used to be a separate
+/// borderless glyph beside the button, and picking a method out of it merged by that method there
+/// and then. Now the menu sets the MODE: it ticks the method in force, the button's label changes
+/// to match, and the next press on the button is what merges. Nothing in the menu performs
+/// anything, so the one irreversible act in this app stays behind the one control that says it.
+///
+/// **The system's split button, drawn by the system, with the fill painted behind it.** A
+/// `Menu` with a `primaryAction` and `.menuStyle(.button)` IS this control on macOS: it draws the
+/// hairline, the chevron, the pressed states and the keyboard, and an inline `Picker` inside it
+/// draws the tick in the menu's state column, which nothing hand rolled can do. What it does not
+/// do is take a colour. Measured on this SDK, rendered offscreen at `controlActiveState.active`:
+/// a `Button` with `.borderedProminent` and `.tint(.red)` comes out red, and the same modifiers on
+/// a `Menu` come out as the neutral capsule, prominent or not, glass or not. So the state's colour
+/// is painted as a rounded rect behind the control and the label is asked for in dark appearance,
+/// which is what makes the system draw it, its chevron and its hairline white. That is two lines
+/// over a native control, against hand drawing a capsule, a divider, a chevron and a tick.
+///
+/// The band's colour is a hard requirement rather than decoration: `PullRequestTint.fill` is the
+/// rule that the one prominent button carries the colour of the band it stands in, so a red
+/// "Checks failing" band ends in a red button. A neutral capsule there would be the strip losing
+/// the signal it exists to carry.
+struct MergeSplitButton: View {
+    /// The method in force for this project. The button promises it, the menu ticks it.
+    var method: GitHub.MergeMethod
+    /// The colour of the band this stands in. Painted only when this is the prominent control.
+    var fill: Color
+    /// Whether merging is what this state is asking for, which is what decides between the filled
+    /// control and the quiet one beside another state's primary.
+    var isPrimary: Bool
+    /// Whether GitHub will take a merge at all. A running agent is not in here: the cluster
+    /// answers for that, once, for every control in it.
+    var canMerge: Bool
+    var help: String?
+    /// Changes the mode and nothing else.
+    var choose: (GitHub.MergeMethod) -> Void
+    /// Merges, by the method in force. Opens the confirmation, like every path to a merge here.
+    var merge: () -> Void
+
+    /// Whether the CLUSTER is enabled, which is where a running agent's answer arrives. Read
+    /// rather than assumed, because the painted fill has to dim with the control it is behind:
+    /// a full strength red capsule under a greyed out label reads as a live button.
+    @Environment(\.isEnabled) private var isClusterEnabled
+
+    private var isLive: Bool { isClusterEnabled && canMerge }
+
+    @ViewBuilder
+    var body: some View {
+        if isPrimary {
+            // Two forms, as every other control in this strip has, and for the same reason: the
+            // headline is the part that must not be what truncates.
+            ViewThatFits(in: .horizontal) {
+                styled.labelStyle(.titleAndIcon)
+                styled.labelStyle(.iconOnly)
+            }
+            .fixedSize()
+        } else {
+            // The quiet form is always the glyph, measured rather than chosen: the band is 380
+            // points, and "Squash and merge" beside "Commit and push" comes to 326 of them with
+            // the number and the gaps still to pay for, which leaves the headline nothing at all.
+            // The old chevron was 19 points for the same job; this is 44, and it is what the
+            // strip can afford. The method is still said out loud, in the tick in the menu and in
+            // the tooltip, which is where an icon only control says everything anyway.
+            styled.labelStyle(.iconOnly).fixedSize()
+        }
+    }
+
+    @ViewBuilder
+    private var styled: some View {
+        if isPrimary {
+            control
+                .buttonStyle(.borderedProminent)
+                // The label, the chevron and the hairline in white. See the type's note: the
+                // system will not tint this control, so the only lever left over its ink is the
+                // appearance it draws itself for.
+                .environment(\.colorScheme, .dark)
+                .background(
+                    // Dimmed rather than hidden when the press is not available, which is how
+                    // AppKit draws a disabled prominent button and therefore how this one has
+                    // to look beside them.
+                    fill.opacity(isLive ? 1 : 0.35),
+                    in: .rect(cornerRadius: Metrics.corner)
+                )
+        } else {
+            // Quiet, beside somebody else's primary. The strip's rule is that the prominent
+            // control is whatever the state is asking for, and when that is Commit and push or
+            // Fix merge conflicts, merging is still one press away rather than gone.
+            control.buttonStyle(.bordered)
+        }
+    }
+
+    private var control: some View {
+        Menu {
+            // An inline `Picker` rather than a `Button` per method, for the reason
+            // `ComposerOptionItems` states: the tick lives in an `NSMenu` item's state column,
+            // which is the menu's to draw and not a label's, and an inline picker is what asks
+            // the platform to draw it. It also cannot perform anything, which is exactly the
+            // promise this menu makes.
+            Picker("Merge method", selection: binding) {
+                ForEach(MergeMethodChoice.offered, id: \.self) { method in
+                    // GitHub's own wording here, because this menu is read beside the web UI.
+                    // The button says `buttonLabel`, which is a promise about the next press.
+                    Text(method.label).tag(method)
+                }
+            }
+            .pickerStyle(.inline)
+            // No heading over three items whose tick says what they are, but the picker keeps its
+            // name, so the menu still announces itself to VoiceOver.
+            .labelsHidden()
+        } label: {
+            Label(method.buttonLabel, systemImage: "arrow.triangle.merge")
+        } primaryAction: {
+            merge()
+        }
+        .menuStyle(.button)
+        .controlSize(.regular)
+        .disabled(!canMerge)
+        // Disabled controls do not explain themselves, and "why is this greyed out" is the whole
+        // question a blocked pull request raises.
+        .help(help ?? "\(method.buttonLabel), or choose another method from the chevron")
+        .fixedSize()
+    }
+
+    /// Writing to it changes the mode. There is deliberately no path from here to a merge.
+    private var binding: Binding<GitHub.MergeMethod> {
+        Binding(get: { method }, set: { choose($0) })
+    }
+}

--- a/Sources/Bloom/Views/Inspector/PullRequestBar.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestBar.swift
@@ -95,6 +95,8 @@ struct PullRequestBar: View {
                 localWork: model.localWork,
                 isWorking: isWorking,
                 branchActions: branchActions,
+                mergeMethod: model.mergeMethod,
+                onChooseMergeMethod: chooseMergeMethod,
                 onMerge: merge,
                 onPush: push,
                 onFixConflicts: { fixConflicts(on: pullRequest) },
@@ -136,12 +138,26 @@ struct PullRequestBar: View {
 
     // MARK: - Actions
 
+    /// Changes how this project merges, and merges nothing.
+    ///
+    /// The whole point of the split button: the menu picks the mode, the button performs it. A
+    /// menu item that merged was the old chevron, and it meant the irreversible press was in two
+    /// places at once, one of them unlabelled until it had already happened.
+    private func chooseMergeMethod(_ method: GitHub.MergeMethod) {
+        Task { await model.chooseMergeMethod(method) }
+    }
+
     private func poll() async {
         // The first pass is an arrival rather than a poll, and it is allowed a recent answer.
         // This runs on `.task(id:)`, so it used to send two gh calls to GitHub every time the
         // window landed on a workspace, including landing back on one it had left four seconds
         // earlier. Every pass after this one asks GitHub properly: twenty seconds is exactly long
         // enough that an answer from the last one is not worth having.
+        // Read on every arrival rather than once per launch, because the choice belongs to the
+        // project and not to this workspace: picking Rebase in one of a project's worktrees has
+        // to be what the band says in the next one, and switching workspace is what starts this.
+        await model.loadMergeMethod()
+
         var maxAge = WorkspaceModel.pullRequestArrivalMaxAge
         while !Task.isCancelled {
             await model.refreshPullRequest(maxAge: maxAge)

--- a/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
@@ -33,6 +33,12 @@ struct PullRequestSummary: View {
     /// none of that may start: see `BranchActionAvailability`, which holds the reason and the
     /// words. `PullRequestCreator` takes the same value for the same reason.
     var branchActions: BranchActionAvailability
+    /// How this project merges, which the split button promises and its menu ticks. Per project
+    /// and remembered: see `MergeMethodChoice`.
+    var mergeMethod: GitHub.MergeMethod
+    /// Changes the method in force. It never merges, which is the whole difference between this
+    /// and `onMerge`.
+    var onChooseMergeMethod: (GitHub.MergeMethod) -> Void
     var onMerge: (GitHub.MergeMethod) -> Void
     /// Hands the outstanding work to the workspace's agent to commit and push.
     var onPush: () -> Void
@@ -206,8 +212,8 @@ struct PullRequestSummary: View {
     /// The primary slot belongs to whatever the state is actually asking for. With local work in
     /// the worktree that is not Merge: merging now would land the pull request WITHOUT what the
     /// reader is looking at and delete the branch it was on. So the primary swaps to Commit and
-    /// push, and merging stays exactly one click away in the menu beside it, which already listed
-    /// all three methods and already opens the same confirmation. Nothing is taken away; what
+    /// push, and merging stays exactly one press away in the quiet split button beside it, which
+    /// carries the same method and opens the same confirmation. Nothing is taken away; what
     /// changes is which of the two the strip is pointing at.
     ///
     /// **The primary control is last in every one of these, and that is the whole rule.** It used
@@ -221,10 +227,11 @@ struct PullRequestSummary: View {
     ///
     /// Everything that is not the primary sits immediately before it, at the tight spacing, so
     /// the pair still reads as one cluster rather than as two controls that happen to be near
-    /// each other. The merge method chevron before Merge is the one place this looks unusual: a
-    /// split button normally carries its chevron on the trailing side. That is worth giving up,
-    /// because the alternative is the trailing edge belonging to a 19 point chevron rather than
-    /// to the button, which is exactly the misalignment being fixed.
+    /// each other. The merge method chevron used to be the awkward one here: it stood BEFORE
+    /// Merge, on the leading side, because a 19 point chevron at the trailing edge is exactly the
+    /// misalignment the rule above was written to fix. It is inside the button now, on the
+    /// trailing side where a split button carries it, and the button's own trailing edge is still
+    /// the pane's inset. See `mergeControl`.
     private var trailing: some View {
         // Disabled here, for the cluster, rather than on each button in it. Everything in this
         // slot ends in a turn that writes to the worktree or the branch, so it is one question,
@@ -244,7 +251,11 @@ struct PullRequestSummary: View {
                 .accessibilityLabel("Working")
         } else if pullRequest.isOpen {
             HStack(spacing: Metrics.spacingTight) {
-                mergeMenu
+                // Only when merging is not what the state is asking for, because then the split
+                // button IS the primary and there is nothing to stand beside it. This is what the
+                // old chevron did in those states: it was the only way to merge a branch whose
+                // primary said Commit and push, and losing it would have taken a route away.
+                if status.remedy != .merge { mergeControl(isPrimary: false) }
                 primaryButton
             }
             .fixedSize()
@@ -273,7 +284,7 @@ struct PullRequestSummary: View {
     @ViewBuilder
     private var primaryButton: some View {
         switch status.remedy {
-        case .merge: mergeButton
+        case .merge: mergeControl(isPrimary: true)
         case .fixConflicts: fixConflictsButton
         case .commitAndPush, .push: pushButton
         }
@@ -467,64 +478,41 @@ struct PullRequestSummary: View {
             )
     }
 
-    /// The other two merge methods, and while there is local work the way to merge at all.
-    private var mergeMenu: some View {
-        Menu {
-            ForEach(GitHub.MergeMethod.allCases, id: \.self) { method in
-                Button(method.label) { propose(method) }
-            }
-        } label: {
-            Label("Choose a merge method", systemImage: "chevron.down")
-        }
-        .labelStyle(.iconOnly)
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        // The state's colour rather than a neutral grey. It stands beside a filled button in
-        // that colour and belongs to it, and a grey chevron a few points off a teal capsule
-        // reads as a stray control that wandered into the strip.
-        .foregroundStyle(tint ?? Palette.accent)
-        .controlSize(.small)
-        // A running agent is not in here: `trailing` disables the whole cluster for that, so the
-        // chevron and the button beside it can never disagree about it.
-        .disabled(!status.canMerge)
-        .help(blockedReason ?? "Merge #\(pullRequest.number), by whichever method")
-    }
-
-    /// The one prominent control in the inspector, and the only solid colour in the strip.
+    /// Merge, and the chevron that chooses which merge, as one control.
     ///
-    /// A real `Button` rather than a `Menu` with a primary action. A menu styled `.button` ignores
-    /// `.borderedProminent` and the tint under it on this SDK and comes out as the same neutral
-    /// capsule as every other control in the bar, which is exactly the signal this control exists
-    /// to carry. The other two methods moved to the chevron beside it, which stays a menu and stays
-    /// quiet because it is not the thing being pointed at.
+    /// This replaces a pair: a prominent `Merge` button that always proposed a squash, and a small
+    /// borderless chevron beside it whose three items each merged by their own method. Nothing has
+    /// been dropped. All three methods are still there, still in GitHub's own wording, still one
+    /// press from a merge; what changed is that picking one now sets the mode and the button says
+    /// which, so the press that lands somebody's branch is always the press on the thing labelled
+    /// with what it will do.
     ///
-    /// Always explicitly tinted, and the tint does take effect: measured on this SDK the fill
-    /// comes out at the tint's own value, where an untinted `.borderedProminent` comes out at
-    /// `#3478F6`, the system accent, which is whatever blue or pink the user set in General. The
-    /// fill is the state's own colour instead, so the strip is one decision from end to end and a
-    /// red bar ends in a red button. Failing checks do not block merging, which is the whole
-    /// reason that has to hold.
+    /// Prominent when merging is what the state is asking for, quiet when it is not. The quiet
+    /// form is the old chevron's other job: with local work in the worktree the primary swaps to
+    /// Commit and push, and merging has to stay reachable rather than disappear.
     ///
-    /// The one thing no tint survives is the window losing key. AppKit draws every prominent
-    /// button in an inactive window as a neutral glass capsule, this one included, and there is no
-    /// override for it short of building the control by hand. That is the platform being
-    /// consistent rather than a bug here, and it is worth knowing before reading a screenshot of
-    /// this strip: a grey Merge button means the screenshot was taken with another app in front.
+    /// **The tint measurement that used to live here has moved to `MergeSplitButton`,** because
+    /// it is the reason that control is drawn the way it is. The short version is unchanged: the
+    /// system will not tint a menu, prominent or otherwise, so the band's colour is painted behind
+    /// it. What no drawing survives is the window losing key, when AppKit draws every prominent
+    /// control as a neutral glass capsule. That is the platform being consistent rather than a bug
+    /// here, and it is worth knowing before reading a screenshot of this strip: a grey Merge
+    /// button means the screenshot was taken with another app in front.
     ///
-    /// Every path through it opens the confirmation. The button proposes a squash merge because
-    /// that is what it says; nothing here ever performs one, and since merging moved onto the
-    /// agent nothing anywhere in this target does either.
-    private var mergeButton: some View {
-        Button("Merge", systemImage: "arrow.triangle.merge") { propose(.squash) }
-            .buttonStyle(.borderedProminent)
-            .tint(status.tone.fill)
-            .controlSize(.regular)
+    /// Every path through it opens the confirmation. Nothing here performs a merge, and since
+    /// merging moved onto the agent nothing anywhere in this target does either.
+    private func mergeControl(isPrimary: Bool) -> some View {
+        MergeSplitButton(
+            method: mergeMethod,
+            fill: status.tone.fill,
+            isPrimary: isPrimary,
             // Only what GitHub says about the pull request. A running agent is the cluster's
-            // answer rather than this button's: see `trailing`.
-            .disabled(!status.canMerge)
-            // Disabled controls do not explain themselves, and "why is this greyed out" is the
-            // whole question a blocked pull request raises.
-            .help(blockedReason ?? "Squash and merge, or choose another method")
+            // answer rather than this control's: see `trailing`.
+            canMerge: status.canMerge,
+            help: blockedReason,
+            choose: onChooseMergeMethod,
+            merge: { propose(mergeMethod) }
+        )
     }
 
     // MARK: - Text

--- a/Sources/BloomCore/GitHub/MergeMethodChoice.swift
+++ b/Sources/BloomCore/GitHub/MergeMethodChoice.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Which of GitHub's three ways of landing a branch this project uses, and what the button that
+/// lands it says.
+///
+/// All three are real here rather than aspirational: `MergePromptContext` renders the method into
+/// the turn as a phrase and as the `gh pr merge` flag that performs it, and `WorkspaceMergeTool`
+/// accepts the same three from an agent. So there is something to choose between, which is what
+/// makes a split button worth drawing at all.
+///
+/// **Per project, and that is the argument worth having.** Squash versus merge commit is a
+/// repository's convention: a team either keeps a linear history or it does not, and the answer
+/// does not change because a different person, or a different worktree, is doing the landing.
+/// Per workspace would ask the same question again on every branch and answer it wrong by default
+/// on the second one; app-wide would carry one repository's convention into every other
+/// repository the owner opens. Neither is what the reader means when they pick Squash.
+///
+/// It is kept in Bloom's own store rather than in the repository's `.bloom/settings.toml`, and
+/// that is deliberate too. A settings file is a file in somebody's working tree: writing to it
+/// from a menu would dirty a branch, land in a commit, and reach a teammate who never asked. This
+/// is a preference about how the owner presses a button, so it lives where the app's other
+/// preferences live.
+public enum MergeMethodChoice {
+    /// What the button does before anybody has chosen.
+    ///
+    /// Squash, because that is what the Merge button proposed for the whole time it was one button
+    /// with a fixed method, so nobody's next press changes meaning under them.
+    public static let fallback = GitHub.MergeMethod.squash
+
+    /// The three, in GitHub's own order, which is the order the web UI lists them in.
+    public static let offered = GitHub.MergeMethod.allCases
+
+    /// Per project. `Store`'s key value table, the way fast mode and the output style are kept per
+    /// session: no column, no migration, and a missing row means "never chosen".
+    public static func key(repoID: RepoID) -> String {
+        "repo.\(repoID).mergeMethod"
+    }
+
+    /// What a stored string means. Anything unreadable falls back rather than failing: a value
+    /// written by a later version of this app, or by a hand editing the database, must not leave
+    /// the strip with no method to merge by.
+    public static func resolve(_ stored: String?) -> GitHub.MergeMethod {
+        guard let stored, let method = GitHub.MergeMethod(rawValue: stored) else { return fallback }
+        return method
+    }
+
+    public static func load(repoID: RepoID, from store: Store) async -> GitHub.MergeMethod {
+        resolve((try? await store.setting(key(repoID: repoID))) ?? nil)
+    }
+
+    /// The chosen method, written whole even when it is the fallback, so that a project where
+    /// somebody deliberately picked squash keeps squash if the fallback is ever changed.
+    public static func save(_ method: GitHub.MergeMethod, repoID: RepoID, to store: Store) async {
+        try? await store.setSetting(key(repoID: repoID), method.rawValue)
+    }
+}
+
+public extension GitHub.MergeMethod {
+    /// What the split button says it will do when this method is the one in force.
+    ///
+    /// Not `label`, which is GitHub's own menu wording and is what the menu and the confirmation
+    /// use. A button is a promise about the next press, and "Merge commit" reads as a noun where
+    /// the other two read as verbs, so the plain merge says "Merge": the same word GitHub puts on
+    /// the button under the same menu.
+    var buttonLabel: String {
+        switch self {
+        case .merge: "Merge"
+        case .squash: "Squash and merge"
+        case .rebase: "Rebase and merge"
+        }
+    }
+}

--- a/Tests/BloomCoreTests/MergeMethodChoiceTests.swift
+++ b/Tests/BloomCoreTests/MergeMethodChoiceTests.swift
@@ -1,0 +1,120 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+/// The merge split button's decisions, which are all of them except the drawing.
+///
+/// The control is a view and cannot be tested; which methods it offers, which one is in force,
+/// what it promises for each and what a stored choice reads back as are not the view's decisions
+/// and are held here.
+@Suite("Merge method choice")
+struct MergeMethodChoiceTests {
+    // MARK: - What is on offer
+
+    @Test("all three of GitHub's methods are offered, in GitHub's order")
+    func offersThree() {
+        #expect(MergeMethodChoice.offered == [.merge, .squash, .rebase])
+    }
+
+    @Test("every offered method can actually be performed")
+    func everyMethodIsReal() {
+        // The turn names the method twice, once for the reader and once for the command. A method
+        // offered in the menu with nothing behind it would be a button that asks an agent to do
+        // something the prompt cannot express.
+        for method in MergeMethodChoice.offered {
+            #expect(!method.phrase.isEmpty)
+            #expect(method.flag == "--\(method.rawValue)")
+        }
+    }
+
+    // MARK: - What the button says
+
+    @Test(
+        "the button promises the method in force",
+        arguments: [
+            (GitHub.MergeMethod.merge, "Merge"),
+            (.squash, "Squash and merge"),
+            (.rebase, "Rebase and merge"),
+        ]
+    )
+    func buttonLabels(method: GitHub.MergeMethod, label: String) {
+        #expect(method.buttonLabel == label)
+    }
+
+    @Test("the menu keeps GitHub's own wording, which is not always the button's")
+    func menuLabels() {
+        // The menu is read beside the web UI the user checks afterwards, so it says what GitHub
+        // says. The button is a promise about the next press. Only the plain merge differs.
+        #expect(GitHub.MergeMethod.merge.label == "Merge commit")
+        #expect(GitHub.MergeMethod.merge.buttonLabel == "Merge")
+        #expect(GitHub.MergeMethod.squash.label == GitHub.MergeMethod.squash.buttonLabel)
+        #expect(GitHub.MergeMethod.rebase.label == GitHub.MergeMethod.rebase.buttonLabel)
+    }
+
+    // MARK: - Reading a stored choice
+
+    @Test("a project nobody has chosen for squashes, as the single button always did")
+    func fallsBack() {
+        #expect(MergeMethodChoice.resolve(nil) == .squash)
+        #expect(MergeMethodChoice.fallback == .squash)
+    }
+
+    @Test("a value this version cannot read falls back rather than leaving no method")
+    func resolvesRubbish() {
+        #expect(MergeMethodChoice.resolve("") == .squash)
+        #expect(MergeMethodChoice.resolve("fast-forward") == .squash)
+        #expect(MergeMethodChoice.resolve("Squash") == .squash)
+    }
+
+    @Test("each method reads back as itself", arguments: MergeMethodChoice.offered)
+    func resolvesEach(method: GitHub.MergeMethod) {
+        #expect(MergeMethodChoice.resolve(method.rawValue) == method)
+    }
+
+    // MARK: - Where it is kept
+
+    @Test("the choice is keyed by project, so two projects cannot share one convention")
+    func keyIsPerProject() {
+        let one = MergeMethodChoice.key(repoID: RepoID("alpha"))
+        let other = MergeMethodChoice.key(repoID: RepoID("beta"))
+        #expect(one != other)
+        #expect(one == "repo.alpha.mergeMethod")
+    }
+
+    @Test("a chosen method survives the app being quit", .tags(.persistence), .scratchDirectory)
+    func roundTrips() async throws {
+        let store = try makeTestStore("merge-method")
+        let repo = try await store.upsert(Repo(name: "r", path: TestScratch.unique("repo")))
+
+        #expect(await MergeMethodChoice.load(repoID: repo.id, from: store) == .squash)
+
+        await MergeMethodChoice.save(.rebase, repoID: repo.id, to: store)
+
+        #expect(await MergeMethodChoice.load(repoID: repo.id, from: store) == .rebase)
+    }
+
+    @Test("choosing for one project leaves every other project alone", .tags(.persistence), .scratchDirectory)
+    func scopedToOneProject() async throws {
+        let store = try makeTestStore("merge-method")
+        let mine = try await store.upsert(Repo(name: "mine", path: TestScratch.unique("mine")))
+        let theirs = try await store.upsert(Repo(name: "theirs", path: TestScratch.unique("theirs")))
+
+        await MergeMethodChoice.save(.merge, repoID: mine.id, to: store)
+
+        #expect(await MergeMethodChoice.load(repoID: mine.id, from: store) == .merge)
+        #expect(await MergeMethodChoice.load(repoID: theirs.id, from: store) == .squash)
+    }
+
+    @Test("a deliberate choice of the fallback is stored rather than left as silence",
+          .tags(.persistence), .scratchDirectory)
+    func storesTheFallbackToo() async throws {
+        let store = try makeTestStore("merge-method")
+        let repo = try await store.upsert(Repo(name: "r", path: TestScratch.unique("repo")))
+
+        await MergeMethodChoice.save(.squash, repoID: repo.id, to: store)
+
+        // Kept whole, so the day the fallback changes, the project that picked squash still
+        // squashes. Silence means "never asked" and nothing else.
+        #expect(try await store.setting(MergeMethodChoice.key(repoID: repo.id)) == "squash")
+    }
+}


### PR DESCRIPTION
The button said Merge and always squashed. The chevron beside it held the three methods and merging happened the moment you picked one, so the label and the press disagreed and choosing was the same gesture as doing.

It is a split button now: the label says which merge ("Merge", "Squash and merge", "Rebase and merge"), the chevron only changes the mode with a tick against the one in force, and the press performs it. All three methods were already real end to end; Bloom composes a turn for the agent rather than running `gh` itself.

The choice is per project, in the store's key value table rather than in `.bloom/settings.toml`: squash versus merge is a repository's convention, so per workspace would re-ask on every branch and app-wide would carry one repository's convention into another, and a settings file lives in the working tree where writing to it from a menu would dirty a branch and reach teammates.

The system split button, verified rather than assumed: the file's old claim that a menu cannot be prominent-tinted is true, checked by rendering offscreen in a window that is never ordered, so the band's colour is painted behind the control instead and the red checks-failing state still reads.