### PR TITLE
A Home that opens on the work that is alive

### DIFF
--- a/Sources/Bloom/Views/Home/HomeBar.swift
+++ b/Sources/Bloom/Views/Home/HomeBar.swift
@@ -1,28 +1,32 @@
 import SwiftUI
 import BloomCore
 
-/// The one strip of chrome Home has: which chip is lit, which projects are listed, and what the
-/// answer adds up to.
+/// The one strip of chrome above Home's list: which chip is lit, and which projects are listed.
 ///
-/// **What came off it, and why the strip is glass now.** It used to hold a hand built search field
-/// with a hand drawn focus ring, a project menu, a "Hide archived" toggle and the readout. The
-/// field is gone: the window has a real `NSSearchToolbarItem` in its toolbar, which is where
-/// Finder and Mail publish search, and which draws its own glass and its own focus ring rather
-/// than an approximation of both. The toggle is gone too, into `HomeScope.live`, because a
-/// narrowing switch beside a set of narrowing chips is two mechanisms for one question.
+/// **What came off it.** It used to hold a hand built search field with a hand drawn focus ring, a
+/// project menu, a "Hide archived" toggle and a readout of what the list added up to. The field is
+/// gone: the window has a real `NSSearchToolbarItem` in its toolbar, which is where Finder and Mail
+/// publish search. The toggle is gone into `HomeScope.live`, because a narrowing switch beside a
+/// set of narrowing chips is two mechanisms for one question. And the readout is gone down to
+/// `HomeStatusBar` at the foot of the pane: a count belongs beside the thing it counts, and this
+/// bar was carrying five chips, a picker and a sentence at one weight, so nothing on it led.
 ///
-/// What is left floats. A bar of controls over a list that scrolls under it is exactly what a
-/// material is for, so this is `.regular` glass in a `GlassEffectContainer` with the chips, which
-/// means a chip lighting up is one shape morphing rather than two surfaces disagreeing about the
-/// ground they stand on. The rows underneath are not glass and must not be: a row is content, and
-/// forty glass rows is noise.
+/// **It was glass and it is not any more.** It was a `GlassEffectContainer` with `.regular` on the
+/// strip and a tinted chip for the selected one, floating over the list on its own rounded plate.
+/// The owner's words were "Bloom doesn't need that glassy stuff behind it", and he is right about
+/// this app in particular: Bloom's ground is a stated ramp rather than a material, the whole
+/// argument for which is on `Palette`, and a strip that samples what is under it is the one
+/// surface in the window whose colour nobody chose.
+///
+/// So it is a band of `Palette.sidebar` with a rule under it, which is what the palette already
+/// names for "the sidebar column, the title bar, and every strip of small controls". Because the
+/// title bar is that same colour, the band reads as attached to it rather than as a plate floating
+/// over the rows, which is where Finder puts a scope bar and where Safari puts its favourites.
 ///
 /// It does not scroll. The list under it is hundreds of rows on a real install, and a strip that
 /// leaves the screen takes the state of the filters with it, which is how a user ends up staring
 /// at eleven rows wondering where the rest went.
 struct HomeBar: View {
-    /// What the list adds up to, worked out by `HomeView`. Empty means there is nothing to say.
-    var summary: String
     var repos: [Repo]
     var counts: HomeScopeCounts
     var isSearching: Bool
@@ -33,10 +37,7 @@ struct HomeBar: View {
     @State private var hovered: HomeScope?
 
     var body: some View {
-        // One sampling pass for the strip and every chip on it rather than one each, which is what
-        // the container is for. `spacing: 0` so two chips that come close do not merge into one
-        // blob, which is the other thing it does.
-        GlassEffectContainer(spacing: 0) {
+        VStack(spacing: 0) {
             HStack(spacing: Metrics.spacingSmall) {
                 ForEach(HomeScope.offered(searching: isSearching), id: \.self) { scope in
                     chip(scope)
@@ -45,47 +46,25 @@ struct HomeBar: View {
                 Spacer(minLength: Metrics.gutter)
 
                 projectMenu
-
-                // Trailing, and the whole reason the count is still on screen at all: it describes
-                // the list rather than the database whenever the two differ, so it has to sit with
-                // the controls that made them differ.
-                //
-                // First to be given up when the pane is narrow. The controls are how the user gets
-                // out of a narrowed list; the readout only explains it.
-                if !summary.isEmpty {
-                    Text(summary)
-                        .font(Typo.caption)
-                        .foregroundStyle(Palette.textSecondary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .layoutPriority(-1)
-                        .accessibilityLabel("Showing \(summary)")
-                }
             }
-            .padding(.horizontal, Metrics.spacingWide)
-            .frame(height: Self.height)
-            .glassEffect(
-                .regular, in: RoundedRectangle(cornerRadius: Metrics.corner, style: .continuous)
-            )
-        }
-        .padding(.horizontal, HomeMetrics.gutter)
-        .padding(.top, Metrics.inset)
-    }
+            .padding(.horizontal, HomeMetrics.gutter)
+            .frame(height: Metrics.barHeight)
 
-    /// A chip and its clearance above and below. Not `Metrics.barHeight`: this strip floats over
-    /// the list rather than being a band ruled off from it, so it is sized by what it holds.
-    private static let height: CGFloat = Metrics.controlHeight + Metrics.spacing * 2
+            Hairline()
+        }
+        .background(Palette.sidebar)
+    }
 
     // MARK: - Scopes
 
     /// One scope, with the number that says what clicking it would show.
     ///
-    /// The count is the half that earns the chip its place on the strip. "Needs you 3" answers the
-    /// question the window was opened with at a glance, without drawing a second list of the same
-    /// rows above the first one.
+    /// **A chip at nought draws no number.** The strip read "Needs you 0, Running 0" at rest, which
+    /// is the state most of the time, so the noughts were what the eye learned to skip and the two
+    /// numbers that matter got skipped with them. See `HomeScopeCounts.badge`.
     private func chip(_ scope: HomeScope) -> some View {
         let isOn = filter.scope == scope
-        let count = counts.count(of: scope, searching: isSearching)
+        let badge = counts.badge(of: scope, searching: isSearching)
         let label = scope.label(searching: isSearching)
 
         return Button {
@@ -95,28 +74,31 @@ struct HomeBar: View {
                 Text(label)
                     .font(Typo.caption)
 
-                Text(count, format: .number)
-                    .font(Typo.micro)
-                    .monospacedDigit()
-                    .foregroundStyle(isOn ? Palette.textInverted.opacity(0.8) : countTint(scope))
+                if let badge {
+                    Text(badge, format: .number)
+                        .font(Typo.micro)
+                        .monospacedDigit()
+                        .foregroundStyle(isOn ? Palette.textInverted.opacity(0.8) : countTint(scope))
+                }
             }
             .foregroundStyle(isOn ? Palette.textInverted : Palette.textSecondary)
             .padding(.horizontal, Metrics.spacing)
             .frame(height: Metrics.controlHeight)
-            .background(hovered == scope && !isOn ? Palette.hover : .clear, in: Capsule())
+            .background(fill(isOn: isOn, isHovered: hovered == scope), in: Capsule())
             .contentShape(Capsule())
         }
         .buttonStyle(.plain)
-        // A tinted glass chip is one control, rather than a coloured control standing next to a
-        // glass one. `.identity` for the unlit ones rather than dropping the modifier: the shape
-        // stays in the container either way, so a chip lighting up morphs instead of appearing,
-        // and the strip is already glass, so a second material inside it would be a surface on a
-        // surface.
-        .glassEffect(isOn ? .regular.tint(Palette.accentFill) : .identity, in: Capsule())
         .onHoverChange { hovered = $0 ? scope : (hovered == scope ? nil : hovered) }
-        .accessibilityLabel("\(label), \(count)")
+        .accessibilityLabel(badge.map { "\(label), \($0)" } ?? label)
         .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
         .help(help(for: scope))
+    }
+
+    /// The selected chip is filled with Bloom's own accent rather than tinted glass, which is the
+    /// same fill an emphasized selection uses everywhere else in the window.
+    private func fill(isOn: Bool, isHovered: Bool) -> Color {
+        if isOn { return Palette.accentFill }
+        return isHovered ? Palette.hover : .clear
     }
 
     /// The one chip whose number is worth noticing before it is read. Everything else on the strip
@@ -145,11 +127,12 @@ struct HomeBar: View {
     /// checkmarks are AppKit's rather than a column of drawn ticks that has to be kept in step
     /// with the selection by hand.
     ///
+    /// **It stays up here rather than going down to the status bar with the counts.** It changes
+    /// what the list shows, and a status bar is a place for reading rather than pressing: Finder's
+    /// says how many items there are and offers nothing to click.
+    ///
     /// `.menuStyle(.button)` because a borderless `Menu` on macOS throws a custom label away and
     /// draws only the chevron, which is what the sidebar's account row used to look like.
-    ///
-    /// No glass on it. It is system drawn already, and a material on top of a control that has its
-    /// own treatment freezes it at this year's version of that treatment.
     private var projectMenu: some View {
         Menu {
             Toggle("All projects", isOn: allProjects)

--- a/Sources/Bloom/Views/Home/HomeGroupHeading.swift
+++ b/Sources/Bloom/Views/Home/HomeGroupHeading.swift
@@ -1,31 +1,64 @@
 import SwiftUI
 
-/// A date heading in Home's list, with how many workspaces are under it.
+/// A heading in Home's list, with how many workspaces are under it.
 ///
 /// The count is the half that makes the heading worth having. "Yesterday" alone is a divider;
 /// "Yesterday 48" is a fact about how much happened, and it is the only place in the window that
 /// says it, because the sidebar counts per project and never per day.
+///
+/// **It was set in caption ink at secondary weight, and it is the structure of the page.** Home is
+/// one flat list, so the date headings are the only thing dividing it, and set that quietly they
+/// read as labels on a list rather than as the shape of it. This is the title rung, in primary
+/// ink, with the count on a quiet plate beside it and a rule running out to the trailing edge, so
+/// the eye can find a day without reading a row.
 struct HomeGroupHeading: View {
     var title: String
     var count: Int
+    /// A secondary heading, for the archived tail under a live list. It is the same heading a step
+    /// down, because the block under it is context rather than the answer: a tail set as loud as
+    /// the day above it would read as the list starting again.
+    var isSecondary = false
+    /// The count's other half, when the block is a sample rather than the whole of something:
+    /// "6 of 17" under a live list, where the tail is capped.
+    var of: Int?
 
     var body: some View {
         HStack(spacing: Metrics.spacingWide) {
             Text(title)
-                .font(Typo.captionEmphasis)
-                .foregroundStyle(Palette.textSecondary)
+                .font(Typo.title)
+                .foregroundStyle(isSecondary ? Palette.textSecondary : Palette.textPrimary)
 
-            Text(count, format: .number)
-                .font(Typo.caption)
+            Text(countText)
+                .font(Typo.micro)
                 .monospacedDigit()
                 .foregroundStyle(Palette.textTertiary)
+                .padding(.horizontal, Metrics.chipInsetH)
+                .padding(.vertical, Metrics.chipInsetV)
+                .background(Palette.hover, in: Capsule())
 
-            Spacer(minLength: 0)
+            // Out to the trailing edge, which is what turns a label into a division. Under
+            // `List`'s own leading inset it starts at the heading and ends at the pane's edge, so
+            // the day above and the day below are two blocks rather than two lines of text.
+            Rectangle()
+                .fill(Palette.border)
+                .frame(height: Metrics.hairline)
         }
+        .padding(.top, Metrics.inset)
+        .padding(.bottom, Metrics.spacingSmall)
         // One phrase, so a VoiceOver user hears "Yesterday, 48 workspaces" rather than a heading
         // and then a loose number.
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(count == 1 ? "\(title), 1 workspace" : "\(title), \(count) workspaces")
+        .accessibilityLabel(accessibilityLabel)
         .accessibilityAddTraits(.isHeader)
+    }
+
+    private var countText: String {
+        guard let of else { return count.formatted() }
+        return "\(count.formatted()) of \(of.formatted())"
+    }
+
+    private var accessibilityLabel: String {
+        if let of { return "\(title), \(count) of \(of) workspaces" }
+        return count == 1 ? "\(title), 1 workspace" : "\(title), \(count) workspaces"
     }
 }

--- a/Sources/Bloom/Views/Home/HomeListRow.swift
+++ b/Sources/Bloom/Views/Home/HomeListRow.swift
@@ -1,11 +1,18 @@
 import SwiftUI
 import BloomCore
 
-/// One workspace on Home, on one line.
+/// One workspace on Home, on two lines.
 ///
 /// The order across the row is the order the questions are asked in. Something at the very leading
 /// edge says "look here"; the project mark says whose work this is; the name says which piece of
-/// it; the mark, the counts and the age on the trailing edge say how it went and how long ago.
+/// it; under the name, the project spelled out and the branch say which worktree; the mark, the
+/// counts and the age on the trailing edge say how it went and how long ago.
+///
+/// **It was one line, and the owner's complaint about the list was that the rows were thin with a
+/// lot of air between the name and the numbers at the right.** He was describing a real hole: a
+/// name at one edge and three columns at the other, with nothing between them on any row. The
+/// second line fills it with the two things a person identifies a worktree by, which Home was the
+/// only list in the window not showing. See `origin`.
 ///
 /// **Why the project mark leads and the status mark does not.** In the sidebar the workspace sits
 /// under its project's heading, so the leading slot is free for the status glyph and that is what
@@ -68,71 +75,16 @@ struct HomeListRow: View {
     private static let diffWidth: CGFloat = 84
 
     var body: some View {
-        HStack(spacing: Metrics.spacing) {
+        HStack(spacing: Metrics.spacingWide) {
             rail
 
             RepoIcon(repo: row.repo)
 
-            if isRenaming {
-                TextField("Workspace name", text: $draft)
-                    .textFieldStyle(.plain)
-                    .focused($fieldFocused)
-                    .onSubmit { end(.submitted) }
-                    .onExitCommand { end(.escaped) }
-                    // Clicking away commits, as it does in Finder, rather than leaving the field
-                    // open on the row holding text nobody ever asked to keep. Guarded on having
-                    // had the focus, so the false the field starts at is not read as losing it.
-                    .onChange(of: fieldFocused) { had, has in
-                        guard had, !has else { return }
-                        end(.focusLost)
-                    }
-                    .task {
-                        draft = workspace.name
-                        hasEnded = false
-                        // A beat, so the field exists before focus moves to it.
-                        try? await Task.sleep(for: .milliseconds(30))
-                        fieldFocused = true
-                    }
-            } else {
-                WorkspaceNameText(workspace, isUnread: isUnread)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-
-                // Why this row is in a search, when the answer is not on the row already.
-                //
-                // The search reaches the name, the branch and the project, so a perfect answer can
-                // have nothing on it that looks like what was typed: searching a branch name gave
-                // a list of workspaces with no visible connection to the query at all. Drawn only
-                // while searching, and only for the two fields the row does not otherwise show.
-                // See `HomeRow.match`.
-                if let match = row.match {
-                    Text(match)
-                        .font(Typo.codeTiny)
-                        .foregroundStyle(Palette.textTertiary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .layoutPriority(-1)
-                }
-
-                // Right after the name, the same place the sidebar puts it, so one workspace is
-                // marked in one way in both lists. No accessibility label of its own: this row is
-                // merged into a single element below, which would swallow it, so the colour is
-                // said in `accessibilityLabel` instead.
-                //
-                // Nothing special for the archived case. The whole row is drained by `grayscale`
-                // a few lines down, which takes the dot with it, and that is the right answer: an
-                // archived workspace cannot be given a colour or have one taken off.
-                WorkspaceColourDot(hex: workspace.colour)
-
-                if workspace.pinned {
-                    Image(systemName: "pin.fill")
-                        .font(Typo.micro)
-                        .foregroundStyle(Palette.textTertiary)
-                        .accessibilityHidden(true)
-                }
+            VStack(alignment: .leading, spacing: Metrics.spacingHair) {
+                name
+                origin
             }
-
-            Spacer(minLength: Metrics.spacingWide)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             trailing
         }
@@ -166,7 +118,7 @@ struct HomeListRow: View {
         // either; they are part of the list Home opens on.
         .grayscale(row.isArchived ? 1 : 0)
         .opacity(row.isArchived ? 0.6 : 1)
-        .frame(minHeight: Metrics.rowHeight)
+        .frame(minHeight: HomeMetrics.rowHeight)
         // The whole row, including the gap the name does not fill, is the click target. Without
         // it only the text is, and a list where half of each row ignores the pointer feels broken
         // long before anyone works out why.
@@ -183,6 +135,92 @@ struct HomeListRow: View {
     }
 
     // MARK: - Parts
+
+    /// The first line: what this workspace is called, and the two marks that travel with the name.
+    @ViewBuilder
+    private var name: some View {
+        HStack(spacing: Metrics.spacing) {
+            if isRenaming {
+                TextField("Workspace name", text: $draft)
+                    .textFieldStyle(.plain)
+                    .focused($fieldFocused)
+                    .onSubmit { end(.submitted) }
+                    .onExitCommand { end(.escaped) }
+                    // Clicking away commits, as it does in Finder, rather than leaving the field
+                    // open on the row holding text nobody ever asked to keep. Guarded on having
+                    // had the focus, so the false the field starts at is not read as losing it.
+                    .onChange(of: fieldFocused) { had, has in
+                        guard had, !has else { return }
+                        end(.focusLost)
+                    }
+                    .task {
+                        draft = workspace.name
+                        hasEnded = false
+                        // A beat, so the field exists before focus moves to it.
+                        try? await Task.sleep(for: .milliseconds(30))
+                        fieldFocused = true
+                    }
+            } else {
+                WorkspaceNameText(workspace, isUnread: isUnread)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                // Right after the name, the same place the sidebar puts it, so one workspace is
+                // marked in one way in both lists. No accessibility label of its own: this row is
+                // merged into a single element below, which would swallow it, so the colour is
+                // said in `accessibilityLabel` instead.
+                //
+                // Nothing special for the archived case. The whole row is drained by `grayscale`
+                // further down, which takes the dot with it, and that is the right answer: an
+                // archived workspace cannot be given a colour or have one taken off.
+                WorkspaceColourDot(hex: workspace.colour)
+
+                if workspace.pinned {
+                    Image(systemName: "pin.fill")
+                        .font(Typo.micro)
+                        .foregroundStyle(Palette.textTertiary)
+                        .accessibilityHidden(true)
+                }
+
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
+    /// The second line: whose work this is, and which branch it is on.
+    ///
+    /// **The row was one line and it was the wrong one line.** A name at the leading edge and three
+    /// numbers at the trailing edge left forty points of nothing between them on every row, on a
+    /// screen whose whole complaint was that it looked sparse. What went in the gap is what a
+    /// person actually identifies a worktree by and what Home was the only list not showing: the
+    /// project, spelled rather than left to a 16 point monogram, and the branch.
+    ///
+    /// It also retired the search's match label. That existed because a row could be a perfect
+    /// answer with nothing on it that looked like what was typed, and the two fields it stood in
+    /// for, the branch and the project, are both on this line now, on every row, searching or not.
+    private var origin: some View {
+        HStack(spacing: Metrics.spacingSmall) {
+            if let repo = row.repo {
+                Text(repo.name)
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textTertiary)
+                    .lineLimit(1)
+
+                Text(verbatim: "/")
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textTertiary.opacity(0.5))
+            }
+
+            Text(workspace.branch)
+                .font(Typo.codeTiny)
+                .foregroundStyle(Palette.textTertiary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Spacer(minLength: 0)
+        }
+        .accessibilityHidden(true)
+    }
 
     /// Always occupies its width, so every name in the list starts on the same vertical line
     /// whether or not its row is marked.

--- a/Sources/Bloom/Views/Home/HomeMetrics.swift
+++ b/Sources/Bloom/Views/Home/HomeMetrics.swift
@@ -6,6 +6,15 @@ import SwiftUI
 /// describe one pane's internal rhythm, and the relationship between them was arrived at by
 /// measuring a window capture rather than by reasoning from the spacing scale.
 enum HomeMetrics {
+    /// A row in Home's list, which is two lines rather than the sidebar's one.
+    ///
+    /// Not `Metrics.rowHeight`, which is the 28 points AppKit gives a source list row: that is the
+    /// pitch for a line of text and a glyph, and this row carries a name over a project and a
+    /// branch. Forty-two is those two lines at their own leading plus the clearance above and below
+    /// that the sidebar's row has, measured rather than derived, and it is the number to re-measure
+    /// if either line changes rung.
+    static let rowHeight: CGFloat = 42
+
     /// What a row asks `List` to keep clear of the pane's edges.
     ///
     /// Not what it gets. `.listStyle(.inset)` adds an inset of its own on top of `listRowInsets`

--- a/Sources/Bloom/Views/Home/HomeStatusBar.swift
+++ b/Sources/Bloom/Views/Home/HomeStatusBar.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import BloomCore
+
+/// The line along the foot of Home's list, saying what is in it.
+///
+/// **It used to be the trailing end of the strip at the top, and the owner's word for it was
+/// "strange".** Two things were wrong with it up there. The bar was doing three jobs in one line,
+/// so five chips, a project picker and a sentence all read at one weight and nothing led. And a
+/// count printed above the thing it counts is a count in the wrong place: Finder says "23 items,
+/// 140 GB available" along the bottom of the window, Mail counts its messages there, and both of
+/// them are next to what they are counting.
+///
+/// Finder's register, deliberately: one line, caption ink, centred, a rule above it, and nothing
+/// on it to press. The project filter stayed up on the strip for that last reason.
+///
+/// **It sits beside `SidebarStatusBar`, and the two are meant to read as one band.** They are both
+/// `Palette.sidebar` at `Metrics.barHeight` with a `Hairline` over them, so what divides them
+/// across the bottom of the window is the split view's own rule and nothing else. The sidebar's
+/// half was on `.bar`, a material, which put it a few units off the column it stands in and off
+/// this; that is the same argument `HomeBar` makes about the glass it lost.
+struct HomeStatusBar: View {
+    /// What the list adds up to, worked out by `HomeList.summary`. Empty means there is nothing to
+    /// say, and then the bar is not drawn at all.
+    var summary: String
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Hairline()
+
+            Text(summary)
+                .font(Typo.caption)
+                .foregroundStyle(Palette.textTertiary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .padding(.horizontal, HomeMetrics.gutter)
+                .frame(maxWidth: .infinity)
+                .frame(height: Metrics.barHeight)
+        }
+        .background(Palette.sidebar)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Showing \(summary)")
+    }
+}

--- a/Sources/Bloom/Views/Home/HomeView.swift
+++ b/Sources/Bloom/Views/Home/HomeView.swift
@@ -73,7 +73,6 @@ struct HomeView: View {
             // centre a message in.
             if hasAnyWorkspace {
                 HomeBar(
-                    summary: summary,
                     repos: app.repos,
                     counts: listing.counts,
                     isSearching: listing.isSearching,
@@ -82,6 +81,12 @@ struct HomeView: View {
             }
 
             content
+
+            // The counts, at the foot of the pane rather than at the trailing end of the strip,
+            // beside the rows they are about. See `HomeStatusBar`.
+            if hasAnyWorkspace, !summary.isEmpty {
+                HomeStatusBar(summary: summary)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Palette.windowBackground)
@@ -199,6 +204,8 @@ struct HomeView: View {
                 }
             }
 
+            recentArchive
+
             transcriptResults
         }
         .listStyle(.inset)
@@ -224,6 +231,71 @@ struct HomeView: View {
         .onDeleteCommand {
             guard let selected, let row = row(for: selected), !row.isArchived else { return }
             Task { await app.archive(row.workspace) }
+        }
+    }
+
+    /// The finished work under the live list: the most recent few, and a way through to the rest.
+    ///
+    /// **This is what makes defaulting to Live honest.** The archive is not behind a chip nobody
+    /// clicks, it is on the page, demoted: a quieter heading saying how many of how many, the same
+    /// rows the list draws anywhere else, and a plain row at the foot that moves the chip to
+    /// Archived. What it is not is the page, which is what it was when Home opened on All and
+    /// seventeen of twenty rows were over. Which rows and how many is `HomeList.tail`.
+    ///
+    /// These rows are real list rows, so the arrow keys walk into them and Return opens one, the
+    /// same as any other archived row on this screen. The "show the rest" row is not: it is a
+    /// control rather than a workspace, and giving the selection somewhere to land that is not a
+    /// workspace would break the one keyboard model the whole pane runs on.
+    @ViewBuilder
+    private var recentArchive: some View {
+        if !listing.tail.isEmpty {
+            Section {
+                ForEach(listing.tail) { row in
+                    HomeListRow(
+                        row: row,
+                        isRunning: false,
+                        now: now,
+                        isRenaming: false,
+                        onCommitRename: { _ in },
+                        onCancelRename: {}
+                    )
+                    .arrivingRow(arrival.isArriving(row.id))
+                    .tag(row.id)
+                    .simultaneousGesture(TapGesture().onEnded { open(row) })
+                    .listRowInsets(Self.rowInsets)
+                    .onHoverChange { hovered = $0 ? row.id : (hovered == row.id ? nil : hovered) }
+                    .listRowBackground(
+                        HomeRowBackground(
+                            isSelected: selected == row.id,
+                            isHovered: hovered == row.id
+                        )
+                    )
+                    .contextMenu {
+                        HomeRowMenu(row: row) { renaming = $0 }
+                    }
+                }
+
+                // Bloom's accent rather than `.link`, which is the system's and is blue glass on a
+                // Mac set to Graphite. The same note is on every prominent button in the app.
+                Button("Show all \(ArchiveDeletion.count(listing.tailTotal, "archived workspace"))") {
+                    app.homeFilter.scope = .archived
+                }
+                .buttonStyle(.plain)
+                .font(Typo.caption)
+                .foregroundStyle(Palette.accent)
+                .padding(.vertical, Metrics.spacingSmall)
+                .listRowInsets(Self.rowInsets)
+                .listRowBackground(Color.clear)
+                .selectionDisabled()
+            } header: {
+                HomeGroupHeading(
+                    title: "Recently archived",
+                    count: listing.tail.count,
+                    isSecondary: true,
+                    of: listing.tailTotal
+                )
+                .padding(.leading, Self.rowInsets.leading)
+            }
         }
     }
 
@@ -286,7 +358,7 @@ struct HomeView: View {
 
     // MARK: - Summary
 
-    /// What the readout at the end of the strip says. `HomeList.summary` in the core, where its
+    /// What the status bar at the foot of the pane says. `HomeList.summary` in the core, where its
     /// branches can be asked about: this was four pieces of view state picking between sentences,
     /// and one of those sentences had already been wrong once.
     private var summary: String {
@@ -402,7 +474,7 @@ struct HomeView: View {
         // In the same breath as `listing` rather than from an `onChange` watching it, so a row
         // and the fact that it is new land in one update and the row's first drawn frame is the
         // faded one.
-        let ids = listing.groups.flatMap { $0.rows.map(\.id) }
+        let ids = listing.groups.flatMap { $0.rows.map(\.id) } + listing.tail.map(\.id)
         if rescoped {
             arrival.adopt(ids)
         } else {
@@ -423,11 +495,13 @@ struct HomeView: View {
         }
     }
 
+    /// The tail is searched too, because those rows are selectable: without it, arrowing into the
+    /// recent archive left Return doing nothing and greyed out every item in the Workspace menu.
     private func row(for id: WorkspaceID) -> HomeRow? {
         for group in listing.groups {
             if let match = group.rows.first(where: { $0.id == id }) { return match }
         }
-        return nil
+        return listing.tail.first { $0.id == id }
     }
 
     /// The highlighted row, offered to the menu bar. It carries the workspace itself because an

--- a/Sources/Bloom/Views/Sidebar/SidebarStatusBar.swift
+++ b/Sources/Bloom/Views/Sidebar/SidebarStatusBar.swift
@@ -80,7 +80,13 @@ struct SidebarStatusBar: View {
             .padding(.horizontal, Metrics.spacingSmall)
             .frame(height: Metrics.barHeight)
         }
-        .background(.bar)
+        // `Palette.sidebar`, not `.bar`. Home grew a status bar of its own at the foot of the
+        // detail column, so these two strips now run side by side across the bottom of the window
+        // and have to read as one line rather than as two competing ones. `.bar` is a material: it
+        // sat a few units off the column it stands in, and it would have sat a few units off the
+        // flat strip next to it. The palette already names one colour for "the sidebar column, the
+        // title bar, and every strip of small controls", and this is one of those.
+        .background(Palette.sidebar)
     }
 
     /// Whether the pane is showing what it shows when nothing has been asked of it.

--- a/Sources/BloomCore/Presentation/HomeList.swift
+++ b/Sources/BloomCore/Presentation/HomeList.swift
@@ -56,6 +56,22 @@ public struct HomeGroup: Identifiable, Hashable, Sendable {
 /// number, and they are worked out in this one pass rather than in five more.
 public struct HomeListing: Sendable {
     public var groups: [HomeGroup]
+    /// The most recent finished work, drawn under the live list and capped.
+    ///
+    /// **Why the resting page carries any archived rows at all, having just defaulted them off.**
+    /// `HomeScope.live` is the right subject for Home and it is not the whole of what a person
+    /// wants on landing: the thing they finished an hour ago is the second question, and a screen
+    /// that answers only the first is a screen with three rows and half a window of ground under
+    /// them. So the archive is present as a tail rather than as the page: `HomeList.tailLimit`
+    /// rows under a heading of their own that says how many of how many, ending in a way through
+    /// to the rest. Three rows that matter above six that do not, instead of three above
+    /// seventeen.
+    ///
+    /// Empty in every other scope, and empty in a search, because in both of those the archive is
+    /// what was asked for rather than context around the answer.
+    public var tail: [HomeRow] = []
+    /// How much finished work the tail is a sample of, which is what its heading counts against.
+    public var tailTotal = 0
     /// The transcripts that matched, one entry per workspace. Empty outside a search, because the
     /// index is only asked when there is something to ask it.
     public var transcripts: [TranscriptWorkspaceMatches]
@@ -74,6 +90,8 @@ public struct HomeListing: Sendable {
 
     public init(
         groups: [HomeGroup],
+        tail: [HomeRow] = [],
+        tailTotal: Int = 0,
         transcripts: [TranscriptWorkspaceMatches] = [],
         counts: HomeScopeCounts = HomeScopeCounts(),
         isSearching: Bool = false,
@@ -83,6 +101,8 @@ public struct HomeListing: Sendable {
         shownArchived: Int
     ) {
         self.groups = groups
+        self.tail = tail
+        self.tailTotal = tailTotal
         self.transcripts = transcripts
         self.counts = counts
         self.isSearching = isSearching
@@ -114,16 +134,18 @@ public struct HomeFilter: Equatable, Sendable {
     /// the same state, which is what stops the menu from reaching a configuration that shows
     /// nothing and offers no way back.
     public var projects: Set<RepoID> = []
-    /// Which chip is lit. `all` includes archived work, so nothing on this Mac is hidden behind a
-    /// control somebody has to remember to check.
+    /// Which chip is lit, starting at `HomeScope.resting`, which is `live`. The argument for that
+    /// default, and for why it hides nothing, is on that function.
     ///
     /// This replaced a "Hide archived" switch, and `HomeScope.live` is what that switch did. A
     /// scope rather than a switch of its own, because the switch was a second narrowing mechanism
     /// beside the field with its own state, its own empty state and its own clause in the summary
     /// line, all to answer a question the chips answer with a number attached.
-    public var scope: HomeScope = .all
+    public var scope: HomeScope = .live
 
-    public init(query: String = "", projects: Set<RepoID> = [], scope: HomeScope = .all) {
+    public init(
+        query: String = "", projects: Set<RepoID> = [], scope: HomeScope = .live
+    ) {
         self.query = query
         self.projects = projects
         self.scope = scope
@@ -250,6 +272,8 @@ public enum HomeList {
 
         return HomeListing(
             groups: groups,
+            tail: tail(after: ordered, from: matched, scope: filter.scope, isSearching: isSearching),
+            tailTotal: counts.archived,
             transcripts: shownTranscripts,
             counts: counts,
             isSearching: isSearching,
@@ -258,6 +282,31 @@ public enum HomeList {
             archived: archived.count,
             shownArchived: ordered.count { $0.isArchived }
         )
+    }
+
+    /// How many finished rows follow the live list. Six: enough to fill the ground under three
+    /// live workspaces on a 1440 by 900 window, few enough that the eye reads it as a sample
+    /// rather than as the list starting again.
+    public static let tailLimit = 6
+
+    /// The recent archive drawn under a live list, newest first.
+    ///
+    /// Only under `live`, and only when the live list has something in it. On a machine where
+    /// nothing is live the pane raises `HomeEmptyState.emptyScope(.live)`, which says every
+    /// workspace here has been archived and carries the button that shows them; six rows of
+    /// archive under that sentence would be the sentence contradicting itself.
+    private static func tail(
+        after ordered: [HomeRow],
+        from matched: [HomeRow],
+        scope: HomeScope,
+        isSearching: Bool
+    ) -> [HomeRow] {
+        guard !isSearching, scope == .live, !ordered.isEmpty else { return [] }
+        return matched
+            .filter(\.isArchived)
+            .sorted { $0.workspace.lastActivityAt > $1.workspace.lastActivityAt }
+            .prefix(tailLimit)
+            .map { $0 }
     }
 
     /// The transcript results the project menu leaves standing.
@@ -388,9 +437,15 @@ public enum HomeList {
         return day.formatted(style)
     }
 
-    /// The line above the list, which describes the list rather than the database.
+    /// The line along the foot of the list, which describes the list rather than the database.
     ///
-    /// A line reading "312 workspaces" above eleven rows is how a forgotten filter becomes a bug
+    /// **It was at the trailing end of the strip at the top, and the owner's word for it was
+    /// "strange".** That bar was carrying five chips, a project picker and a sentence at one
+    /// weight, so nothing on it led; and a count printed above the thing it counts is a count in
+    /// the wrong place. It is a status bar now, at the foot of the pane, which is where Finder
+    /// puts "23 items, 140 GB available" and Mail puts its message count. See `HomeStatusBar`.
+    ///
+    /// A line reading "312 workspaces" under eleven rows is how a forgotten filter becomes a bug
     /// report about missing work, so a narrowed list says so in the same breath as the total it
     /// was narrowed from.
     ///
@@ -398,16 +453,16 @@ public enum HomeList {
     /// comment on its first clause records that the expression had already produced a wrong
     /// answer once**: "0 workspaces" about a machine holding three, printed directly above a
     /// panel saying all three existed. That is the whole argument for this being here. A sentence
-    /// assembled in a body is a sentence nothing can be asked about, and this one has five
-    /// branches and four counts.
+    /// assembled in a body is a sentence nothing can be asked about, and this one has branches
+    /// enough to prove it.
     ///
-    /// Empty when there is nothing to describe. The strip is not drawn then, and on a machine
-    /// with no project there is nothing to count.
+    /// **It follows the chip, which it did not before.** While it sat an inch from the chips it
+    /// deliberately ignored them, because each of them carries its own number in plain sight.
+    /// Down at the foot of the list it is beside the rows instead, so it has to be about the
+    /// rows: narrowed to Archived it counts archived work, not the machine.
     ///
-    /// **It says less than it used to, and that is the point.** It used to carry the archived
-    /// count and the running count as trailing clauses, because nothing else on the strip did.
-    /// Both of those are chips now, with their own numbers, six inches to the left of this
-    /// sentence, so repeating them here was the same fact printed twice on one line.
+    /// Empty when there is nothing to describe. On a machine with no project there is nothing to
+    /// count and no bar is drawn.
     public static func summary(
         listing: HomeListing,
         filter: HomeFilter,
@@ -416,34 +471,54 @@ public enum HomeList {
         guard listing.considered > 0 || listing.archived > 0 else { return "" }
 
         // Searching, the only fact worth carrying is how many answers came back, because the
-        // chips beside it have already split them by kind.
+        // chips above have already split them by kind.
         if listing.isSearching {
             let found = listing.counts.count(of: filter.scope, searching: true)
-            return "\(ArchiveDeletion.count(found, "result")) for \u{201C}\(filter.query.trimmingCharacters(in: .whitespaces))\u{201D}"
+            let query = filter.query.trimmingCharacters(in: .whitespaces)
+            return "\(ArchiveDeletion.count(found, "result")) for \u{201C}\(query)\u{201D}"
         }
 
-        if filter.isNarrowed {
-            return "Showing \(listing.shown) of \(ArchiveDeletion.count(listing.considered, "workspace"))"
+        if !filter.projects.isEmpty {
+            let total = ArchiveDeletion.count(listing.considered, "workspace")
+            return "Showing \(listing.shown) of \(total)"
         }
 
-        // What the machine holds, in the two halves the chips do not repeat: how it is spread
-        // over projects, and how much of it is finished. "48 workspaces" reads very differently
-        // once you know 30 of them are over.
-        var text = projects > 1
-            ? ArchiveDeletion.count(projects, "project")
-            : ArchiveDeletion.count(listing.considered, "workspace")
-
-        if projects > 1 {
-            text += " \u{00B7} \(listing.counts.live) live"
-        } else if listing.counts.archived > 0 {
-            text += ", \(listing.counts.live) live"
+        let counts = listing.counts
+        switch filter.scope {
+        case .needsYou:
+            return counts.needsYou == 0
+                ? "Nothing waiting on you"
+                : "\(counts.needsYou) waiting on you"
+        case .running:
+            return counts.running == 0 ? "Nothing running" : "\(counts.running) running"
+        case .archived:
+            return counts.archived == 0
+                ? "Nothing archived"
+                : "\(counts.archived) archived\(inProjects(projects))"
+        case .live:
+            // The archived half is the pointer to the chip that shows it, and the one clause that
+            // keeps the default scope honest: a page about live work says out loud how much
+            // finished work it is not showing.
+            let head = counts.live == 0
+                ? "Nothing live"
+                : "\(counts.live) live\(inProjects(projects))"
+            return counts.archived == 0 ? head : "\(head) \u{00B7} \(counts.archived) archived"
+        default:
+            // What the machine holds, split the way the chips do not repeat: how it is spread over
+            // projects, and how much of it is finished. "48 workspaces" reads very differently once
+            // you know 30 of them are over.
+            var text = ArchiveDeletion.count(listing.considered, "workspace") + inProjects(projects)
+            if counts.archived > 0 {
+                text += " \u{00B7} \(counts.live) live, \(counts.archived) archived"
+            }
+            return text
         }
+    }
 
-        if listing.counts.archived > 0 {
-            text += ", \(listing.counts.archived) archived"
-        }
-
-        return text
+    /// The clause naming how many projects a count is spread over, and nothing at all on a machine
+    /// with one. "3 live in 1 project" is a fact about a machine that has no other kind.
+    private static func inProjects(_ projects: Int) -> String {
+        projects > 1 ? " in \(ArchiveDeletion.count(projects, "project"))" : ""
     }
 }
 

--- a/Sources/BloomCore/Presentation/HomeScope.swift
+++ b/Sources/BloomCore/Presentation/HomeScope.swift
@@ -34,12 +34,37 @@ public enum HomeScope: String, Hashable, Sendable, CaseIterable, Codable {
 
     /// The chips on offer, in the order they are drawn.
     ///
-    /// `live` sits between `running` and `archived` because the three are one gradient of how
-    /// finished the work is, and because `archived` next to it says what `live` excludes.
+    /// **Browsing, `live` leads, because it is what Home opens on.** A strip whose first chip is
+    /// one nobody wants selected reads as a strip you have to correct. After it come the two
+    /// subsets of it, `needsYou` and `running`, which are the two questions asked ABOUT live work
+    /// rather than instead of it; then `archived`, which is the other half of the machine; then
+    /// `all`, which is the widest net and the way out of every narrowing to its left.
+    ///
+    /// Searching, `all` leads, because there is no default worth having: what was typed is the
+    /// narrowing, and the chips only split the answer by kind.
     public static func offered(searching: Bool) -> [HomeScope] {
         searching
             ? [.all, .workspaces, .transcripts, .archived]
-            : [.all, .needsYou, .running, .live, .archived]
+            : [.live, .needsYou, .running, .archived, .all]
+    }
+
+    /// What the strip is set to when nothing has been asked of it.
+    ///
+    /// **Browsing, that is `live` rather than `all`, and it is the biggest decision on this
+    /// screen.** Home is what somebody sees on launch, so it has to answer "what was I doing, and
+    /// what needs me" before anything else. On the machine this was redesigned against, `all` was
+    /// twenty rows of which seventeen were archived: a page about the past, in which the three
+    /// workspaces that could still be acted on were outnumbered six to one and drawn almost the
+    /// same.
+    ///
+    /// Nothing is hidden by it. `archived` is a chip on the same strip carrying its own count, and
+    /// `HomeList` follows a live list with a capped tail of the most recent archived work, which
+    /// is more than the "Hide archived" switch this scope replaced ever said.
+    ///
+    /// Searching, it is `all`: a search is a question about the whole machine, archived work
+    /// included, and narrowing one by default would be answering a question that was not asked.
+    public static func resting(searching: Bool) -> HomeScope {
+        searching ? .all : .live
     }
 
     public func label(searching: Bool) -> String {
@@ -56,13 +81,17 @@ public enum HomeScope: String, Hashable, Sendable, CaseIterable, Codable {
 
     /// The scope to hold after the field has been typed into or emptied.
     ///
-    /// A chip that is not on offer in the set now being drawn falls back to `all` rather than
-    /// staying selected and invisible, which is how a list ends up showing nothing with no
-    /// control on screen explaining why. `archived` survives the crossing in both directions,
-    /// deliberately: somebody who narrowed to finished work and then typed a name is still asking
-    /// about finished work.
+    /// A chip that is not on offer in the set now being drawn falls back to the resting scope
+    /// rather than staying selected and invisible, which is how a list ends up showing nothing
+    /// with no control on screen explaining why. `archived` survives the crossing in both
+    /// directions, deliberately: somebody who narrowed to finished work and then typed a name is
+    /// still asking about finished work.
+    ///
+    /// `live` crossing into a search becomes `all`, which is right rather than merely tidy: a
+    /// search of live work alone would silently refuse to find the archived workspace somebody is
+    /// searching for the name of.
     public static func settle(_ scope: HomeScope, searching: Bool) -> HomeScope {
-        offered(searching: searching).contains(scope) ? scope : .all
+        offered(searching: searching).contains(scope) ? scope : resting(searching: searching)
     }
 
     /// Whether workspace rows are drawn at all under this scope.
@@ -156,6 +185,21 @@ public struct HomeScopeCounts: Sendable, Equatable {
     public var transcriptWorkspaces = 0
 
     public init() {}
+
+    /// The number a chip draws, or nothing at all.
+    ///
+    /// **A nought is not a number worth printing.** The resting strip on a quiet machine read
+    /// "Needs you 0, Running 0", which is two facts stated in the least useful way there is: they
+    /// are the state most of the time, so the noughts are what the eye learns to skip, and the
+    /// numbers beside them get skipped with them. Bare, the chip says the same thing by saying
+    /// nothing, and a number arriving on it is itself the signal.
+    ///
+    /// The chip stays on the strip either way. Dropping it would reflow the row every time an
+    /// agent started or stopped, which is movement under the pointer for no gain.
+    public func badge(of scope: HomeScope, searching: Bool) -> Int? {
+        let value = count(of: scope, searching: searching)
+        return value == 0 ? nil : value
+    }
 
     /// What one chip says. `all` is the sum of the two kinds in a search and the whole list
     /// outside one.

--- a/Tests/BloomCoreTests/HomeListTests.swift
+++ b/Tests/BloomCoreTests/HomeListTests.swift
@@ -354,18 +354,21 @@ struct HomeListTests {
         #expect(listing.groups.first?.rows.count == 2)
     }
 
-    @Test("archived workspaces are listed by default and the Live scope is what leaves them out")
-    func archivedIsListedByDefaultAndCountedWhileHidden() {
+    /// **The default is `live` and this is the test that pins it.** Home opened on `all`, which on
+    /// the machine it was redesigned against was twenty rows of which seventeen were archived: a
+    /// page about the past, in which the three workspaces that could still be acted on were
+    /// outnumbered six to one. The archive is not hidden by it, which is the second half of what
+    /// is checked here: the Archived chip carries its own count, and the tail below the list draws
+    /// the most recent of it.
+    @Test("Home lists live work by default, and says how much archived work it is not listing")
+    func liveIsTheDefaultAndArchivedIsStillCounted() {
         let now = date(2025, 8, 19, 12, 0, 0)
         let archived = [
             workspace("gone", at: date(2025, 8, 18, 9, 0, 0), state: .archived),
             workspace("older", at: date(2025, 8, 10, 9, 0, 0), state: .archived),
         ]
 
-        // The default. Home is the flat list of every workspace on the machine, and it is the
-        // only screen that lists an archived one at all, so leaving them out until somebody
-        // found a switch meant the one place they exist was the one place they could not be seen.
-        let shown = HomeList.build(
+        let resting = HomeList.build(
             repos: [repo("repo")],
             workspaces: [workspace("live", at: now)],
             archived: archived,
@@ -374,30 +377,131 @@ struct HomeListTests {
             calendar: Self.calendar
         )
 
-        #expect(shown.shown == 3)
-        #expect(shown.considered == 3)
-        #expect(shown.archived == 2)
-        #expect(shown.shownArchived == 2)
-        #expect(shown.groups.flatMap(\.rows).map(\.id.rawValue) == ["live", "gone", "older"])
+        #expect(resting.shown == 1)
+        // Every workspace on the machine is considered whichever chip is lit: the chips have to
+        // count what clicking them would show, so the pass cannot stop at the selected one.
+        #expect(resting.considered == 3)
+        #expect(resting.archived == 2)
+        #expect(resting.shownArchived == 0)
+        #expect(resting.counts.archived == 2)
+        #expect(resting.counts.live == 1)
 
-        let hidden = HomeList.build(
+        // And All is still the whole machine in one date-ordered list, which is what it was.
+        let everything = HomeList.build(
             repos: [repo("repo")],
             workspaces: [workspace("live", at: now)],
             archived: archived,
-            filter: HomeFilter(scope: .live),
+            filter: HomeFilter(scope: .all),
             now: now,
             calendar: Self.calendar
         )
 
-        #expect(hidden.shown == 1)
-        // Every workspace on the machine is considered now, whichever chip is lit: the chips have
-        // to count what clicking them would show, so the pass cannot stop at the selected one.
-        #expect(hidden.considered == 3)
-        #expect(hidden.archived == 2)
-        #expect(hidden.shownArchived == 0)
-        // And the Archived chip still says two while the Live chip is the one lit.
-        #expect(hidden.counts.archived == 2)
-        #expect(hidden.counts.live == 1)
+        #expect(everything.shown == 3)
+        #expect(everything.shownArchived == 2)
+        #expect(everything.groups.flatMap(\.rows).map(\.id.rawValue) == ["live", "gone", "older"])
+    }
+
+    // MARK: - The tail
+
+    /// Three rows in a 1440 by 900 window is a screen with half its ground empty, so the resting
+    /// page follows the live list with the most recent finished work rather than nothing at all.
+    @Test("a live list is followed by a capped tail of the recent archive")
+    func theTailFollowsTheLiveList() {
+        let now = date(2025, 8, 19, 12, 0, 0)
+        let archived = (1...9).map { hours in
+            workspace(
+                "gone-\(hours)",
+                at: now.addingTimeInterval(TimeInterval(-3_600 * hours)),
+                state: .archived
+            )
+        }
+
+        let listing = HomeList.build(
+            repos: [repo("repo")],
+            workspaces: [workspace("live", at: now)],
+            archived: archived,
+            filter: HomeFilter(),
+            now: now,
+            calendar: Self.calendar
+        )
+
+        #expect(listing.tail.count == HomeList.tailLimit)
+        #expect(listing.tailTotal == 9)
+        // Newest first, like the list above it, and never mixed into it.
+        #expect(
+            listing.tail.map(\.id.rawValue)
+                == ["gone-1", "gone-2", "gone-3", "gone-4", "gone-5", "gone-6"]
+        )
+        let everyTailRowIsArchived = listing.tail.allSatisfy { $0.isArchived }
+        #expect(everyTailRowIsArchived)
+        #expect(listing.groups.flatMap(\.rows).map(\.id.rawValue) == ["live"])
+        // The tail is context around an answer, so it is not counted as part of one.
+        #expect(listing.shown == 1)
+        #expect(listing.shownArchived == 0)
+    }
+
+    /// On a machine where nothing is live the pane raises `HomeEmptyState.emptyScope(.live)`,
+    /// which says every workspace here has been archived and carries the button that shows them.
+    /// Six rows of archive under that sentence would be the sentence contradicting itself.
+    @Test("nothing live means no tail either")
+    func anEmptyLiveListHasNoTail() {
+        let now = date(2025, 8, 19, 12, 0, 0)
+        let listing = HomeList.build(
+            repos: [repo("repo")],
+            workspaces: [],
+            archived: [workspace("gone", at: now, state: .archived)],
+            filter: HomeFilter(),
+            now: now,
+            calendar: Self.calendar
+        )
+
+        #expect(listing.isEmpty)
+        #expect(listing.tail.isEmpty)
+    }
+
+    /// Under every other chip, and in a search, the archive is what was asked for rather than
+    /// context around the answer, so drawing a second helping of it below would be the same rows
+    /// twice.
+    @Test("only the Live chip grows a tail")
+    func onlyLiveGrowsATail() {
+        let now = date(2025, 8, 19, 12, 0, 0)
+        func tail(_ filter: HomeFilter) -> [HomeRow] {
+            HomeList.build(
+                repos: [repo("repo")],
+                workspaces: [workspace("live", at: now)],
+                archived: [workspace("gone", at: now, state: .archived)],
+                filter: filter,
+                now: now,
+                calendar: Self.calendar
+            ).tail
+        }
+
+        #expect(!tail(HomeFilter()).isEmpty)
+        #expect(tail(HomeFilter(scope: .all)).isEmpty)
+        #expect(tail(HomeFilter(scope: .archived)).isEmpty)
+        #expect(tail(HomeFilter(scope: .needsYou)).isEmpty)
+        #expect(tail(HomeFilter(query: "live", scope: .all)).isEmpty)
+    }
+
+    /// The project menu narrows the tail with everything else, or the page would answer a question
+    /// about one project with rows from another.
+    @Test("the project filter reaches the tail")
+    func theProjectFilterReachesTheTail() {
+        let now = date(2025, 8, 19, 12, 0, 0)
+        let listing = HomeList.build(
+            repos: [repo("a"), repo("b")],
+            workspaces: [workspace("live", repoID: RepoID("a"), at: now)],
+            archived: [
+                workspace("mine", repoID: RepoID("a"), at: now, state: .archived),
+                workspace("theirs", repoID: RepoID("b"), at: now, state: .archived),
+            ],
+            filter: HomeFilter(projects: [RepoID("a")]),
+            now: now,
+            calendar: Self.calendar
+        )
+
+        #expect(listing.tail.map(\.id.rawValue) == ["mine"])
+        #expect(listing.tailTotal == 1)
     }
 
     @Test("an archived row sorts by recency like any other, not to the bottom")
@@ -407,7 +511,7 @@ struct HomeListTests {
             repos: [repo("repo")],
             workspaces: [workspace("old", at: date(2025, 8, 1, 9, 0, 0))],
             archived: [workspace("recent", at: now, state: .archived)],
-            filter: HomeFilter(),
+            filter: HomeFilter(scope: .all),
             now: now,
             calendar: Self.calendar
         )
@@ -430,7 +534,7 @@ struct HomeListTests {
                 repos: repos,
                 workspaces: workspaces,
                 archived: [],
-                filter: HomeFilter(query: query),
+                filter: HomeFilter(query: query, scope: .all),
                 now: now,
                 calendar: Self.calendar
             ).groups.flatMap(\.rows).map(\.id.rawValue)
@@ -544,7 +648,7 @@ struct HomeListTests {
                     workspace("Sidebar rewrite", repoID: RepoID("a"), branch: "agent/glass", at: now),
                 ],
                 archived: [],
-                filter: HomeFilter(query: query),
+                filter: HomeFilter(query: query, scope: .all),
                 now: now,
                 calendar: Self.calendar
             ).groups.flatMap(\.rows)
@@ -574,7 +678,7 @@ struct HomeListTests {
                 workspace("sidebar last month", at: date(2025, 6, 1, 9, 0, 0)),
             ],
             archived: [],
-            filter: HomeFilter(query: "sidebar"),
+            filter: HomeFilter(query: "sidebar", scope: .all),
             now: now,
             calendar: Self.calendar
         )
@@ -600,7 +704,7 @@ struct HomeListTests {
                 transcriptResult("quiet", matches: 6),
                 transcriptResult("sidebar rewrite", matches: 4),
             ],
-            filter: HomeFilter(query: "sidebar"),
+            filter: HomeFilter(query: "sidebar", scope: .all),
             now: now,
             calendar: Self.calendar
         )
@@ -629,7 +733,7 @@ struct HomeListTests {
             ],
             archived: [],
             transcripts: [transcriptResult("one", matches: 3), transcriptResult("two", matches: 9)],
-            filter: HomeFilter(query: "sidebar", projects: [RepoID("a")]),
+            filter: HomeFilter(query: "sidebar", projects: [RepoID("a")], scope: .all),
             now: now,
             calendar: Self.calendar
         )
@@ -648,7 +752,7 @@ struct HomeListTests {
             workspaces: [workspace("here", at: now)],
             archived: [],
             transcripts: [transcriptResult("deleted", matches: 4)],
-            filter: HomeFilter(query: "sidebar"),
+            filter: HomeFilter(query: "sidebar", scope: .all),
             now: now,
             calendar: Self.calendar
         )
@@ -736,7 +840,7 @@ struct HomeListTests {
             workspaces: [workspace("quiet", at: now)],
             archived: [],
             transcripts: [transcriptResult("quiet", matches: 4)],
-            filter: HomeFilter(query: "sidebar"),
+            filter: HomeFilter(query: "sidebar", scope: .all),
             now: now,
             calendar: Self.calendar
         )

--- a/Tests/BloomCoreTests/HomeScopeTests.swift
+++ b/Tests/BloomCoreTests/HomeScopeTests.swift
@@ -38,7 +38,7 @@ struct HomeScopeTests {
 
     /// Browsing narrows the rows by what is happening in them; searching narrows the answer by
     /// what kind of thing matched. Two questions, two sets.
-    @Test("the two sets share exactly one chip, and it is the resting one")
+    @Test("the two sets share exactly one chip, and it is the widest one")
     func theSetsShareOnlyAll() {
         let browsing = Set(HomeScope.offered(searching: false))
         let searching = Set(HomeScope.offered(searching: true))
@@ -62,11 +62,37 @@ struct HomeScopeTests {
 
     /// A chip that is not on offer in the set being drawn would leave a list showing nothing with
     /// no control on screen explaining why.
-    @Test("a chip that is not on offer falls back to All")
+    @Test("a chip that is not on offer falls back to the resting one")
     func aScopeThatIsNotOfferedSettles() {
         #expect(HomeScope.settle(.running, searching: true) == .all)
-        #expect(HomeScope.settle(.transcripts, searching: false) == .all)
+        #expect(HomeScope.settle(.transcripts, searching: false) == .live)
         #expect(HomeScope.settle(.all, searching: true) == .all)
+    }
+
+    /// Home opens on live work, because it is what somebody sees on launch and the question they
+    /// arrive with is what needs them, not what is finished. A search opens on everything, because
+    /// a search narrowed by default answers a question nobody asked.
+    @Test("Home rests on Live, and a search rests on Everything")
+    func theRestingScopeIsLive() {
+        #expect(HomeScope.resting(searching: false) == .live)
+        #expect(HomeScope.resting(searching: true) == .all)
+        #expect(HomeFilter().scope == .live)
+    }
+
+    /// The default leads, because a strip whose first chip is one nobody wants selected reads as a
+    /// strip you have to correct. Its two subsets follow it, then the other half of the machine,
+    /// then the widest net.
+    @Test("Live leads the browsing chips and All closes them")
+    func liveLeadsTheStrip() {
+        #expect(HomeScope.offered(searching: false) == [.live, .needsYou, .running, .archived, .all])
+        #expect(HomeScope.offered(searching: true).first == .all)
+    }
+
+    /// A search of live work alone would refuse to find the archived workspace somebody is
+    /// searching for the name of.
+    @Test("Live widens to everything when a search starts")
+    func liveWidensIntoASearch() {
+        #expect(HomeScope.settle(.live, searching: true) == .all)
     }
 
     /// Somebody who narrowed to finished work and then typed a name is still asking about finished
@@ -150,6 +176,24 @@ struct HomeScopeTests {
             #expect(listing.counts.needsYou == 1)
             #expect(listing.counts.count(of: .all, searching: false) == 4)
         }
+    }
+
+    /// The resting strip read "Needs you 0, Running 0", which is two facts stated in the least
+    /// useful way there is: the noughts are the state most of the time, so they are what the eye
+    /// learns to skip, and the numbers beside them get skipped with them.
+    @Test("a chip at nought draws no number")
+    func aNoughtDrawsNoNumber() {
+        var counts = HomeScopeCounts()
+        counts.live = 3
+        counts.archived = 17
+        #expect(counts.badge(of: .live, searching: false) == 3)
+        #expect(counts.badge(of: .archived, searching: false) == 17)
+        #expect(counts.badge(of: .all, searching: false) == 20)
+        #expect(counts.badge(of: .needsYou, searching: false) == nil)
+        #expect(counts.badge(of: .running, searching: false) == nil)
+        // The chip is still offered, because a strip that reflowed every time an agent started
+        // would be movement under the pointer for no gain.
+        #expect(HomeScope.offered(searching: false).contains(.running))
     }
 
     /// The project menu narrows what the chips count, because it narrows what clicking one would

--- a/Tests/BloomCoreTests/HomeSummaryTests.swift
+++ b/Tests/BloomCoreTests/HomeSummaryTests.swift
@@ -1,17 +1,17 @@
 import Testing
 @testable import BloomCore
 
-/// The line at the end of Home's strip, which used to be four pieces of view state picking between
-/// sentences inside a body.
+/// The line along the foot of Home's list, which used to be four pieces of view state picking
+/// between sentences inside a body.
 ///
 /// The comment on its first clause recorded that the expression had already produced a wrong
 /// answer once: "0 workspaces" about a machine holding three, printed directly above a panel
 /// saying all three existed.
 ///
-/// It says less than it did, and that is the change to check for rather than a regression. The
-/// archived count and the running count are chips on the same strip now, each carrying its own
-/// number, so a clause repeating either of them here would be the same fact printed twice on one
-/// line.
+/// It has moved twice over. It came out of the body into here, and then out of the trailing end of
+/// the chip strip into a status bar at the foot of the pane, where Finder puts "23 items". The
+/// move is why it now follows the chip: standing an inch from five numbered chips it could afford
+/// to ignore them, and standing beside the rows it has to be about the rows.
 @Suite("What Home says about its list")
 struct HomeSummaryTests {
     private func listing(
@@ -19,6 +19,8 @@ struct HomeSummaryTests {
         considered: Int,
         live: Int = 0,
         archived: Int = 0,
+        needsYou: Int = 0,
+        running: Int = 0,
         workspaces: Int = 0,
         transcripts: Int = 0,
         isSearching: Bool = false
@@ -26,6 +28,8 @@ struct HomeSummaryTests {
         var counts = HomeScopeCounts()
         counts.live = live
         counts.archived = archived
+        counts.needsYou = needsYou
+        counts.running = running
         counts.workspaces = workspaces
         counts.transcripts = transcripts
         return HomeListing(
@@ -51,41 +55,57 @@ struct HomeSummaryTests {
         #expect(text == "Showing 11 of 312 workspaces")
     }
 
-    @Test("an unnarrowed list leads with projects only when there is more than one")
+    /// "3 live in 1 project" is a fact about a machine that has no other kind, so the clause is
+    /// dropped rather than printed with a one in it.
+    @Test("the project clause appears only when there is more than one project")
     func projectsAreNamedWhenThereAreSeveral() {
         #expect(
             HomeList.summary(
                 listing: listing(shown: 8, considered: 8, live: 8),
                 filter: HomeFilter(),
                 projects: 1
-            ) == "8 workspaces"
+            ) == "8 live"
         )
         #expect(
             HomeList.summary(
                 listing: listing(shown: 8, considered: 8, live: 8),
                 filter: HomeFilter(),
                 projects: 3
-            ) == "3 projects \u{00B7} 8 live"
+            ) == "8 live in 3 projects"
+        )
+    }
+
+    /// The resting page is about live work, so the resting line is too, and the archived clause is
+    /// the pointer to the chip that shows the rest. It is also what keeps the default honest: a
+    /// page that leads with live work says out loud how much finished work it is not showing.
+    @Test("resting on Live, the line counts live work and names the archive")
+    func theRestingLineIsAboutLiveWork() {
+        #expect(
+            HomeList.summary(
+                listing: listing(shown: 3, considered: 20, live: 3, archived: 17),
+                filter: HomeFilter(),
+                projects: 4
+            ) == "3 live in 4 projects \u{00B7} 17 archived"
         )
     }
 
     /// "48 workspaces" reads very differently once you know 30 of them are over, and the split is
-    /// the one thing on the strip the chips do not already say in the same breath.
-    @Test("finished work is split out of the total")
+    /// the one thing the chips do not already say in the same breath.
+    @Test("finished work is split out of the total under All")
     func archivedIsSplitOut() {
         #expect(
             HomeList.summary(
                 listing: listing(shown: 48, considered: 48, live: 18, archived: 30),
-                filter: HomeFilter(),
+                filter: HomeFilter(scope: .all),
                 projects: 1
-            ) == "48 workspaces, 18 live, 30 archived"
+            ) == "48 workspaces \u{00B7} 18 live, 30 archived"
         )
         #expect(
             HomeList.summary(
                 listing: listing(shown: 47, considered: 47, live: 35, archived: 12),
-                filter: HomeFilter(),
+                filter: HomeFilter(scope: .all),
                 projects: 6
-            ) == "6 projects \u{00B7} 35 live, 12 archived"
+            ) == "47 workspaces in 6 projects \u{00B7} 35 live, 12 archived"
         )
     }
 
@@ -93,12 +113,61 @@ struct HomeSummaryTests {
     /// a clause about an absence.
     @Test("a machine with nothing archived does not mention it")
     func nothingArchivedIsNotMentioned() {
-        let text = HomeList.summary(
-            listing: listing(shown: 5, considered: 5, live: 5),
-            filter: HomeFilter(),
-            projects: 1
+        #expect(
+            HomeList.summary(
+                listing: listing(shown: 5, considered: 5, live: 5),
+                filter: HomeFilter(scope: .all),
+                projects: 1
+            ) == "5 workspaces"
         )
-        #expect(text == "5 workspaces")
+        #expect(
+            HomeList.summary(
+                listing: listing(shown: 5, considered: 5, live: 5),
+                filter: HomeFilter(),
+                projects: 1
+            ) == "5 live"
+        )
+    }
+
+    /// A count printed under the rows has to be a count OF the rows. Narrowed to Archived, the
+    /// line that says how many workspaces the machine holds is answering a question nobody asked.
+    @Test("the line follows the chip")
+    func theLineFollowsTheChip() {
+        let machine = listing(
+            shown: 17, considered: 20, live: 3, archived: 17, needsYou: 2, running: 1
+        )
+        #expect(
+            HomeList.summary(listing: machine, filter: HomeFilter(scope: .archived), projects: 4)
+                == "17 archived in 4 projects"
+        )
+        #expect(
+            HomeList.summary(listing: machine, filter: HomeFilter(scope: .needsYou), projects: 4)
+                == "2 waiting on you"
+        )
+        #expect(
+            HomeList.summary(listing: machine, filter: HomeFilter(scope: .running), projects: 4)
+                == "1 running"
+        )
+    }
+
+    /// A chip with nothing in it raises an empty state above this line, and "0 waiting on you"
+    /// under it would be arithmetic where the pane is already using words.
+    @Test("an empty scope says so in words rather than with a nought")
+    func anEmptyScopeSaysSoInWords() {
+        let quiet = listing(shown: 0, considered: 20, live: 3, archived: 17)
+        #expect(
+            HomeList.summary(listing: quiet, filter: HomeFilter(scope: .needsYou), projects: 4)
+                == "Nothing waiting on you"
+        )
+        #expect(
+            HomeList.summary(listing: quiet, filter: HomeFilter(scope: .running), projects: 4)
+                == "Nothing running"
+        )
+        let allArchived = listing(shown: 0, considered: 17, live: 0, archived: 17)
+        #expect(
+            HomeList.summary(listing: allArchived, filter: HomeFilter(), projects: 4)
+                == "Nothing live \u{00B7} 17 archived"
+        )
     }
 
     /// Searching, the chips have already split the answer by kind, so the only fact left worth
@@ -109,7 +178,7 @@ struct HomeSummaryTests {
             shown: 4, considered: 47, workspaces: 4, transcripts: 37, isSearching: true
         )
         #expect(
-            HomeList.summary(listing: found, filter: HomeFilter(query: "sidebar"), projects: 6)
+            HomeList.summary(listing: found, filter: HomeFilter(query: "sidebar", scope: .all), projects: 6)
                 == "41 results for \u{201C}sidebar\u{201D}"
         )
         // The count follows the chip, because the chip is what decided what is in the pane.
@@ -128,7 +197,7 @@ struct HomeSummaryTests {
     func theQuotesAreTypographic() {
         let text = HomeList.summary(
             listing: listing(shown: 1, considered: 4, workspaces: 1, isSearching: true),
-            filter: HomeFilter(query: "  blue  "),
+            filter: HomeFilter(query: "  blue  ", scope: .all),
             projects: 1
         )
         #expect(text.contains("\u{201C}blue\u{201D}"))


### PR DESCRIPTION
Twenty rows of which seventeen are archived is a page about the past. Home now rests on a Live scope, with the six most recent archives under the live list as "Recently archived, 6 of 17" and a row that flips to the Archived chip. Nothing is hidden: the chip carries its own count, and a search widens the scope on its own so archived work is still reachable.

The glass came off the chip strip, on the owner's instruction. It is a flat band on the sidebar's colour with a hairline under it, continuous with the title bar.

The counts moved to a status bar along the foot of the list, the way Finder puts "23 items" there, and it follows the chip: "3 live in 4 projects · 17 archived" resting, "2 waiting on you", "41 results for sidebar" while searching. The sidebar's own status bar moves onto the same colour so the two read as one band across the window's foot. The project picker stays in the top bar, because it changes what the list shows and a status bar is for reading.

A chip with a count of nought no longer draws the nought, so the resting state stops being a row of noughts.

Rows are two lines, name over project and branch, which fills the gap between the name and the numbers and retires the search-match caption, since both fields it stood in for are now on every row. Date headings go up to title weight in primary ink with a counter and a rule.

One cost I could not remove: searching and then clearing leaves you on All rather than back on Live. Fixing it needs remembered state the search field's binding would have to maintain, which was not worth the machinery.