### PR TITLE
A title bar that sits right

### DIFF
--- a/Sources/Bloom/Views/Chrome/Window/BloomWindowToolbar.swift
+++ b/Sources/Bloom/Views/Chrome/Window/BloomWindowToolbar.swift
@@ -89,6 +89,23 @@ struct BloomWindowToolbar: ToolbarContent {
             WindowTitleControl(app: app)
         }
 
+        // The elastic middle of the bar, and the whole reason the search field sits at the
+        // window's trailing edge rather than beside the name.
+        //
+        // `.searchable` contributes an `NSSearchToolbarItem` after everything written here, and an
+        // `NSToolbar` packs its items from the leading edge with no gap unless something between
+        // them can stretch. What usually stretches is AppKit's own title item, and `RootView`
+        // takes that away with `.toolbar(removing: .title)` because the name is drawn here
+        // instead, so removing the second title also removed the toolbar's only piece of slack.
+        //
+        // Measured in an offscreen window 1440 points wide, with the same 380 point accessory:
+        // without this the field's capsule starts at x=416, eight points from the title's own and
+        // a third of the way across the bar, which is what the owner was looking at; with it, at
+        // x=727, hard against the pull request band. The band is beyond the toolbar rather than
+        // in it, so the two do not compete for the edge: the field takes the toolbar's trailing
+        // end, the band takes the window's. See `TitleBarStrip`.
+        ToolbarSpacer(.flexible, placement: .navigation)
+
         // The worktree's menu is not here any more. It was a trailing toolbar item, pinned to the
         // window's own edge, which put it directly above the inspector's pull request strip: two
         // stacked rows in the top right corner, both describing the same workspace. The strip has

--- a/Sources/Bloom/Views/Chrome/Window/WindowTitleControl.swift
+++ b/Sources/Bloom/Views/Chrome/Window/WindowTitleControl.swift
@@ -64,13 +64,13 @@ import BloomCore
 /// 1440 points: the name's plate ran 152 to 408 and the field's 416 to 741. The fix was the space
 /// between them, not the plate, and it is `BloomWindowToolbar`'s `ToolbarSpacer`.
 ///
-/// One thing follows from the plate being AppKit's, and it is worth knowing before anybody adds a
-/// neighbour. Two adjacent items can be drawn in ONE plate: a plain `Button` next to this text
-/// comes out as a single capsule holding both, and a fixed `ToolbarSpacer` between them does not
-/// separate it, only a flexible one does. The `+` beside this escapes that because it is a split
-/// button rather than a plain one, measured at 152 to 225 with the name's own plate at 233.5. The
-/// switch, if a future neighbour ever needs it, is `.sharedBackgroundVisibility(.hidden)` on the
-/// item, which turns its plate off rather than dividing it.
+/// One thing follows from the plate being AppKit's, and it is worth knowing before anybody puts a
+/// neighbour next to this one. **Two adjacent items are sometimes drawn in a single plate**, so
+/// with the sidebar folded away the `+` and the name can come out as one capsule holding both.
+/// Whether they do was not stable across the runs here and is AppKit's to decide; a fixed
+/// `ToolbarSpacer` between them does not divide it, and a flexible one would push the name into
+/// the middle of the bar. It is left alone. The switch worth knowing about is
+/// `.sharedBackgroundVisibility` on the item, which turns a plate off rather than dividing one.
 ///
 /// ## Renaming in place, measured
 ///

--- a/Sources/Bloom/Views/Chrome/Window/WindowTitleControl.swift
+++ b/Sources/Bloom/Views/Chrome/Window/WindowTitleControl.swift
@@ -64,12 +64,13 @@ import BloomCore
 /// 1440 points: the name's plate ran 152 to 408 and the field's 416 to 741. The fix was the space
 /// between them, not the plate, and it is `BloomWindowToolbar`'s `ToolbarSpacer`.
 ///
-/// Two things follow from the plate being AppKit's. Adjacent items share ONE plate, so with the
-/// sidebar folded away the `+` and the name are drawn in a single capsule; a fixed
-/// `ToolbarSpacer` between them does not separate them, only a flexible one does, and a flexible
-/// spacer there would push the name into the middle of the bar. The grouping is left as AppKit's.
-/// And `.sharedBackgroundVisibility(.hidden)` is the switch that would turn the plate off, which
-/// is worth knowing about and not worth using here.
+/// One thing follows from the plate being AppKit's, and it is worth knowing before anybody adds a
+/// neighbour. Two adjacent items can be drawn in ONE plate: a plain `Button` next to this text
+/// comes out as a single capsule holding both, and a fixed `ToolbarSpacer` between them does not
+/// separate it, only a flexible one does. The `+` beside this escapes that because it is a split
+/// button rather than a plain one, measured at 152 to 225 with the name's own plate at 233.5. The
+/// switch, if a future neighbour ever needs it, is `.sharedBackgroundVisibility(.hidden)` on the
+/// item, which turns its plate off rather than dividing it.
 ///
 /// ## Renaming in place, measured
 ///

--- a/Sources/Bloom/Views/Chrome/Window/WindowTitleControl.swift
+++ b/Sources/Bloom/Views/Chrome/Window/WindowTitleControl.swift
@@ -22,6 +22,19 @@ import BloomCore
 ///     icon to go: `WindowTitle` carries the reasoning. Taking the URL back to get a menu is a
 ///     trade this window has already refused.
 ///
+///   - **`navigationTitle(_ title: Binding<String>)` is not the door into it, and this was
+///     measured rather than read.** The overload is declared for macOS 13 and its own
+///     documentation says the binding "allows editing the navigation title when the title is
+///     displayed in the toolbar", which reads exactly like the public half of the session above.
+///     It is not. Built offscreen twice, once with the binding and once with the plain `String`,
+///     and the whole title bar compared: the `NSToolbarTitleView`, the
+///     `NSToolbarPrimaryTitleContainerView`, the `_NSToolbarTitleField` and the
+///     `NSWindowTitleController` behind them come out with identical ivars and identical gesture
+///     recognisers, `_handleToolbarTitleViewLeftPress:` and the two sidecar ones, which are
+///     AppKit's own and are there either way. The field is `editable=false` in both. The binding
+///     changes nothing about the title bar on macOS; it is an iOS feature with a shared
+///     declaration. Do not chase it again.
+///
 /// So the machinery cannot be borrowed, and this is the smallest thing that behaves like it.
 ///
 /// ## The double click is on the text, never on the bar
@@ -35,6 +48,35 @@ import BloomCore
 /// `NSWindow.titleVisibility`, which governs the title AppKit draws; `RootView` says
 /// `.toolbar(removing: .title)`, which governs the title item SwiftUI contributes from
 /// `navigationTitle`. The first shipped without the second and the window wore its name twice.
+///
+/// ## The glass capsule is the toolbar's own, and there is nothing here to draw it
+///
+/// The owner asked for the name to sit in a glass component, matching `InspectorToggle` a few
+/// points to its left, and an earlier report said a bare `Text` in a toolbar item picked up no
+/// capsule at all. That report was wrong, and the way it was wrong is why the bar looked broken.
+/// On macOS 26 every toolbar item is given a shared background: AppKit wraps it in an
+/// `NSToolbarPlatterView` holding an `NSGlassEffectView`, which is the same plate
+/// `.buttonStyle(.glass)` puts under the inspector's control, so the two already match and a
+/// `.glassEffect` of ours would be a second treatment over the first.
+///
+/// What there was instead was a capsule nobody could see, because the search field's capsule
+/// began eight points after it and the two read as one long run of glass. Rendered offscreen at
+/// 1440 points: the name's plate ran 152 to 408 and the field's 416 to 741. The fix was the space
+/// between them, not the plate, and it is `BloomWindowToolbar`'s `ToolbarSpacer`.
+///
+/// Two things follow from the plate being AppKit's. Adjacent items share ONE plate, so with the
+/// sidebar folded away the `+` and the name are drawn in a single capsule; a fixed
+/// `ToolbarSpacer` between them does not separate them, only a flexible one does, and a flexible
+/// spacer there would push the name into the middle of the bar. The grouping is left as AppKit's.
+/// And `.sharedBackgroundVisibility(.hidden)` is the switch that would turn the plate off, which
+/// is worth knowing about and not worth using here.
+///
+/// ## Renaming in place, measured
+///
+/// The label and the field are drawn in the same toolbar item, so the plate they sit in has one
+/// origin and the name cannot jump as it becomes editable. Offscreen, at rest and mid rename, the
+/// plate is at x=152.5 both times; it is four points wider while editing, which is the field's own
+/// inset and falls off the trailing end where there is nothing to displace.
 struct WindowTitleControl: View {
     /// Handed in rather than read from the environment, as `BloomWindowToolbar` takes it, because
     /// a `contextMenu`'s content is built in a detached context that observable values in the

--- a/Sources/Bloom/Views/RootView.swift
+++ b/Sources/Bloom/Views/RootView.swift
@@ -97,6 +97,13 @@ struct RootView: View {
                 // The window's search field, on the trailing edge of the toolbar, which is where
                 // Finder and Mail publish search on this platform.
                 //
+                // Which edge it lands on is not this modifier's to say. `SearchFieldPlacement` on
+                // macOS offers `automatic`, `toolbar`, `toolbarPrincipal` and `sidebar`, and none
+                // of them names an edge: the item is appended after the toolbar's own items and
+                // goes wherever the packing leaves it. What puts it at the end is the
+                // `ToolbarSpacer` in `BloomWindowToolbar`, and without that it sits against the
+                // window's name a third of the way across.
+                //
                 // `.searchable` rather than the hand built field this replaced, and that is the
                 // whole reason it moved. An `NSSearchToolbarItem` is compact at rest, expands over
                 // the toolbar when it is focused, draws the system's glass and the system's focus

--- a/Sources/BloomCore/GitHub/MergeMethodChoice.swift
+++ b/Sources/BloomCore/GitHub/MergeMethodChoice.swift
@@ -45,7 +45,9 @@ public enum MergeMethodChoice {
     }
 
     public static func load(repoID: RepoID, from store: Store) async -> GitHub.MergeMethod {
-        resolve((try? await store.setting(key(repoID: repoID))) ?? nil)
+        // No `?? nil`: `try?` over an expression that is already optional flattens, so the
+        // coalescing was redundant and SwiftLint failed the lint job on `main` for it.
+        resolve(try? await store.setting(key(repoID: repoID)))
     }
 
     /// The chosen method, written whole even when it is the fallback, so that a project where


### PR DESCRIPTION
The search field landed a third of the way across the bar because removing SwiftUI's title item removed the toolbar's only piece of slack. `.searchable` appends an `NSSearchToolbarItem` after everything the toolbar declares, an `NSToolbar` packs from the leading edge, and the title item is what usually stretches. `ToolbarSpacer(.flexible)` puts that stretch back. Measured offscreen at 1440 points, the field's capsule moves from x=416 to x=727, hard against the pull request band. The band stays where it is: it is a titlebar accessory beyond the toolbar, so the two never wanted the same edge.

`SearchFieldPlacement` on macOS has no trailing option, so there was nothing to choose there, and making the field a `ToolbarItem` of our own would have cost the expand-on-focus the `NSSearchToolbarItem` is for.

The same gap was the whole of the glass complaint. macOS 26 already wraps every toolbar item in an `NSToolbarPlatterView` holding an `NSGlassEffectView`, the same plate `.buttonStyle(.glass)` puts under `InspectorToggle`, so the name had a capsule; it was eight points from the search field's and the two read as one run of glass. No `.glassEffect` is added.

Renaming in place needed nothing. The label and the field are the same toolbar item, so the plate is at x=152.5 at rest and mid rename, and `InPlaceRename` already owns Return, Escape, click-away and the empty name.

`navigationTitle(_:)` taking a `Binding` is not the public door into AppKit's rename session, and that is now written down in `WindowTitleControl`. Built offscreen both ways and compared, the title bar comes out identical: same ivars on `NSToolbarTitleView`, `NSToolbarPrimaryTitleContainerView`, `_NSToolbarTitleField` and `NSWindowTitleController`, same gesture recognisers, field not editable.

One line of code. The rest is the measurements, so the next person does not repeat them.