### PR TITLE
A pill you can take off

### DIFF
--- a/Sources/Bloom/Views/Center/Composer/ComposerChipText.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerChipText.swift
@@ -386,8 +386,12 @@ final class AttachmentChipCell: NSTextAttachmentCell {
 
     override func cellBaselineOffset() -> NSPoint { baselineOffset }
 
+    /// The fallback TextKit does not take: it draws an attachment through the overload below,
+    /// which is the only one that says which character it is drawing. `NSNotFound` rather than
+    /// zero, so a chip reached this way cannot be mistaken for the one the pointer is on when
+    /// that one happens to be the first character of the draft.
     override func draw(withFrame cellFrame: NSRect, in controlView: NSView?) {
-        draw(withFrame: cellFrame, in: controlView, characterIndex: 0)
+        draw(withFrame: cellFrame, in: controlView, characterIndex: NSNotFound)
     }
 
     override func draw(
@@ -409,18 +413,15 @@ final class AttachmentChipCell: NSTextAttachmentCell {
             width: side,
             height: side
         )
-        if isRemovable(from: controlView, at: characterIndex) {
-            close?.draw(
-                in: iconRect, from: .zero, operation: .sourceOver, fraction: 1,
-                respectFlipped: true, hints: nil
-            )
-        } else {
-            let icon = FileTypeIcon.icon(for: filename)
-            icon.draw(
-                in: iconRect, from: .zero, operation: .sourceOver, fraction: 1,
-                respectFlipped: true, hints: nil
-            )
-        }
+        // The file's own icon, unless the pointer is on the chip, in which case the slot is the
+        // close control instead. A symbol that would not load falls back to the icon rather than
+        // to an empty slot.
+        let mark = (isRemovable(from: controlView, at: characterIndex) ? close : nil)
+            ?? FileTypeIcon.icon(for: filename)
+        mark.draw(
+            in: iconRect, from: .zero, operation: .sourceOver, fraction: 1,
+            respectFlipped: true, hints: nil
+        )
 
         let name = NSAttributedString(string: filename, attributes: nameAttributes)
         let height = name.size().height
@@ -464,8 +465,8 @@ final class AttachmentChipCell: NSTextAttachmentCell {
 
     /// Where a click takes the file off rather than opening it: the icon's slot and the padding
     /// around it, up to halfway across the gap before the name. Wider than the glyph on purpose,
-    /// because it is thirteen points across, and short of the name because reading the name is
-    /// what tells you which file you are about to remove.
+    /// which is fourteen points in a twenty point pill, and stopping short of the name because
+    /// reading the name is what tells you which file you are about to remove.
     private func closeRect(in frame: NSRect) -> NSRect {
         NSRect(
             x: frame.minX,

--- a/Sources/Bloom/Views/Center/Composer/ComposerChipText.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerChipText.swift
@@ -402,7 +402,6 @@ final class AttachmentChipCell: NSTextAttachmentCell {
         plate.lineWidth = 1
         plate.stroke()
 
-        let icon = FileTypeIcon.icon(for: filename)
         let side = iconSize
         let iconRect = NSRect(
             x: frame.minX + Self.padding,
@@ -410,7 +409,18 @@ final class AttachmentChipCell: NSTextAttachmentCell {
             width: side,
             height: side
         )
-        icon.draw(in: iconRect, from: .zero, operation: .sourceOver, fraction: 1, respectFlipped: true, hints: nil)
+        if isRemovable(from: controlView, at: characterIndex) {
+            close?.draw(
+                in: iconRect, from: .zero, operation: .sourceOver, fraction: 1,
+                respectFlipped: true, hints: nil
+            )
+        } else {
+            let icon = FileTypeIcon.icon(for: filename)
+            icon.draw(
+                in: iconRect, from: .zero, operation: .sourceOver, fraction: 1,
+                respectFlipped: true, hints: nil
+            )
+        }
 
         let name = NSAttributedString(string: filename, attributes: nameAttributes)
         let height = name.size().height
@@ -421,6 +431,48 @@ final class AttachmentChipCell: NSTextAttachmentCell {
             height: height
         )
         name.draw(with: nameRect, options: [.usesLineFragmentOrigin])
+    }
+
+    // MARK: - Taking it off
+
+    /// Whether this chip is showing its close control, which is the pointer resting on it inside a
+    /// composer. A chip in a sent turn is drawn by another view entirely and has nothing to
+    /// remove: the prompt the agent read named that file, so the transcript cannot un-name it.
+    private func isRemovable(from controlView: NSView?, at characterIndex: Int) -> Bool {
+        guard let composer = controlView as? ComposerTextView else { return false }
+        return composer.isChipHovered(at: characterIndex)
+    }
+
+    /// The close control, which takes the icon's place rather than a slot of its own.
+    ///
+    /// The width is measured once at init and TextKit has already laid the line out around it, so
+    /// a control beside the name would have to come out of the name. Swapping the icon costs the
+    /// name nothing, keeps the chip exactly the width it had so the line does not reflow under the
+    /// pointer, and is what `AttachmentChip` and `SlashCommandChip` already do above the box.
+    ///
+    /// `.secondaryLabelColor` because it is only ever drawn on the composer's own ground; the
+    /// bubble's ink is not reached through here, because a sent turn is never removable.
+    ///
+    /// Built per draw rather than held: one chip shows it, only while the pointer is on it, and
+    /// SF Symbols does its own caching underneath.
+    private var close: NSImage? {
+        let size = NSImage.SymbolConfiguration(pointSize: iconSize, weight: .regular)
+        let ink = NSImage.SymbolConfiguration(paletteColors: [.secondaryLabelColor])
+        return NSImage(systemSymbolName: "xmark.circle.fill", accessibilityDescription: "Remove")?
+            .withSymbolConfiguration(size.applying(ink))
+    }
+
+    /// Where a click takes the file off rather than opening it: the icon's slot and the padding
+    /// around it, up to halfway across the gap before the name. Wider than the glyph on purpose,
+    /// because it is thirteen points across, and short of the name because reading the name is
+    /// what tells you which file you are about to remove.
+    private func closeRect(in frame: NSRect) -> NSRect {
+        NSRect(
+            x: frame.minX,
+            y: frame.minY,
+            width: Self.padding + iconSize + Self.gap / 2,
+            height: frame.height
+        )
     }
 
     /// The chip answers a click itself, so opening a file is a click on the file rather than a
@@ -437,6 +489,14 @@ final class AttachmentChipCell: NSTextAttachmentCell {
     ) -> Bool {
         guard event.clickCount >= 1, let composer = controlView as? ComposerTextView else {
             return false
+        }
+        // Only where the control is actually showing. Without that, the click that makes an
+        // inactive window key would remove a file whose X the reader never saw: the tracking area
+        // is `.activeInKeyWindow`, so nothing has hovered yet.
+        if isRemovable(from: controlView, at: charIndex),
+           closeRect(in: cellFrame).contains(composer.convert(event.locationInWindow, from: nil)) {
+            composer.removeAttachment(at: charIndex)
+            return true
         }
         composer.openAttachment?(path)
         return true

--- a/Sources/Bloom/Views/Center/Composer/ComposerTextView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerTextView.swift
@@ -27,8 +27,8 @@ final class ComposerTextView: NSTextView {
     /// draws the file above the box.
     var hoverAttachment: (@MainActor (String?) -> Void)?
 
-    /// Where the pointer is now, and the wait before it counts as settled.
-    fileprivate var hoveredPath: String?
+    /// Which chip the pointer is on now, and the wait before it counts as settled.
+    fileprivate var hoveredChip: HoveredChip?
     fileprivate var hoverTask: Task<Void, Never>?
     fileprivate var hoverArea: NSTrackingArea?
 
@@ -260,7 +260,7 @@ extension ComposerTextView {
 
     override func mouseMoved(with event: NSEvent) {
         super.mouseMoved(with: event)
-        hover(over: attachmentPath(at: convert(event.locationInWindow, from: nil)))
+        hover(over: chip(at: convert(event.locationInWindow, from: nil)))
     }
 
     override func mouseExited(with event: NSEvent) {
@@ -268,13 +268,13 @@ extension ComposerTextView {
         hover(over: nil)
     }
 
-    /// The file under a point, or nil for anywhere that is not a chip.
+    /// The chip under a point, or nil for anywhere that is not one.
     ///
     /// The glyph's own rectangle is checked rather than the insertion point the same coordinates
     /// would give: an insertion index is the nearest gap between characters and exists everywhere
     /// in the box, including the empty space to the right of the last word, which would raise a
     /// card for a file the pointer is nowhere near.
-    private func attachmentPath(at point: CGPoint) -> String? {
+    private func chip(at point: CGPoint) -> HoveredChip? {
         guard let layout = layoutManager, let container = textContainer else { return nil }
         let origin = textContainerOrigin
         let inContainer = CGPoint(x: point.x - origin.x, y: point.y - origin.y)
@@ -292,24 +292,93 @@ extension ComposerTextView {
 
         let index = layout.characterIndexForGlyph(at: glyph)
         guard index < (string as NSString).length else { return nil }
-        return textStorage?.attribute(
+        guard let path = textStorage?.attribute(
             ComposerChipText.pathKey, at: index, effectiveRange: nil
-        ) as? String
+        ) as? String else { return nil }
+        return HoveredChip(path: path, index: index)
     }
 
-    private func hover(over path: String?) {
-        guard path != hoveredPath else { return }
-        hoveredPath = path
+    private func hover(over chip: HoveredChip?) {
+        guard chip != hoveredChip else { return }
+        let was = hoveredChip
+        hoveredChip = chip
         hoverTask?.cancel()
 
-        guard let path else {
+        // The close control lives in the chip's own icon slot, so crossing into or out of one is
+        // a redraw. The whole box rather than the two glyph rects: it is twelve lines at most, and
+        // this runs when the pointer crosses a chip's edge rather than while it moves along one.
+        if was?.index != chip?.index { needsDisplay = true }
+
+        guard let chip else {
             hoverAttachment?(nil)
             return
         }
         hoverTask = Task { [weak self] in
             try? await Task.sleep(for: Self.hoverDelay)
-            guard !Task.isCancelled, let self, self.hoveredPath == path else { return }
-            self.hoverAttachment?(path)
+            guard !Task.isCancelled, let self, self.hoveredChip == chip else { return }
+            self.hoverAttachment?(chip.path)
         }
+    }
+}
+
+/// A chip and where it is, which is what the pointer is on rather than just which file it names:
+/// the same screenshot can be in the sentence twice, and the close control belongs to the one
+/// under the pointer.
+struct HoveredChip: Equatable {
+    var path: String
+    /// The character the chip is, in the text view's own storage.
+    var index: Int
+}
+
+// MARK: - Taking one off
+
+extension ComposerTextView {
+    /// Whether the chip at this character is the one under the pointer, which is what puts the
+    /// close control in its icon slot. Asked by the cell as it draws.
+    func isChipHovered(at characterIndex: Int) -> Bool {
+        hoveredChip?.index == characterIndex
+    }
+
+    /// Takes one file out of the draft, as an edit rather than as a new draft.
+    ///
+    /// Through the text system for the reason `ComposerEditorHandle.insert` goes through it: this
+    /// is the undo of an attachment, and Command+Z has to put the file back in the sentence where
+    /// it was, in order with the words typed either side of it. Rewriting the binding would leave
+    /// the text right and the undo stack describing a draft that no longer exists.
+    ///
+    /// **The copy under `.bloom/attachments` deliberately stays.** It is deleted when the turn
+    /// goes, by `PromptAttachmentStore.settle`, which discards every copy the sentence no longer
+    /// names. Deleting it here would mean an X and then a Command+Z left a chip in the sentence
+    /// pointing at a file that is not there any more, and it would make this button a delete from
+    /// somebody's disk rather than an edit to their draft. It is exactly what backspacing the chip
+    /// away already does, which is the other half of why: two ways to take a file off must not
+    /// have two different answers about the file.
+    func removeAttachment(at characterIndex: Int) {
+        guard let storage = textStorage else { return }
+        let held = attributedString()
+        let chips = ComposerChipText.attachments(in: held)
+        let draft = ComposerChipText.draft(of: held)
+        let parsed = AttachmentDraft.parse(draft, paths: chips.map(\.path))
+        // By where the chip is in the draft rather than by which chip it is in the storage. See
+        // `AttachmentDraft.attachment(startingAt:)` for the draft the two disagree about.
+        guard let occurrence = parsed.attachment(
+            startingAt: ComposerChipText.draftOffset(forStorage: characterIndex, in: held)
+        ), let cut = parsed.removal(ofAttachment: occurrence) else { return }
+        let start = ComposerChipText.storageOffset(forDraft: cut.location, in: held)
+        let end = ComposerChipText.storageOffset(forDraft: cut.upperBound, in: held)
+        let range = NSRange(location: start, length: max(end - start, 0))
+
+        breakUndoCoalescing()
+        guard shouldChangeText(in: range, replacementString: "") else { return }
+        storage.beginEditing()
+        storage.replaceCharacters(in: range, with: "")
+        storage.endEditing()
+        didChangeText()
+        breakUndoCoalescing()
+        undoManager?.setActionName("Remove Attachment")
+        setSelectedRange(NSRange(location: range.location, length: 0))
+        // The chip the card was about has gone, so the card goes with it rather than hanging over
+        // the box until the pointer next moves.
+        hover(over: nil)
     }
 }

--- a/Sources/BloomCore/Transcript/AttachmentDraft.swift
+++ b/Sources/BloomCore/Transcript/AttachmentDraft.swift
@@ -264,6 +264,27 @@ public struct AttachmentDraft: Equatable, Sendable {
         return result
     }
 
+    /// The file whose token starts at this offset in the draft, as its place in reading order.
+    ///
+    /// The way a chip in a text view names itself to the rules here, and it goes by position
+    /// rather than by counting: a path somebody typed inside backticks is a file to `parse` and
+    /// still plain text in the storage, because nothing rewrites the storage while the draft it
+    /// stands for is unchanged. The two lists then differ, and a chip's ordinal in one of them is
+    /// the wrong file in the other.
+    public func attachment(startingAt offset: Int) -> Int? {
+        var seen = 0
+        var location = 0
+        for segment in segments {
+            let length = (segment.text as NSString).length
+            if case .attachment = segment {
+                if location == offset { return seen }
+                seen += 1
+            }
+            location += length
+        }
+        return nil
+    }
+
     /// Where one file sits in the draft, together with the single space that was written beside
     /// it. Nil when the draft names no such file.
     ///

--- a/Sources/BloomCore/Transcript/AttachmentDraft.swift
+++ b/Sources/BloomCore/Transcript/AttachmentDraft.swift
@@ -264,6 +264,51 @@ public struct AttachmentDraft: Equatable, Sendable {
         return result
     }
 
+    /// Where one file sits in the draft, together with the single space that was written beside
+    /// it. Nil when the draft names no such file.
+    ///
+    /// `occurrence` counts files in reading order rather than naming a path, because the same
+    /// screenshot can be in the sentence twice and taking one chip off must take that chip off.
+    ///
+    /// A range rather than the resulting draft, because the caller that matters applies it as an
+    /// edit to the text view so that the text system's own undo covers it. `removing(attachment:)`
+    /// is the same answer for anyone holding only the string.
+    ///
+    /// The space rule is `keeping`'s, asked of one file instead of all of them: one space goes,
+    /// the one before it where there is one, otherwise the one after, so the words either side
+    /// close up without being joined.
+    public func removal(ofAttachment occurrence: Int) -> NSRange? {
+        let string = text as NSString
+        var seen = 0
+        var location = 0
+
+        for segment in segments {
+            let length = (segment.text as NSString).length
+            guard case .attachment = segment, seen == occurrence else {
+                if case .attachment = segment { seen += 1 }
+                location += length
+                continue
+            }
+            var range = NSRange(location: location, length: length)
+            if range.location > 0,
+               string.substring(with: NSRange(location: range.location - 1, length: 1)) == " " {
+                range.location -= 1
+                range.length += 1
+            } else if range.upperBound < string.length,
+                      string.substring(with: NSRange(location: range.upperBound, length: 1)) == " " {
+                range.length += 1
+            }
+            return range
+        }
+        return nil
+    }
+
+    /// The draft with one file taken out of it, closed up behind.
+    public func removing(attachment occurrence: Int) -> String {
+        guard let range = removal(ofAttachment: occurrence) else { return text }
+        return (text as NSString).replacingCharacters(in: range, with: "")
+    }
+
     /// The draft with every file taken out of it: what the sentence says on its own.
     ///
     /// Used where the words are read by something other than the agent. A workspace is named after

--- a/Tests/BloomCoreTests/AttachmentDraftTests.swift
+++ b/Tests/BloomCoreTests/AttachmentDraftTests.swift
@@ -206,6 +206,21 @@ struct AttachmentDraftTests {
         #expect(AttachmentDraft.parse("`\(Self.copy)`").removal(ofAttachment: 1) == nil)
     }
 
+    /// How a chip in the composer says which file it is: by where it starts, because a path typed
+    /// inside backticks is a file here and still plain text over there.
+    @Test("A file is found by where it starts in the draft")
+    func findsByOffset() {
+        let draft = "a `\(Self.copy)` b `\(Self.spaced)`"
+        let parsed = AttachmentDraft.parse(draft)
+
+        #expect(parsed.attachment(startingAt: 2) == 0)
+        #expect(parsed.attachment(startingAt: 2 + (Self.copy as NSString).length + 5) == 1)
+        // Anywhere that is not the first character of a token names nothing.
+        #expect(parsed.attachment(startingAt: 0) == nil)
+        #expect(parsed.attachment(startingAt: 3) == nil)
+        #expect(parsed.attachment(startingAt: (draft as NSString).length) == nil)
+    }
+
     /// Every removal is a removal of one, so doing it once per file has to land on the same
     /// sentence `keeping` gives for all of them at once.
     @Test("Taking every chip off one at a time agrees with taking them all at once")

--- a/Tests/BloomCoreTests/AttachmentDraftTests.swift
+++ b/Tests/BloomCoreTests/AttachmentDraftTests.swift
@@ -153,6 +153,75 @@ struct AttachmentDraftTests {
         #expect(AttachmentDraft.parse(draft).keeping { _ in false } == "what is this")
     }
 
+    @Test("Taking one chip off leaves the others where they were")
+    func removesOneOccurrence() {
+        let draft = "compare `\(Self.copy)` with `\(Self.spaced)` please"
+        let parsed = AttachmentDraft.parse(draft)
+
+        #expect(parsed.removing(attachment: 0) == "compare with `\(Self.spaced)` please")
+        #expect(parsed.removing(attachment: 1) == "compare `\(Self.copy)` with please")
+    }
+
+    /// The same file twice is two chips, and the X on one of them is about that one.
+    @Test("The same file named twice is taken off one chip at a time")
+    func removesTheChipThatWasClicked() {
+        let draft = "`\(Self.copy)` and again `\(Self.copy)`"
+        let parsed = AttachmentDraft.parse(draft)
+
+        #expect(parsed.removing(attachment: 0) == "and again `\(Self.copy)`")
+        #expect(parsed.removing(attachment: 1) == "`\(Self.copy)` and again")
+    }
+
+    @Test("A file at the start of the draft takes the space that follows it")
+    func removesAtStart() {
+        let draft = "`\(Self.copy)` what is this"
+        #expect(AttachmentDraft.parse(draft).removal(ofAttachment: 0)?.location == 0)
+        #expect(AttachmentDraft.parse(draft).removing(attachment: 0) == "what is this")
+    }
+
+    @Test("A file that is the whole draft leaves nothing behind")
+    func removesTheOnlyWord() {
+        #expect(AttachmentDraft.parse("`\(Self.copy)`").removing(attachment: 0).isEmpty)
+        #expect(AttachmentDraft.parse("`\(Self.copy)` ").removing(attachment: 0).isEmpty)
+    }
+
+    /// The range is what the editor deletes, so it has to be the token plus at most one space and
+    /// never a character of the sentence around it.
+    @Test("The range covers the file and one space, and nothing else")
+    func removalRange() throws {
+        let draft = "have a look at `\(Self.copy)` and fix the spacing"
+        let range = AttachmentDraft.parse(draft).removal(ofAttachment: 0)
+        let cut = (draft as NSString).substring(with: try #require(range))
+
+        #expect(cut == " `\(Self.copy)`")
+        #expect(AttachmentDraft.parse(draft).removing(attachment: 0)
+            == "have a look at and fix the spacing")
+    }
+
+    @Test("A draft with no such file is left exactly as it was")
+    func removesNothing() {
+        let draft = "run `git status` first"
+        #expect(AttachmentDraft.parse(draft).removal(ofAttachment: 0) == nil)
+        #expect(AttachmentDraft.parse(draft).removing(attachment: 0) == draft)
+        #expect(AttachmentDraft.parse("`\(Self.copy)`").removal(ofAttachment: 1) == nil)
+    }
+
+    /// Every removal is a removal of one, so doing it once per file has to land on the same
+    /// sentence `keeping` gives for all of them at once.
+    @Test("Taking every chip off one at a time agrees with taking them all at once")
+    func agreesWithKeeping() {
+        for row in Self.drafts {
+            var text = row.draft
+            while true {
+                let parsed = AttachmentDraft.parse(text, paths: row.known)
+                guard !parsed.paths.isEmpty else { break }
+                text = parsed.removing(attachment: 0)
+            }
+            let all = AttachmentDraft.parse(row.draft, paths: row.known).keeping { _ in false }
+            #expect(text == all, "one at a time disagreed for: \(row.draft)")
+        }
+    }
+
     @Test("What the sentence says without its files")
     func withoutAttachments() {
         #expect(


### PR DESCRIPTION
An attached file in the composer had no way off it. Hovering a pill now swaps its icon for an X,
the way `AttachmentChip` and `SlashCommandChip` already do above the box, and clicking that takes
the file out of the draft.

The pill is a text attachment inside the text view, so removal is an edit to the text rather than
a hidden list: it goes through `shouldChangeText`/`didChangeText`, so Command+Z puts the file back
in the sentence where it was. The copy under `.bloom/attachments` stays until the turn goes, which
is what `PromptAttachmentStore.settle` already does with every copy the sentence stopped naming,
and is what backspacing a pill away has always done.

Backspace with the caret after a pill already deleted it in one press. That is unchanged. What the
X adds over it is closing the sentence up: `AttachmentDraft.removal(ofAttachment:)` takes the one
space that was written with the file, so "look at `shot.png` and fix" becomes "look at and fix"
rather than keeping the double space Backspace leaves.

The name keeps every point it had, because the X takes the icon's slot rather than a slot of its
own, which also stops the line reflowing under the pointer.
