### PR TITLE
Let the Merge button say which merge it will do

### DIFF
--- a/Sources/Bloom/Views/Inspector/MergeSplitButton.swift
+++ b/Sources/Bloom/Views/Inspector/MergeSplitButton.swift
@@ -9,6 +9,13 @@ import BloomCore
 /// to match, and the next press on the button is what merges. Nothing in the menu performs
 /// anything, so the one irreversible act in this app stays behind the one control that says it.
 ///
+/// **It is the merge button and nothing else.** It is drawn only where the strip's primary action
+/// is a merge. An earlier version also stood, quiet and icon only, where the primary was Commit
+/// and push or Fix merge conflicts, on the argument that the old chevron was the only way to merge
+/// in those states. The owner has overruled that: a menu about merging beside a button about
+/// committing is a control the band did not ask for. `PullRequestSummary.mergeControl` carries
+/// what that costs.
+///
 /// **The system's split button, drawn by the system, with the fill painted behind it.** A
 /// `Menu` with a `primaryAction` and `.menuStyle(.button)` IS this control on macOS: it draws the
 /// hairline, the chevron, the pressed states and the keyboard, and an inline `Picker` inside it
@@ -25,13 +32,11 @@ import BloomCore
 /// "Checks failing" band ends in a red button. A neutral capsule there would be the strip losing
 /// the signal it exists to carry.
 struct MergeSplitButton: View {
-    /// The method in force for this project. The button promises it, the menu ticks it.
+    /// The method in force for this project. The button promises it and the menu ticks it, and
+    /// they are the same value: see `body` for what it takes to keep that true.
     var method: GitHub.MergeMethod
-    /// The colour of the band this stands in. Painted only when this is the prominent control.
+    /// The colour of the band this stands in.
     var fill: Color
-    /// Whether merging is what this state is asking for, which is what decides between the filled
-    /// control and the quiet one beside another state's primary.
-    var isPrimary: Bool
     /// Whether GitHub will take a merge at all. A running agent is not in here: the cluster
     /// answers for that, once, for every control in it.
     var canMerge: Bool
@@ -48,49 +53,38 @@ struct MergeSplitButton: View {
 
     private var isLive: Bool { isClusterEnabled && canMerge }
 
-    @ViewBuilder
     var body: some View {
-        if isPrimary {
-            // Two forms, as every other control in this strip has, and for the same reason: the
-            // headline is the part that must not be what truncates.
-            ViewThatFits(in: .horizontal) {
-                styled.labelStyle(.titleAndIcon)
-                styled.labelStyle(.iconOnly)
-            }
-            .fixedSize()
-        } else {
-            // The quiet form is always the glyph, measured rather than chosen: the band is 380
-            // points, and "Squash and merge" beside "Commit and push" comes to 326 of them with
-            // the number and the gaps still to pay for, which leaves the headline nothing at all.
-            // The old chevron was 19 points for the same job; this is 44, and it is what the
-            // strip can afford. The method is still said out loud, in the tick in the menu and in
-            // the tooltip, which is where an icon only control says everything anyway.
-            styled.labelStyle(.iconOnly).fixedSize()
+        // Two forms, as every other control in this strip has, and for the same reason: the
+        // headline is the part that must not be what truncates.
+        ViewThatFits(in: .horizontal) {
+            styled.labelStyle(.titleAndIcon)
+            styled.labelStyle(.iconOnly)
         }
+        .fixedSize()
+        // **The label and the tick are one value, and this is what makes that true.** A `Menu`'s
+        // content is not evaluated when the view is rebuilt; it is evaluated when the menu opens,
+        // out of the closure SwiftUI stored, and the tick is drawn from the selection that closure
+        // captured. The label is re-read on every rebuild. So the button said "Rebase and merge"
+        // over a menu still ticking Squash: two ages of one value, which is the exact fault this
+        // control exists to remove. Giving it the value's identity makes a changed method a new
+        // control, so there is no older closure left to evaluate.
+        .id(method)
     }
 
-    @ViewBuilder
     private var styled: some View {
-        if isPrimary {
-            control
-                .buttonStyle(.borderedProminent)
-                // The label, the chevron and the hairline in white. See the type's note: the
-                // system will not tint this control, so the only lever left over its ink is the
-                // appearance it draws itself for.
-                .environment(\.colorScheme, .dark)
-                .background(
-                    // Dimmed rather than hidden when the press is not available, which is how
-                    // AppKit draws a disabled prominent button and therefore how this one has
-                    // to look beside them.
-                    fill.opacity(isLive ? 1 : 0.35),
-                    in: .rect(cornerRadius: Metrics.corner)
-                )
-        } else {
-            // Quiet, beside somebody else's primary. The strip's rule is that the prominent
-            // control is whatever the state is asking for, and when that is Commit and push or
-            // Fix merge conflicts, merging is still one press away rather than gone.
-            control.buttonStyle(.bordered)
-        }
+        control
+            .buttonStyle(.borderedProminent)
+            // The label, the chevron and the hairline in white. See the type's note: the system
+            // will not tint this control, so the only lever left over its ink is the appearance
+            // it draws itself for.
+            .environment(\.colorScheme, .dark)
+            .background(
+                // Dimmed rather than hidden when the press is not available, which is how AppKit
+                // draws a disabled prominent button and therefore how this one has to look beside
+                // them.
+                fill.opacity(isLive ? 1 : 0.35),
+                in: .rect(cornerRadius: Metrics.corner)
+            )
     }
 
     private var control: some View {
@@ -101,10 +95,10 @@ struct MergeSplitButton: View {
             // the platform to draw it. It also cannot perform anything, which is exactly the
             // promise this menu makes.
             Picker("Merge method", selection: binding) {
-                ForEach(MergeMethodChoice.offered, id: \.self) { method in
+                ForEach(MergeMethodChoice.offered, id: \.self) { offered in
                     // GitHub's own wording here, because this menu is read beside the web UI.
                     // The button says `buttonLabel`, which is a promise about the next press.
-                    Text(method.label).tag(method)
+                    Text(offered.label).tag(offered)
                 }
             }
             .pickerStyle(.inline)

--- a/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
@@ -212,9 +212,8 @@ struct PullRequestSummary: View {
     /// The primary slot belongs to whatever the state is actually asking for. With local work in
     /// the worktree that is not Merge: merging now would land the pull request WITHOUT what the
     /// reader is looking at and delete the branch it was on. So the primary swaps to Commit and
-    /// push, and merging stays exactly one press away in the quiet split button beside it, which
-    /// carries the same method and opens the same confirmation. Nothing is taken away; what
-    /// changes is which of the two the strip is pointing at.
+    /// push, and the strip offers that and nothing else, because a merge control standing beside
+    /// a commit button is an offer to do the thing the state has just said not to do.
     ///
     /// **The primary control is last in every one of these, and that is the whole rule.** It used
     /// to be first, with the merge method chevron or Archive after it, so the button the strip
@@ -225,13 +224,14 @@ struct PullRequestSummary: View {
     /// only thing that gives way, and the primary's trailing edge is the pane's own inset in
     /// every state the strip can be in.
     ///
-    /// Everything that is not the primary sits immediately before it, at the tight spacing, so
-    /// the pair still reads as one cluster rather than as two controls that happen to be near
-    /// each other. The merge method chevron used to be the awkward one here: it stood BEFORE
-    /// Merge, on the leading side, because a 19 point chevron at the trailing edge is exactly the
-    /// misalignment the rule above was written to fix. It is inside the button now, on the
-    /// trailing side where a split button carries it, and the button's own trailing edge is still
-    /// the pane's inset. See `mergeControl`.
+    /// Where something DOES stand beside the primary, which is Continue beside Archive on a
+    /// merged pull request, it sits immediately before it at the tight spacing, so the pair reads
+    /// as one cluster rather than as two controls that happen to be near each other. An open pull
+    /// request has no such pair any more. The merge method chevron used to be the awkward one
+    /// here: it stood BEFORE Merge, on the leading side, because a 19 point chevron at the
+    /// trailing edge is exactly the misalignment the rule above was written to fix. It is inside
+    /// the button now, on the trailing side where a split button carries it, and it is drawn
+    /// nowhere else. See `mergeControl`.
     private var trailing: some View {
         // Disabled here, for the cluster, rather than on each button in it. Everything in this
         // slot ends in a turn that writes to the worktree or the branch, so it is one question,
@@ -250,15 +250,10 @@ struct PullRequestSummary: View {
                 .controlSize(.small)
                 .accessibilityLabel("Working")
         } else if pullRequest.isOpen {
-            HStack(spacing: Metrics.spacingTight) {
-                // Only when merging is not what the state is asking for, because then the split
-                // button IS the primary and there is nothing to stand beside it. This is what the
-                // old chevron did in those states: it was the only way to merge a branch whose
-                // primary said Commit and push, and losing it would have taken a route away.
-                if status.remedy != .merge { mergeControl(isPrimary: false) }
-                primaryButton
-            }
-            .fixedSize()
+            // One control, and only the one the state is asking for. Nothing stands beside it:
+            // the merge method chevron is inside the merge button now, and it is drawn nowhere a
+            // merge is not what the button does.
+            primaryButton.fixedSize()
         } else if pullRequest.isMerged {
             HStack(spacing: Metrics.spacingTight) {
                 continueButton
@@ -284,7 +279,7 @@ struct PullRequestSummary: View {
     @ViewBuilder
     private var primaryButton: some View {
         switch status.remedy {
-        case .merge: mergeControl(isPrimary: true)
+        case .merge: mergeControl
         case .fixConflicts: fixConflictsButton
         case .commitAndPush, .push: pushButton
         }
@@ -481,15 +476,21 @@ struct PullRequestSummary: View {
     /// Merge, and the chevron that chooses which merge, as one control.
     ///
     /// This replaces a pair: a prominent `Merge` button that always proposed a squash, and a small
-    /// borderless chevron beside it whose three items each merged by their own method. Nothing has
-    /// been dropped. All three methods are still there, still in GitHub's own wording, still one
-    /// press from a merge; what changed is that picking one now sets the mode and the button says
-    /// which, so the press that lands somebody's branch is always the press on the thing labelled
-    /// with what it will do.
+    /// borderless chevron beside it whose three items each merged by their own method. All three
+    /// methods are still there, still in GitHub's own wording, still one press from a merge; what
+    /// changed is that picking one now sets the mode and the button says which, so the press that
+    /// lands somebody's branch is always the press on the thing labelled with what it will do.
     ///
-    /// Prominent when merging is what the state is asking for, quiet when it is not. The quiet
-    /// form is the old chevron's other job: with local work in the worktree the primary swaps to
-    /// Commit and push, and merging has to stay reachable rather than disappear.
+    /// **Drawn only where the primary action is a merge, which is the one thing the old chevron
+    /// did that has not been kept.** That chevron was also the way to merge a branch whose primary
+    /// said Commit and push or Fix merge conflicts, and a quiet form of this control was standing
+    /// there for exactly that reason until the owner saw it: a merge menu beside a commit button
+    /// is a control the band did not ask for. So in those two states the band is what it was
+    /// before any of this. Merging waits for the state that is blocking it to clear, which is a
+    /// push or a resolved conflict away and is what the primary button is there to do. Nothing
+    /// else in this app offers a merge from a menu, so those two states now have no merge press at
+    /// all; asking this workspace's agent in the composer still lands one, which is all this
+    /// button does anyway.
     ///
     /// **The tint measurement that used to live here has moved to `MergeSplitButton`,** because
     /// it is the reason that control is drawn the way it is. The short version is unchanged: the
@@ -501,11 +502,10 @@ struct PullRequestSummary: View {
     ///
     /// Every path through it opens the confirmation. Nothing here performs a merge, and since
     /// merging moved onto the agent nothing anywhere in this target does either.
-    private func mergeControl(isPrimary: Bool) -> some View {
+    private var mergeControl: some View {
         MergeSplitButton(
             method: mergeMethod,
             fill: status.tone.fill,
-            isPrimary: isPrimary,
             // Only what GitHub says about the pull request. A running agent is the cluster's
             // answer rather than this control's: see `trailing`.
             canMerge: status.canMerge,


### PR DESCRIPTION
The button said Merge and always squashed, and the chevron beside it merged the moment you picked a method. So the label and the action disagreed, and choosing was the same gesture as doing.

It is a split button now: the label says which merge, the chevron only sets the mode with a tick against the one in force, and the press performs it. All three methods were already real end to end; Bloom composes a turn for the agent rather than running `gh` itself.

The choice is per project, in the store's key value table rather than in `.bloom/settings.toml`: squash versus merge is a repository's convention, so per workspace would re-ask on every branch and app-wide would carry one repository's convention into another, and a settings file lives in the working tree where writing to it from a menu would dirty a branch and reach teammates.

Two faults found after the first round. The label and the tick disagreed because a SwiftUI menu's contents are evaluated when the menu opens, out of a closure stored earlier, while the label is re-read on every rebuild: one value, two ages of it. A changed method is now a new control, so no stale closure survives. And a quiet copy of the control appeared in the states whose primary action is not a merge, which put a menu about merging next to a button about committing; it is gone, and the fifty points it took go back to the headline.

That leaves merging unreachable from the band in those two states, so it gains a Workspace menu item in the menu bar sweep, which is where a Mac app should have had it all along.