### PR TITLE
Publish every action in a menu, starting with the split nobody wanted

### DIFF
--- a/Sources/Bloom/Design/WorkspaceMenuItems.swift
+++ b/Sources/Bloom/Design/WorkspaceMenuItems.swift
@@ -112,18 +112,9 @@ struct WorkspaceMenuItems: View {
         copyBranchItem
         setupItem
         Divider()
-        Button(workspace.pinned ? "Unpin" : "Pin") {
-            Task { await app.togglePinned(workspace) }
-        }
-        // One item that changes its label rather than two, and which of the two it is is decided
-        // in the core so the sidebar and Home cannot disagree about one workspace. See
-        // `WorkspaceUnreadMark`, which is also where the archived case is argued out.
-        if let mark = WorkspaceUnreadMark.action(for: workspace) {
-            Button(mark.title) {
-                Task { await app.setUnread(workspace, mark.unread) }
-            }
-        }
-        colourPicker
+        WorkspacePinItem(workspace: workspace, app: app)
+        WorkspaceUnreadItem(workspace: workspace, app: app)
+        WorkspaceColourItem(workspace: workspace, app: app)
         renameItem
         Divider()
         // Straight through, with no dialog of its own. Whether this needs confirming is not
@@ -204,17 +195,68 @@ struct WorkspaceMenuItems: View {
         }
     }
 
-    /// The colour submenu: None, then the ten colours, with the tick on the current one.
-    ///
-    /// A bare `Picker`, which is what makes its own submenu titled "Colour" with the state column
-    /// filled in for us. A `Button` carrying a checkmark symbol in its label never gets one, which
-    /// is the same thing `ComposerOptionMenu` found.
-    ///
-    /// None is offered as its own row rather than by pressing the current colour again, which is
-    /// how Finder clears a tag. A press that means "set" everywhere except on one row, where it
-    /// means "clear", is a rule you can only find out about by losing a colour you wanted.
-    private var colourPicker: some View {
-        Picker("Colour", selection: colourSelection) {
+}
+
+// MARK: - The three that are about the row, and are now in two menus
+
+/// Pin, as a menu item.
+///
+/// Its own view rather than a property on `WorkspaceMenuItems`, because the Workspace menu at the
+/// top of the screen offers the same item and a `Commands` body is not in the environment this
+/// file reads `AppModel` from. Handing the model in is what lets one implementation serve both, so
+/// a workspace cannot be offered Pin on its row and Unpin in the menu bar.
+///
+/// One item that changes its label rather than two, which is the shape all three of these have.
+struct WorkspacePinItem: View {
+    var workspace: Workspace
+    var app: AppModel
+
+    var body: some View {
+        MenuCommand(.pin, alternate: workspace.pinned) {
+            Task { await app.togglePinned(workspace) }
+        }
+    }
+}
+
+/// The unread mark, as a menu item.
+///
+/// Which of the two labels it wears is decided in the core, so the sidebar, Home and the menu bar
+/// cannot disagree about one workspace. See `WorkspaceUnreadMark`, which is also where the
+/// archived case is argued out: an archived row's `unread` is a flag nothing draws.
+///
+/// Absent rather than greyed on a row that has no answer, which is what a context menu does. The
+/// menu bar's copy greys instead, because a menu bar is a map of what the app can do; that greying
+/// is `WorkspaceMenuSubject.allows` and happens before this view is built at all.
+struct WorkspaceUnreadItem: View {
+    var workspace: Workspace
+    var app: AppModel
+
+    var body: some View {
+        if let mark = WorkspaceUnreadMark.action(for: workspace) {
+            MenuCommand(.unreadMark, alternate: mark == .markRead) {
+                Task { await app.setUnread(workspace, mark.unread) }
+            }
+        }
+    }
+}
+
+/// The colour submenu: None, then the ten colours, with the tick on the current one.
+///
+/// A bare `Picker`, which is what makes its own submenu titled "Colour" with the state column
+/// filled in for us. A `Button` carrying a checkmark symbol in its label never gets one, which
+/// is the same thing `ComposerOptionMenu` found.
+///
+/// None is offered as its own row rather than by pressing the current colour again, which is
+/// how Finder clears a tag. A press that means "set" everywhere except on one row, where it
+/// means "clear", is a rule you can only find out about by losing a colour you wanted.
+struct WorkspaceColourItem: View {
+    var workspace: Workspace
+    var app: AppModel
+
+    var body: some View {
+        // The picker's own label, which is what it draws as the submenu's title. It comes from the
+        // table so the row menu and the menu bar cannot spell it two ways.
+        Picker(MenuBarCatalogue[.colour].title, selection: selection) {
             Text("None").tag("")
             ForEach(WorkspaceColour.all) { colour in
                 Label {
@@ -237,7 +279,7 @@ struct WorkspaceMenuItems: View {
     /// A workspace holding a hex that is not in the list selects nothing, so no row is ticked and
     /// the dot on the row goes on being drawn in the colour it was given. That is the right way
     /// round: the stored value is the truth and this list is only the menu's opinion of it.
-    private var colourSelection: Binding<String> {
+    private var selection: Binding<String> {
         Binding(
             get: { workspace.colour ?? "" },
             set: { hex in

--- a/Sources/Bloom/Views/Center/Panes/PaneDuplicate.swift
+++ b/Sources/Bloom/Views/Center/Panes/PaneDuplicate.swift
@@ -65,6 +65,13 @@ enum PaneDuplicate {
         PaneSplit.duplicating(content, tabKind: tab(for: content, in: model)?.kind).opensAPane
     }
 
+    /// Which row of the View menu's Split submenus means "another one of these", and therefore
+    /// carries `Cmd+\`. Nil on the review and the notes, which have no kind of their own for the
+    /// key to sit on. See `PaneDuplicateOutcome.sameAgainKind`.
+    static func sameAgainKind(_ content: PaneContent, in model: WorkspaceModel) -> PaneKind? {
+        PaneSplit.duplicating(content, tabKind: tab(for: content, in: model)?.kind).sameAgainKind
+    }
+
     private static func tab(for content: PaneContent, in model: WorkspaceModel) -> CenterTab? {
         guard case .tool(let tabID) = content else { return nil }
         return CenterTabStore.shared.tabs(for: model.workspace.id).first { $0.id == tabID }

--- a/Sources/Bloom/Views/Center/Panes/SessionTabsView.swift
+++ b/Sources/Bloom/Views/Center/Panes/SessionTabsView.swift
@@ -190,6 +190,14 @@ struct SessionTabsView: View {
         // it was wrong by exactly one await: this body has no suspension point in it, so it ran
         // while `WorkspaceModel` was still on the `Store` actor and judged real tool tabs against
         // an empty session list. It is `CenterColumnView`'s task now, after `onAppear`.
+        // Rename Tab from the File menu, which reaches the one field this strip owns. It renames
+        // the selected tab, which is the tab the menu item was greyed against.
+        .onReceive(NotificationCenter.default.publisher(for: .bloomRenameTab)) { _ in
+            guard let selected = store.selectedTab(in: model) else { return }
+            // `PaneContent.id` is the same string this strip files an open field under, for both
+            // kinds, which is what lets one notification carry no id of its own.
+            renamingID = selected.id
+        }
         .task(id: model.workspace.id) {
             tabs.load(workspaceID: model.workspace.id)
             // The icons this Mac has already seen, read back once per launch. Here rather than at
@@ -285,7 +293,7 @@ struct SessionTabsView: View {
             // already see.
             editableTitle: tabs.displayTitle(of: tab, in: model),
             canClose: true,
-            canRename: tab.kind != .review && tab.kind != .notes,
+            canRename: TabRenaming.canRename(.tool(tab.id), tabKind: tab.kind),
             closeTitle: closeTitle(for: tab),
             onSelect: { store.select(.tool(tab.id), in: model) },
             onStartRename: { renamingID = tab.id },
@@ -406,10 +414,12 @@ struct SessionTabsView: View {
         return store.canAbsorb(content)
     }
 
+    /// Whether asking for this tab beside itself would produce anything. The rule was written out
+    /// here as a third copy of `kind != .review && kind != .notes`; it is `PaneSplit`'s, through
+    /// the same door the split itself goes through, so the menu item and the split cannot come to
+    /// different answers about one tab.
     private func duplicable(_ content: PaneContent) -> Bool {
-        guard case .tool(let id) = content else { return true }
-        let kind = tabs.tabs(for: model.workspace.id).first { $0.id == id }?.kind
-        return kind != .review && kind != .notes
+        PaneDuplicate.canOpen(content, in: model)
     }
 
     /// Opens a tab beside the one the user asked from, rather than in place of it. The menu item

--- a/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
+++ b/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
@@ -25,6 +25,10 @@ struct BloomCommands: Commands {
     /// The focused window's Save, when it has one. See `FocusedMenuValues`.
     @FocusedValue(\.saveAction) private var saveAction: SaveAction?
 
+    /// Landing the branch, published by the pull request band because that is where the
+    /// confirmation lives. Nil whenever that band is not on screen, which greys the item.
+    @FocusedValue(\.mergeAction) private var mergeAction: MergeAction?
+
     init(model: AppModel) {
         self.model = model
     }
@@ -407,6 +411,15 @@ struct BloomCommands: Commands {
             }
 
             Divider()
+
+            // The title is the band's when the band is on screen, and the table's fallback when
+            // it is not, which is what lets a greyed row still say what the item is. It goes
+            // through the band's own `propose`, so the sign in gate and the confirmation are the
+            // ones the button raises rather than a second copy of them. See `MergeAction`.
+            Button(mergeAction?.title ?? MenuBarCatalogue[.merge].title) {
+                mergeAction?.perform()
+            }
+            .disabled(mergeAction?.isEnabled != true)
 
             MenuCommand(.archive) {
                 guard let workspace = workspace(for: .archive) else { return }

--- a/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
+++ b/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
@@ -40,7 +40,7 @@ struct BloomCommands: Commands {
         // somewhere else. The update check below stays a group of its own so the separator between
         // the two is still there.
         CommandGroup(replacing: .appInfo) {
-            Button("About Bloom") {
+            MenuCommand(.about) {
                 AboutWindow.show()
             }
         }
@@ -53,7 +53,7 @@ struct BloomCommands: Commands {
         // dead menu item invites the same click every time. See `SoftwareUpdate.availability`.
         CommandGroup(after: .appInfo) {
             if case .configured = updater.availability {
-                Button("Check for Updates…") {
+                MenuCommand(.checkForUpdates) {
                     updater.checkForUpdates()
                 }
                 .disabled(!updater.canCheckForUpdates)
@@ -61,13 +61,12 @@ struct BloomCommands: Commands {
         }
 
         CommandGroup(replacing: .newItem) {
-            Button("New Workspace…") {
+            MenuCommand(.newWorkspace) {
                 // The sheet lives in RootView, and the sidebar and Home already open it this
                 // way. Setting a flag on the model instead would leave it stuck true with no
                 // sheet.
                 NotificationCenter.default.post(name: .bloomNewWorkspace, object: nil)
             }
-            .keyboardShortcut("n", modifiers: .command)
             .disabled(model.repos.isEmpty)
 
             // Directly under New Workspace, because it starts one, and at the top level of File
@@ -78,7 +77,7 @@ struct BloomCommands: Commands {
             //
             // No key equivalent. It is the rarer of the two ways to start a workspace and the item
             // alone is what was missing.
-            Button("New Workspace from Pull Request…") {
+            MenuCommand(.newWorkspaceFromPullRequest) {
                 NotificationCenter.default.post(
                     name: .bloomNewWorkspace, object: nil,
                     userInfo: [Notification.bloomPullRequestKey: true]
@@ -86,11 +85,10 @@ struct BloomCommands: Commands {
             }
             .disabled(model.repos.isEmpty)
 
-            Button("New Session") {
+            MenuCommand(.newSession) {
                 guard let workspace = model.selectedModel else { return }
                 Task { await workspace.createSession() }
             }
-            .keyboardShortcut("t", modifiers: .command)
             .disabled(model.selectedModel == nil)
 
             // The other four things that open a tab in the workspace's centre column, which until
@@ -114,12 +112,10 @@ struct BloomCommands: Commands {
             // it learnable.
             Divider()
 
-            Button("New Terminal Tab") { openPane(.terminal) }
-                .keyboardShortcut("t", modifiers: [.command, .shift])
+            MenuCommand(.newTerminalTab) { openPane(.terminal) }
                 .disabled(model.selectedModel == nil)
 
-            Button("New Browser Tab") { openBrowserPane() }
-                .keyboardShortcut("b", modifiers: [.command, .shift])
+            MenuCommand(.newBrowserTab) { openBrowserPane() }
                 .disabled(model.selectedModel == nil)
 
             // The same key both ways, as the hidden button had it: show me the change, or give me
@@ -127,11 +123,10 @@ struct BloomCommands: Commands {
             // with changes, unlike the `+` menu's own row, because half of what this key does is
             // the way back out of a review and a workspace can have a review open with nothing
             // left in it.
-            Button("Show Changes") {
+            MenuCommand(.showChanges) {
                 guard let workspace = model.selectedModel else { return }
                 FileReview.toggle(in: workspace)
             }
-            .keyboardShortcut("d", modifiers: [.command, .shift])
             .disabled(model.selectedModel == nil)
 
             // Shift+Cmd+N, which nothing in Bloom held. It is the initial of the thing, which is
@@ -139,14 +134,20 @@ struct BloomCommands: Commands {
             // of four is easier to remember than four separate facts. Never disabled beyond
             // needing a workspace, because an empty note is exactly what somebody opening this is
             // about to fix.
-            Button("Show Notes") {
+            MenuCommand(.showNotes) {
                 guard let workspace = model.selectedModel else { return }
                 WorkspaceNotes.open(in: workspace)
             }
-            .keyboardShortcut("n", modifiers: [.command, .shift])
             .disabled(model.selectedModel == nil)
 
             Divider()
+
+            // Renaming a tab existed on the tab's own context menu and on its VoiceOver actions
+            // rotor, and in no menu at the top of the screen. It sits above Close Tab because the
+            // two are the same noun: this row and the one under it are what you can do to the tab
+            // in front. No key, for the reason `WorkspaceMenuItems` gives about Rename.
+            MenuCommand(.renameTab) { renameSelectedTab() }
+                .disabled(isMainWindowFocused != true || renamableTab == nil)
 
             // Cmd+W belongs to the tab, not the window, and this used to be Close Session, which
             // is not the same claim. It closed the workspace's active conversation whatever was in
@@ -163,18 +164,16 @@ struct BloomCommands: Commands {
             // scene below. The menu bar is shared with Settings and with each project's settings
             // window, and unscoped this item both closed the wrong thing from those windows and
             // left them with no working Cmd+W of their own.
-            Button("Close Tab") {
+            MenuCommand(.closeTab) {
                 closeSelectedTab()
             }
-            .keyboardShortcut("w", modifiers: .command)
             // Scoped to the main window as well as to there being a tab, because this item holds
             // Cmd+W for the whole app. See `MainWindowFocus`.
             .disabled(isMainWindowFocused != true || closableTab == nil)
 
             Divider()
 
-            Button("Add Project Folder…", action: addProjectFolder)
-            .keyboardShortcut("o", modifiers: [.command, .shift])
+            MenuCommand(.addProjectFolder, perform: addProjectFolder)
         }
 
         // The item this file used to say did not exist. Two views bind Cmd+S (the project settings
@@ -191,8 +190,7 @@ struct BloomCommands: Commands {
         // published a Save the item is disabled, and a disabled item does not consume its key, so a
         // view that still keeps Cmd+S to itself keeps working. See `FocusedMenuValues`.
         CommandGroup(replacing: .saveItem) {
-            Button("Save") { saveAction?.perform() }
-                .keyboardShortcut("s", modifiers: .command)
+            MenuCommand(.save) { saveAction?.perform() }
                 .disabled(saveAction?.isEnabled != true)
         }
 
@@ -207,8 +205,7 @@ struct BloomCommands: Commands {
             // never been asked for. A submenu called Find, because that is where Mail, Safari,
             // Preview and Xcode all keep these three.
             Menu("Find") {
-                Button("Find…", action: find)
-                    .keyboardShortcut("f", modifiers: .command)
+                MenuCommand(.find, perform: find)
                     // Never disabled. Whatever is in front either finds in place or falls through
                     // to the search, and which of those it is cannot be read from here anyway:
                     // this body is rebuilt when an `@Observable` moves, and first responder is not
@@ -216,11 +213,9 @@ struct BloomCommands: Commands {
                     // responder chain at the moment the key is pressed.
                     .disabled(model.repos.isEmpty && !FindInPlace.isAvailable)
 
-                Button("Find Next") { step(.nextMatch) }
-                    .keyboardShortcut("g", modifiers: .command)
+                MenuCommand(.findNext) { step(.nextMatch) }
 
-                Button("Find Previous") { step(.previousMatch) }
-                    .keyboardShortcut("g", modifiers: [.command, .shift])
+                MenuCommand(.findPrevious) { step(.previousMatch) }
             }
 
             // "Search", not "Find Workspace". It searches names, branches, projects and the full
@@ -236,10 +231,9 @@ struct BloomCommands: Commands {
             // which is what somebody in a terminal needs it to mean. Cmd+F still lands here
             // whenever nothing in front can find, so the key that used to open the Search screen
             // still reaches the search.
-            Button("Search") {
+            MenuCommand(.search) {
                 NotificationCenter.default.post(name: .bloomFocusSearch, object: nil)
             }
-            .keyboardShortcut("f", modifiers: [.command, .shift])
             // Keyed on projects rather than on live workspaces, because search also finds archived
             // ones and a machine whose every workspace is archived still has something to find.
             .disabled(model.repos.isEmpty)
@@ -249,22 +243,29 @@ struct BloomCommands: Commands {
         // owns it for splitting shells, and one keystroke that splits two different things
         // depending on where the pointer last was is worse than two that each mean one thing.
         CommandGroup(after: .sidebar) {
-            // Greyed on a tab that cannot be split rather than on no workspace at all. The
-            // review and the notes have exactly one copy each by design, so `PaneDuplicate` has
-            // always refused them, and these two items said nothing about it: on the Notes tab
-            // Split Right read as available and then did nothing when it was pressed. See
-            // `PaneSplit` in the core, which is the rule both sides read now.
-            Button("Split Right", systemImage: PaneSymbol.splitRight) { splitCentre(.horizontal) }
-                .keyboardShortcut("\\", modifiers: .command)
-                .disabled(!canSplitCentre)
+            splitMenu(.splitRight, axis: .horizontal, symbol: PaneSymbol.splitRight)
+            splitMenu(.splitDown, axis: .vertical, symbol: PaneSymbol.splitDown)
 
-            Button("Split Down", systemImage: PaneSymbol.splitDown) { splitCentre(.vertical) }
-                .keyboardShortcut("\\", modifiers: [.command, .shift])
-                .disabled(!canSplitCentre)
-
-            Button("Close Pane", systemImage: PaneSymbol.closePane) { closeCentrePane() }
-                .keyboardShortcut("w", modifiers: [.command, .control])
+            MenuCommand(.closePane, symbol: PaneSymbol.closePane) { closeCentrePane() }
                 .disabled(model.selectedModel == nil)
+
+            // The two a terminal tab's shell tree can do and nothing else in the column can. They
+            // were on the AppKit menu a shell returns from `menu(for:)` and nowhere a reader can
+            // browse, so the zoom's key was drawn on a menu the app opens on a right click and on
+            // no menu at the top of the screen, and stepping focus between panes had no written
+            // account anywhere at all.
+            //
+            // Greyed rather than absent on every other kind of tab, which is what a menu bar does:
+            // an item that vanishes cannot teach that the feature exists.
+            MenuCommand(.zoomPane, symbol: PaneSymbol.zoomIn) { terminalPane(.toggleZoom) }
+                .disabled(!canCommandTerminalPane)
+
+            MenuCommandGroup(.focusPane) {
+                ForEach(SplitDirection.allCases, id: \.self) { direction in
+                    Button(direction.title) { terminalPane(.focus(direction)) }
+                }
+            }
+            .disabled(!canCommandTerminalPane)
 
             Divider()
 
@@ -274,12 +275,10 @@ struct BloomCommands: Commands {
             // them could be moved between: the full shortcut grep across this app found 74
             // bindings and not one for `[`, `]`, Ctrl+Tab or Cmd+1, and there was no menu item to
             // carry one. Which tab is next is `TabCycle` in the core, wrapping included.
-            Button("Previous Tab") { cycleCentreTab(by: -1) }
-                .keyboardShortcut("[", modifiers: [.command, .shift])
+            MenuCommand(.previousTab) { cycleCentreTab(by: -1) }
                 .disabled(!canCycleCentreTabs)
 
-            Button("Next Tab") { cycleCentreTab(by: 1) }
-                .keyboardShortcut("]", modifiers: [.command, .shift])
+            MenuCommand(.nextTab) { cycleCentreTab(by: 1) }
                 .disabled(!canCycleCentreTabs)
 
             goToTabMenu
@@ -292,61 +291,53 @@ struct BloomCommands: Commands {
             // hidden button and on a menu item is not a tie, the button wins and the item never
             // fires, so it has to be one or the other. Here it is the menu, which greys itself out
             // when there is nothing to step through and says the keys out loud.
-            Button("Next Changed File") { stepChangedFile(1) }
-                .keyboardShortcut("j", modifiers: [.command, .option])
+            MenuCommand(.nextChangedFile) { stepChangedFile(1) }
                 .disabled(!canStepChangedFiles)
 
-            Button("Previous Changed File") { stepChangedFile(-1) }
-                .keyboardShortcut("k", modifiers: [.command, .option])
+            MenuCommand(.previousChangedFile) { stepChangedFile(-1) }
                 .disabled(!canStepChangedFiles)
 
             Divider()
         }
 
         CommandGroup(after: .sidebar) {
-            Button("Toggle Sidebar") {
+            MenuCommand(.toggleSidebar) {
                 // `NavigationSplitView` owns the sidebar's visibility through the binding RootView
                 // holds, not through `toggleSidebar(_:)` on the responder chain, so this goes to
                 // RootView rather than to first responder.
                 NotificationCenter.default.post(name: .bloomToggleSidebar, object: nil)
             }
-            .keyboardShortcut("s", modifiers: [.command, .control])
 
-            Button("Toggle Inspector") {
+            MenuCommand(.toggleInspector) {
                 guard model.selectedModel != nil else { return }
                 model.isInspectorVisible.toggle()
             }
-            .keyboardShortcut("i", modifiers: [.command, .option])
             .disabled(model.selectedModel == nil)
 
             Divider()
 
-            Button("Next Workspace") {
+            MenuCommand(.nextWorkspace) {
                 model.selectNextWorkspace(offset: 1)
             }
-            .keyboardShortcut(.downArrow, modifiers: [.command, .option])
             .disabled(model.workspaces.isEmpty)
 
-            Button("Previous Workspace") {
+            MenuCommand(.previousWorkspace) {
                 model.selectNextWorkspace(offset: -1)
             }
-            .keyboardShortcut(.upArrow, modifiers: [.command, .option])
             .disabled(model.workspaces.isEmpty)
 
-            Button("Next Unread") {
+            MenuCommand(.nextUnread) {
                 model.selectNextUnread()
             }
-            .keyboardShortcut("u", modifiers: [.command, .shift])
             .disabled(!model.workspaces.contains(where: \.unread))
 
             // Cmd+Shift+H, not Cmd+0. Cmd+0 is Actual Size on this platform and now belongs to the
             // Zoom group below; two items in one menu cannot share a key equivalent, and the one
             // AppKit finds first would silently have killed the other. Cmd+Shift+H is what Home is
             // bound to in Finder and in Safari anyway, so this is where it should always have been.
-            Button("Go to Home") {
+            MenuCommand(.goToHome) {
                 model.selection = .home
             }
-            .keyboardShortcut("h", modifiers: [.command, .shift])
             .disabled(model.selection == .home)
         }
 
@@ -358,16 +349,13 @@ struct BloomCommands: Commands {
         CommandGroup(after: .sidebar) {
             Divider()
 
-            Button("Zoom In") { TextZoom.zoomIn() }
-                .keyboardShortcut("+", modifiers: .command)
+            MenuCommand(.zoomIn) { TextZoom.zoomIn() }
                 .disabled(!zoom.canZoomIn)
 
-            Button("Zoom Out") { TextZoom.zoomOut() }
-                .keyboardShortcut("-", modifiers: .command)
+            MenuCommand(.zoomOut) { TextZoom.zoomOut() }
                 .disabled(!zoom.canZoomOut)
 
-            Button("Actual Size") { TextZoom.actualSize() }
-                .keyboardShortcut("0", modifiers: .command)
+            MenuCommand(.actualSize) { TextZoom.actualSize() }
                 .disabled(!zoom.canResetSize)
         }
 
@@ -381,7 +369,7 @@ struct BloomCommands: Commands {
             // Rename had no menu item at all: it existed on the row context menus alone, which a
             // keyboard-only user reaches only through VoiceOver. No key equivalent, because Finder
             // gives Rename none either and both lists already spend Return on opening a row.
-            Button("Rename") {
+            MenuCommand(.renameWorkspace) {
                 guard let workspace = workspace(for: .rename) else { return }
                 NotificationCenter.default.post(
                     name: .bloomRenameWorkspace, object: nil,
@@ -390,13 +378,40 @@ struct BloomCommands: Commands {
             }
             .disabled(workspace(for: .rename) == nil)
 
+            // The three that were on a workspace row's own menu and in no menu at the top of the
+            // screen. They are the row group `WorkspaceMenuItems` describes: none of them touches
+            // the checkout, all three are about how the workspace reads in a list.
+            //
+            // Drawn by the same views the rows draw, rather than by a second copy of each, so one
+            // workspace cannot be offered "Pin" in the sidebar and "Unpin" up here. The model is
+            // passed rather than read from the environment because a `Commands` body is not in one.
+            if let workspace = workspace(for: .pin) {
+                WorkspacePinItem(workspace: workspace, app: model)
+            } else {
+                MenuCommand(.pin) {}.disabled(true)
+            }
+
+            if let workspace = workspace(for: .unreadMark) {
+                WorkspaceUnreadItem(workspace: workspace, app: model)
+            } else {
+                MenuCommand(.unreadMark) {}.disabled(true)
+            }
+
+            if let workspace = workspace(for: .colour) {
+                WorkspaceColourItem(workspace: workspace, app: model)
+            } else {
+                // A plain dead row rather than an empty submenu. A `Menu` with nothing in it draws
+                // a disclosure arrow onto a list that is not there, which reads as broken instead
+                // of as unavailable.
+                MenuCommand(.colour) {}.disabled(true)
+            }
+
             Divider()
 
-            Button("Archive Workspace") {
+            MenuCommand(.archive) {
                 guard let workspace = workspace(for: .archive) else { return }
                 archive(workspace)
             }
-            .keyboardShortcut(.delete, modifiers: .command)
             .disabled(workspace(for: .archive) == nil)
 
             // The way back, which the menu bar had no item for at all. Before this the only path
@@ -404,7 +419,7 @@ struct BloomCommands: Commands {
             // had just happened, so a workspace archived yesterday could not be brought back from
             // anywhere. See `ArchivedWorkspaceView` for why reading it and restoring it are two
             // different things.
-            Button("Restore Workspace") {
+            MenuCommand(.restore) {
                 guard let workspace = restorableWorkspace else { return }
                 Task { await model.restore(workspace) }
             }
@@ -412,28 +427,34 @@ struct BloomCommands: Commands {
 
             Divider()
 
-            Button("Open in Editor") {
+            MenuCommand(.openInEditor) {
                 guard let workspace = workspace(for: .openInEditor) else { return }
                 Reveal.inEditor(workspace.path)
             }
-            .keyboardShortcut("e", modifiers: [.command, .shift])
             .disabled(workspace(for: .openInEditor) == nil)
 
-            Button("Reveal in Finder") {
+            MenuCommand(.revealInFinder) {
                 guard let workspace = workspace(for: .revealInFinder) else { return }
                 Reveal.inFinder(workspace.path)
             }
-            .keyboardShortcut("r", modifiers: [.command, .shift])
             .disabled(workspace(for: .revealInFinder) == nil)
+
+            // The window title's own menu was the only place in the app that put a workspace's
+            // name on the clipboard. Above Copy Branch Name because they are one pair and this is
+            // the one people mean more often. See `WorkspaceMenuItems`.
+            MenuCommand(.copyName) {
+                guard let workspace = workspace(for: .copyName) else { return }
+                Clipboard.copy(workspace.name)
+            }
+            .disabled(workspace(for: .copyName) == nil)
 
             // The one item an archived workspace still answers to. A branch name means something
             // once the worktree has gone, and opening an editor on a path that is not there does
             // not: that pair is the whole of `WorkspaceMenuSubject.allows`.
-            Button("Copy Branch Name") {
+            MenuCommand(.copyBranchName) {
                 guard let workspace = workspace(for: .copyBranchName) else { return }
                 Clipboard.copy(workspace.branch)
             }
-            .keyboardShortcut("c", modifiers: [.command, .shift])
             .disabled(workspace(for: .copyBranchName) == nil)
 
             Divider()
@@ -445,28 +466,26 @@ struct BloomCommands: Commands {
             // The subject's own model rather than the selected one, so a row highlighted on Home
             // stops the agent that row is about. It is `existingModel`, which only reads: a
             // workspace this launch has never opened has no transcript to stop anyway.
-            Button("Stop Agent") {
+            MenuCommand(.stopAgent) {
                 subjectModel?.activeTranscript?.stop()
             }
-            .keyboardShortcut(".", modifiers: .command)
             .disabled(subjectModel?.activeTranscript?.isRunning != true)
         }
 
         CommandGroup(replacing: .help) {
             // The docs, not the repository. This pointed at github.com/spatie/Bloom#readme,
             // which is not where Bloom lives and would have 404'd for everyone who pressed it.
-            Button("Bloom Help") {
+            MenuCommand(.help) {
                 guard let url = URL(string: "https://runbloom.app/docs") else { return }
                 NSWorkspace.shared.open(url)
             }
-            .keyboardShortcut("?", modifiers: .command)
 
             // The first run window, on demand. A real item rather than a debug flag: somebody who
             // waved the welcome away and wants it back has exactly the same need as somebody who
             // has never seen it, and "was anything wrong with my setup" is a Help menu question
             // in every Mac app that can answer it. It re-checks on every visit, so it is also the
             // shortest way to find out whether the CLI you just installed was found.
-            Button("Welcome to Bloom…") {
+            MenuCommand(.welcome) {
                 WelcomeWindow.show()
             }
 
@@ -482,12 +501,11 @@ struct BloomCommands: Commands {
             // The sheets themselves are raised from `RootView`, through `FeedbackPresenter`, for
             // the reason the create sheet is: a menu item cannot present anything, and the draft
             // has to outlive the sheet it was typed into.
-            Button("Send Feedback…") {
+            MenuCommand(.sendFeedback) {
                 FeedbackPresenter.shared.open(.report)
             }
-            .keyboardShortcut("f", modifiers: [.command, .option])
 
-            Button("Submit a Prompt…") {
+            MenuCommand(.submitPrompt) {
                 FeedbackPresenter.shared.open(.prompt)
             }
         }
@@ -542,7 +560,7 @@ struct BloomCommands: Commands {
     @ViewBuilder
     private var runScriptsMenu: some View {
         if let workspace = model.selectedModel, !workspace.settings.runScripts.isEmpty {
-            Menu("Run") {
+            MenuCommandGroup(.runScripts) {
                 ForEach(workspace.settings.runScripts) { script in
                     Button(script.name) { run(script, in: workspace) }
                 }
@@ -565,30 +583,125 @@ struct BloomCommands: Commands {
         WorkspaceTabsStore.shared.select(.tool(tab.id), in: workspace)
     }
 
-    /// Splits the pane the user is in and shows the same thing in the half that opens, which is
-    /// what splitting means in every editor: the same thing twice, and then you change one of them.
+    // MARK: - Splitting the centre column
+
+    /// One direction, and the three things that can be put in the half that opens.
     ///
-    /// A shell or a page cannot actually be shown twice, and asking for it has been possible here
-    /// since panes existed. `PaneDuplicate` is where that is refused and a fresh one of the same
-    /// kind offered instead; it is the same door the strip's own split items use.
-    /// Whether Split Right and Split Down would actually open a pane, read on every rebuild of
-    /// this body. `WorkspaceTabsStore` and `CenterTabStore` are both `@Observable`, so selecting
-    /// another tab greys and ungreys the two items on its own, the way `zoom` does above.
-    private var canSplitCentre: Bool {
-        guard let workspace = model.selectedModel else { return false }
-        let tabs = WorkspaceTabsStore.shared
-        guard let tab = tabs.selectedTab(in: workspace) else { return false }
-        return PaneDuplicate.canOpen(tabs.content(of: tabs.focusedPane(of: tab), in: tab), in: workspace)
+    /// **These two used to be plain items that always duplicated**, so `Cmd+\` on a conversation
+    /// showed the same transcript twice and `Cmd+\` on a shell opened another shell, and the split
+    /// people actually ask for, a page or a terminal beside the conversation, existed only in the
+    /// pane's own right click menu, two levels down, with no key on it and no route from the menu
+    /// bar at all. `CenterPaneMenu` says outright that a second copy of a transcript is almost
+    /// never the point.
+    ///
+    /// So the direction and what goes in it are one gesture here too, drawn from the same
+    /// `PaneKind` the pane's menu and the strip's `+` draw theirs from, and doing the same thing:
+    /// `NewPane` opens a new one of that kind and the half is filled with it.
+    ///
+    /// **What that changes about the keystroke, said out loud.** `Cmd+\` and `Shift+Cmd+\` now
+    /// mean "another one of these, beside this one" rather than "this one again". On a terminal
+    /// that is what they already did. On a browser it opens the address field rather than the page
+    /// you were on, and on a conversation it starts a new one rather than showing the same
+    /// transcript in both halves. That last is the split the View menu was publishing and nobody
+    /// wanted.
+    ///
+    /// Not greyed on the review or the notes any more, and that is the other half of the same
+    /// change. Those two have no second copy of themselves, which is why the duplicate had to
+    /// refuse them, but a shell or a page beside a review is perfectly ordinary and the pane's own
+    /// menu has always offered it. What has nowhere to go on those tabs is the key, and
+    /// `PaneDuplicateOutcome.sameAgainKind` answers nil for exactly them.
+    private func splitMenu(_ action: MenuBarAction, axis: SplitAxis, symbol: String) -> some View {
+        MenuCommandGroup(action, symbol: symbol) {
+            ForEach(PaneKind.allCases) { kind in
+                splitRow(action, axis: axis, kind: kind)
+            }
+        }
+        .disabled(model.selectedModel == nil)
     }
 
-    private func splitCentre(_ axis: SplitAxis) {
+    /// One kind, carrying the key when it is the kind this pane is already showing.
+    ///
+    /// The key is here rather than on the item the submenu hangs off because AppKit never sends
+    /// the action of an item that has a submenu, so a key equivalent written on the parent is
+    /// drawn beside a row that cannot fire. `TerminalPaneMenu` puts `Cmd+D` on its Terminal row
+    /// for the same reason.
+    @ViewBuilder
+    private func splitRow(_ action: MenuBarAction, axis: SplitAxis, kind: PaneKind) -> some View {
+        let row = Button(kind.title, systemImage: kind.symbol) {
+            splitCentre(axis, opening: kind)
+        }
+        if kind == sameAgainKind, let key = MenuBarCatalogue[action].key {
+            row.keyboardShortcut(key.equivalent, modifiers: key.eventModifiers)
+        } else {
+            row
+        }
+    }
+
+    /// Which row of the two submenus carries the key, read on every rebuild of this body.
+    /// `WorkspaceTabsStore` and `CenterTabStore` are both `@Observable`, so selecting another tab
+    /// moves the key on its own, the way `zoom` greys itself above.
+    private var sameAgainKind: PaneKind? {
+        guard let workspace = model.selectedModel else { return nil }
+        let tabs = WorkspaceTabsStore.shared
+        guard let tab = tabs.selectedTab(in: workspace) else { return nil }
+        return PaneDuplicate.sameAgainKind(
+            tabs.content(of: tabs.focusedPane(of: tab), in: tab), in: workspace
+        )
+    }
+
+    /// The same call `CenterPaneView` makes for the same row of its own menu, so the two cannot
+    /// end up splitting differently.
+    private func splitCentre(_ axis: SplitAxis, opening kind: PaneKind) {
         guard let workspace = model.selectedModel else { return }
         let tabs = WorkspaceTabsStore.shared
         guard let tab = tabs.selectedTab(in: workspace) else { return }
         let pane = tabs.focusedPane(of: tab)
 
-        PaneDuplicate.open(tabs.content(of: pane, in: tab), in: workspace) { content in
+        NewPane.open(kind, in: workspace) { content in
             tabs.split(tab: tab, pane: pane, axis: axis, showing: content)
+        }
+    }
+
+    // MARK: - A terminal tab's own panes
+
+    /// The tab the two terminal items act on: the shell tree in front, if what is in front is one.
+    ///
+    /// A shell tree is the only thing in the centre column that has panes of its own to zoom or to
+    /// step focus around, which is why these two items are the terminal's rather than the column's.
+    private var terminalOwnerID: String? {
+        guard let workspace = model.selectedModel else { return nil }
+        let tabs = WorkspaceTabsStore.shared
+        guard let tab = tabs.selectedTab(in: workspace),
+              case .tool(let id) = tabs.content(of: tabs.focusedPane(of: tab), in: tab),
+              CenterTabStore.shared.tabs(for: workspace.workspace.id)
+                  .first(where: { $0.id == id })?.kind == .terminal else { return nil }
+        return id
+    }
+
+    /// Greyed on a shell that has not been split, because there is nothing to zoom and nowhere to
+    /// move focus to. `TerminalSplitStore` is `@Observable`, so splitting a shell ungreys both
+    /// items without anything here asking again.
+    private var canCommandTerminalPane: Bool {
+        guard let ownerID = terminalOwnerID else { return false }
+        return TerminalSplitStore.shared.panes(of: ownerID).count > 1
+    }
+
+    /// Straight to the store rather than through the terminal view, because the arrangement is the
+    /// store's and neither of these two touches a shell. It is the same store `TerminalSplitView`
+    /// calls when the keystroke arrives in a pane instead, so one command has one implementation.
+    private func terminalPane(_ command: TerminalPaneCommand) {
+        guard let ownerID = terminalOwnerID else { return }
+        let splits = TerminalSplitStore.shared
+        switch command {
+        case .toggleZoom:
+            _ = splits.toggleZoom(in: ownerID)
+        case .focus(let direction):
+            _ = splits.moveFocus(direction, in: ownerID)
+        // Splitting and closing a shell pane are the tab's own, and the menu bar reaches neither
+        // from here: Split Right opens in the CENTRE column and Close Pane closes a centre pane,
+        // which are the two items directly above these in the same menu.
+        case .split, .close:
+            return
         }
     }
 
@@ -619,7 +732,7 @@ struct BloomCommands: Commands {
     private var goToTabMenu: some View {
         if let workspace = model.selectedModel {
             let entries = WorkspaceTabsStore.shared.entries(in: workspace)
-            Menu("Go to Tab") {
+            MenuCommandGroup(.goToTab) {
                 ForEach(TabCycle.numbered(entries), id: \.tab) { entry in
                     tabItem(entry.tab, ordinal: entry.ordinal, in: workspace)
                 }
@@ -652,6 +765,26 @@ struct BloomCommands: Commands {
             selectedTab: tab,
             focusedPaneContent: tabs.content(of: tabs.focusedPane(of: tab), in: tab)
         )
+    }
+
+    /// What Rename Tab would open a field on: the tab in front, when it is one that has a name to
+    /// change. The review and the notes are named after what they show, so a name written on
+    /// either would be a label the next reopen throws away. See `TabRenaming` in the core, which is
+    /// also what the tab's own menu asks.
+    private var renamableTab: PaneContent? {
+        guard let workspace = model.selectedModel else { return nil }
+        let tabs = WorkspaceTabsStore.shared
+        guard let selected = tabs.selectedTab(in: workspace) else { return nil }
+        let kind = CenterTabStore.shared.tabs(for: workspace.workspace.id)
+            .first { $0.id == selected.id }?.kind
+        return TabRenaming.canRename(selected, tabKind: kind) ? selected : nil
+    }
+
+    /// The field belongs to the strip, which owns the one that can be open at a time, so this asks
+    /// rather than reaches. The same shape as the workspace rename above and for the same reason.
+    private func renameSelectedTab() {
+        guard renamableTab != nil else { return }
+        NotificationCenter.default.post(name: .bloomRenameTab, object: nil)
     }
 
     /// Closing a conversation still goes through `CloseSessionAlert`, which asks when there is

--- a/Sources/Bloom/Views/Chrome/App/FocusedMenuValues.swift
+++ b/Sources/Bloom/Views/Chrome/App/FocusedMenuValues.swift
@@ -27,6 +27,19 @@ extension FocusedValues {
     /// that binds Cmd+S should publish this as well: a view that keeps the key to itself is a key
     /// equivalent the menu bar cannot advertise, and unadvertised is undiscoverable.
     @Entry var saveAction: SaveAction?
+
+    /// Landing the branch, offered by the one control that can raise the confirmation for it.
+    ///
+    /// **Merging had no menu item at all.** `WorkspaceModel.requestMerge` had two callers, the
+    /// pull request band's button and the `workspace_merge` bridge tool an agent calls, so the
+    /// most consequential thing a person can ask Bloom to do to a workspace was reachable from one
+    /// button that is only drawn in some states, and from nothing at the top of the screen.
+    ///
+    /// It travels as a focused value rather than as a notification because the item has to grey
+    /// honestly. The confirmation is a modifier on `PullRequestSummary`, so a menu item can only
+    /// ask that view to raise it; with the inspector closed, or its pane on another tab, there is
+    /// no view to ask and the item has to say so rather than swallow the press.
+    @Entry var mergeAction: MergeAction?
 }
 
 /// A row a list has highlighted, carrying the workspace itself.
@@ -57,5 +70,35 @@ struct SaveAction: Equatable {
 
     static func == (lhs: SaveAction, rhs: SaveAction) -> Bool {
         lhs.subject == rhs.subject && lhs.isEnabled == rhs.isEnabled
+    }
+}
+
+/// Landing this branch, offered to the menu bar by the band that owns the confirmation.
+///
+/// **The title names the method, and that is a decision rather than a detail.** The method is a
+/// per-project mode, set from the split button's chevron and remembered; an item that merely said
+/// "Merge" over a project set to squash would be the exact fault `MergeSplitButton` was built to
+/// remove, where the label and the press disagreed. So the item says `buttonLabel`, which is the
+/// same phrase the button says, and the two cannot come apart.
+///
+/// **And it is not a submenu of the three.** A submenu here would be a second place to set a
+/// project's mode, and picking a row in it would have to both change the mode and merge, which is
+/// the one thing `MergeSplitButton`'s own menu refuses to do: nothing in that menu performs
+/// anything. Choosing the method stays where the mode is set.
+///
+/// `perform` is the band's own `propose`, so a press from the menu bar goes through the sign in
+/// gate and the confirmation exactly as a press on the button does. Nothing here merges.
+struct MergeAction: Equatable {
+    /// What the item says, which is what the button says: "Merge", "Squash and merge", "Rebase
+    /// and merge". No ellipsis, even though a confirmation follows, because the button carries
+    /// none and one action may not be named two ways.
+    var title: String
+    /// False while a turn is running, while GitHub is refusing, or while the band is working. The
+    /// item greys rather than vanishing, which is the menu bar's rule.
+    var isEnabled: Bool
+    var perform: @MainActor () -> Void
+
+    static func == (lhs: MergeAction, rhs: MergeAction) -> Bool {
+        lhs.title == rhs.title && lhs.isEnabled == rhs.isEnabled
     }
 }

--- a/Sources/Bloom/Views/Chrome/App/MenuCommand.swift
+++ b/Sources/Bloom/Views/Chrome/App/MenuCommand.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+import BloomCore
+
+/// One row of the menu bar, drawn from `MenuBarCatalogue`.
+///
+/// **The title and the key come from the table, and this view supplies neither.** That is the
+/// whole point of it: `BloomCommands` is a `Commands` body, which is a view, so a title written
+/// there is a title nothing can check and a key written there is a key nothing can compare against
+/// the rest of the bar. Two items on one keystroke is not a tie AppKit reports; it picks whichever
+/// it finds first and the other never fires, which is how `Cmd+0` was lost once already.
+///
+/// What stays in the view is the closure, the greying and the separators, because all three depend
+/// on state the core cannot hold.
+struct MenuCommand: View {
+    var action: MenuBarAction
+    /// Which half of a two-state item to draw: already pinned, already unread. Ignored by every
+    /// item that has one title.
+    var alternate = false
+    /// The glyph, for the handful of rows that wear one. It is not in the table because the
+    /// symbols are `PaneSymbol`, which is the app target's and is shared with two AppKit menus.
+    var symbol: String?
+    var perform: @MainActor () -> Void
+
+    /// Spelled out rather than left to the memberwise one, so a row reads as the action it is.
+    init(
+        _ action: MenuBarAction,
+        alternate: Bool = false,
+        symbol: String? = nil,
+        perform: @escaping @MainActor () -> Void
+    ) {
+        self.action = action
+        self.alternate = alternate
+        self.symbol = symbol
+        self.perform = perform
+    }
+
+    private var item: MenuBarItem { MenuBarCatalogue[action] }
+
+    var body: some View {
+        button
+            // Nothing when the table says the key belongs to a row of this item's submenu, which
+            // is what the two splits do: AppKit never fires an item that has a submenu, so a key
+            // written here would be drawn beside a row that cannot answer it.
+            .modifier(MenuKeyEquivalent(key: item.keyOnSameAgainRow ? nil : item.key))
+    }
+
+    @ViewBuilder
+    private var button: some View {
+        if let symbol {
+            Button(item.title(alternate: alternate), systemImage: symbol, action: perform)
+        } else {
+            Button(item.title(alternate: alternate), action: perform)
+        }
+    }
+}
+
+/// A submenu whose title comes from the table, for the items that hang a list off themselves.
+struct MenuCommandGroup<Content: View>: View {
+    var action: MenuBarAction
+    var symbol: String?
+    @ViewBuilder var content: Content
+
+    init(_ action: MenuBarAction, symbol: String? = nil, @ViewBuilder content: () -> Content) {
+        self.action = action
+        self.symbol = symbol
+        self.content = content()
+    }
+
+    private var title: String { MenuBarCatalogue[action].title }
+
+    var body: some View {
+        if let symbol {
+            Menu(title, systemImage: symbol) { content }
+        } else {
+            Menu(title) { content }
+        }
+    }
+}
+
+/// The key equivalent, or none, without the caller having to branch.
+///
+/// `keyboardShortcut` has no "no shortcut" argument, so an item with no key has to be a different
+/// view. A modifier says that once rather than at every call site.
+private struct MenuKeyEquivalent: ViewModifier {
+    var key: MenuShortcut?
+
+    func body(content: Content) -> some View {
+        if let key {
+            content.keyboardShortcut(key.equivalent, modifiers: key.eventModifiers)
+        } else {
+            content
+        }
+    }
+}
+
+extension MenuShortcut {
+    /// The one place a key in the table becomes a key on the screen. Every spelling of every
+    /// shortcut in this app passes through here, so there is exactly one of each.
+    var equivalent: KeyEquivalent {
+        switch trigger {
+        case .character(let character): KeyEquivalent(character)
+        case .upArrow: .upArrow
+        case .downArrow: .downArrow
+        case .leftArrow: .leftArrow
+        case .rightArrow: .rightArrow
+        // Backspace, which is what Archive Workspace takes and what `KeyEquivalent` spells
+        // `.delete`. Forward delete is `.deleteForward` and is not used anywhere here.
+        case .delete: .delete
+        case .return: .return
+        case .comma: KeyEquivalent(",")
+        }
+    }
+
+    var eventModifiers: EventModifiers {
+        var result: EventModifiers = []
+        if modifiers.contains(.command) { result.insert(.command) }
+        if modifiers.contains(.shift) { result.insert(.shift) }
+        if modifiers.contains(.option) { result.insert(.option) }
+        if modifiers.contains(.control) { result.insert(.control) }
+        return result
+    }
+}

--- a/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
@@ -116,6 +116,25 @@ struct PullRequestSummary: View {
         } onConfirm: { method in
             onMerge(method)
         }
+        // The Workspace menu's copy of the merge, which had no item anywhere until now. It is
+        // published from here because here is the only place that can raise the confirmation
+        // above, so the menu item asks this view rather than growing a second path to a merge.
+        // See `MergeAction`.
+        .focusedSceneValue(\.mergeAction, mergeAction)
+    }
+
+    /// What the menu bar's Merge item says and does, or nil when this strip has nothing to land:
+    /// a pull request that is closed or already merged has no merge to offer, and neither has one
+    /// whose band is mid request.
+    private var mergeAction: MergeAction? {
+        guard pullRequest.isOpen, !isWorking else { return nil }
+        return MergeAction(
+            title: mergeMethod.buttonLabel,
+            // The same two answers the button reads, in the same order: the cluster's, which is
+            // whether a turn may start at all, and then GitHub's.
+            isEnabled: branchActions.isAllowed && status.canMerge,
+            perform: { propose(mergeMethod) }
+        )
     }
 
     // MARK: - Parts

--- a/Sources/Bloom/Views/RootView.swift
+++ b/Sources/Bloom/Views/RootView.swift
@@ -399,6 +399,13 @@ extension Notification.Name {
     /// at a time, and a menu item cannot reach into either. Both lists listen, and each ignores a
     /// workspace it is not drawing, so the post can be made without knowing which is on screen.
     static let bloomRenameWorkspace = Notification.Name("bloom.renameWorkspace")
+    /// The File menu's Rename Tab, aimed at the strip that owns the field.
+    ///
+    /// The same shape as the workspace rename above and for the same reason: the field belongs to
+    /// a tab inside a strip, the strip owns the one field that can be open at a time, and a menu
+    /// item can reach neither. It carries no id, because unlike the two workspace lists there is
+    /// only ever one strip on screen and it renames the tab it has selected.
+    static let bloomRenameTab = Notification.Name("bloom.renameTab")
 }
 
 extension Notification {

--- a/Sources/BloomCore/Presentation/MenuBarCatalogue.swift
+++ b/Sources/BloomCore/Presentation/MenuBarCatalogue.swift
@@ -1,0 +1,365 @@
+import Foundation
+
+/// Every item the menu bar publishes: which menu it is in, what it is called, and which key it
+/// carries.
+///
+/// **It is the source of truth rather than a description of one.** `BloomCommands` is a
+/// `Commands` body, which is a view and so is a thing no test can look at, and the four questions
+/// this table answers are decisions: which items exist, what each is called, which key it carries
+/// and roughly when it can be pressed. Written inside the view, all four were only checkable by
+/// opening the menus and reading them. Written here, `MenuBarCatalogueTests` can hold the one that
+/// actually bites, which is that no two items in the bar claim the same keystroke: two items in
+/// one menu sharing a key equivalent is not a tie AppKit reports, it silently picks the one it
+/// finds first. That bug has been hit here at least twice, once between Go to Home and Actual Size
+/// over `Cmd+0`, and each time it was found by pressing the key rather than by a test.
+///
+/// **Enablement is not in the table, and that is deliberate.** Whether Split Right can be pressed
+/// depends on the live pane tree, whether Stop Agent can depends on a running turn, and neither is
+/// a value the core can hold. What is here is `availability`, which says what KIND of thing has to
+/// be true, so a reader can see at a glance which items are always live and the app target has one
+/// place to be consistent with. The rules themselves stay where the state is, and the ones already
+/// extracted (`PaneSplit`, `TabClosure`, `WorkspaceMenuSubject`, `TabCycle`) are named on the
+/// items that read them.
+///
+/// **Greyed rather than absent.** A menu bar is a map of what the app can do, so an item that
+/// vanishes when it cannot be pressed teaches nothing. That is the opposite of the habit the
+/// context menus have, on purpose: a context menu is a shortcut to somewhere you already are. The
+/// two exceptions in the table are the run scripts and the setup script, which are absent when the
+/// project defines none, because a permanently empty submenu teaches nothing either.
+public enum MenuBarCatalogue {
+    /// The item for one action. Traps on an action with no row, which cannot happen: `commands`
+    /// covers every case and `MenuBarCatalogueTests.everyActionHasARow` holds it.
+    public static subscript(_ action: MenuBarAction) -> MenuBarItem {
+        guard let item = byAction[action] else {
+            preconditionFailure("no menu bar row for \(action)")
+        }
+        return item
+    }
+
+    /// The items of one menu, in the order they are drawn.
+    public static func items(in menu: MenuBarMenu) -> [MenuBarItem] {
+        commands.filter { $0.menu == menu }
+    }
+
+    private static let byAction: [MenuBarAction: MenuBarItem] = Dictionary(
+        uniqueKeysWithValues: commands.map { ($0.action, $0) }
+    )
+
+    // MARK: - The table
+
+    /// Ordered by menu, and within a menu by where the item is drawn. The separators are not here:
+    /// a rule between two items is a layout decision, and drawing one is the only thing the view
+    /// still gets to decide for itself.
+    public static let commands: [MenuBarItem] = [
+        // MARK: Bloom
+
+        MenuBarItem(.about, in: .bloom, "About Bloom"),
+        MenuBarItem(.checkForUpdates, in: .bloom, "Check for Updates…", availability: .sometimes),
+
+        // MARK: File
+
+        MenuBarItem(.newWorkspace, in: .file, "New Workspace…", key: .command("n"), availability: .needsProject),
+        MenuBarItem(.newWorkspaceFromPullRequest, in: .file, "New Workspace from Pull Request…", availability: .needsProject),
+        MenuBarItem(.projectSettings, in: .file, "Project Settings…", key: .init("comma", .command, .shift), availability: .needsProject),
+        MenuBarItem(.newSession, in: .file, "New Session", key: .command("t"), availability: .needsWorkspace),
+        MenuBarItem(.newTerminalTab, in: .file, "New Terminal Tab", key: .init("t", .command, .shift), availability: .needsWorkspace),
+        MenuBarItem(.newBrowserTab, in: .file, "New Browser Tab", key: .init("b", .command, .shift), availability: .needsWorkspace),
+        MenuBarItem(.showChanges, in: .file, "Show Changes", key: .init("d", .command, .shift), availability: .needsWorkspace),
+        MenuBarItem(.showNotes, in: .file, "Show Notes", key: .init("n", .command, .shift), availability: .needsWorkspace),
+        // The rename a tab has always had on its own context menu and on its VoiceOver actions
+        // rotor, and nowhere else. No key: Finder gives Rename none either, and the strip already
+        // spends a double click on it.
+        MenuBarItem(.renameTab, in: .file, "Rename Tab", availability: .needsTab),
+        MenuBarItem(.closeTab, in: .file, "Close Tab", key: .command("w"), availability: .needsTab),
+        MenuBarItem(.addProjectFolder, in: .file, "Add Project Folder…", key: .init("o", .command, .shift)),
+        MenuBarItem(.save, in: .file, "Save", key: .command("s"), availability: .sometimes),
+
+        // MARK: Edit
+
+        MenuBarItem(.find, in: .edit, "Find…", key: .command("f")),
+        MenuBarItem(.findNext, in: .edit, "Find Next", key: .command("g")),
+        MenuBarItem(.findPrevious, in: .edit, "Find Previous", key: .init("g", .command, .shift)),
+        MenuBarItem(.search, in: .edit, "Search", key: .init("f", .command, .shift), availability: .needsProject),
+
+        // MARK: View
+
+        // The two splits are submenus of the three kinds, and the key sits on the row that means
+        // "the same again" rather than on the parent. See `PaneDuplicateOutcome.sameAgainKind`.
+        MenuBarItem(.splitRight, in: .view, "Split Right", key: .command("\\"), keyOnSameAgainRow: true, availability: .needsSplittablePane),
+        MenuBarItem(.splitDown, in: .view, "Split Down", key: .init("\\", .command, .shift), keyOnSameAgainRow: true, availability: .needsSplittablePane),
+        MenuBarItem(.closePane, in: .view, "Close Pane", key: .init("w", .command, .control), availability: .needsWorkspace),
+        // Both of these are a terminal tab's, because a shell tree is the only thing in the centre
+        // column that can zoom a pane or step focus between them. They were reachable from a right
+        // click inside a shell and from nowhere else, so the zoom's key was written on a menu the
+        // app draws and never on one a reader can browse.
+        MenuBarItem(.zoomPane, in: .view, "Zoom Pane", key: .init(.return, .command, .shift), availability: .needsTerminalPane),
+        MenuBarItem(.focusPane, in: .view, "Focus Pane", availability: .needsTerminalPane),
+        MenuBarItem(.previousTab, in: .view, "Previous Tab", key: .init("[", .command, .shift), availability: .needsSeveralTabs),
+        MenuBarItem(.nextTab, in: .view, "Next Tab", key: .init("]", .command, .shift), availability: .needsSeveralTabs),
+        MenuBarItem(.goToTab, in: .view, "Go to Tab", availability: .needsTab),
+        MenuBarItem(.nextChangedFile, in: .view, "Next Changed File", key: .init("j", .command, .option), availability: .needsReview),
+        MenuBarItem(.previousChangedFile, in: .view, "Previous Changed File", key: .init("k", .command, .option), availability: .needsReview),
+        MenuBarItem(.toggleSidebar, in: .view, "Toggle Sidebar", key: .init("s", .command, .control)),
+        MenuBarItem(.toggleInspector, in: .view, "Toggle Inspector", key: .init("i", .command, .option), availability: .needsWorkspace),
+        MenuBarItem(.nextWorkspace, in: .view, "Next Workspace", key: .init(.downArrow, .command, .option), availability: .needsAnyWorkspace),
+        MenuBarItem(.previousWorkspace, in: .view, "Previous Workspace", key: .init(.upArrow, .command, .option), availability: .needsAnyWorkspace),
+        MenuBarItem(.nextUnread, in: .view, "Next Unread", key: .init("u", .command, .shift), availability: .sometimes),
+        MenuBarItem(.goToHome, in: .view, "Go to Home", key: .init("h", .command, .shift), availability: .sometimes),
+        MenuBarItem(.zoomIn, in: .view, "Zoom In", key: .command("+"), availability: .sometimes),
+        MenuBarItem(.zoomOut, in: .view, "Zoom Out", key: .command("-"), availability: .sometimes),
+        MenuBarItem(.actualSize, in: .view, "Actual Size", key: .command("0"), availability: .sometimes),
+
+        // MARK: Workspace
+
+        MenuBarItem(.renameWorkspace, in: .workspace, "Rename", availability: .needsWorkspaceSubject),
+        // The three that were on a workspace row's own menu and in no menu bar at all. None takes
+        // a key: each is done once in a workspace's life, and a key spent here is a key not
+        // available to something done every few minutes.
+        MenuBarItem(.pin, in: .workspace, "Pin", alternateTitle: "Unpin", availability: .needsWorkspaceSubject),
+        // The two labels are `UnreadMarkAction`'s rather than a second copy of them, because a
+        // workspace row's menu draws the same item off that rule and the two must not word one
+        // workspace differently.
+        MenuBarItem(
+            .unreadMark, in: .workspace, UnreadMarkAction.markUnread.title,
+            alternateTitle: UnreadMarkAction.markRead.title, availability: .needsWorkspaceSubject
+        ),
+        MenuBarItem(.colour, in: .workspace, "Colour", availability: .needsWorkspaceSubject),
+        MenuBarItem(.archive, in: .workspace, "Archive Workspace", key: .init(.delete, .command), availability: .needsWorkspaceSubject),
+        MenuBarItem(.restore, in: .workspace, "Restore Workspace", availability: .needsWorkspaceSubject),
+        MenuBarItem(.openInEditor, in: .workspace, "Open in Editor", key: .init("e", .command, .shift), availability: .needsWorkspaceSubject),
+        MenuBarItem(.revealInFinder, in: .workspace, "Reveal in Finder", key: .init("r", .command, .shift), availability: .needsWorkspaceSubject),
+        // Copy Name is the window title's menu item, which was the only place in the app that put
+        // a workspace's own name on the clipboard.
+        MenuBarItem(.copyName, in: .workspace, "Copy Name", availability: .needsWorkspaceSubject),
+        MenuBarItem(.copyBranchName, in: .workspace, "Copy Branch Name", key: .init("c", .command, .shift), availability: .needsWorkspaceSubject),
+        // The one item whose title is not ours: `SetupRunOffer` words it, because the workspace
+        // row's menu offers the same run and the two must not disagree about what it is called or
+        // when it can be pressed.
+        MenuBarItem(.runSetup, in: .workspace, "Run Setup", availability: .absentWhenUnavailable),
+        MenuBarItem(.runScripts, in: .workspace, "Run", availability: .absentWhenUnavailable),
+        MenuBarItem(.stopAgent, in: .workspace, "Stop Agent", key: .command("."), availability: .sometimes),
+
+        // MARK: Help
+
+        MenuBarItem(.help, in: .help, "Bloom Help", key: .command("?")),
+        MenuBarItem(.welcome, in: .help, "Welcome to Bloom…"),
+        MenuBarItem(.sendFeedback, in: .help, "Send Feedback…", key: .init("f", .command, .option)),
+        MenuBarItem(.submitPrompt, in: .help, "Submit a Prompt…")
+    ]
+}
+
+/// The menus Bloom contributes items to.
+///
+/// Window is not here. Everything in it is SwiftUI's and AppKit's, and the one thing Bloom used to
+/// add was a second item for the Discovered Seas window that a `Window` scene already contributes
+/// for free. See the head of `OceansWindow`, which is where that measurement is written down.
+public enum MenuBarMenu: String, CaseIterable, Sendable {
+    case bloom
+    case file
+    case edit
+    case view
+    case workspace
+    case help
+}
+
+/// One item of the menu bar, named so the app target and a test can refer to the same row.
+///
+/// A `String` raw value so a failing test names the item rather than an ordinal.
+public enum MenuBarAction: String, CaseIterable, Sendable {
+    case about
+    case checkForUpdates
+
+    case newWorkspace
+    case newWorkspaceFromPullRequest
+    case projectSettings
+    case newSession
+    case newTerminalTab
+    case newBrowserTab
+    case showChanges
+    case showNotes
+    case renameTab
+    case closeTab
+    case addProjectFolder
+    case save
+
+    case find
+    case findNext
+    case findPrevious
+    case search
+
+    case splitRight
+    case splitDown
+    case closePane
+    case zoomPane
+    case focusPane
+    case previousTab
+    case nextTab
+    case goToTab
+    case nextChangedFile
+    case previousChangedFile
+    case toggleSidebar
+    case toggleInspector
+    case nextWorkspace
+    case previousWorkspace
+    case nextUnread
+    case goToHome
+    case zoomIn
+    case zoomOut
+    case actualSize
+
+    case renameWorkspace
+    case pin
+    case unreadMark
+    case colour
+    case archive
+    case restore
+    case openInEditor
+    case revealInFinder
+    case copyName
+    case copyBranchName
+    case runSetup
+    case runScripts
+    case stopAgent
+
+    case help
+    case welcome
+    case sendFeedback
+    case submitPrompt
+}
+
+public struct MenuBarItem: Equatable, Sendable, Identifiable {
+    public var action: MenuBarAction
+    public var menu: MenuBarMenu
+    /// What the row says. It matches the wording of the context menu offering the same thing,
+    /// wherever both exist, so the two surfaces cannot teach different names for one action.
+    public var title: String
+    /// The other half of a two-state item, which is what Pin and the unread mark are. One row that
+    /// changes its label rather than two rows one of which is always wrong.
+    public var alternateTitle: String?
+    public var key: MenuShortcut?
+    /// The key is drawn on a row of this item's submenu rather than on the item itself, because
+    /// AppKit never fires an item that has a submenu. Only the two splits do this.
+    public var keyOnSameAgainRow: Bool
+    public var availability: MenuBarAvailability
+
+    public var id: MenuBarAction { action }
+
+    init(
+        _ action: MenuBarAction,
+        in menu: MenuBarMenu,
+        _ title: String,
+        alternateTitle: String? = nil,
+        key: MenuShortcut? = nil,
+        keyOnSameAgainRow: Bool = false,
+        availability: MenuBarAvailability = .always
+    ) {
+        self.action = action
+        self.menu = menu
+        self.title = title
+        self.alternateTitle = alternateTitle
+        self.key = key
+        self.keyOnSameAgainRow = keyOnSameAgainRow
+        self.availability = availability
+    }
+
+    /// The title for a two-state item, given which state it is in. `isAlternate` is "already
+    /// pinned", "already unread", and so on.
+    public func title(alternate isAlternate: Bool) -> String {
+        isAlternate ? (alternateTitle ?? title) : title
+    }
+}
+
+/// What has to be true before an item can be pressed, coarsely, so a reader can see which rows are
+/// always live and the app target has one place to be consistent with.
+///
+/// It is not the rule. The rules live where the state does, and the ones that have been extracted
+/// are named on the item that reads them.
+public enum MenuBarAvailability: String, Equatable, Sendable {
+    /// Never greyed.
+    case always
+    /// Greyed on something the core cannot hold: a running turn, an unread workspace, a window
+    /// that has published a Save.
+    case sometimes
+    /// A project has been added.
+    case needsProject
+    /// A workspace is selected in the sidebar.
+    case needsWorkspace
+    /// Any workspace exists at all, selected or not.
+    case needsAnyWorkspace
+    /// A workspace is the Workspace menu's subject, and that subject allows this action. See
+    /// `WorkspaceMenuSubject`.
+    case needsWorkspaceSubject
+    /// The centre column has a tab. See `TabClosure` for which one an action lands on.
+    case needsTab
+    /// The strip has more than one tab, so there is somewhere to move to. See `TabCycle`.
+    case needsSeveralTabs
+    /// The focused pane is one a split would actually open something beside. See `PaneSplit`.
+    case needsSplittablePane
+    /// The tab in front is a terminal, which is the only thing in the centre column with a shell
+    /// tree to zoom or to step focus around.
+    case needsTerminalPane
+    /// A review is open and the worktree has something changed in it.
+    case needsReview
+    /// The one shape the menu bar does not grey: absent when the project defines none, because a
+    /// permanently empty submenu teaches nothing either.
+    case absentWhenUnavailable
+}
+
+/// A key equivalent, in a form the core can hold.
+///
+/// `KeyEquivalent` and `EventModifiers` belong to the framework only the app target may import,
+/// and this table has to be readable by a suite that cannot see that target at all. The app maps
+/// one onto the other in one place, so there is still exactly one spelling of every key.
+public struct MenuShortcut: Equatable, Hashable, Sendable {
+    public enum Trigger: Equatable, Hashable, Sendable {
+        case character(Character)
+        case upArrow
+        case downArrow
+        case leftArrow
+        case rightArrow
+        /// Backspace, which is what Archive Workspace takes.
+        case delete
+        case `return`
+        /// The comma, spelled out because a literal comma in this table reads as a separator.
+        case comma
+    }
+
+    public struct Modifiers: OptionSet, Hashable, Sendable {
+        public let rawValue: Int
+        public init(rawValue: Int) { self.rawValue = rawValue }
+
+        public static let command = Modifiers(rawValue: 1 << 0)
+        public static let shift = Modifiers(rawValue: 1 << 1)
+        public static let option = Modifiers(rawValue: 1 << 2)
+        public static let control = Modifiers(rawValue: 1 << 3)
+    }
+
+    public var trigger: Trigger
+    public var modifiers: Modifiers
+
+    public init(_ trigger: Trigger, _ modifiers: Modifiers...) {
+        self.trigger = trigger
+        self.modifiers = modifiers.reduce(into: []) { $0.formUnion($1) }
+    }
+
+    /// A character key, written as a one character string.
+    ///
+    /// A `String` rather than a `Character` so that every row of the table reads the same way, and
+    /// so `"comma"` can be spelled out: a bare comma inside an argument list reads as a separator.
+    /// It traps on anything else that is not one character, which is a table this module builds
+    /// itself and therefore a typo caught the first time anything runs.
+    public init(_ key: String, _ modifiers: Modifiers...) {
+        if key == "comma" {
+            self.trigger = .comma
+        } else {
+            precondition(key.count == 1, "a menu key is one character, or the word comma")
+            self.trigger = .character(Character(key))
+        }
+        self.modifiers = modifiers.reduce(into: []) { $0.formUnion($1) }
+    }
+
+    /// The common case, spelled short so the table stays one row per item.
+    public static func command(_ key: String) -> MenuShortcut {
+        MenuShortcut(key, .command)
+    }
+}

--- a/Sources/BloomCore/Presentation/MenuBarCatalogue.swift
+++ b/Sources/BloomCore/Presentation/MenuBarCatalogue.swift
@@ -124,6 +124,20 @@ public enum MenuBarCatalogue {
             alternateTitle: UnreadMarkAction.markRead.title, availability: .needsWorkspaceSubject
         ),
         MenuBarItem(.colour, in: .workspace, "Colour", availability: .needsWorkspaceSubject),
+        // Landing the branch, which had no item in any menu: `requestMerge` was reachable from the
+        // pull request band's button and from the bridge tool an agent calls, and from nothing at
+        // the top of the screen. Directly above Archive because those two are the ends of a
+        // workspace's life and that is the order they happen in.
+        //
+        // **No key, and that is the point of it having one fewer thing than the items around it.**
+        // A key is worth spending on something done every few minutes; this is the most
+        // consequential thing a person can ask Bloom to do to a branch and it happens once per
+        // workspace. The item alone is what was missing.
+        //
+        // The title here is the greyed one. When the band is on screen the item says which merge,
+        // because the method is a per-project mode and a row reading "Merge" over a project set to
+        // squash is the fault the split button was built to remove. See `MergeAction`.
+        MenuBarItem(.merge, in: .workspace, "Merge", availability: .sometimes),
         MenuBarItem(.archive, in: .workspace, "Archive Workspace", key: .init(.delete, .command), availability: .needsWorkspaceSubject),
         MenuBarItem(.restore, in: .workspace, "Restore Workspace", availability: .needsWorkspaceSubject),
         MenuBarItem(.openInEditor, in: .workspace, "Open in Editor", key: .init("e", .command, .shift), availability: .needsWorkspaceSubject),
@@ -144,7 +158,7 @@ public enum MenuBarCatalogue {
         MenuBarItem(.help, in: .help, "Bloom Help", key: .command("?")),
         MenuBarItem(.welcome, in: .help, "Welcome to Bloom…"),
         MenuBarItem(.sendFeedback, in: .help, "Send Feedback…", key: .init("f", .command, .option)),
-        MenuBarItem(.submitPrompt, in: .help, "Submit a Prompt…")
+        MenuBarItem(.submitPrompt, in: .help, "Submit a Prompt…"),
     ]
 }
 
@@ -211,6 +225,7 @@ public enum MenuBarAction: String, CaseIterable, Sendable {
     case pin
     case unreadMark
     case colour
+    case merge
     case archive
     case restore
     case openInEditor

--- a/Sources/BloomCore/Presentation/PaneSplit.swift
+++ b/Sources/BloomCore/Presentation/PaneSplit.swift
@@ -44,6 +44,31 @@ public enum PaneDuplicateOutcome: Equatable, Sendable {
     /// is enabled and does nothing when it is pressed is worse than one that is greyed, because
     /// the first press teaches the user that the menu lies and there is no second lesson.
     public var opensAPane: Bool { self != .nothing }
+
+    /// Which of the three kinds in a Split submenu means "this pane again", and therefore carries
+    /// the split's key equivalent.
+    ///
+    /// **This is the whole of why the View menu's two items became submenus.** They were plain
+    /// items that always duplicated, so `Cmd+\` on a shell opened another shell, and there was no
+    /// menu route at all to the split people actually ask for, which is a page or a terminal
+    /// beside the conversation. That one lived in a two-level context menu with no key on it.
+    ///
+    /// The key goes on a row rather than on the item the submenu hangs off, because AppKit never
+    /// sends the action of an item that has a submenu: a key equivalent written on the parent is
+    /// drawn beside a row that cannot fire. `TerminalPaneMenu` already puts `Cmd+D` on Terminal
+    /// for exactly that reason, and this is the same trick with the row worked out rather than
+    /// fixed.
+    ///
+    /// Nil when nothing can be opened, which is the review and the notes: a workspace has exactly
+    /// one of each, so there is no row for the key to sit on and the whole submenu greys.
+    public var sameAgainKind: PaneKind? {
+        switch self {
+        case .sameContent: .chat
+        case .freshTerminal: .terminal
+        case .freshBrowser: .browser
+        case .nothing: nil
+        }
+    }
 }
 
 /// The one place that decides what splitting a pane produces.

--- a/Sources/BloomCore/Presentation/SplitLayout.swift
+++ b/Sources/BloomCore/Presentation/SplitLayout.swift
@@ -26,6 +26,17 @@ public enum SplitDirection: String, Sendable, Hashable, CaseIterable {
         case .up, .down: .vertical
         }
     }
+
+    /// What the View menu's Focus Pane rows are called. Capitalised here rather than by the view,
+    /// because a menu item's title is a decision and the raw value is a stored spelling.
+    public var title: String {
+        switch self {
+        case .left: "Left"
+        case .right: "Right"
+        case .up: "Up"
+        case .down: "Down"
+        }
+    }
 }
 
 /// One node of the split tree: either a terminal, or a split holding two more nodes.

--- a/Sources/BloomCore/Presentation/TabRenaming.swift
+++ b/Sources/BloomCore/Presentation/TabRenaming.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Which tabs of the centre strip can be given a name.
+///
+/// One rule, read by the tab itself and by the File menu's Rename Tab. It was the tab's alone, as
+/// `tab.kind != .review && tab.kind != .notes` written inside a view, until the menu bar grew an
+/// item that has to grey against the same answer. Two spellings of it would eventually let a menu
+/// item open a field on a tab that has no name to change.
+public enum TabRenaming {
+    /// - Parameter tabKind: the kind of the tool tab, or nil when `content` is a conversation or
+    ///   points at a tab that is no longer open.
+    ///
+    /// **The review and the notes are refused.** A workspace has exactly one of each by design and
+    /// both are named after what they show, so a name written on either would be a label with
+    /// nothing behind it: reopening the tab draws the fixed title again. Every other tab carries a
+    /// name somebody chose, or a name taken from what is in it, and both are worth editing.
+    ///
+    /// A pointer at a tab that has gone is refused as well, which is the same answer `PaneSplit`
+    /// gives it, so the menu greys rather than opening a field on nothing.
+    public static func canRename(_ content: PaneContent, tabKind: CenterTabKind?) -> Bool {
+        switch content {
+        case .chat:
+            return true
+        case .tool:
+            switch tabKind {
+            case .terminal, .browser: return true
+            case .review, .notes, nil: return false
+            }
+        }
+    }
+}

--- a/Sources/BloomCore/Presentation/WorkspaceMenuSubject.swift
+++ b/Sources/BloomCore/Presentation/WorkspaceMenuSubject.swift
@@ -77,11 +77,16 @@ public enum WorkspaceMenuSubject: Hashable, Sendable {
         case .live:
             action != .restore
         case .archived:
-            // Reading a branch name is the one thing that still means something once the worktree
-            // is gone. Opening an editor or a Finder window on a path that is not there is not,
-            // and neither is archiving what is already archived. Renaming is left out because
-            // Home's own menu leaves it out: an archived row is a record rather than a workspace.
-            action == .restore || action == .copyBranchName
+            // Reading a name or a branch name is what still means something once the worktree is
+            // gone. Opening an editor or a Finder window on a path that is not there is not, and
+            // neither is archiving what is already archived. Renaming is left out because Home's
+            // own menu leaves it out: an archived row is a record rather than a workspace.
+            //
+            // Pin, the unread mark and the colour are all about a ROW IN A LIST, and the sidebar
+            // never lists an archived workspace at all. The unread mark has the same answer for a
+            // second reason of its own, written out on `WorkspaceUnreadMark.action(for:)`: an
+            // archived row's `unread` is a flag nothing draws and the user has no way to answer.
+            action == .restore || action == .copyBranchName || action == .copyName
         }
     }
 }
@@ -90,6 +95,11 @@ public enum WorkspaceMenuSubject: Hashable, Sendable {
 ///
 /// Setup, the run scripts and Stop Agent are not here: each needs a live `WorkspaceModel` rather
 /// than a row, and what they can do is decided by that model rather than by which list is focused.
+///
+/// The last four arrived when the menu bar was swept for actions that existed only on a right
+/// click. Pin, the unread mark and the colour were on a workspace row's own menu and in no menu at
+/// the top of the screen; Copy Name was on the window title's menu and nowhere else, which made it
+/// the one way in the whole app to put a workspace's name on the clipboard.
 public enum WorkspaceMenuAction: String, Hashable, Sendable, CaseIterable {
     case archive
     case restore
@@ -97,4 +107,8 @@ public enum WorkspaceMenuAction: String, Hashable, Sendable, CaseIterable {
     case revealInFinder
     case copyBranchName
     case rename
+    case pin
+    case unreadMark
+    case colour
+    case copyName
 }

--- a/Tests/BloomCoreTests/MenuBarCatalogueTests.swift
+++ b/Tests/BloomCoreTests/MenuBarCatalogueTests.swift
@@ -194,4 +194,31 @@ struct MenuBarCatalogueTests {
             #expect(MenuBarCatalogue[action].key == nil, "\(action)")
         }
     }
+
+    /// Merging is the most consequential thing a person can ask Bloom to do to a branch, it
+    /// happens once per workspace, and it is the one item in the bar whose press is not undone by
+    /// pressing it again. A keystroke there buys a slip.
+    @Test("merging is an item and not a keystroke")
+    func mergeTakesNoKey() {
+        let item = MenuBarCatalogue[.merge]
+        #expect(item.menu == .workspace)
+        #expect(item.key == nil)
+        // The greyed wording. When the band is on screen the item says which merge, off
+        // `GitHub.MergeMethod.buttonLabel`, which is also what the split button says.
+        #expect(item.title == "Merge")
+    }
+
+    /// Merge sits directly above Archive, because those two are the ends of a workspace's life and
+    /// that is the order they happen in. Said as a test because a table is a list and an insert in
+    /// the wrong place is invisible in a diff.
+    @Test("merging is read directly above archiving")
+    func mergeSitsAboveArchive() {
+        let workspace = MenuBarCatalogue.items(in: .workspace).map(\.action)
+        guard let merge = workspace.firstIndex(of: .merge),
+              let archive = workspace.firstIndex(of: .archive) else {
+            Issue.record("the Workspace menu is missing one of the two")
+            return
+        }
+        #expect(archive == merge + 1)
+    }
 }

--- a/Tests/BloomCoreTests/MenuBarCatalogueTests.swift
+++ b/Tests/BloomCoreTests/MenuBarCatalogueTests.swift
@@ -1,0 +1,197 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// The menu bar as a table: which items exist, what they are called, and which key each carries.
+///
+/// `BloomCommands` is a `Commands` body, which is a view, so before this table existed none of
+/// those four facts could be checked by anything but opening the menus and reading them. The one
+/// that bites is the last: two items claiming one keystroke is not a tie AppKit reports, it picks
+/// whichever it finds first and the other never fires. That has been hit here at least twice.
+@Suite("MenuBarCatalogue")
+struct MenuBarCatalogueTests {
+    /// Every key in the bar, paired with the item that holds it.
+    private var keyed: [(MenuShortcut, MenuBarItem)] {
+        MenuBarCatalogue.commands.compactMap { item in
+            item.key.map { ($0, item) }
+        }
+    }
+
+    @Test("every action has exactly one row, so a lookup cannot trap")
+    func everyActionHasARow() {
+        for action in MenuBarAction.allCases {
+            #expect(MenuBarCatalogue[action].action == action, "\(action)")
+        }
+        #expect(MenuBarCatalogue.commands.count == MenuBarAction.allCases.count)
+    }
+
+    /// The bug this table was written for. Two items on one keystroke, anywhere in the bar, is a
+    /// silent loss of whichever AppKit looks at second.
+    @Test("no two items in the whole bar claim the same keystroke")
+    func noCollisions() {
+        var seen: [MenuShortcut: MenuBarAction] = [:]
+        for (key, item) in keyed {
+            if let other = seen[key] {
+                Issue.record("\(item.action) and \(other) both claim \(key)")
+            }
+            seen[key] = item.action
+        }
+    }
+
+    /// Every key in this app is a Command key. A menu item bound to a bare letter would eat that
+    /// letter out of every text field in the window.
+    @Test("every key equivalent carries Command")
+    func everyKeyIsACommandKey() {
+        for (key, item) in keyed {
+            #expect(key.modifiers.contains(.command), "\(item.action)")
+        }
+    }
+
+    @Test("every item is in a menu that exists and says something")
+    func everyItemIsNamed() {
+        for item in MenuBarCatalogue.commands {
+            #expect(!item.title.isEmpty, "\(item.action)")
+            #expect(item.title.trimmingCharacters(in: .whitespaces) == item.title, "\(item.action)")
+            #expect(MenuBarCatalogue.items(in: item.menu).contains(item), "\(item.action)")
+        }
+    }
+
+    /// Every menu Bloom claims to fill has something in it. An empty menu title in the bar is a
+    /// word with nothing under it.
+    @Test("no menu is empty")
+    func noEmptyMenu() {
+        for menu in MenuBarMenu.allCases {
+            #expect(!MenuBarCatalogue.items(in: menu).isEmpty, "\(menu)")
+        }
+    }
+
+    /// The two splits are the only items whose key lives on a submenu row, because they are the
+    /// only submenus with a "same again" row for it to sit on. Anything else marked this way would
+    /// be a key drawn beside an item AppKit never fires.
+    @Test("only the two splits put their key on a submenu row")
+    func onlyTheSplitsDeferTheirKey() {
+        let deferred = MenuBarCatalogue.commands.filter(\.keyOnSameAgainRow).map(\.action)
+        #expect(Set(deferred) == [.splitRight, .splitDown])
+        for action in deferred {
+            #expect(MenuBarCatalogue[action].key != nil, "\(action)")
+        }
+    }
+
+    /// A two-state item is one row that changes its label. Both labels have to be there, or the
+    /// item says "Pin" on a workspace that is already pinned.
+    @Test("a two-state item carries both of its titles")
+    func twoStateItems() {
+        let twoState = MenuBarCatalogue.commands.filter { $0.alternateTitle != nil }
+        #expect(Set(twoState.map(\.action)) == [.pin, .unreadMark])
+        for item in twoState {
+            #expect(item.title(alternate: false) == item.title, "\(item.action)")
+            #expect(item.title(alternate: true) == item.alternateTitle, "\(item.action)")
+        }
+        // An item with one title answers the same way whichever state it is asked about, so a
+        // caller cannot get an empty row by asking the wrong question.
+        #expect(MenuBarCatalogue[.archive].title(alternate: true) == "Archive Workspace")
+    }
+
+    // MARK: - One action, one name
+
+    /// The rule the whole sweep turns on: an item in the bar and the context menu offering the
+    /// same thing say the same words, or the two teach different names for one action.
+    @Test("the bar words a workspace's actions the way its own row menu does")
+    func workspaceWording() {
+        #expect(MenuBarCatalogue[.openInEditor].title == "Open in Editor")
+        #expect(MenuBarCatalogue[.revealInFinder].title == "Reveal in Finder")
+        #expect(MenuBarCatalogue[.copyBranchName].title == "Copy Branch Name")
+        #expect(MenuBarCatalogue[.copyName].title == "Copy Name")
+        #expect(MenuBarCatalogue[.renameWorkspace].title == "Rename")
+        #expect(MenuBarCatalogue[.colour].title == "Colour")
+        #expect(MenuBarCatalogue[.pin].title == "Pin")
+        #expect(MenuBarCatalogue[.pin].alternateTitle == "Unpin")
+    }
+
+    /// The unread mark's two labels are `WorkspaceUnreadMark`'s, because a workspace row offers
+    /// the same item and the two must not disagree about one workspace.
+    @Test("the unread item is worded by the rule the rows already read")
+    func unreadWording() {
+        let item = MenuBarCatalogue[.unreadMark]
+        #expect(item.title == UnreadMarkAction.markUnread.title)
+        #expect(item.alternateTitle == UnreadMarkAction.markRead.title)
+    }
+
+    /// Split Right and Split Down are worded the same in the bar, in a pane's own menu and in the
+    /// AppKit menu a terminal returns, which is what makes one gesture out of three surfaces.
+    @Test("the splits are worded as the pane menus word them")
+    func splitWording() {
+        #expect(MenuBarCatalogue[.splitRight].title == "Split Right")
+        #expect(MenuBarCatalogue[.splitDown].title == "Split Down")
+        #expect(MenuBarCatalogue[.closePane].title == "Close Pane")
+        #expect(MenuBarCatalogue[.zoomPane].title == "Zoom Pane")
+    }
+
+    // MARK: - Where the keys went
+
+    /// Every key a focused view takes before the menu bar sees it, and what the bar spends it on.
+    ///
+    /// **A view that has first responder beats the menu bar**, measured, so a key on both sides
+    /// means the menu item silently does not fire while that view has the keyboard. Some of those
+    /// overlaps are deliberate: `Cmd+W` closes a pane in a shell and a tab everywhere else, and
+    /// the zoom trio resolves onto the terminal either way, so the two routes agree. Two do not
+    /// agree, and they are recorded here rather than quietly fixed, because changing either is a
+    /// decision about muscle memory rather than about menus. See `docs/MENUS.md`.
+    ///
+    /// The value is what the bar draws for that key, or nil for a key the bar does not spend at
+    /// all. A new overlap fails this test, which is the point of writing it out.
+    @Test("every key a focused view takes is either unspent in the bar or a known overlap")
+    func theKeysTheViewsOwn() {
+        let claimedByViews: [MenuShortcut: MenuBarAction?] = [
+            // A terminal splits a shell with these, which is iTerm's binding and Ghostty's.
+            // Shift+Cmd+D is also Show Changes: in a shell it splits, everywhere else it opens the
+            // review, and nothing in the app says which you are about to get.
+            MenuShortcut("d", .command): nil,
+            MenuShortcut("d", .command, .shift): .showChanges,
+            // It clears itself with this one, which nothing in the bar claims and no menu shows.
+            MenuShortcut("k", .command): nil,
+            // Deliberate: the pane in a shell, the tab everywhere else.
+            MenuShortcut("w", .command): .closeTab,
+            // Deliberate: the same action reached two ways.
+            MenuShortcut(.return, .command, .shift): .zoomPane,
+            // A terminal steps pane focus with all four arrows. Two of them are also how you move
+            // between workspaces, and the terminal wins without saying so.
+            MenuShortcut(.leftArrow, .command, .option): nil,
+            MenuShortcut(.rightArrow, .command, .option): nil,
+            MenuShortcut(.upArrow, .command, .option): .previousWorkspace,
+            MenuShortcut(.downArrow, .command, .option): .nextWorkspace,
+            // Deliberate: `TextZoom` walks up from first responder, so the menu and the terminal
+            // grow the same shell.
+            MenuShortcut("+", .command): .zoomIn,
+            MenuShortcut("-", .command): .zoomOut,
+            MenuShortcut("0", .command): .actualSize,
+            // A browser page finds in itself with the same three the Edit menu draws, which is the
+            // same action arriving by a shorter route.
+            MenuShortcut("f", .command): .find,
+            MenuShortcut("g", .command): .findNext,
+            MenuShortcut("g", .command, .shift): .findPrevious
+        ]
+
+        let inTheBar = Dictionary(uniqueKeysWithValues: keyed.map { ($0.0, $0.1.action) })
+        for (key, expected) in claimedByViews {
+            #expect(inTheBar[key] == expected, "\(key) is drawn as \(String(describing: inTheBar[key]))")
+        }
+    }
+
+    /// `Cmd+\` and `Shift+Cmd+\` are the editor split, `Cmd+D` and `Shift+Cmd+D` are the shell
+    /// split, and that allocation is the reason the two never fight.
+    @Test("the splits keep the editor's key rather than the shell's")
+    func theSplitsKeepTheirKey() {
+        #expect(MenuBarCatalogue[.splitRight].key == MenuShortcut("\\", .command))
+        #expect(MenuBarCatalogue[.splitDown].key == MenuShortcut("\\", .command, .shift))
+    }
+
+    /// The items added by the sweep that deliberately carry no key. A key is worth having for
+    /// something done often; a row with no key still teaches that the action exists.
+    @Test("the once-in-a-workspace items take no key")
+    func theItemsWithNoKey() {
+        for action in [MenuBarAction.pin, .unreadMark, .colour, .copyName, .renameTab, .focusPane] {
+            #expect(MenuBarCatalogue[action].key == nil, "\(action)")
+        }
+    }
+}

--- a/Tests/BloomCoreTests/PaneSplitTests.swift
+++ b/Tests/BloomCoreTests/PaneSplitTests.swift
@@ -50,4 +50,39 @@ struct PaneSplitTests {
     func wireFormat() {
         #expect(CenterTabKind.allCases.map(\.rawValue) == ["terminal", "browser", "review", "notes"])
     }
+
+    // MARK: - Which row of a Split submenu carries the key
+
+    /// The View menu's Split Right offers Chat, Terminal and Browser, and `Cmd+\` is drawn on
+    /// whichever of the three means "this pane again". A key on the parent would be drawn beside a
+    /// row AppKit never fires.
+    @Test("the same again row is the kind a duplicate would have produced")
+    func theRowThatCarriesTheKey() {
+        #expect(PaneSplit.duplicating(chat, tabKind: nil).sameAgainKind == .chat)
+        #expect(PaneSplit.duplicating(tool, tabKind: .terminal).sameAgainKind == .terminal)
+        #expect(PaneSplit.duplicating(tool, tabKind: .browser).sameAgainKind == .browser)
+    }
+
+    /// The review and the notes have no second copy, so there is no row to put the key on and the
+    /// whole submenu greys. The two answers have to agree, or a greyed submenu would still be
+    /// eating `Cmd+\`.
+    @Test("a pane that cannot be split has no row for the key")
+    func noRowWhenNothingOpens() {
+        for kind in [CenterTabKind.review, .notes] {
+            let outcome = PaneSplit.duplicating(tool, tabKind: kind)
+            #expect(outcome.sameAgainKind == nil, "\(kind)")
+            #expect(!outcome.opensAPane, "\(kind)")
+        }
+        #expect(PaneSplit.duplicating(tool, tabKind: nil).sameAgainKind == nil)
+    }
+
+    /// Said as one rule rather than four cases, because these are the two halves of one question
+    /// and a new outcome must not be able to answer them differently.
+    @Test("an outcome opens a pane exactly when it has a row to put the key on")
+    func theTwoAnswersAgree() {
+        let outcomes: [PaneDuplicateOutcome] = [.sameContent, .freshTerminal, .freshBrowser, .nothing]
+        for outcome in outcomes {
+            #expect(outcome.opensAPane == (outcome.sameAgainKind != nil), "\(outcome)")
+        }
+    }
 }

--- a/Tests/BloomCoreTests/TabRenamingTests.swift
+++ b/Tests/BloomCoreTests/TabRenamingTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// Which tabs can be given a name, asked by the tab's own menu and by the File menu's Rename Tab.
+/// It was the tab's alone, written inside a view, until a menu bar item had to grey against the
+/// same answer.
+@Suite("TabRenaming")
+struct TabRenamingTests {
+    private let chat = PaneContent.chat(SessionID(rawValue: "s-one"))
+    private let tool = PaneContent.tool("t-one")
+
+    @Test("a conversation always has a name to change")
+    func chatRenames() {
+        #expect(TabRenaming.canRename(chat, tabKind: nil))
+    }
+
+    @Test("a shell and a page carry a name somebody chose")
+    func toolsRename() {
+        #expect(TabRenaming.canRename(tool, tabKind: .terminal))
+        #expect(TabRenaming.canRename(tool, tabKind: .browser))
+    }
+
+    /// Both are named after what they show and there is exactly one of each per workspace, so a
+    /// name written on either is thrown away by the next reopen.
+    @Test("the review and the notes have no name of their own")
+    func theFixedTitles() {
+        #expect(!TabRenaming.canRename(tool, tabKind: .review))
+        #expect(!TabRenaming.canRename(tool, tabKind: .notes))
+    }
+
+    /// The same answer `PaneSplit` gives a pointer at a tab that has gone, so the menu greys
+    /// rather than opening a field on nothing.
+    @Test("a tab that is no longer open cannot be renamed")
+    func missingTab() {
+        #expect(!TabRenaming.canRename(tool, tabKind: nil))
+    }
+
+    @Test("every kind is decided, so a new one cannot arrive renameable by default")
+    func everyKindIsAnswered() {
+        let renameable = CenterTabKind.allCases.filter { TabRenaming.canRename(tool, tabKind: $0) }
+        #expect(Set(renameable) == [.terminal, .browser])
+    }
+}

--- a/Tests/BloomCoreTests/WorkspaceMenuSubjectTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceMenuSubjectTests.swift
@@ -92,6 +92,14 @@ struct WorkspaceMenuSubjectTests {
         #expect(!subject.allows(.openInEditor))
         #expect(!subject.allows(.revealInFinder))
         #expect(!subject.allows(.rename))
+        // The three that are about a row in a list, and the sidebar never lists an archived
+        // workspace at all.
+        #expect(!subject.allows(.pin))
+        #expect(!subject.allows(.unreadMark))
+        #expect(!subject.allows(.colour))
+        // A name still means something once the worktree has gone, which is why it sits with Copy
+        // Branch Name rather than with the four that touch the disk.
+        #expect(subject.allows(.copyName))
         #expect(subject.liveID == nil)
         #expect(subject.archivedID == live)
         #expect(subject.id == live)

--- a/docs/MENUS.md
+++ b/docs/MENUS.md
@@ -49,6 +49,7 @@ contribute for free.
 | New Browser Tab | `⇧⌘B` | a workspace is selected |
 | Show Changes | `⇧⌘D` | a workspace is selected |
 | Show Notes | `⇧⌘N` | a workspace is selected |
+| Rename Tab | | the tab in front has a name to change |
 | Close Tab | `⌘W` | main window is key and a tab is closable |
 | Add Project Folder… | `⇧⌘O` | always |
 | Save | `⌘S` | a window has published a `SaveAction` |
@@ -67,9 +68,11 @@ contribute for free.
 
 | Item | Key | Enabled when |
 | --- | --- | --- |
-| Split Right | `⌘\` | the focused pane can be split |
-| Split Down | `⇧⌘\` | the focused pane can be split |
+| Split Right > Chat / Terminal / Browser | `⌘\` on the kind this pane is | a workspace is selected |
+| Split Down > Chat / Terminal / Browser | `⇧⌘\` on the kind this pane is | a workspace is selected |
 | Close Pane | `⌃⌘W` | a workspace is selected |
+| Zoom Pane | `⇧⌘↩` | a split shell is in front |
+| Focus Pane > Left / Right / Up / Down | | a split shell is in front |
 | Previous Tab / Next Tab | `⇧⌘[` `⇧⌘]` | the strip has more than one tab |
 | Go to Tab > (each tab) | `⌘1`…`⌘9` | the strip is not empty |
 | Next / Previous Changed File | `⌥⌘J` `⌥⌘K` | a review is open and something changed |
@@ -86,10 +89,15 @@ contribute for free.
 | Item | Key | Enabled when |
 | --- | --- | --- |
 | Rename | | a workspace is the subject |
+| Pin / Unpin | | a live workspace is the subject |
+| Mark as Unread / Mark as Read | | a live workspace is the subject |
+| Colour > None and ten colours | | a live workspace is the subject |
+| Merge / Squash and merge / Rebase and merge | | the pull request band is on screen and GitHub will take a merge |
 | Archive Workspace | `⌘⌫` | a live workspace is the subject |
 | Restore Workspace | | an archived workspace is the subject |
 | Open in Editor | `⇧⌘E` | a live workspace is the subject |
 | Reveal in Finder | `⇧⌘R` | a live workspace is the subject |
+| Copy Name | | live or archived |
 | Copy Branch Name | `⇧⌘C` | live or archived |
 | Run Setup / Run Setup Again | | the project has a setup script |
 | Run > (each run script) | | the project has run scripts |
@@ -100,6 +108,13 @@ contribute for free.
 Entirely SwiftUI's and AppKit's: Minimise `⌘M`, Zoom, Fill and Arrange, Bloom, Discovered Seas,
 Bring All to Front, then the window list. `⇧⌘W` closes the window, forced onto the item by
 `WindowCloseShortcut` because `⌘W` belongs to the tab.
+
+**Nothing was added to it, and that is the answer rather than an omission.** Each `Window` scene
+contributes its own item, which both opens the window when it is closed and raises it when it is
+not, so Bloom and Discovered Seas are already there and a command of our own would print either
+name twice. The project settings windows are a `WindowGroup(id:for:)`, which contributes no item
+of its own and is opened from File instead, where a project is already dealt with. What is left is
+the standard set, and it is complete.
 
 ### Help
 
@@ -113,15 +128,21 @@ The columns are: is it in the menu bar, does it carry a key, is that key discove
 
 | Action | In the menu bar | Key |
 | --- | --- | --- |
-| Split Right > Chat / Terminal / Browser | **no** | none |
-| Split Down > Chat / Terminal / Browser | **no** | none |
+| Split Right > Chat / Terminal / Browser | yes | `⌘\` on the kind this pane is |
+| Split Down > Chat / Terminal / Browser | yes | `⇧⌘\` on the kind this pane is |
 | Close Pane | yes | `⌃⌘W` |
 
-**This is the headline gap.** The View menu's Split Right and Split Down always DUPLICATE: a chat
-twice, a fresh shell, the same page again. The split people actually want, a browser or a terminal
-beside the conversation, exists only in this two-level context menu with no key on it and no menu
-bar item anywhere. `CenterPaneMenu`'s own doc says a second copy of a transcript is almost never
-the point.
+**This was the headline gap and it is closed.** The View menu's Split Right and Split Down used to
+DUPLICATE: a chat twice, a fresh shell, the same page again. The split people actually want, a
+browser or a terminal beside the conversation, existed only in this two-level context menu with no
+key on it and no menu bar item anywhere. `CenterPaneMenu`'s own doc says a second copy of a
+transcript is almost never the point.
+
+The keystroke changed meaning with it, and that is worth knowing: `⌘\` now means "another one of
+these, beside this one" rather than "this one again". On a shell it does what it always did. On a
+browser it opens the address field rather than the page you were on, and on a conversation it
+starts a new one rather than showing the same transcript in both halves. The context menu still
+carries no key equivalents, for the reason written at the head of `CenterPaneMenu`.
 
 ### A terminal pane's menu (`TerminalPaneMenu`, AppKit, right click in a shell)
 
@@ -225,6 +246,8 @@ A browser with no Back in any menu is the second most obvious gap after the spli
 | Comment on This Line | diff line menu | **no** | none |
 | Send This Failure to the Agent | check row menu | **no** | none |
 | Open on GitHub, Copy link (pull request) | summary menu | **no** | none |
+| Merge, Squash and merge, Rebase and merge | the band's split button | yes | none |
+| Choose the merge method | the split button's chevron | **no**, deliberately | none |
 | Create pull request, Continue, Archive, Fix merge conflicts | buttons | Archive only | `⌘⌫` |
 | Save an edited file | hidden button | greyed, always | `⌘S` |
 
@@ -313,8 +336,9 @@ decision about muscle memory rather than about menus.
 **This branch.** The split, which was the finding that started this: the View menu's two items take
 the same three kinds the context menus have, and `⌘\` and `⇧⌘\` move onto the row meaning "the same
 again". Then the actions that belong to the window and to a workspace: the Workspace menu becomes
-everything a workspace row's menu offers, the tab actions are completed, the terminal pane's own
-actions are published, and the standard menus are checked for shape.
+everything a workspace row's menu offers, plus the merge, which had no item in any menu at all; the
+tab actions are completed, the terminal pane's own actions are published, and the standard menus
+are checked for shape.
 
 **Left for a second pass**, in the order they are worth doing:
 
@@ -323,8 +347,9 @@ actions are published, and the standard menus are checked for shape.
    the session, and `BrowserToolbar.Control.name` already holds the wording. `⌘[`, `⌘]` and `⌘R`
    are free.
 2. **The inspector.** The tab picker, the diff scope, the file bar's three toggles, Revert file,
-   Copy path, and the pull request items. Two of these need `⌘E` and `⌘S` moved off their hidden
-   buttons onto `@FocusedValue`s, which is what `FocusedMenuValues` already asks for.
+   Copy path, and the remaining pull request items. Two of these need `⌘E` and `⌘S` moved off their
+   hidden buttons onto `@FocusedValue`s, which is what `FocusedMenuValues` already asks for and
+   what the merge item on this branch is the worked example of.
 3. **A Project menu, or a project group in File.** Rename, Reveal in Finder, Hide, Remove. Four
    items that exist only on a right click.
 4. **The composer and the transcript.** Attach a file, insert a quick prompt, fast mode, and the
@@ -337,9 +362,15 @@ actions are published, and the standard menus are checked for shape.
   behind it. Dragging a tab onto a pane edge is Open in Split Right, which does belong in a menu.
 - **The composer's Return and Shift Return.** They are text editing, not commands, and a menu item
   for "type a newline" is noise.
-- **Rows of a list.** The tabs are in Go to Tab because nine keys hang off them. The workspaces are
-  in the sidebar and reachable with `⌥⌘↑↓`; a Workspaces submenu listing every workspace on the
-  machine would be a second sidebar that goes stale.
+- **Rows of a list.** An item that acts on the row the pointer is over has no subject at the top of
+  the screen: Reveal in Finder on a changed file, Copy path on a folder, Open Terminal Tab Here on
+  a tree row. The tabs are in Go to Tab because nine keys hang off them and the selected tab is a
+  real subject. The workspaces are in the sidebar and reachable with `⌥⌘↑↓`; a Workspaces submenu
+  listing every workspace on the machine would be a second sidebar that goes stale.
+- **Choosing the merge method.** It is a per-project mode, set from the split button's chevron and
+  remembered. A submenu of the three in the menu bar would be a second place to set it, and a row
+  in it would have to both change the mode and merge, which is the one thing that button's own menu
+  refuses to do. The menu bar's item says which merge is in force and performs that one.
 - **Anything inside Settings or the project settings window.** Removing a run script is a button in
   the editor that owns it. A menu bar item for it would have to name which script.
 - **Discovered Seas.** A `Window` scene contributes its own Window menu item, and a command of our

--- a/docs/MENUS.md
+++ b/docs/MENUS.md
@@ -1,0 +1,347 @@
+# Menus and keys
+
+Every action Bloom can perform, where it is reachable from, and which key it carries. Read off the
+source on 2026-08-26 rather than remembered.
+
+## The rule this document exists to hold
+
+**A premium Mac app publishes every action in the menu bar, with its key beside it, so you learn
+the keys by using the menus.** A context menu is a shortcut to somewhere you already are; the menu
+bar is the map of what the app can do. An action that lives only on a right click, only on a hover
+button, or only as a keystroke nobody wrote down is an action most users will never find.
+
+Three corollaries, and each of them is a decision the code has already taken somewhere:
+
+- **Greyed rather than absent, in the menu bar.** The opposite of what the context menus do.
+  `BloomCommands` already greys Split Right on a Notes tab rather than dropping it, and the
+  Workspace menu greys every item when nothing is selected. A row that vanishes teaches nothing.
+- **One action, one name.** A menu item and the context menu offering the same thing say the same
+  words. `PaneKind.title`, `PaneNaming`, `BrowserToolbar.Control.name` and `SetupRunOffer.title`
+  each exist because two surfaces were naming one action two ways.
+- **A key equivalent claimed by a focused view beats the menu bar**, and a key registered on both
+  a hidden button and a menu item is not a tie: the button wins and the item never fires. This was
+  measured three times in this repository. So a key is either the menu's or the view's, never both.
+
+## The menu bar today
+
+`Sources/Bloom/Views/Chrome/App/BloomCommands.swift`, plus `RepoSettingsCommands` in
+`Sources/Bloom/Views/RepoSettings/RepoSettingsWindow.swift`, plus what SwiftUI and AppKit
+contribute for free.
+
+### Bloom
+
+| Item | Key | Source |
+| --- | --- | --- |
+| About Bloom | | ours, replacing `.appInfo` |
+| Check for Updates… | | ours, Sparkle |
+| Settings… | `⌘,` | SwiftUI's `Settings` scene |
+| Services, Hide, Hide Others, Show All, Quit | `⌘H` `⌥⌘H` `⌘Q` | AppKit |
+
+### File
+
+| Item | Key | Enabled when |
+| --- | --- | --- |
+| New Workspace… | `⌘N` | a project exists |
+| New Workspace from Pull Request… | | a project exists |
+| Project Settings… | `⇧⌘,` | a project exists |
+| New Session | `⌘T` | a workspace is selected |
+| New Terminal Tab | `⇧⌘T` | a workspace is selected |
+| New Browser Tab | `⇧⌘B` | a workspace is selected |
+| Show Changes | `⇧⌘D` | a workspace is selected |
+| Show Notes | `⇧⌘N` | a workspace is selected |
+| Close Tab | `⌘W` | main window is key and a tab is closable |
+| Add Project Folder… | `⇧⌘O` | always |
+| Save | `⌘S` | a window has published a `SaveAction` |
+
+### Edit
+
+| Item | Key | Notes |
+| --- | --- | --- |
+| Undo, Redo, Cut, Copy, Paste, Select All | `⌘Z` `⇧⌘Z` `⌘X` `⌘C` `⌘V` `⌘A` | AppKit |
+| Find > Find… | `⌘F` | falls through to Search when nothing in front can find |
+| Find > Find Next | `⌘G` | |
+| Find > Find Previous | `⇧⌘G` | |
+| Search | `⇧⌘F` | a project exists |
+
+### View
+
+| Item | Key | Enabled when |
+| --- | --- | --- |
+| Split Right | `⌘\` | the focused pane can be split |
+| Split Down | `⇧⌘\` | the focused pane can be split |
+| Close Pane | `⌃⌘W` | a workspace is selected |
+| Previous Tab / Next Tab | `⇧⌘[` `⇧⌘]` | the strip has more than one tab |
+| Go to Tab > (each tab) | `⌘1`…`⌘9` | the strip is not empty |
+| Next / Previous Changed File | `⌥⌘J` `⌥⌘K` | a review is open and something changed |
+| Toggle Sidebar | `⌃⌘S` | always |
+| Toggle Inspector | `⌥⌘I` | a workspace is selected |
+| Next / Previous Workspace | `⌥⌘↓` `⌥⌘↑` | any workspace exists |
+| Next Unread | `⇧⌘U` | something is unread |
+| Go to Home | `⇧⌘H` | not already on Home |
+| Zoom In / Zoom Out / Actual Size | `⌘+` `⌘-` `⌘0` | the focused text can zoom |
+| Enter Full Screen | `⌃⌘F` | AppKit |
+
+### Workspace
+
+| Item | Key | Enabled when |
+| --- | --- | --- |
+| Rename | | a workspace is the subject |
+| Archive Workspace | `⌘⌫` | a live workspace is the subject |
+| Restore Workspace | | an archived workspace is the subject |
+| Open in Editor | `⇧⌘E` | a live workspace is the subject |
+| Reveal in Finder | `⇧⌘R` | a live workspace is the subject |
+| Copy Branch Name | `⇧⌘C` | live or archived |
+| Run Setup / Run Setup Again | | the project has a setup script |
+| Run > (each run script) | | the project has run scripts |
+| Stop Agent | `⌘.` | a turn is running |
+
+### Window
+
+Entirely SwiftUI's and AppKit's: Minimise `⌘M`, Zoom, Fill and Arrange, Bloom, Discovered Seas,
+Bring All to Front, then the window list. `⇧⌘W` closes the window, forced onto the item by
+`WindowCloseShortcut` because `⌘W` belongs to the tab.
+
+### Help
+
+Bloom Help `⌘?`, Welcome to Bloom…, Send Feedback… `⌥⌘F`, Submit a Prompt…
+
+## Every other surface, and what it holds
+
+The columns are: is it in the menu bar, does it carry a key, is that key discoverable.
+
+### The centre pane's own menu (`CenterPaneMenu`, right click on a pane)
+
+| Action | In the menu bar | Key |
+| --- | --- | --- |
+| Split Right > Chat / Terminal / Browser | **no** | none |
+| Split Down > Chat / Terminal / Browser | **no** | none |
+| Close Pane | yes | `⌃⌘W` |
+
+**This is the headline gap.** The View menu's Split Right and Split Down always DUPLICATE: a chat
+twice, a fresh shell, the same page again. The split people actually want, a browser or a terminal
+beside the conversation, exists only in this two-level context menu with no key on it and no menu
+bar item anywhere. `CenterPaneMenu`'s own doc says a second copy of a transcript is almost never
+the point.
+
+### A terminal pane's menu (`TerminalPaneMenu`, AppKit, right click in a shell)
+
+| Action | In the menu bar | Key | Who claims the key |
+| --- | --- | --- | --- |
+| Split Right > Chat / Terminal / Browser | **no** | `⌘D` on Terminal | `BloomTerminalView.performKeyEquivalent` |
+| Split Down > Chat / Terminal / Browser | **no** | `⇧⌘D` on Terminal | same |
+| Zoom Pane / Zoom Out | **no** | `⇧⌘↩` | same |
+| Close Pane | yes | `⌘W` | same, and it means the pane rather than the tab |
+
+`⌘D` is drawn on the Terminal row rather than on the parent, because AppKit never fires the action
+of an item that has a submenu. That trick is the one the View menu should borrow.
+
+### A terminal pane, keys with no menu item at all
+
+| Action | Key | Anywhere in a menu |
+| --- | --- | --- |
+| Focus pane left / right / up / down | `⌥⌘←→↑↓` | **no** |
+| Clear the shell and its scrollback | `⌘K` | **no** |
+| Copy, Paste | `⌘C` `⌘V` | Edit menu's, but the terminal answers them itself |
+| Terminal text bigger / smaller / actual | `⌘+` `⌘-` `⌘0` | View menu's Zoom trio, resolved onto the terminal |
+
+### A tab (`TabItemView`, right click on a tab)
+
+| Action | In the menu bar | Key |
+| --- | --- | --- |
+| Open in Split Right / Split Down | **no** | none |
+| Rename | **no** | none |
+| Close | yes, as Close Tab | `⌘W` |
+
+Dragging a tab onto a pane's edge does the same thing as Open in Split Right, and is discoverable
+only by trying it.
+
+### A workspace row (`WorkspaceMenuItems`, sidebar and Home)
+
+| Action | In the menu bar | Key |
+| --- | --- | --- |
+| Open in Editor | yes | `⇧⌘E` |
+| Reveal in Finder | yes | `⇧⌘R` |
+| Copy Branch Name | yes | `⇧⌘C` |
+| Run Setup / Run Setup Again | yes | none |
+| Pin / Unpin | **no** | none |
+| Mark as Read / Mark as Unread | **no** | none |
+| Colour > None and ten colours | **no** | none |
+| Rename | yes | none |
+| Archive | yes | `⌘⌫` |
+
+An archived row (`HomeRowMenu`) offers Open, Restore Workspace and Copy Branch Name. Restore and
+Copy Branch Name are in the menu bar; **Open, which opens an archived transcript for reading, is
+not.**
+
+### The window's title (`WorkspaceMenuItems`, scope `.title`)
+
+Rename, Copy Name, Copy Branch Name, Open in Editor, Reveal in Finder. **Copy Name is nowhere in
+the menu bar**; the other four are. Double clicking the title renames, which is discoverable only
+from the tooltip.
+
+### A project header (`ProjectMenuItems`, right click on a project)
+
+| Action | In the menu bar | Key |
+| --- | --- | --- |
+| New workspace | yes, as New Workspace… | `⌘N` |
+| Rename | **no** | none |
+| Project settings… | yes | `⇧⌘,` |
+| Reveal in Finder | **no** | none |
+| Hide project / Unhide project | **no** | none |
+| Remove project | **no** | none |
+
+The File menu's Project Settings… acts on the selected workspace's project; this menu acts on the
+project it was raised from. The two are not always the same project, which is worth saying out
+loud somewhere a user can read it.
+
+### The browser pane
+
+| Action | Where it lives | In the menu bar | Key |
+| --- | --- | --- | --- |
+| Back / Forward | toolbar arrows | **no** | none |
+| Jump back or forward several pages | right click on an arrow | **no** | none |
+| Reload / Stop | toolbar | **no** | none |
+| Send a Screenshot to the Agent | toolbar, and the page menu | **no** | none |
+| Share | toolbar | **no** | none |
+| Open in External Browser | page context menu | **no** | none |
+| Find in page, next, previous | find bar | yes, Edit > Find | `⌘F` `⌘G` `⇧⌘G` |
+| Downloads bar dismissal | the bar itself | **no** | none |
+
+A browser with no Back in any menu is the second most obvious gap after the split.
+
+### The inspector
+
+| Action | Where it lives | In the menu bar | Key |
+| --- | --- | --- | --- |
+| Changes / Files / Pull Request tabs | segmented picker | **no** | none |
+| What the changes are measured from (`DiffScopeMenuItems`) | toolbar menu | **no** | none |
+| Copy Branch Name, Reveal Worktree in Finder, Open in… (`WorktreeMenuItems`) | overflow menu | partly | `⇧⌘C`, `⇧⌘R` |
+| Open Pull Request, Share pull request | overflow menu | **no** | none |
+| Toggle diff and edit | hidden button | **no** | `⌘E` |
+| Unified / side by side | file bar menu | **no** | none |
+| Ignore whitespace | file bar menu | **no** | none |
+| Revert file | file bar menu and row menu | **no** | none |
+| Reveal in Finder, Copy path (a changed file, a folder, a tree row) | row menus | **no** | none |
+| Comment on This Line | diff line menu | **no** | none |
+| Send This Failure to the Agent | check row menu | **no** | none |
+| Open on GitHub, Copy link (pull request) | summary menu | **no** | none |
+| Create pull request, Continue, Archive, Fix merge conflicts | buttons | Archive only | `⌘⌫` |
+| Save an edited file | hidden button | greyed, always | `⌘S` |
+
+`⌘E` and `⌘S` are both hidden `keyboardShortcut` buttons with no menu item, which is the exact
+pattern this repository has already removed twice (the four tab keys, and the review's `⌥⌘J/K`).
+`FileEditPane` binds `⌘S` and does not publish a `SaveAction`, so the File menu's Save is greyed
+while a file edit is exactly what `⌘S` would write. `FocusedMenuValues` asks for that publication
+in its own doc comment.
+
+### The composer
+
+| Action | Where it lives | In the menu bar | Key |
+| --- | --- | --- | --- |
+| Send | Return in the box | **no** | `↩` |
+| Newline | `⇧↩` | **no** | `⇧↩` |
+| Stop the agent | stop button | yes | `⌘.` |
+| Insert a quick prompt | footer button and `/` menu | **no** | none |
+| Edit or delete a quick prompt | row menu | **no** | none |
+| Attach a file | footer button, paste, drop | **no** | none |
+| Fast mode | footer toggle | **no** | none |
+| Slash commands | `/` menu | **no** | none |
+| File mentions | `@` menu | **no** | none |
+| Show a review comment in the diff, remove it | chip menu | **no** | none |
+
+### The transcript
+
+| Action | Where it lives | In the menu bar | Key |
+| --- | --- | --- | --- |
+| Copy answer, Copy files touched, Copy raw event | turn footer menu | **no** | none |
+| Copy Link, Open Link, Open in External Browser, open in a split | link menu | **no** | none |
+| Allow once / This session / Always allow / Deny / Deny and stop | permission card | **no** | `⌘↩` on the default |
+| Copy the subject of a permission ask | card menu | **no** | none |
+| Answer an agent's question | question card | **no** | `↩` on the default |
+| Run this repository's setup script again | failed setup row | yes | none |
+
+### Home and the sidebar
+
+| Action | Where it lives | In the menu bar | Key |
+| --- | --- | --- | --- |
+| Home scopes: All, Needs you, Running, Live, Archived | chip strip | **no** | none |
+| Home project filter | menu | **no** | none |
+| Sidebar filter: which workspaces, hidden projects (`SidebarFilterMenuItems`) | status bar menu | **no** | none |
+| What the sidebar glyphs mean | status bar button | **no** | none |
+| Settings | status bar button | yes | `⌘,` |
+| Reorder projects, reorder workspaces | drag | **no** | none |
+| Archive a workspace, with a confirmation | row hover button | yes, without the confirmation | `⌘⌫` |
+| Resize the sidebar, the inspector, the composer, a pane | drag a divider | **no** | none |
+
+### Settings and the project settings window
+
+Storage, agents, appearance, prompts and the per project settings are all reachable from `⌘,` and
+`⇧⌘,`. Removing a project from Settings, and removing a run script, are buttons inside those
+windows and belong there.
+
+## Keys, and who wins
+
+Every key equivalent registered anywhere, and which registration takes the press. A view that has
+first responder beats the menu bar; a hidden `keyboardShortcut` button in the view hierarchy beats
+a menu item.
+
+| Key | Menu bar | View claim | Winner when both apply |
+| --- | --- | --- | --- |
+| `⌘\` `⇧⌘\` | Split Right / Down | none | menu bar |
+| `⌘D` `⇧⌘D` | none | terminal splits a shell | terminal |
+| `⇧⌘↩` | none | terminal zooms the pane | terminal |
+| `⌥⌘←→` | none | terminal moves pane focus | terminal |
+| `⌥⌘↑↓` | Previous / Next Workspace | terminal moves pane focus | **terminal, silently** |
+| `⌘W` | Close Tab | terminal closes the pane | terminal, deliberately |
+| `⌘K` | none | terminal clears the shell | terminal |
+| `⌘C` `⌘V` | Edit's own | terminal copies and pastes | terminal |
+| `⌘+` `⌘-` `⌘0` | Zoom In / Out / Actual Size | terminal text size | terminal, and both act on the same shell |
+| `⌘F` `⌘G` `⇧⌘G` | Find submenu | browser finds in the page | browser, when the page has the keyboard |
+| `⌘G` `⇧⌘G` | Find Next / Previous | the browser find bar's own buttons | the bar, while it is up |
+| `⌘E` | none | inspector toggles diff and edit | the hidden button |
+| `⌘S` | Save | `FileEditPane`, `RepoSettingsSaveBar` | the button, and Save is greyed for the first |
+| `⇧⌘[` `⇧⌘]` | Previous / Next Tab | the create sheet's source picker | the sheet, while it is up |
+
+**One of these is a bug rather than an allocation.** `⌥⌘↑` and `⌥⌘↓` mean Previous and Next
+Workspace in the View menu and mean "move the focus one pane up or down" inside a terminal. Both
+are reasonable bindings taken from different applications, and nothing in the app says which one
+you are about to get. It is listed here rather than fixed here, because changing either is a
+decision about muscle memory rather than about menus.
+
+## Where the work was cut
+
+**This branch.** The split, which was the finding that started this: the View menu's two items take
+the same three kinds the context menus have, and `⌘\` and `⇧⌘\` move onto the row meaning "the same
+again". Then the actions that belong to the window and to a workspace: the Workspace menu becomes
+everything a workspace row's menu offers, the tab actions are completed, the terminal pane's own
+actions are published, and the standard menus are checked for shape.
+
+**Left for a second pass**, in the order they are worth doing:
+
+1. **The browser.** Back, Forward, Reload and Stop, Open in External Browser, Send a Screenshot to
+   the Agent, Share. Needs no new plumbing: `CenterTabStore.liveBrowser(for:)` already hands over
+   the session, and `BrowserToolbar.Control.name` already holds the wording. `⌘[`, `⌘]` and `⌘R`
+   are free.
+2. **The inspector.** The tab picker, the diff scope, the file bar's three toggles, Revert file,
+   Copy path, and the pull request items. Two of these need `⌘E` and `⌘S` moved off their hidden
+   buttons onto `@FocusedValue`s, which is what `FocusedMenuValues` already asks for.
+3. **A Project menu, or a project group in File.** Rename, Reveal in Finder, Hide, Remove. Four
+   items that exist only on a right click.
+4. **The composer and the transcript.** Attach a file, insert a quick prompt, fast mode, and the
+   turn footer's three copies.
+
+## What should stay out of the menu bar, and why
+
+- **Dragging.** Reordering projects and workspaces, dragging a tab onto a pane edge, and every
+  divider. Each has a menu equivalent already or is a direct manipulation with no discrete action
+  behind it. Dragging a tab onto a pane edge is Open in Split Right, which does belong in a menu.
+- **The composer's Return and Shift Return.** They are text editing, not commands, and a menu item
+  for "type a newline" is noise.
+- **Rows of a list.** The tabs are in Go to Tab because nine keys hang off them. The workspaces are
+  in the sidebar and reachable with `⌥⌘↑↓`; a Workspaces submenu listing every workspace on the
+  machine would be a second sidebar that goes stale.
+- **Anything inside Settings or the project settings window.** Removing a run script is a button in
+  the editor that owns it. A menu bar item for it would have to name which script.
+- **Discovered Seas.** A `Window` scene contributes its own Window menu item, and a command of our
+  own printed the name twice. See the comment at the head of `OceansWindow`.
+- **Ask Siri.** macOS puts it on context menus itself. It is not ours to move or to mirror.


### PR DESCRIPTION
`docs/MENUS.md` is the inventory: every surface in the app, one table each, with three columns for whether an action is in the menu bar, whether it carries a key, and whether that key is discoverable. Plus a who-wins table for every key equivalent, because a focused view beats the menu bar and that was written down nowhere.

The finding that started it: View > Split Right and Split Down always **duplicated** the pane you were in, so the menu bar published the one split the app's own comments call almost never the point. They are submenus of Chat / Terminal / Browser now, the same three the pane's context menu has, through the same door. `⌘\` and `⇧⌘\` move onto the row matching the pane in front, because AppKit never fires an item that has a submenu, so the keystroke now means "another one of these, beside this one" rather than "this one again".

Merge gains a Workspace menu item, above Archive. It travels as a focused value published by the band, so a press goes through the same sign-in gate and the same confirmation the button opens, and it names the method the split button says. Deliberately not a submenu of the three methods: that would be a second place to set a per-project mode.

Also added: Pin, Mark as Read and Unread, Colour and Copy Name to Workspace; Rename Tab to File; Zoom Pane and Focus Pane to View. Only two new keys, on the argument that a key is worth having for something done often and an item with no key still teaches that the action exists.

Two key collisions found, both undocumented and both left alone: `⇧⌘D` is Show Changes in File and splits a shell downwards, and `⌥⌘↑`/`⌥⌘↓` are Previous/Next Workspace and step pane focus in a terminal. Both are reasonable bindings taken from different applications, so changing one is a decision about muscle memory rather than about menus. They are recorded so a new collision fails a test.

`MenuBarCatalogue` in the core is the source of truth for every item's menu, title and key, and the commands read from it, so the table cannot become decorative.