### PR TITLE
Let a row that draws nothing say it is nothing tall

### DIFF
--- a/Sources/Bloom/Design/ProbeHarness.swift
+++ b/Sources/Bloom/Design/ProbeHarness.swift
@@ -110,14 +110,34 @@ struct ProbeHarness {
     ///
     /// The wait loop is a loop because there is no window for the first moments of a launch, and
     /// a probe that asked once got nil and reported nothing at all.
+    /// **`--window-hidden`: a run the owner cannot see.**
+    ///
+    /// `open -g` keeps a probe from taking the keyboard, and it does not keep a 1,440 point window
+    /// off the display: the run still opens one, on the desktop he is working on. Transparent, the
+    /// window lays out, draws and reports frames exactly as it did, and there is nothing on his
+    /// screen. Polled rather than set once, because the window is on screen from the moment it
+    /// opens and the wait below is three seconds long.
+    private func hideWindowsAsTheyOpen() async {
+        guard Self.isPresent("--window-hidden") else { return }
+        for _ in 0..<300 {
+            for window in NSApp.windows where window.alphaValue > 0 { window.alphaValue = 0 }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
     func window() async -> (window: NSWindow, content: NSView) {
+        // Alongside the wait rather than before it, so a window that opens during the settle is
+        // hidden on the frame it opens rather than three seconds later.
+        async let hiding: Void = hideWindowsAsTheyOpen()
         await settle()
+        await hiding
         for _ in 0..<60 {
             let candidate = NSApp.windows.first {
                 $0.isVisible && $0.contentView != nil && $0.parent == nil
                     && $0.styleMask.contains(.titled)
             }
             if let candidate, let content = candidate.contentView {
+                if Self.isPresent("--window-hidden") { candidate.alphaValue = 0 }
                 await resize(candidate)
                 return (candidate, content)
             }

--- a/Sources/Bloom/Design/ScrollProbe.swift
+++ b/Sources/Bloom/Design/ScrollProbe.swift
@@ -41,6 +41,8 @@ enum ScrollProbe {
 
     private static var workspace: String? { ProbeHarness.value(for: "--scroll-workspace") }
     private static var sweeps: Int { ProbeHarness.count("--scroll-sweeps", or: 4) }
+    /// `--scroll-composer 400`: grow the composer to this many points instead of scrolling.
+    private static var composer: Double? { ProbeHarness.value(for: "--scroll-composer").flatMap(Double.init) }
     private static var step: CGFloat { ProbeHarness.points("--scroll-step", or: 24) }
 
     // MARK: - Entry
@@ -65,7 +67,20 @@ enum ScrollProbe {
         }
 
         guard let scroll = ProbeHarness.transcriptScrollView(in: contentView) else {
+            // What was on screen instead, because "no transcript" is usually a run that attached
+            // to the wrong window: the welcome window on a fresh defaults domain is one.
+            let windows = NSApp.windows.map { "\($0.title) \($0.frame)" }
+            FileHandle.standardError.write(Data("windows: \(windows)\n".utf8))
             harness.fail("no transcript NSScrollView found")
+        }
+
+        if let composer {
+            await growComposer(to: composer, scroll: scroll)
+            harness.write(report(
+                recorder: FrameRecorder(view: contentView) { 0 }, travel: 0, wall: 0,
+                window: window, scroll: scroll, heightBefore: scroll.documentView?.frame.height ?? 0
+            ))
+            exit(0)
         }
 
         // Sampled before the sweep and again in the report, because these two disagreeing is
@@ -103,6 +118,31 @@ enum ScrollProbe {
             heightBefore: heightBefore
         ))
         exit(0)
+    }
+
+    /// **The owner's own reproduction, without his hand on the divider.**
+    ///
+    /// "When I resize the editor to be higher, the chat content will get empty lines as well." The
+    /// composer's height is `@AppStorage("composer.editorHeight")`, so the gesture is a write to
+    /// that key: the box grows, the transcript above it gets shorter, and nothing about its width
+    /// moves. Nothing is scrolled here on purpose, because a sweep would draw every row it passed
+    /// and correct exactly what this is trying to catch.
+    ///
+    /// The nudge is what makes the census speak. It is taken on a movement of the clip view, so a
+    /// point down and back is how a run asks for one.
+    private static func growComposer(to points: Double, scroll: NSScrollView) async {
+        nudge(scroll)
+        try? await Task.sleep(for: .seconds(1))
+        UserDefaults.standard.set(points, forKey: "composer.editorHeight")
+        try? await Task.sleep(for: .seconds(3))
+        nudge(scroll)
+        try? await Task.sleep(for: .seconds(1))
+    }
+
+    private static func nudge(_ scroll: NSScrollView) {
+        let origin = scroll.contentView.bounds.origin
+        scroll.contentView.setBoundsOrigin(CGPoint(x: origin.x, y: max(0, origin.y - 1)))
+        scroll.reflectScrolledClipView(scroll.contentView)
     }
 
     // MARK: - Driving

--- a/Sources/Bloom/Design/TranscriptHoldCensus.swift
+++ b/Sources/Bloom/Design/TranscriptHoldCensus.swift
@@ -33,6 +33,18 @@ enum TranscriptHoldCensus {
     /// it was told. See `TranscriptTable.Coordinator.checkCorrected`, which carries the bug.
     private(set) static var correctedRows = 0
     private(set) static var uncorrectedRows = 0
+    /// **What is on the screen, and how much of it is a guess.** Sampled on every movement of the
+    /// clip view: the most rows the reader could see at once that the table was drawing at a
+    /// height nobody has measured, and the most it was drawing at a height that disagrees with
+    /// what was measured. Either of them above nought is white space the reader can see.
+    private(set) static var screenEstimated = 0
+    private(set) static var screenWrong = 0
+    private(set) static var screensSeen = 0
+    /// The same two on the last screen sampled after the movement stopped, which is what tells a
+    /// guess that is being corrected as the reader flies past from one that is simply standing
+    /// there. See `TranscriptTable.Coordinator.scheduleSettle`.
+    private(set) static var screenEstimatedSettled = 0
+    private(set) static var screenWrongSettled = 0
 
     static func held(_ what: TranscriptPaneHold.PaneHeld, underAHand hand: Bool, liveResize: Bool) {
         switch what {
@@ -54,6 +66,17 @@ enum TranscriptHoldCensus {
 
     static func released(estimated: Int) { estimatedRows = estimated }
 
+    /// One screenful, as it was drawn. The worst of them is what is kept.
+    static func sawScreen(estimated: Int, wrong: Int, settled: Bool = false) {
+        screensSeen += 1
+        screenEstimated = max(screenEstimated, estimated)
+        screenWrong = max(screenWrong, wrong)
+        if settled {
+            screenEstimatedSettled = estimated
+            screenWrongSettled = wrong
+        }
+    }
+
     /// One batch of corrections, and the ones that did not take.
     static func corrected(rows: Int, uncorrected: Int) {
         correctedRows += rows
@@ -71,6 +94,11 @@ enum TranscriptHoldCensus {
         estimatedRows = 0
         correctedRows = 0
         uncorrectedRows = 0
+        screenEstimated = 0
+        screenWrong = 0
+        screensSeen = 0
+        screenEstimatedSettled = 0
+        screenWrongSettled = 0
     }
 
     static func summary() -> [String: Double] {
@@ -85,6 +113,11 @@ enum TranscriptHoldCensus {
             "estimatedRows": Double(estimatedRows),
             "correctedRows": Double(correctedRows),
             "uncorrectedRows": Double(uncorrectedRows),
+            "screenEstimated": Double(screenEstimated),
+            "screenWrong": Double(screenWrong),
+            "screensSeen": Double(screensSeen),
+            "screenEstimatedSettled": Double(screenEstimatedSettled),
+            "screenWrongSettled": Double(screenWrongSettled),
         ]
     }
 }

--- a/Sources/Bloom/Views/Transcript/TranscriptTable.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTable.swift
@@ -627,6 +627,44 @@ struct TranscriptTable: NSViewRepresentable {
             TranscriptHoldCensus.corrected(rows: owed.count, uncorrected: wrong)
         }
 
+        /// **What the reader can see, and how much of it is a guess.**
+        ///
+        /// `checkCorrected` can only speak for rows that reported. A row that never reports at all
+        /// is answered from the mean for ever and nothing above would say so, which is the shape
+        /// of blank this file has now been wrong about twice. This counts the visible rows the
+        /// table is drawing at a height nobody has measured, on every movement of the clip view:
+        /// two dictionary lookups per visible row, which at a screenful is nothing.
+        private func censusOfTheScreen(settled: Bool = false) {
+            guard let tableView, heights.isReady else { return }
+            var estimated = 0
+            var wrong = 0
+            for row in visibleRows where entries.indices.contains(row) {
+                let key = entries[row].contentKey
+                guard let measured = heights.height(for: key) else {
+                    estimated += 1
+                    continue
+                }
+                let told = Double(tableView.rect(ofRow: row).height)
+                if !TranscriptRowHeights.isSameHeight(told, max(Double(Self.hair), measured)) {
+                    wrong += 1
+                }
+            }
+            TranscriptHoldCensus.sawScreen(estimated: estimated, wrong: wrong, settled: settled)
+            #if DEBUG
+            // Which rows, once the screen has stopped moving, because a guess that is standing
+            // there is worth naming and a guess mid flick is not.
+            if settled, estimated > 0 {
+                let named = visibleRows
+                    .filter { entries.indices.contains($0) }
+                    .filter { heights.height(for: entries[$0].contentKey) == nil }
+                    .map { entries[$0].id.description }
+                FileHandle.standardError.write(Data(
+                    "transcript: \(estimated) guessed rows on screen: \(named)\n".utf8
+                ))
+            }
+            #endif
+        }
+
         /// Every height change in this file goes through here.
         ///
         /// **`noteHeightOfRows(withIndexesChanged:)` animates, and almost never should.** It is
@@ -949,6 +987,7 @@ struct TranscriptTable: NSViewRepresentable {
             // nobody is holding it any more.
             if holdsEnd, !isPutting, !currentGeometry.isAtEnd { releaseEnd() }
             reportGeometry()
+            censusOfTheScreen()
             scheduleSettle()
         }
 
@@ -990,6 +1029,7 @@ struct TranscriptTable: NSViewRepresentable {
                 try? await Task.sleep(for: .milliseconds(150))
                 guard !Task.isCancelled, let self, !isLiveScrolling else { return }
                 settleWork = nil
+                censusOfTheScreen(settled: true)
                 onSettled?()
             }
         }
@@ -1245,7 +1285,13 @@ private struct HostedRow: View {
     var fills = true
 
     var body: some View {
-        let measured = content
+        // **The stack is what makes an empty row report.** Sixty per cent of a real session is
+        // rows that draw nothing: a stream event, a tool result whose call is on the row above.
+        // Modifiers on a view whose body is empty lay nothing out, so the reader behind it never
+        // appeared and nought was never reported, and those rows kept the running mean for ever:
+        // three or four of them between two one line Bash rows is the hundred points of blank this
+        // was reported for. A stack is a container and lays out at nothing, which is a height.
+        let measured = VStack(alignment: .leading, spacing: 0) { content }
             .frame(maxWidth: .infinity, alignment: .leading)
             .fixedSize(horizontal: false, vertical: true)
             .background(


### PR DESCRIPTION
The transcript showed permanent blank gaps between rows in the shipped build. The cause is invisible rows.

A stream-event row that is not an init draws nothing, and a real session is full of them: the workspace this was measured against holds 1,804 of them out of 2,981 rows, interleaved as toolUse, system, system, toolResult, system, system. Since nothing was measured up front, each was answered with the running mean, about twenty points each, and three to five of them sit between every pair of one line Bash rows.

They were never corrected because they never reported. A view whose body is empty lays nothing out, so the geometry reader behind it never appeared and nought never came back. The check added in the previous commit could not see it either, because it only speaks for rows that reported.

The fix is a container around the row's content: a container with nothing in it still lays out, at nothing, which is a height.

Measured on that session, before and after, same probe and same machine: rows drawn at an unmeasured height on a settled screen 17 to 0, corrected rows over one sweep 139 to 1,096, and the document 66,983 points to 32,394. That difference is the white space. Nothing is measured up front either way, so the win from not measuring on arrival is intact.

Also in here, from the previous round: corrections are filed against the row's identity rather than its index, which a renumbering could misplace, and the census that made this findable at all.