### PR TITLE
Open a terminal tab where you are looking

### DIFF
--- a/Sources/Bloom/State/AppModel+TabBridge.swift
+++ b/Sources/Bloom/State/AppModel+TabBridge.swift
@@ -136,7 +136,13 @@ extension AppModel {
             case .terminal:
                 return .terminal(
                     WorkspaceTabTerminal(
-                        directory: model.workspace.path,
+                        // The folder the tab was opened on, which for all but one route to a
+                        // shell is the worktree root, and by the same rule the fork reads. An
+                        // agent asking where a pane is standing used to be told the root whatever
+                        // the pane said in the strip.
+                        directory: FolderTerminal.launchDirectory(
+                            requested: tab.directory, root: model.workspace.path
+                        ),
                         // Every pane of the tab, because a split terminal is one tab with two
                         // shells and either of them being alive makes the tab a live one.
                         isLive: TerminalSplitStore.shared.panes(of: tab.id).contains {

--- a/Sources/Bloom/Views/Center/Panes/CenterTab.swift
+++ b/Sources/Bloom/Views/Center/Panes/CenterTab.swift
@@ -48,6 +48,12 @@ struct CenterTab: Identifiable, Hashable, Codable, Sendable {
     /// whose owner called it Browser must not then start renaming itself from every page it
     /// visits.
     var isNamed: Bool = false
+    /// Terminal only: the folder inside the worktree its shell was asked to start in, empty for
+    /// the root, which is where every terminal but one opened from a folder row starts.
+    ///
+    /// Absolute, and read at fork time rather than trusted: a tab outlives the folder under it.
+    /// See `FolderTerminal.launchDirectory`.
+    var directory: String = ""
     /// Review only: the file being read, relative to the worktree. Kept here rather than taken
     /// from `WorkspaceModel.selectedFilePath` because that one is only ever a CHANGED file: the
     /// poll drops any selection git no longer reports, which would throw the reader out of a file
@@ -91,11 +97,13 @@ struct CenterTab: Identifiable, Hashable, Codable, Sendable {
         path = try container.decodeIfPresent(String.self, forKey: .path) ?? ""
         pageTitle = try container.decodeIfPresent(String.self, forKey: .pageTitle) ?? ""
         isNamed = try container.decodeIfPresent(Bool.self, forKey: .isNamed) ?? false
+        directory = try container.decodeIfPresent(String.self, forKey: .directory) ?? ""
     }
 
     init(
         id: String = newID(), workspaceID: WorkspaceID, kind: Kind, title: String,
-        url: String = "", path: String = "", pageTitle: String = "", isNamed: Bool = false
+        url: String = "", path: String = "", pageTitle: String = "", isNamed: Bool = false,
+        directory: String = ""
     ) {
         self.id = id
         self.workspaceID = workspaceID
@@ -105,5 +113,6 @@ struct CenterTab: Identifiable, Hashable, Codable, Sendable {
         self.path = path
         self.pageTitle = pageTitle
         self.isNamed = isNamed
+        self.directory = directory
     }
 }

--- a/Sources/Bloom/Views/Center/Panes/CenterTabStore.swift
+++ b/Sources/Bloom/Views/Center/Panes/CenterTabStore.swift
@@ -128,9 +128,13 @@ final class CenterTabStore {
     /// A title given here is a named tab, which matters for exactly one kind: a browser's name is
     /// otherwise the page's, so `pane_open` asking for a browser called "Docs" would have watched
     /// the first page it loaded rename it. See `CenterTab.isNamed` and `BrowserTabTitle`.
+    ///
+    /// `directory` is a terminal's, and only a folder row in the inspector passes one. See
+    /// `FolderTerminal`.
     @discardableResult
     func add(
-        kind: CenterTab.Kind, workspaceID: WorkspaceID, url: String = "", title: String? = nil
+        kind: CenterTab.Kind, workspaceID: WorkspaceID, url: String = "", title: String? = nil,
+        directory: String = ""
     ) -> CenterTab {
         var tabs = tabs(for: workspaceID)
         let tab = CenterTab(
@@ -138,7 +142,8 @@ final class CenterTabStore {
             kind: kind,
             title: title ?? Self.nextTitle(for: kind, in: tabs),
             url: url,
-            isNamed: title != nil
+            isNamed: title != nil,
+            directory: directory
         )
         tabs.append(tab)
         apply(tabs, to: workspaceID)

--- a/Sources/Bloom/Views/Center/Panes/FolderTerminalTab.swift
+++ b/Sources/Bloom/Views/Center/Panes/FolderTerminalTab.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+import BloomCore
+
+/// The one way a terminal is opened on a folder of the worktree.
+///
+/// `FileReview` next door is the same shape and exists for the same reason: two trees in the
+/// inspector offer this, and neither of them should have to know how a tab is made or where the
+/// centre column puts one. It goes through `NewPane.open`, which is the door the strip's `+`, the
+/// pane menus and `pane_open` all use, so a shell opened from a folder row is exactly the tab a
+/// terminal normally is.
+@MainActor
+enum FolderTerminalTab {
+    /// Opens a terminal tab in `folder`, named after it, and brings it forward.
+    ///
+    /// Nothing happens if the folder has gone between the right click and the click, which is the
+    /// same answer `FolderTerminal.canOpen` gave the menu when it decided whether to draw the item
+    /// at all.
+    static func open(folder: String, in model: WorkspaceModel) {
+        guard let target = target(folder: folder, in: model) else { return }
+        NewPane.open(
+            .terminal, in: model, title: target.title, directory: target.directory
+        ) { content in
+            WorkspaceTabsStore.shared.reveal(content, in: model)
+        }
+    }
+
+    /// The tab a folder would make in this workspace, numbered against the terminals it already
+    /// has, or nothing if the folder is empty or not on disk.
+    ///
+    /// Asked by `PaneDuplicate` as well, so that duplicating a shell standing in `resources/css`
+    /// opens another one there rather than back at the worktree root.
+    static func target(folder: String, in model: WorkspaceModel) -> FolderTerminal.Target? {
+        let taken = CenterTabStore.shared.tabs(for: model.workspace.id)
+            .filter { $0.kind == .terminal }
+            .map(\.title)
+        return FolderTerminal.target(folder: folder, taken: taken)
+    }
+}

--- a/Sources/Bloom/Views/Center/Panes/NewPane.swift
+++ b/Sources/Bloom/Views/Center/Panes/NewPane.swift
@@ -31,11 +31,16 @@ enum NewPane {
     /// what the pane is for: `pane_open` and `pane_split` carry the name an agent gave, because
     /// four tabs called Terminal are four a reader cannot tell apart. Nil takes the numbering each
     /// kind has always had, so no menu changed when this argument arrived.
+    ///
+    /// `directory` is only read for a terminal, and only a folder row in the inspector passes one.
+    /// Empty is the worktree root, which is where every other route to a shell starts. See
+    /// `FolderTerminal`.
     static func open(
         _ kind: PaneKind,
         in model: WorkspaceModel,
         url: String = "",
         title: String? = nil,
+        directory: String = "",
         place: @escaping @MainActor (PaneContent) -> Void
     ) {
         switch kind {
@@ -49,7 +54,8 @@ enum NewPane {
         // port first, because both are baked into the process the moment it is forked.
         case .terminal:
             let tab = CenterTabStore.shared.add(
-                kind: .terminal, workspaceID: model.workspace.id, title: title
+                kind: .terminal, workspaceID: model.workspace.id, title: title,
+                directory: directory
             )
             place(.tool(tab.id))
 

--- a/Sources/Bloom/Views/Center/Panes/PaneDuplicate.swift
+++ b/Sources/Bloom/Views/Center/Panes/PaneDuplicate.swift
@@ -33,8 +33,15 @@ enum PaneDuplicate {
         case .sameContent:
             place(content)
 
+        // In the folder the shell being duplicated is standing in, for the same reason the browser
+        // below opens on the page it is showing. The worktree root when it was opened at the root,
+        // and the root again when the folder has gone since.
         case .freshTerminal:
-            NewPane.open(.terminal, in: model, place: place)
+            let folder = FolderTerminalTab.target(folder: tab?.directory ?? "", in: model)
+            NewPane.open(
+                .terminal, in: model, title: folder?.title,
+                directory: folder?.directory ?? "", place: place
+            )
 
         // On the page it is already showing, rather than on the empty address a split browser
         // normally opens with. This is the one route that means "the same again", and the same

--- a/Sources/Bloom/Views/Center/Panes/ToolPaneView.swift
+++ b/Sources/Bloom/Views/Center/Panes/ToolPaneView.swift
@@ -48,6 +48,7 @@ struct ToolPaneView: View {
                             workspace: model.workspace,
                             repo: model.repo,
                             port: model.port,
+                            directory: tab.directory,
                             onCloseTab: { Task { await CenterTabStore.shared.close(tab) } },
                             splitColumn: splitColumn
                         )

--- a/Sources/Bloom/Views/Inspector/ChangedFileList.swift
+++ b/Sources/Bloom/Views/Inspector/ChangedFileList.swift
@@ -226,7 +226,10 @@ struct ChangedFileList: View {
                     isExpanded: !collapsed.contains(item.node.path),
                     depth: item.depth,
                     fullPath: fullPath(item.node.path),
-                    action: { activate(folder: item.node.path) }
+                    action: { activate(folder: item.node.path) },
+                    onOpenTerminal: {
+                        FolderTerminalTab.open(folder: fullPath(item.node.path), in: model)
+                    }
                 )
                 .equatable()
             }

--- a/Sources/Bloom/Views/Inspector/ChangedFolderRow.swift
+++ b/Sources/Bloom/Views/Inspector/ChangedFolderRow.swift
@@ -31,6 +31,8 @@ struct ChangedFolderRow: View, Equatable {
     /// The folder's location in the worktree, for the menu items that hand it to another app.
     var fullPath: String
     var action: () -> Void
+    /// Opens a shell in this folder. See `FolderTerminal`.
+    var onOpenTerminal: () -> Void
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -69,6 +71,13 @@ struct ChangedFolderRow: View, Equatable {
         .contextMenu {
             Button("Reveal in Finder") { Reveal.inFinder(fullPath) }
             OpenInItems(target: .folder(fullPath))
+            // With the two above rather than beside Copy path, and worded exactly as the worktree
+            // tree words it: the two trees share a pane and must not name one action two ways.
+            // Absent when the folder is not on disk, which here is a directory git reports out of
+            // a diff after the agent deleted it.
+            if FolderTerminal.canOpen(folder: fullPath) {
+                Button(FolderTerminal.menuTitle, action: onOpenTerminal)
+            }
             Button("Copy path", action: copyPath)
         }
         .help(path)

--- a/Sources/Bloom/Views/Inspector/FileTreeRow.swift
+++ b/Sources/Bloom/Views/Inspector/FileTreeRow.swift
@@ -24,6 +24,8 @@ struct FileTreeRow: View, Equatable {
     /// The node's location on disk, for the menu items that hand it to another app.
     var fullPath: String
     var action: () -> Void
+    /// Opens a shell in this row, which only a folder row offers. See `FolderTerminal`.
+    var onOpenTerminal: () -> Void
 
     @Environment(\.isOnEmphasizedSelection) private var isOnSelection
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -77,6 +79,13 @@ struct FileTreeRow: View, Equatable {
             // not handed to a terminal.
             OpenInItems(target: item.node.isDirectory ? .folder(fullPath) : .file(fullPath))
             Button("Reveal in Finder") { Reveal.inFinder(fullPath) }
+            // With the two above rather than beside Copy path: all three hand this row to
+            // something that opens it, and only the last is about the clipboard. `canOpen` is
+            // what keeps it off a file row, where the submenu above turns into Open File in, and
+            // off a folder that is not on disk.
+            if FolderTerminal.canOpen(folder: fullPath) {
+                Button(FolderTerminal.menuTitle, action: onOpenTerminal)
+            }
             Button("Copy path", action: copyPath)
         }
         .help(item.node.path)

--- a/Sources/Bloom/Views/Inspector/FileTreeView.swift
+++ b/Sources/Bloom/Views/Inspector/FileTreeView.swift
@@ -118,7 +118,8 @@ struct FileTreeView: View {
                 isExpanded: expanded.contains(path),
                 isChanged: changedPaths.contains(path),
                 fullPath: fullPath(path),
-                action: { activate(item.node) }
+                action: { activate(item.node) },
+                onOpenTerminal: { FolderTerminalTab.open(folder: fullPath(path), in: model) }
             )
             .equatable()
         }

--- a/Sources/Bloom/Views/Terminal/TerminalSessionStore.swift
+++ b/Sources/Bloom/Views/Terminal/TerminalSessionStore.swift
@@ -133,11 +133,16 @@ final class TerminalSessionStore {
     }
 
     /// The live shell for a tab, forked on first use and reused forever after.
+    ///
+    /// `directory` is what the tab asked for, empty for the worktree root, and it is checked here
+    /// rather than trusted: a tab opened on a folder outlives that folder. See
+    /// `FolderTerminal.launchDirectory`.
     func terminal(
         for tab: TerminalTab,
         workspace: Workspace,
         repo: Repo?,
-        port: Int
+        port: Int,
+        directory: String = ""
     ) -> BloomTerminalView {
         if let existing = terminals[tab.id.rawValue] { return existing }
 
@@ -161,13 +166,14 @@ final class TerminalSessionStore {
         // `tab.id.rawValue` is the pane id here: a split hands each pane a `TerminalTab` carrying its own id,
         // and an unsplit tab is its own single pane.
         paneOwner[tab.id.rawValue] = workspace.id
+        let start = FolderTerminal.launchDirectory(requested: directory, root: workspace.path)
         if let persistence, let command = persistence.command,
            let session = persistence.decision(workspaceID: workspace.id, paneID: tab.id.rawValue).session {
             view.start(TerminalLaunch.tmux(
-                command: command, session: session, directory: workspace.path, extra: extra
+                command: command, session: session, directory: start, extra: extra
             ))
         } else {
-            view.start(TerminalLaunch.loginShell(directory: workspace.path, extra: extra))
+            view.start(TerminalLaunch.loginShell(directory: start, extra: extra))
         }
 
         terminals[tab.id.rawValue] = view

--- a/Sources/Bloom/Views/Terminal/TerminalSplitView.swift
+++ b/Sources/Bloom/Views/Terminal/TerminalSplitView.swift
@@ -19,6 +19,9 @@ struct TerminalSplitView: View {
     var workspace: Workspace
     var repo: Repo?
     var port: Int
+    /// The folder every pane of this tab forks in, empty for the worktree root. See
+    /// `FolderTerminal`.
+    var directory: String = ""
     /// Called when the user closes the last pane, which is the tab asking to go away.
     var onCloseTab: @MainActor () -> Void
     /// Called when a split asks for something a shell tree cannot hold. See `handle`.
@@ -87,6 +90,7 @@ struct TerminalSplitView: View {
             workspace: workspace,
             repo: repo,
             port: port,
+            directory: directory,
             isFocusedPane: isFocused,
             focusRequest: focusRequest,
             onFocus: { splits.focus(id, in: ownerID) },

--- a/Sources/Bloom/Views/Terminal/TerminalView.swift
+++ b/Sources/Bloom/Views/Terminal/TerminalView.swift
@@ -557,6 +557,10 @@ struct TerminalView: NSViewRepresentable {
     var workspace: Workspace
     var repo: Repo?
     var port: Int
+    /// The folder this pane's shell starts in, empty for the worktree root. Every pane of a tab
+    /// gets the tab's, so splitting a terminal opened on a folder stays in that folder, which is
+    /// what splitting does in every other terminal.
+    var directory: String = ""
 
     /// Split panes only. A tab holding one terminal is always its own focused pane and never moves
     /// the keyboard, so it leaves all four of these alone.
@@ -602,7 +606,7 @@ struct TerminalView: NSViewRepresentable {
 
     @MainActor private var session: BloomTerminalView {
         TerminalSessionStore.shared.terminal(
-            for: tab, workspace: workspace, repo: repo, port: port
+            for: tab, workspace: workspace, repo: repo, port: port, directory: directory
         )
     }
 }

--- a/Sources/BloomCore/Presentation/FolderTerminal.swift
+++ b/Sources/BloomCore/Presentation/FolderTerminal.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Opening a shell in one folder of a worktree rather than at its root.
+///
+/// The rules, not the tab. Three questions live here because three different places ask them and
+/// none of those places can be tested: the two file trees in the inspector ask whether to offer
+/// the item and what the tab would be called, and `TerminalSessionStore` asks where the shell is
+/// actually forked at the moment it forks one.
+public enum FolderTerminal {
+    /// One name for the item, because two trees in the same pane draw it. `Open` rather than `New`
+    /// to sit with `Reveal in Finder` and `Open Folder in`, which is the group it belongs to.
+    public static let menuTitle = "Open Terminal Tab Here"
+
+    /// What a row's item resolves to: where the shell goes, and what the tab is called.
+    public struct Target: Sendable, Equatable {
+        /// Absolute, because that is what a launch takes.
+        public var directory: String
+        public var title: String
+
+        public init(directory: String, title: String) {
+            self.directory = directory
+            self.title = title
+        }
+    }
+
+    /// Whether the item is offered for a folder at all.
+    ///
+    /// Absent rather than present and refusing, for a folder that is not on disk. The changed file
+    /// tree draws its directories out of a diff, so it shows one the agent has just deleted, and a
+    /// workspace keeps its rows after its worktree has been removed. `Reveal in Finder` next to it
+    /// can hand a dead path to another application and let that application shrug; this one would
+    /// leave a tab in Bloom's own window holding a shell that never started, which is a mess the
+    /// reader then has to clear up. Absent rather than greyed is what the Run submenu next door
+    /// already does with an empty list.
+    public static func canOpen(folder path: String) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) else {
+            return false
+        }
+        return isDirectory.boolValue
+    }
+
+    /// The tab to make for a folder, or nothing if it has gone between the right click and the
+    /// click.
+    ///
+    /// Named after the folder rather than `Terminal 3`, so somebody who asked for a shell in
+    /// `resources/css` can see which of their tabs it is. `taken` is the workspace's other
+    /// terminal titles, so two shells in two folders both called `css` are told apart by exactly
+    /// the numbering every other pane is named by.
+    public static func target(folder path: String, taken: some Sequence<String>) -> Target? {
+        guard canOpen(folder: path) else { return nil }
+        let name = (path as NSString).lastPathComponent
+        let base = name.isEmpty ? PaneNaming.terminal : name
+        return Target(directory: path, title: PaneNaming.nextTitle(base: base, taken: taken))
+    }
+
+    /// Where a terminal tab's shell is forked.
+    ///
+    /// The folder it was opened in while that is still there, and the worktree root otherwise. A
+    /// tab outlives the folder under it: checking out another branch takes directories with it,
+    /// and the tab comes back from user defaults on the next launch whatever the worktree looks
+    /// like by then. A shell forked into a path that is not there is a pane that never draws a
+    /// prompt, so the root answers instead.
+    public static func launchDirectory(requested: String, root: String) -> String {
+        guard !requested.isEmpty, canOpen(folder: requested) else { return root }
+        return requested
+    }
+}

--- a/Tests/BloomCoreTests/FolderTerminalTests.swift
+++ b/Tests/BloomCoreTests/FolderTerminalTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Folder terminal")
+struct FolderTerminalTests {
+    /// A real directory, removed when the test that made it is over.
+    private func makeDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("folder-terminal-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    @Test("A folder on disk is offered")
+    func offersAFolder() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(FolderTerminal.canOpen(folder: root.path))
+    }
+
+    /// The changed file tree draws directories out of a diff, so it lists ones the agent has just
+    /// deleted, and a workspace keeps its rows after its worktree is gone.
+    @Test("A folder that is not on disk is not offered")
+    func refusesAMissingFolder() throws {
+        let root = try makeDirectory()
+        let gone = root.appendingPathComponent("resources", isDirectory: true).path
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(!FolderTerminal.canOpen(folder: gone))
+        #expect(FolderTerminal.target(folder: gone, taken: []) == nil)
+    }
+
+    /// A file has no shell to open in, and neither tree offers the item on a file row. This is the
+    /// same answer said where it can be tested.
+    @Test("A file is not a folder")
+    func refusesAFile() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let file = root.appendingPathComponent("README.md")
+        try Data().write(to: file)
+
+        #expect(!FolderTerminal.canOpen(folder: file.path))
+        #expect(FolderTerminal.target(folder: file.path, taken: []) == nil)
+    }
+
+    @Test("The tab is named after the folder, not after Terminal")
+    func namesAfterTheFolder() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let css = root.appendingPathComponent("resources/css", isDirectory: true)
+        try FileManager.default.createDirectory(at: css, withIntermediateDirectories: true)
+
+        let target = FolderTerminal.target(folder: css.path, taken: [])
+        #expect(target?.title == "css")
+        #expect(target?.directory == css.path)
+    }
+
+    /// Two shells in two folders of the same name are numbered apart by the rule every other pane
+    /// is numbered by, rather than sitting in the strip as two rows nobody can tell apart.
+    @Test("A second tab for a folder of the same name is numbered")
+    func numbersASecondOfTheSameName() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let css = root.appendingPathComponent("css", isDirectory: true)
+        try FileManager.default.createDirectory(at: css, withIntermediateDirectories: true)
+
+        #expect(FolderTerminal.target(folder: css.path, taken: ["css"])?.title == "css 2")
+        #expect(
+            FolderTerminal.target(folder: css.path, taken: ["Terminal", "css"])?.title == "css 2"
+        )
+    }
+
+    @Test("A tab asking for nothing in particular is forked at the worktree root")
+    func rootWhenNothingIsAsked() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(FolderTerminal.launchDirectory(requested: "", root: root.path) == root.path)
+    }
+
+    @Test("A tab asking for a folder is forked in it")
+    func forksInTheFolder() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let css = root.appendingPathComponent("css", isDirectory: true)
+        try FileManager.default.createDirectory(at: css, withIntermediateDirectories: true)
+
+        #expect(FolderTerminal.launchDirectory(requested: css.path, root: root.path) == css.path)
+    }
+
+    /// The tab outlives the folder: another branch checked out, or a relaunch reading the tab back
+    /// out of user defaults. A shell forked into a path that is not there never draws a prompt.
+    @Test("A tab whose folder has gone falls back to the worktree root")
+    func fallsBackWhenTheFolderGoes() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let css = root.appendingPathComponent("css", isDirectory: true)
+        try FileManager.default.createDirectory(at: css, withIntermediateDirectories: true)
+        try FileManager.default.removeItem(at: css)
+
+        #expect(FolderTerminal.launchDirectory(requested: css.path, root: root.path) == root.path)
+    }
+}

--- a/Tests/BloomCoreTests/TerminalPaneCensusTests.swift
+++ b/Tests/BloomCoreTests/TerminalPaneCensusTests.swift
@@ -106,14 +106,16 @@ struct TerminalPaneCensusTests {
         let (name, defaults) = domain()
         defer { clean(name) }
 
-        // Byte for byte what `CenterTabStore.persist` writes today, and then, as the second
-        // element, a record from before `url` and `path` were added. Both name their pane: this
-        // reads two fields rather than the whole tab exactly so an older record still counts.
+        // What `CenterTabStore.persist` writes today, then a record from before `url` and `path`
+        // were added, then one carrying the folder a tab opened on a directory row remembers. All
+        // three name their pane: this reads two fields rather than the whole tab exactly so a
+        // record written on either side of a new field still counts.
         let current = #"{"id":"t1","workspaceID":"w1","kind":"terminal","title":"Terminal","url":"","path":""}"#
         let legacy = #"{"id":"t2","workspaceID":"w1","kind":"terminal","title":"Server"}"#
-        defaults.set(Data("[\(current),\(legacy)]".utf8), forKey: "center.tabs.w1")
+        let folder = #"{"id":"t3","workspaceID":"w1","kind":"terminal","title":"css","directory":"/tmp/w/css"}"#
+        defaults.set(Data("[\(current),\(legacy),\(folder)]".utf8), forKey: "center.tabs.w1")
 
-        #expect(TerminalPaneCensus.terminalTabs(of: workspace, in: defaults) == ["t1", "t2"])
+        #expect(TerminalPaneCensus.terminalTabs(of: workspace, in: defaults) == ["t1", "t2", "t3"])
     }
 
     /// The keys themselves, written out rather than built, because the literal is the contract.


### PR DESCRIPTION
A folder in either file tree gains **Open Terminal Tab Here**, opening a terminal in the centre column standing in that folder. It sits with Reveal in Finder and Open Folder in, which are the other items that hand the folder to something; Copy path stays last because it is the clipboard rather than an opening.

The tab is named after the folder, so `resources/css` gives a tab called `css`, numbered against the workspace's other terminals by the same rule every other pane is named by.

Folders only, and absent rather than greyed when the folder is not on disk. The changed-file tree draws directories out of a diff, so it will happily list one the agent deleted: Reveal in Finder beside it can hand a dead path to another application and let that application shrug, where this one would leave a tab in Bloom's own window holding a shell that never started. A tab also outlives the folder under it, so it falls back to the worktree root at the moment it forks.

One directory path, not a second: `TerminalLaunch` already took a directory and it was hard wired to the worktree root. Two things that would otherwise be half done came with it: a duplicated pane opens in the same folder, by the argument its own comment already makes for a browser, and the bridge stopped reporting the worktree root as every terminal pane's directory, so an agent asking where a pane stands now gets the answer the strip shows.

Not in the menu bar: it is scoped to the row under the pointer, which a menu bar item cannot name, and `docs/MENUS.md` on the menu sweep branch already records that rule for row items.