### PR TITLE
Let a quick prompt send itself, or open a chat of its own

### DIFF
--- a/Sources/Bloom/Design/QuickPromptGallery.swift
+++ b/Sources/Bloom/Design/QuickPromptGallery.swift
@@ -22,6 +22,13 @@ import BloomCore
 /// hanging off it, the picker on each of its two tabs, a name too long for the row, and the
 /// question Delete asks. Every one of those was reported from a screenshot rather than caught
 /// here, which is what a page missing a state costs.
+///
+/// The fourth column is the two switches, which are the reason a row can now do something other
+/// than write into the box. Three of the four things a prompt can do are drawn: what the two
+/// switches read like at rest is the column beside it, and the sentence under them is the whole of
+/// how clear this is, so it is here rather than described. The list on the left carries prompts
+/// with the switches on, because the marks on those rows are the only warning somebody arrowing
+/// down the list gets.
 struct QuickPromptGallery: View {
     var app: AppModel
 
@@ -36,10 +43,13 @@ struct QuickPromptGallery: View {
                 text: "Explain the changes made in this PR as HTML. Open it as a new tab in this workspace.",
                 sortOrder: 0
             ),
+            // Sends without stopping in the box, and a name long enough that the mark saying so
+            // has to hold its column against the truncation.
             QuickPrompt(
                 name: "Run the tests and fix whatever comes back failing",
                 symbol: "checkmark.seal",
                 text: "Run make test. If anything fails, fix it and run the failing test again on its own.",
+                sendsImmediately: true,
                 sortOrder: 1
             ),
             // The mark that has to hold its own beside the tinted ones on either side of it.
@@ -49,16 +59,24 @@ struct QuickPromptGallery: View {
                 text: "Run the failing test twenty times and say what makes it fail.",
                 sortOrder: 2
             ),
+            // A chat and no send, on the row that has no name of its own: one mark on a one line
+            // row, and the chat this opens is called `Chat` rather than the first half of the
+            // sentence. See `QuickPrompt.chatTitle`.
             QuickPrompt(
                 name: "",
                 symbol: "text.alignleft",
                 text: "Walk me through the diff, file by file, and say why each change is there.",
+                opensNewChat: true,
                 sortOrder: 3
             ),
+            // Both switches, which is the one press that opens a chat and runs. Two marks on one
+            // row, in the order the sentence says them.
             QuickPrompt(
                 name: "Ship it",
                 symbol: "\u{1F680}",
                 text: "Push the branch, open the pull request, and wait for the checks.",
+                sendsImmediately: true,
+                opensNewChat: true,
                 sortOrder: 4
             ),
             // Longer than the panel by a wide margin, which is the case that has to truncate
@@ -109,6 +127,12 @@ struct QuickPromptGallery: View {
                 form("The picker, open on Emojis", prompt: prompts[4], picking: true)
                 Spacer(minLength: 0)
             }
+
+            VStack(alignment: .leading, spacing: Metrics.pane) {
+                form("Both switches on: one press opens a chat and runs", prompt: prompts[4])
+                form("A chat, and the words left waiting in it", prompt: prompts[3])
+                Spacer(minLength: 0)
+            }
         }
         .padding(Metrics.pane)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -138,7 +162,7 @@ struct QuickPromptGallery: View {
             QuickPromptForm(
                 editing: prompt,
                 startsPickingMark: picking,
-                onCancel: {}, onSave: { _, _, _ in }, onDelete: {}
+                onCancel: {}, onSave: { _ in }, onDelete: {}
             )
             .frame(width: 380)
             .background(Palette.surface, in: RoundedRectangle(cornerRadius: Metrics.corner + 2))
@@ -256,7 +280,7 @@ extension Gallery {
     static let quickPrompts = Gallery(
         name: "quick-prompts",
         title: "Quick prompts",
-        size: CGSize(width: 1320, height: 1440),
+        size: CGSize(width: 1720, height: 1600),
         needsFocus: false,
         view: { app in AnyView(QuickPromptGallery(app: app)) }
     )

--- a/Sources/Bloom/Views/Center/Composer/ComposerPrompt.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerPrompt.swift
@@ -500,8 +500,8 @@ struct ComposerPrompt<Footer: View>: View {
         return true
     }
 
-    /// A quick prompt chosen from the panel in the footer: its words go into the draft where the
-    /// caret is, and nothing is sent.
+    /// A quick prompt written into the draft where the caret is. Nothing here sends it: see
+    /// `ComposerPromptActions.insert` for who decides that and `QuickPromptDelivery` for the rule.
     ///
     /// Written into the body rather than into the whole draft, exactly as a picked file is: the
     /// caret the composer holds counts from the start of the prompt written after any `/command`,

--- a/Sources/Bloom/Views/Center/Composer/ComposerPromptActions.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerPromptActions.swift
@@ -11,7 +11,10 @@ import BloomCore
 struct ComposerPromptActions {
     /// The paperclip: opens the file panel, and writes what is chosen into the draft at the caret.
     var attach: @MainActor () -> Void
-    /// A quick prompt chosen from the panel: its words go into the draft at the caret, and nothing
-    /// is sent. See `QuickPromptInsertion`.
+    /// A quick prompt written into the draft at the caret, and nothing else: this is the writing
+    /// half only. What a chosen prompt actually does is `QuickPromptDelivery`, decided by whoever
+    /// owns the draft, because sending it and opening a chat for it are both things this surface
+    /// has no way to do. `ComposerView.fire` is that decision made; the create sheet has neither
+    /// of the other two routes and so only ever calls this.
     var insert: @MainActor (QuickPrompt) -> Void
 }

--- a/Sources/Bloom/Views/Center/Composer/ComposerView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerView.swift
@@ -107,7 +107,7 @@ struct ComposerView: View {
                 canSend: canSend,
                 project: transcript.workspace.path,
                 onAttach: actions.attach,
-                onQuickPrompt: actions.insert,
+                onQuickPrompt: { fire($0, insert: actions.insert) },
                 onSend: send,
                 onStop: transcript.stop
             )
@@ -378,6 +378,62 @@ struct ComposerView: View {
             }.value
             await transcript.submit(composed)
             await model?.removeReviewComments(ids: comments.map(\.id))
+        }
+    }
+
+    // MARK: - Quick prompts
+
+    /// What choosing a quick prompt does here.
+    ///
+    /// The four routes are `QuickPromptDelivery`'s and not this view's, which is the whole reason
+    /// that type exists: the rule has cases worth holding still, and a decision taken in a view is
+    /// one nothing can test. What is left here is the doing, and both halves of it are the paths
+    /// that already exist. Sending is `send()`, the same function Return and the Send button call,
+    /// so a prompt fired while a turn is running queues behind it exactly as a typed message does.
+    /// A new chat is `WorkspaceModel.createSession`, which is what the `+` in the strip presses.
+    ///
+    /// `canOpenNewChat` is a real question rather than a constant: this composer is dropped in
+    /// wherever a transcript exists, and without the workspace model there is no strip to open a
+    /// second chat on. A prompt that asked for one then writes into this box instead.
+    private func fire(_ prompt: QuickPrompt, insert: @MainActor (QuickPrompt) -> Void) {
+        switch QuickPromptDelivery.decided(
+            for: prompt, canSend: true, canOpenNewChat: model != nil
+        ) {
+        case .compose:
+            insert(prompt)
+        case .send:
+            // Written into the draft first and then sent, rather than submitted straight from the
+            // prompt: what goes is the box, so half a sentence already typed goes with it instead
+            // of being left behind under a turn that answered something else. The form's own line
+            // says so before the switch is turned on.
+            insert(prompt)
+            send()
+        case .composeInNewChat:
+            openChat(for: prompt, sending: false)
+        case .sendInNewChat:
+            openChat(for: prompt, sending: true)
+        }
+    }
+
+    /// Opens a chat for a quick prompt and puts the words in it, sent or waiting.
+    ///
+    /// The draft goes to the store before it goes to the transcript, and that order is the bug
+    /// this avoids: the new chat's `TranscriptModel` is already loading by the time
+    /// `createSession` returns, and the last thing that load does is read the draft out of the
+    /// store. Written the other way round, the load lands afterwards and puts the empty box back.
+    /// Both are written, so a load that had already finished is not left holding nothing, and the
+    /// two agree because the store now says the same words.
+    private func openChat(for prompt: QuickPrompt, sending: Bool) {
+        guard let model else { return }
+        let text = prompt.text
+        Task { @MainActor in
+            guard let session = await model.createSession(title: prompt.chatTitle) else { return }
+            guard sending else {
+                try? await app.store?.saveDraft(sessionID: session.id, body: text)
+                model.transcript(for: session).draft = text
+                return
+            }
+            await model.transcript(for: session).submit(text)
         }
     }
 

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptCatalog.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptCatalog.swift
@@ -11,7 +11,7 @@ import BloomCore
 ///
 /// Every edit is made against the store first and then applied here, so the list on screen is
 /// whatever the row says rather than what the form hoped it would say. The writes are narrow:
-/// `Store.update(quickPromptID:)` names the three columns a form can change and leaves the order
+/// `Store.update(quickPromptID:)` names the five columns a form can change and leaves the order
 /// and the creation date alone.
 @MainActor
 @Observable
@@ -85,11 +85,15 @@ final class QuickPromptCatalog {
     }
 
     @discardableResult
-    func add(
-        name: String, symbol: String, text: String, in store: Store?
-    ) async -> QuickPrompt? {
+    func add(_ fields: QuickPrompt.Fields, in store: Store?) async -> QuickPrompt? {
         guard let store else { return nil }
-        let prompt = QuickPrompt(name: name, symbol: symbol, text: text)
+        let prompt = QuickPrompt(
+            name: fields.name,
+            symbol: fields.symbol,
+            text: fields.text,
+            sendsImmediately: fields.sendsImmediately,
+            opensNewChat: fields.opensNewChat
+        )
         guard let written = try? await store.insert(prompt) else { return nil }
         prompts.append(written)
         return written
@@ -97,14 +101,10 @@ final class QuickPromptCatalog {
 
     @discardableResult
     func save(
-        id: QuickPromptID, name: String, symbol: String, text: String, in store: Store?
+        id: QuickPromptID, _ fields: QuickPrompt.Fields, in store: Store?
     ) async -> QuickPrompt? {
         guard let store else { return nil }
-        let changed = try? await store.update(quickPromptID: id) { prompt in
-            prompt.name = name
-            prompt.symbol = symbol
-            prompt.text = text
-        }
+        let changed = try? await store.update(quickPromptID: id) { $0.fields = fields }
         guard let changed else { return nil }
         if let index = prompts.firstIndex(where: { $0.id == id }) {
             prompts[index] = changed

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptForm.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptForm.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 import BloomCore
 
-/// Writing a quick prompt, or changing one: a name, a mark and the words. Nothing else.
+/// Writing a quick prompt, or changing one: a name, a mark, the words, and the two switches that
+/// say what pressing it does.
 ///
-/// One form for both jobs, because they are the same three fields. Editing adds Delete, on the left
+/// One form for both jobs, because they are the same five fields. Editing adds Delete, on the left
 /// of the row Save is on, which is where a destructive button goes in a Mac form and the only place
 /// this one lives. It asks before it deletes: see `QuickPromptDeletion`.
 ///
@@ -38,13 +39,15 @@ struct QuickPromptForm: View {
     /// without a click.
     var startsPickingMark = false
     var onCancel: @MainActor () -> Void
-    var onSave: @MainActor (_ name: String, _ symbol: String, _ text: String) -> Void
+    var onSave: @MainActor (QuickPrompt.Fields) -> Void
     /// Asks for the prompt to go. The panel owns the question, because the list can ask it too.
     var onDelete: @MainActor () -> Void
 
     @State private var name = ""
     @State private var symbol = QuickPrompt.defaultSymbol
     @State private var text = ""
+    @State private var sendsImmediately = false
+    @State private var opensNewChat = false
     /// Whether the fields have been filled from `editing` yet. A `task` rather than `onAppear`
     /// would run again when the panel is rebuilt under an open form and would throw away what has
     /// been typed since.
@@ -106,6 +109,8 @@ struct QuickPromptForm: View {
                     }
                     .accessibilityLabel("Quick prompt text")
             }
+
+            behaviour
 
             buttons
         }
@@ -187,6 +192,66 @@ struct QuickPromptForm: View {
         )
     }
 
+    /// The two switches, and one line saying what the pair of them will do.
+    ///
+    /// **Neither switch greys the other out**, and the sentence is why that is affordable. All
+    /// four combinations mean something, including the quiet one: a new chat with the words
+    /// waiting in its composer and nothing sent. Disabling the second switch while the first is
+    /// off would forbid that, and a disabled control in a panel this small has nowhere to carry
+    /// the reason it is disabled. So both stand alone and the line underneath reads the
+    /// combination back, which is the thing somebody wants to know before pressing Save.
+    ///
+    /// The sentence is `QuickPromptDelivery`'s rather than this view's, because what a prompt does
+    /// when it is chosen is a decision, and a decision taken in a view is one nothing can test.
+    private var behaviour: some View {
+        field("When you choose it") {
+            VStack(alignment: .leading, spacing: Metrics.spacing) {
+                toggle("Send it straight away", isOn: $sendsImmediately)
+                toggle("Open it in a new chat tab", isOn: $opensNewChat)
+
+                Text(delivery.sentence)
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    /// What the two switches add up to, which is what the line under them says.
+    private var delivery: QuickPromptDelivery {
+        QuickPromptDelivery(sendsImmediately: sendsImmediately, opensNewChat: opensNewChat)
+    }
+
+    /// One switch, drawn as a settings row rather than as SwiftUI lays a bare `Toggle` out.
+    ///
+    /// The label is on the left and the switch is at the trailing edge, which is where every
+    /// switch on this Mac is, and the label is a target of its own, because a switch is a small
+    /// thing to hit in a panel with the room for a whole row of words.
+    ///
+    /// The gesture is on the words and not on the row around them. A row-wide one sits behind the
+    /// switch as well, and the two would both fire on the same click: the switch moves and the
+    /// gesture moves it back, which reads as a control that does not work.
+    private func toggle(_ title: String, isOn: Binding<Bool>) -> some View {
+        HStack(spacing: Metrics.spacing) {
+            Text(title)
+                .font(Typo.body)
+                .foregroundStyle(Palette.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+                .contentShape(Rectangle())
+                .onTapGesture { isOn.wrappedValue.toggle() }
+
+            Spacer(minLength: Metrics.spacing)
+
+            // Labelled and then hidden, rather than built with an empty label: the words above are
+            // drawn by this row, and VoiceOver still has to be told what the switch is called.
+            Toggle(title, isOn: isOn)
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.small)
+        }
+    }
+
     private var buttons: some View {
         HStack(spacing: Metrics.spacingWide) {
             if editing != nil {
@@ -208,9 +273,13 @@ struct QuickPromptForm: View {
 
             Button("Save") {
                 onSave(
-                    name.trimmingCharacters(in: .whitespacesAndNewlines),
-                    symbol,
-                    text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    QuickPrompt.Fields(
+                        name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+                        symbol: symbol,
+                        text: text.trimmingCharacters(in: .whitespacesAndNewlines),
+                        sendsImmediately: sendsImmediately,
+                        opensNewChat: opensNewChat
+                    )
                 )
             }
             .keyboardShortcut(.defaultAction)
@@ -244,6 +313,10 @@ struct QuickPromptForm: View {
         name = editing?.name ?? suggestedName
         symbol = editing.map { QuickPrompt.resolvedSymbol($0.symbol) } ?? QuickPrompt.defaultSymbol
         text = editing?.text ?? ""
+        // Off for a new prompt, and whatever the row says for one being edited. Cancelling writes
+        // nothing, so opening the form and leaving it cannot move either switch.
+        sendsImmediately = editing?.sendsImmediately ?? false
+        opensNewChat = editing?.opensNewChat ?? false
         isNameFocused = true
     }
 }

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptMenu.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptMenu.swift
@@ -4,9 +4,12 @@ import BloomCore
 /// The panel behind the composer's quick prompt button: a search field, the prompts under it, and
 /// one row at the foot to write a new one.
 ///
-/// **Choosing a row puts its words in the box and stops.** Nothing is sent: every one of these
-/// starts a turn against a real worktree, and a list somebody arrows through by accident is the
-/// wrong place to be one keystroke away from that. See `QuickPromptInsertion`.
+/// **Choosing a row puts its words in the box and stops**, unless that one prompt was written to
+/// do more. Every one of these starts a turn against a real worktree, and a list somebody arrows
+/// through by accident is the wrong place to be one keystroke away from that, so the two switches
+/// on the form are off on every prompt until somebody turns them on. A prompt that has them on
+/// says so on its own row, which is what makes arrowing past it safe: see `QuickPromptRow` for the
+/// marks and `QuickPromptDelivery` for the four things a press can do.
 ///
 /// A `.popover` rather than a `Menu`, for the reason `WorkspaceSourcePicker` writes down: an
 /// `NSMenu` cannot contain a text field, so a menu with a search box in it is not a thing macOS
@@ -290,7 +293,7 @@ struct QuickPromptMenu: View {
             editing: editing,
             suggestedName: suggested,
             onCancel: { self.editor = nil },
-            onSave: { name, symbol, text in save(editing, name: name, symbol: symbol, text: text) },
+            onSave: { fields in save(editing, fields) },
             onDelete: {
                 guard let editing else { return }
                 deleting = editing
@@ -305,15 +308,15 @@ struct QuickPromptMenu: View {
         onPick(prompt)
     }
 
-    private func save(_ editing: QuickPrompt?, name: String, symbol: String, text: String) {
+    private func save(_ editing: QuickPrompt?, _ fields: QuickPrompt.Fields) {
         let catalog = catalog
         let store = app.store
         editor = nil
         Task {
             if let editing {
-                await catalog.save(id: editing.id, name: name, symbol: symbol, text: text, in: store)
+                await catalog.save(id: editing.id, fields, in: store)
             } else {
-                let written = await catalog.add(name: name, symbol: symbol, text: text, in: store)
+                let written = await catalog.add(fields, in: store)
                 // The prompt somebody has just written is the one they were looking for, so the
                 // list comes back with it highlighted and Return away from being used.
                 if let written { selected = written }

--- a/Sources/Bloom/Views/Center/Composer/QuickPromptRow.swift
+++ b/Sources/Bloom/Views/Center/Composer/QuickPromptRow.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 import BloomCore
 
-/// One quick prompt in the panel: its mark, its name, the first stretch of its words, and the
-/// pencil that opens it for editing.
+/// One quick prompt in the panel: its mark, its name, the first stretch of its words, whatever it
+/// does beyond writing into the box, and the pencil that opens it for editing.
 ///
 /// The same shape as `WorkspaceSourceRow` and `FileMentionRow`, deliberately: they are all the same
 /// thing, a filtered floating list somebody arrows through, and a second idiom for the third one is
@@ -58,6 +58,8 @@ struct QuickPromptRow: View {
 
                 Spacer(minLength: Metrics.spacingSmall)
 
+                deliveryMarks
+
                 // The space is always taken, and only the pencil comes and goes. Shown and hidden
                 // by presence, a name long enough to need the room lost forty points of it the
                 // moment the row was arrowed onto: the text reflowed into an ellipsis under the
@@ -74,7 +76,11 @@ struct QuickPromptRow: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(prompt.resolvedName)
-        .accessibilityValue(prompt.preview)
+        .accessibilityValue(
+            QuickPromptDelivery(prompt) == .compose
+                ? prompt.preview
+                : prompt.preview + ". " + QuickPromptDelivery(prompt).sentence
+        )
         // The labels above set no emphasized colour, and that is the other half of this decision.
         // They used to switch to white whenever the row was selected and the window was active,
         // which was right while the fill was the accent one and became white text on light grey the
@@ -101,6 +107,35 @@ struct QuickPromptRow: View {
             Button("Edit", action: onEdit)
             Button("Delete", role: .destructive, action: onDelete)
         }
+    }
+
+    /// What this row does beyond writing its words into the box, when it does anything.
+    ///
+    /// **A list somebody arrows through must not hide a send.** The panel's whole safety argument
+    /// was that choosing a row cannot start a turn, and a prompt with the switches on breaks that
+    /// for itself. So it says so on the row, at the trailing edge beside the pencil, before the
+    /// press rather than after it. Two glyphs and not a word, because the row spends its width
+    /// on a name and a preview, and the sentence they stand for is on the tooltip and in the
+    /// accessibility value.
+    ///
+    /// The chat comes before the paperplane, in the order the thing happens and in the order
+    /// `QuickPromptDelivery.sentence` says it.
+    @ViewBuilder
+    private var deliveryMarks: some View {
+        let delivery = QuickPromptDelivery(prompt)
+        if delivery != .compose {
+            HStack(spacing: Metrics.spacingSmall) {
+                if delivery.opensNewChat { glyph("plus.bubble") }
+                if delivery.sends { glyph("paperplane") }
+            }
+            .help(delivery.sentence)
+        }
+    }
+
+    private func glyph(_ name: String) -> some View {
+        Image(systemName: name)
+            .imageScale(.small)
+            .foregroundStyle(Palette.textTertiary)
     }
 
     /// A button inside the row's own button, which AppKit resolves the way it looks: a click on the

--- a/Sources/Bloom/Views/Sidebar/CreateWorkspaceSheet.swift
+++ b/Sources/Bloom/Views/Sidebar/CreateWorkspaceSheet.swift
@@ -568,6 +568,10 @@ struct CreateWorkspaceSheet: View {
                 // exist yet and a style the project defines is already in the repository.
                 project: repo?.path,
                 onAttach: actions.attach,
+                // Written into the box, whatever the prompt's own two switches say. There is no
+                // conversation here to send into and no strip to open a chat on, and the sheet is
+                // not going to cut a worktree because a row was arrowed onto. `QuickPromptDelivery`
+                // is the same fallback said once, for a surface that can do neither.
                 onQuickPrompt: actions.insert,
                 onSend: create
             )

--- a/Sources/BloomCore/Bridge/QuickPromptTool.swift
+++ b/Sources/BloomCore/Bridge/QuickPromptTool.swift
@@ -163,6 +163,14 @@ enum QuickPromptCall {
 
     /// One prompt, whole. The text is not truncated: a model asked to change a prompt has to be
     /// able to read the one it is changing, and the preview the panel draws is not the prompt.
+    ///
+    /// The two switches are reported and cannot be written by any of these four tools, which is a
+    /// decision rather than an omission. They say what happens when the OWNER presses a row: one
+    /// of the four turns his next press into a turn he did not read first, and a tool that could
+    /// set them would be an agent arranging that. `quick_prompt_update` rewrites the words of a
+    /// prompt somebody already trusts; it does not get to change what pressing it does. Read as
+    /// `sends_immediately` and `opens_new_chat`, so a model changing the text of a prompt can at
+    /// least see which kind of prompt it is editing.
     static func json(_ prompt: QuickPrompt) -> JSONValue {
         .object([
             "id": .string(prompt.id.rawValue),
@@ -170,6 +178,8 @@ enum QuickPromptCall {
             "shown_as": .string(prompt.resolvedName),
             "symbol": .string(prompt.symbol),
             "text": .string(prompt.text),
+            "sends_immediately": .bool(prompt.sendsImmediately),
+            "opens_new_chat": .bool(prompt.opensNewChat),
             "sort_order": .integer(prompt.sortOrder),
             "created_at": .string(prompt.createdAt.formatted(.iso8601)),
         ])
@@ -513,7 +523,10 @@ public struct QuickPromptUpdateTool: BridgeToolHandling {
 ///    That is the same argument the project tools are held to.
 /// 2. **The answer carries the prompt back.** A worktree cannot be handed to a model in a tool
 ///    result; a quick prompt is a name, a mark and a few lines, and all three are in the answer.
-///    `quick_prompt_create` writes it back verbatim, which is an undo that costs one call.
+///    `quick_prompt_create` writes it back verbatim, which is an undo that costs one call. The two
+///    delivery switches are the one thing that does not come back, because no tool here can set
+///    them: see `QuickPromptCall.json`. The answer still reports them, so the owner is told what
+///    the prompt he has to turn back on was doing.
 ///
 /// **Deleting a built-in behaves exactly as deleting one in the window does**, because it is the
 /// same call: `Store.deleteQuickPrompt`. Nothing here writes `QuickPromptSeed.versionKey`, and
@@ -533,7 +546,9 @@ public struct QuickPromptDeleteTool: BridgeToolHandling {
 
             There is no undo and Bloom keeps no copy. The answer repeats the whole prompt, its \
             name, its mark and its text, so quick_prompt_create can write it back if this turns \
-            out to have been the wrong one. That is the only way back.
+            out to have been the wrong one. That is the only way back, and it comes back as an \
+            ordinary prompt: if sends_immediately or opens_new_chat was set, say so to the owner, \
+            because no tool can set those and only he can turn them on again.
 
             Deleting one of Bloom's own built-in prompts is a deletion like any other: it stays \
             deleted, and no later launch and no later version of Bloom puts it back.

--- a/Sources/BloomCore/Persistence/Store.swift
+++ b/Sources/BloomCore/Persistence/Store.swift
@@ -756,6 +756,36 @@ public actor Store {
                 created_at REAL NOT NULL
             );
             """),
+
+            // The two switches on a quick prompt: whether choosing it sends the words rather than
+            // leaving them in the composer, and whether it opens a new chat for them.
+            //
+            // Zero rather than NULL, and no backfill. Every prompt in the table was written when
+            // insert-and-stop was the only thing a quick prompt could do, and off is exactly that
+            // behaviour, so the default is not a guess about what the owner wanted, it is what the
+            // row has always done. See `QuickPromptDelivery`.
+            //
+            // Real code rather than SQL for the reason the two steps above give: `ADD COLUMN` has
+            // no `IF NOT EXISTS`, and the store's own tests rewind `user_version` to reproduce an
+            // old schema, so a step that could not be replayed would throw and take the whole
+            // migration transaction with it.
+            { db in
+                let existing = Set(
+                    try db.query("PRAGMA table_info(quick_prompt);").compactMap { $0.string("name") }
+                )
+                if !existing.contains("sends_immediately") {
+                    try db.execute("""
+                        ALTER TABLE quick_prompt
+                        ADD COLUMN sends_immediately INTEGER NOT NULL DEFAULT 0;
+                        """)
+                }
+                if !existing.contains("opens_new_chat") {
+                    try db.execute("""
+                        ALTER TABLE quick_prompt
+                        ADD COLUMN opens_new_chat INTEGER NOT NULL DEFAULT 0;
+                        """)
+                }
+            },
         ]
 
         let current = Int(db.userVersion)
@@ -2294,8 +2324,16 @@ public actor Store {
         guard var row = try quickPrompt(id: quickPromptID) else { return nil }
         change(&row)
         try db.run(
-            "UPDATE quick_prompt SET name = ?, symbol = ?, text = ? WHERE id = ?",
-            [.text(row.name), .text(row.symbol), .text(row.text), .text(quickPromptID)]
+            """
+            UPDATE quick_prompt
+            SET name = ?, symbol = ?, text = ?, sends_immediately = ?, opens_new_chat = ?
+            WHERE id = ?
+            """,
+            [
+                .text(row.name), .text(row.symbol), .text(row.text),
+                .int(row.sendsImmediately ? 1 : 0), .int(row.opensNewChat ? 1 : 0),
+                .text(quickPromptID),
+            ]
         )
         row.id = quickPromptID
         return row
@@ -2337,11 +2375,14 @@ public actor Store {
     private func insertQuickPromptRow(_ prompt: QuickPrompt) throws {
         try db.run(
             """
-            INSERT INTO quick_prompt (id, name, symbol, text, sort_order, created_at)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO quick_prompt (
+                id, name, symbol, text, sends_immediately, opens_new_chat, sort_order, created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
                 .text(prompt.id), .text(prompt.name), .text(prompt.symbol), .text(prompt.text),
+                .int(prompt.sendsImmediately ? 1 : 0), .int(prompt.opensNewChat ? 1 : 0),
                 .int(Int64(prompt.sortOrder)),
                 .double(prompt.createdAt.timeIntervalSince1970),
             ]
@@ -2705,6 +2746,11 @@ public actor Store {
             name: row.string("name") ?? "",
             symbol: row.string("symbol") ?? QuickPrompt.defaultSymbol,
             text: row.string("text") ?? "",
+            // A row read before the migration ran, or through a query that did not name the
+            // column, has no value here at all, and no value means the prompt behaves the way it
+            // always has. See `QuickPromptDelivery`.
+            sendsImmediately: row.int("sends_immediately") == 1,
+            opensNewChat: row.int("opens_new_chat") == 1,
             sortOrder: Int(row.int("sort_order") ?? 0),
             createdAt: row.date("created_at") ?? Date()
         )

--- a/Sources/BloomCore/Transcript/QuickPrompt.swift
+++ b/Sources/BloomCore/Transcript/QuickPrompt.swift
@@ -23,8 +23,18 @@ public struct QuickPrompt: Identifiable, Sendable, Hashable {
     /// held nothing but symbol names still reads back correctly. `QuickPromptMark` is what tells
     /// the two apart.
     public var symbol: String
-    /// The words that go into the draft. Never sent on their own: see `QuickPromptInsertion`.
+    /// The words that go into the draft. Where they land, and whether they go on their own, is
+    /// `QuickPromptDelivery` reading the two switches below.
     public var text: String
+    /// Whether choosing it sends the words rather than leaving them in the composer to be edited.
+    ///
+    /// Off for every prompt written before this existed, which is what the migration on
+    /// `quick_prompt` defaults it to. The whole library behaved that way for its whole life, and a
+    /// stored row must not change what it does because Bloom learned a new column.
+    public var sendsImmediately: Bool
+    /// Whether choosing it opens a new chat for the words rather than using the one on screen.
+    /// Off by default, for the reason above.
+    public var opensNewChat: Bool
     /// Where it sits in the list. There is no reordering, so this only ever says which order they
     /// were written in; search is the ordering anybody actually uses.
     public var sortOrder: Int
@@ -35,6 +45,8 @@ public struct QuickPrompt: Identifiable, Sendable, Hashable {
         name: String,
         symbol: String = QuickPrompt.defaultSymbol,
         text: String,
+        sendsImmediately: Bool = false,
+        opensNewChat: Bool = false,
         sortOrder: Int = 0,
         createdAt: Date = Date()
     ) {
@@ -42,8 +54,58 @@ public struct QuickPrompt: Identifiable, Sendable, Hashable {
         self.name = name
         self.symbol = symbol
         self.text = text
+        self.sendsImmediately = sendsImmediately
+        self.opensNewChat = opensNewChat
         self.sortOrder = sortOrder
         self.createdAt = createdAt
+    }
+
+    /// Everything about a prompt the owner chooses, which is everything the form writes.
+    ///
+    /// A value rather than five arguments, because the form hands this down through a closure and
+    /// a catalogue method, and `onSave(name, symbol, text, true, false)` is a call nobody can read
+    /// at either end. The id, the order and the date are not here: none of the three is a thing a
+    /// person types, and all three belong to the row rather than to what is written into it.
+    public struct Fields: Sendable, Equatable {
+        public var name: String
+        public var symbol: String
+        public var text: String
+        public var sendsImmediately: Bool
+        public var opensNewChat: Bool
+
+        public init(
+            name: String,
+            symbol: String = QuickPrompt.defaultSymbol,
+            text: String,
+            sendsImmediately: Bool = false,
+            opensNewChat: Bool = false
+        ) {
+            self.name = name
+            self.symbol = symbol
+            self.text = text
+            self.sendsImmediately = sendsImmediately
+            self.opensNewChat = opensNewChat
+        }
+    }
+
+    /// What the form opens with, and what it writes back.
+    public var fields: Fields {
+        get {
+            Fields(
+                name: name,
+                symbol: symbol,
+                text: text,
+                sendsImmediately: sendsImmediately,
+                opensNewChat: opensNewChat
+            )
+        }
+        set {
+            name = newValue.name
+            symbol = newValue.symbol
+            text = newValue.text
+            sendsImmediately = newValue.sendsImmediately
+            opensNewChat = newValue.opensNewChat
+        }
     }
 
     /// What a row without an icon gets, and what an unknown symbol name falls back to.
@@ -103,6 +165,19 @@ public struct QuickPrompt: Identifiable, Sendable, Hashable {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.isEmpty else { return trimmed }
         return preview
+    }
+
+    /// What a chat opened for this prompt is called, or nil for the strip's own numbered `Chat`.
+    ///
+    /// The name the owner typed, and only that. `PaneNaming` is emphatic that a chat is furniture
+    /// rather than a description of what is in it, with the exception it names being a chat opened
+    /// FOR something, which is what the pull request and merge buttons pass a title for. A quick
+    /// prompt somebody called "Ship it" is exactly that case. A quick prompt with no name is not:
+    /// `resolvedName` would hand the strip the first stretch of the words, which is the fragment of
+    /// somebody's sentence that rule exists to keep out of the tab bar.
+    public var chatTitle: String? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     /// Whether the row has anything to say on a second line.

--- a/Sources/BloomCore/Transcript/QuickPromptDelivery.swift
+++ b/Sources/BloomCore/Transcript/QuickPromptDelivery.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// What choosing a quick prompt does: where its words land, and whether they go on their own.
+///
+/// **Insert and stop is still what a quick prompt does.** Both switches are off on every prompt
+/// that exists, off on every prompt written from now on unless somebody turns them on, and off on
+/// every row the store reads back that predates the columns. Everything below is what somebody can
+/// opt one prompt into, one prompt at a time.
+///
+/// **Four cases rather than two booleans, because the pair is one decision.** A view asking
+/// "should I send?" and then "should I open a chat?" is two questions with three answers between
+/// them, and the interesting one is the combination: opening a chat and NOT sending is a tab with
+/// words waiting in its composer, which is a coherent thing to want and reads nothing like the
+/// other three. So the pair is collapsed here, once, and every surface switches over the four.
+///
+/// **Neither switch disables the other in the form.** All four combinations do something a person
+/// might have meant, so there is nothing to grey out; what the form draws instead is `sentence`,
+/// which says in words what the combination will do. A disabled control with no reason attached is
+/// worse than a sentence, and hiding one would hide a real behaviour.
+///
+/// **A surface that cannot do what a prompt asks composes instead.** The create sheet has no chat
+/// to send into and no strip to open a tab on, and a conversation dropped in without a workspace
+/// model behind it has no way to make a second one. Falling back to the draft is the only answer
+/// that loses nothing: the words are in the box, and the person presses Send.
+public enum QuickPromptDelivery: Equatable, Sendable, CaseIterable {
+    /// The words go into the draft at the caret. Nothing is sent. What every prompt does today.
+    case compose
+    /// The words go into the draft and the draft is sent, by the same path the Send button takes.
+    case send
+    /// A new chat opens with the words waiting in its composer.
+    case composeInNewChat
+    /// A new chat opens and the words are sent in it.
+    case sendInNewChat
+
+    /// The pair as the form holds it, before any surface has said what it can do.
+    public init(sendsImmediately: Bool, opensNewChat: Bool) {
+        switch (sendsImmediately, opensNewChat) {
+        case (false, false): self = .compose
+        case (true, false): self = .send
+        case (false, true): self = .composeInNewChat
+        case (true, true): self = .sendInNewChat
+        }
+    }
+
+    public init(_ prompt: QuickPrompt) {
+        self.init(
+            sendsImmediately: prompt.sendsImmediately, opensNewChat: prompt.opensNewChat
+        )
+    }
+
+    /// What this prompt does on a surface that can do only some of it.
+    ///
+    /// - Parameters:
+    ///   - canSend: whether there is a conversation here to send into.
+    ///   - canOpenNewChat: whether a second chat can be opened beside this one.
+    public static func decided(
+        for prompt: QuickPrompt, canSend: Bool, canOpenNewChat: Bool
+    ) -> QuickPromptDelivery {
+        switch QuickPromptDelivery(prompt) {
+        case .compose:
+            return .compose
+        case .send:
+            return canSend ? .send : .compose
+        case .composeInNewChat:
+            return canOpenNewChat ? .composeInNewChat : .compose
+        case .sendInNewChat:
+            // Not sent here instead. The whole of that switch is that this conversation is not
+            // where the words belong, so when there is no chat to open the send falls away with
+            // it and the words wait in the box.
+            guard canOpenNewChat else { return .compose }
+            return canSend ? .sendInNewChat : .composeInNewChat
+        }
+    }
+
+    /// Whether the words go without being read again.
+    public var sends: Bool { self == .send || self == .sendInNewChat }
+
+    /// Whether a chat is opened for them.
+    public var opensNewChat: Bool { self == .composeInNewChat || self == .sendInNewChat }
+
+    /// What the form says under the two switches, in the words of what will happen.
+    ///
+    /// Written here rather than in the form because it is the same decision the four cases above
+    /// are, said to a person instead of to a `switch`, and because a sentence a suite can read back
+    /// is a sentence that stays true when a fifth case is added.
+    ///
+    /// The middle one names the rest of the draft on purpose. Sending straight away sends what is
+    /// already in the box along with the prompt, which is the one thing about these switches
+    /// somebody could be surprised by after the fact.
+    public var sentence: String {
+        switch self {
+        case .compose:
+            "The words go in the composer here, and nothing is sent until you send it."
+        case .send:
+            "The words go in the composer here and are sent at once, "
+                + "along with anything already typed there."
+        case .composeInNewChat:
+            "A new chat tab opens with the words waiting in its composer. Nothing is sent."
+        case .sendInNewChat:
+            "A new chat tab opens and the words are sent in it straight away."
+        }
+    }
+}

--- a/Sources/BloomCore/Transcript/QuickPromptInsertion.swift
+++ b/Sources/BloomCore/Transcript/QuickPromptInsertion.swift
@@ -3,9 +3,12 @@ import Foundation
 /// What choosing a quick prompt does to the draft: its text goes in at the caret, and nothing is
 /// sent.
 ///
-/// **Insert, never send.** Every one of these starts a turn against a real worktree, and a list
-/// somebody arrows through is the wrong place to be one keystroke away from that. So the prompt is
-/// a starting point: it can be edited, appended to, and a second one can be stacked after it.
+/// **Insert, never send, unless this one prompt was written to send.** Every one of these starts a
+/// turn against a real worktree, and a list somebody arrows through is the wrong place to be one
+/// keystroke away from that. So the prompt is a starting point by default: it can be edited,
+/// appended to, and a second one can be stacked after it. `QuickPromptDelivery` is the switch out
+/// of that, per prompt and off until somebody turns it on, and the row in the panel says which
+/// prompts have it. This type is what every one of those four routes writes with.
 ///
 /// It goes in as plain text and not as a chip. Bloom draws chips for files and for a `/command`
 /// because each of those stands for something the CLI resolves later, and a chip is a thing you can

--- a/Tests/BloomCoreTests/QuickPromptDeliveryTests.swift
+++ b/Tests/BloomCoreTests/QuickPromptDeliveryTests.swift
@@ -1,0 +1,137 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+/// What a quick prompt does when it is chosen: the four combinations of its two switches, what a
+/// surface that cannot do all four falls back to, and the sentence the form reads back.
+@Suite("Quick prompt delivery")
+struct QuickPromptDeliveryTests {
+    private static func prompt(sends: Bool = false, newChat: Bool = false) -> QuickPrompt {
+        QuickPrompt(
+            name: "Ship it",
+            text: "Push the branch.",
+            sendsImmediately: sends,
+            opensNewChat: newChat
+        )
+    }
+
+    /// The one that is not negotiable. Every prompt that exists was written when insert-and-stop
+    /// was the only thing a quick prompt could do, and the value with nothing said about it has to
+    /// still be that.
+    @Test("a prompt with nothing turned on writes into the box and stops")
+    func offByDefault() {
+        let plain = QuickPrompt(name: "Explain", text: "Explain the changes.")
+        #expect(!plain.sendsImmediately)
+        #expect(!plain.opensNewChat)
+        #expect(QuickPromptDelivery(plain) == .compose)
+        #expect(!QuickPromptDelivery(plain).sends)
+        #expect(!QuickPromptDelivery(plain).opensNewChat)
+    }
+
+    @Test("the two switches are the four things a press can do")
+    func theFour() {
+        #expect(QuickPromptDelivery(Self.prompt()) == .compose)
+        #expect(QuickPromptDelivery(Self.prompt(sends: true)) == .send)
+        #expect(QuickPromptDelivery(Self.prompt(newChat: true)) == .composeInNewChat)
+        #expect(QuickPromptDelivery(Self.prompt(sends: true, newChat: true)) == .sendInNewChat)
+    }
+
+    @Test("each case says whether it sends and whether it opens a chat")
+    func readsBack() {
+        for delivery in QuickPromptDelivery.allCases {
+            let round = QuickPromptDelivery(
+                sendsImmediately: delivery.sends, opensNewChat: delivery.opensNewChat
+            )
+            #expect(round == delivery)
+        }
+    }
+
+    // MARK: - What a surface can do
+
+    /// The create sheet: no conversation to send into, no strip to open a chat on. Every prompt
+    /// writes into the box there, which is what it did before either switch existed.
+    @Test("a surface that can do neither writes into the box, whatever the prompt asks")
+    func composeOnlySurface() {
+        for delivery in QuickPromptDelivery.allCases {
+            let asked = Self.prompt(sends: delivery.sends, newChat: delivery.opensNewChat)
+            let decided = QuickPromptDelivery.decided(
+                for: asked, canSend: false, canOpenNewChat: false
+            )
+            #expect(decided == .compose)
+        }
+    }
+
+    /// A composer dropped in without a workspace model: it can send, and it has no strip.
+    @Test("with no strip to open a chat on, a send in place still sends")
+    func sendsInPlace() {
+        let decided = QuickPromptDelivery.decided(
+            for: Self.prompt(sends: true), canSend: true, canOpenNewChat: false
+        )
+        #expect(decided == .send)
+    }
+
+    /// The one worth arguing about. A prompt that asked for a new chat AND a send does not send
+    /// here instead: the switch said this conversation is not where the words belong, so the send
+    /// falls away with the chat and the words wait in the box.
+    @Test("a prompt that wanted a chat it cannot have waits in the box rather than sending here")
+    func neverSendsSomewhereItWasNotAskedTo() {
+        let both = QuickPromptDelivery.decided(
+            for: Self.prompt(sends: true, newChat: true), canSend: true, canOpenNewChat: false
+        )
+        #expect(both == .compose)
+
+        let quiet = QuickPromptDelivery.decided(
+            for: Self.prompt(newChat: true), canSend: true, canOpenNewChat: false
+        )
+        #expect(quiet == .compose)
+    }
+
+    @Test("a conversation with a strip behind it does what the prompt asks")
+    func fullSurface() {
+        for delivery in QuickPromptDelivery.allCases {
+            let asked = Self.prompt(sends: delivery.sends, newChat: delivery.opensNewChat)
+            let decided = QuickPromptDelivery.decided(
+                for: asked, canSend: true, canOpenNewChat: true
+            )
+            #expect(decided == delivery)
+        }
+    }
+
+    // MARK: - What the form says
+
+    /// The line under the two switches is the whole of how clear this is, so it is pinned: four
+    /// cases, four different sentences, none of them empty.
+    @Test("every combination has its own sentence")
+    func sentences() {
+        let said = QuickPromptDelivery.allCases.map(\.sentence)
+        #expect(Set(said).count == QuickPromptDelivery.allCases.count)
+        #expect(said.allSatisfy { !$0.isEmpty })
+    }
+
+    /// Sending in place sends the rest of the draft with the prompt, which is the one thing about
+    /// these switches somebody could be surprised by afterwards. The sentence has to say so.
+    @Test("the sentence for sending in place names what is already in the box")
+    func namesTheDraft() {
+        #expect(QuickPromptDelivery.send.sentence.contains("already typed"))
+    }
+
+    @Test("both of the new chat sentences say a chat opens, and only one of them sends")
+    func namesTheChat() {
+        #expect(QuickPromptDelivery.composeInNewChat.sentence.contains("new chat"))
+        #expect(QuickPromptDelivery.sendInNewChat.sentence.contains("new chat"))
+        #expect(QuickPromptDelivery.composeInNewChat.sentence.contains("Nothing is sent"))
+    }
+
+    // MARK: - What the chat is called
+
+    /// A chat opened for a prompt takes the name the owner gave the prompt, and nothing else.
+    /// `PaneNaming` is why: a tab is furniture, and the alternative here is the first stretch of
+    /// somebody's sentence in the tab bar.
+    @Test("a named prompt names the chat it opens, and an unnamed one leaves it to the strip")
+    func chatTitle() {
+        #expect(Self.prompt().chatTitle == "Ship it")
+        #expect(QuickPrompt(name: "", text: "Walk me through the diff.").chatTitle == nil)
+        #expect(QuickPrompt(name: "   ", text: "Walk me through the diff.").chatTitle == nil)
+        #expect(QuickPrompt(name: "  Ship it  ", text: "Push.").chatTitle == "Ship it")
+    }
+}

--- a/Tests/BloomCoreTests/QuickPromptStoreTests.swift
+++ b/Tests/BloomCoreTests/QuickPromptStoreTests.swift
@@ -49,6 +49,8 @@ struct QuickPromptStoreTests {
         #expect(loaded.count == 1)
         #expect(loaded[0].name == "Run tests")
         #expect(loaded[0].symbol == "hammer")
+        #expect(!loaded[0].sendsImmediately)
+        #expect(!loaded[0].opensNewChat)
         #expect(loaded[0].text == "Run make test.")
         #expect(loaded[0].sortOrder == written.sortOrder)
         // Not exact equality: a `Date` goes to SQLite as seconds since 1970 and comes back
@@ -74,6 +76,63 @@ struct QuickPromptStoreTests {
         #expect(try await store.quickPrompts().map(\.name) == ["second"])
     }
 
+    /// Both switches, through the two writes a form can make. A prompt is written with them off,
+    /// turned on, and read back off the disk as on.
+    @Test("the two switches round-trip, on the insert and on the update")
+    func roundTripsDelivery() async throws {
+        let store = try makeTestStore("quick-prompts")
+        let written = try await store.insert(
+            QuickPrompt(name: "Ship it", text: "Push the branch.")
+        )
+        #expect(!written.sendsImmediately)
+        #expect(!written.opensNewChat)
+        #expect(try await store.quickPrompts().first?.sendsImmediately == false)
+
+        let changed = try await store.update(quickPromptID: written.id) {
+            $0.sendsImmediately = true
+            $0.opensNewChat = true
+        }
+        #expect(changed?.sendsImmediately == true)
+
+        let loaded = try #require(try await store.quickPrompt(id: written.id))
+        #expect(loaded.sendsImmediately)
+        #expect(loaded.opensNewChat)
+        #expect(loaded.text == "Push the branch.")
+
+        // And back off again, because a switch that cannot be turned off is worse than one that
+        // was never there.
+        _ = try await store.update(quickPromptID: written.id) { $0.sendsImmediately = false }
+        let after = try #require(try await store.quickPrompt(id: written.id))
+        #expect(!after.sendsImmediately)
+        #expect(after.opensNewChat)
+    }
+
+    /// Every prompt in the table was written when insert-and-stop was the only thing a quick
+    /// prompt could do, and off is exactly that behaviour. Replaying the step must neither throw
+    /// nor move what is stored. Same shape as `ProjectVisibilityTests.migration`, same reason.
+    @Test("a prompt written before the columns existed reads with both switches off")
+    func migration() async throws {
+        let path = TestScratch.unique("quick-prompt-delivery-migration") + ".sqlite"
+        let store = try Store(path: path)
+        let old = try await store.insert(QuickPrompt(name: "Explain", text: "Explain the changes."))
+        let opted = try await store.insert(QuickPrompt(name: "Ship it", text: "Push."))
+        _ = try await store.update(quickPromptID: opted.id) { $0.sendsImmediately = true }
+
+        let raw = try SQLiteDatabase(path: path)
+        raw.userVersion = 0
+
+        let reopened = try Store(path: path)
+        let plain = try #require(try await reopened.quickPrompt(id: old.id))
+        #expect(!plain.sendsImmediately)
+        #expect(!plain.opensNewChat)
+        // The replay is not allowed to clear what somebody had already turned on either.
+        #expect(try await reopened.quickPrompt(id: opted.id)?.sendsImmediately == true)
+
+        let fresh = try await reopened.insert(QuickPrompt(name: "New", text: "Anything."))
+        #expect(!fresh.sendsImmediately)
+        #expect(!fresh.opensNewChat)
+    }
+
     @Test("a fresh database is seeded with the built-ins")
     func seeds() async throws {
         let store = try makeTestStore("quick-prompts")
@@ -81,6 +140,9 @@ struct QuickPromptStoreTests {
 
         #expect(seeded.count == QuickPromptSeed.all.count)
         #expect(seeded.map(\.name) == QuickPromptSeed.all.map(\.name))
+        // A built-in is an ordinary prompt from the moment it is inserted, and no ordinary prompt
+        // sends itself.
+        #expect(seeded.allSatisfy { !$0.sendsImmediately && !$0.opensNewChat })
         #expect(try await store.setting(QuickPromptSeed.versionKey) == String(QuickPromptSeed.version))
     }
 

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -218,7 +218,12 @@ copy of what was there before. Three things hold that in: both are owner only, s
 client the owner is typing into rather than an agent running for ten minutes unattended; neither is
 self-approved, so the call stops and asks a person who is sitting there; and the delete's answer
 carries the whole prompt back, name, mark and text, so `quick_prompt_create` writes it again
-verbatim, which is an undo that costs one call. That last one is what a worktree does not have and
+verbatim, which is an undo that costs one call. The two delivery switches are the exception, and
+deliberately: `sends_immediately` and `opens_new_chat` are reported by every one of these tools and
+set by none of them, because they say what happens when the OWNER presses a row and a tool that
+could arm them would be an agent arranging a turn he never read. A prompt restored by
+`quick_prompt_create` comes back as an ordinary one, and the delete's answer says what he has to
+turn back on. That last one is what a worktree does not have and
 is why archiving is still not here.
 
 A quick prompt deleted over the bridge is deleted exactly as one deleted in the panel is, because


### PR DESCRIPTION
Two switches on the edit sheet, both off by default and both off for every prompt that already exists: send it straight away, and open it in a new chat tab.

The labels say what happens rather than naming a setting, and a line under the pair reads the combination back, which is where most of the clarity is. The send sentence names the rest of the draft on purpose, since sending straight away sends what was already in the box with it, and that is the one thing somebody could be surprised by afterwards.

Both switches stand alone. All four combinations do something real, including the quiet one where a tab opens with the words waiting, so greying the second would forbid a genuine behaviour.

The decision is `QuickPromptDelivery` in the core with a suite, including the fallback: a prompt that asked for a new chat and cannot have one composes rather than sending, because the switch said this conversation is not where the words belong.

Two columns with a default of zero, so a stored prompt without them decodes as both off. The panel's rows now mark a prompt that opts out of the quiet behaviour, because its documented safety argument was that arrowing through it cannot start a turn.