### PR TITLE
Hold the window to the panes it is drawing, not to the ones it could

### DIFF
--- a/Sources/Bloom/BloomApp.swift
+++ b/Sources/Bloom/BloomApp.swift
@@ -83,21 +83,41 @@ struct BloomApp: App {
         #endif
     }
 
-    /// The narrowest the window may be dragged.
+    /// The thicknesses the window's minimum width is built out of.
     ///
-    /// Derived rather than a literal. It used to be a flat 1000, which was chosen before the
-    /// centre column and the inspector became an `NSSplitViewController` with real minimum
-    /// thicknesses. Those minimums do not negotiate: at 1000 the split view needed 121 points more
-    /// than it was given and simply overflowed, so a window dragged to its own minimum clipped the
-    /// sidebar's rows off their leading edge and the inspector's Create Pull Request button off
-    /// the trailing one. `NavigationSplitView` does not shrink its sidebar to make room either, so
-    /// the sidebar's MAXIMUM is what the rest has to be added to.
-    private static let minimumWindowWidth =
-        Self.sidebarMaximumWidth + DetailSplitViewController.minimumWidth + 1
+    /// Derived rather than a literal, and conditional rather than derived once. The minimum used to
+    /// be a flat 1000, which was chosen before the centre column and the inspector became an
+    /// `NSSplitViewController` with real minimum thicknesses. Those minimums do not negotiate: at
+    /// 1000 the split view needed 121 points more than it was given and simply overflowed, so a
+    /// window dragged to its own minimum clipped the sidebar's rows off their leading edge and the
+    /// inspector's Create Pull Request button off the trailing one.
+    ///
+    /// It then became 1122, which is those panes added up with the sidebar at its maximum, and 1122
+    /// is what a window showing two panes was still being held to. `WindowWidths` is where that
+    /// stopped being a constant: it carries the numbers below, answers the minimum for the state
+    /// the window is actually in, and owns the companion rule that makes a conditional minimum safe
+    /// rather than a trap. Read its head before changing any of these five numbers.
+    static let widths = WindowWidths(
+        sidebar: Self.sidebarMaximumWidth,
+        sidebarMinimum: Self.sidebarMinimumWidth,
+        detail: DetailSplitViewController.detailMinimum,
+        inspector: DetailSplitViewController.inspectorMinimum,
+        // AppKit's `.thin` divider, which is one point. Both boundaries in this window use it.
+        divider: 1
+    )
 
     /// What the sidebar column may be dragged out to. Shared with `RootView`, which declares it on
     /// the column, so the window minimum above can never fall out of step with it.
+    ///
+    /// This is also what the window RESERVES for that column, rather than the width it is at, and
+    /// the obvious next saving is to reserve the real width instead. Read why that is not taken in
+    /// `WindowWidths` before reaching for it: it is worth up to 220 points and it puts a minimum
+    /// that rises under a window that will not grow behind a control the owner drags constantly.
     static let sidebarMaximumWidth: CGFloat = 420
+
+    /// And what it may be squeezed to, which is the same arrangement: declared on the column in
+    /// `RootView`, and the number `WindowWidths` folds the column away below.
+    static let sidebarMinimumWidth: CGFloat = 200
 
     var body: some Scene {
         // A single `Window` rather than a `WindowGroup`. Bloom's whole model is one window
@@ -106,7 +126,14 @@ struct BloomApp: App {
         Window("Bloom", id: "main") {
             RootView()
                 .environment(model)
-                .frame(minWidth: Self.minimumWindowWidth, minHeight: 620)
+                // Conditional, because the window does not need room for a pane that is not on
+                // screen. It goes back up when the inspector is presented, and `WindowWidths`
+                // explains why raising it is not enough on its own: see
+                // `DetailSplitViewController.makeRoomForInspector`, which is the other half.
+                .frame(
+                    minWidth: Self.widths.minimum(withInspector: model.isInspectorPresented),
+                    minHeight: 620
+                )
                 .handlesBloomURLs(using: model)
                 // What the rest of the OS is told: the App Nap assertion and the dock badge,
                 // the worktree behind the title bar, and the optional menu bar item. All three

--- a/Sources/Bloom/State/AppModel.swift
+++ b/Sources/Bloom/State/AppModel.swift
@@ -943,6 +943,20 @@ final class AppModel {
         return workspaces.first { $0.id == id }
     }
 
+    /// Whether the inspector is actually on screen, rather than merely switched on.
+    ///
+    /// Keyed on `selectedWorkspace` rather than on `selection`, because `DetailColumn` already
+    /// falls back to Home when a selected id no longer resolves to a workspace, and an inspector
+    /// over Home has nothing to say.
+    ///
+    /// Here rather than in `RootView`, which is where it was, because the window's own minimum
+    /// width now depends on it and `BloomApp` cannot see a private computed property on a view.
+    /// Two spellings of one rule is how the window ends up refusing a width for a pane it is not
+    /// drawing. See `WindowWidths`.
+    var isInspectorPresented: Bool {
+        isInspectorVisible && selectedWorkspace != nil
+    }
+
     /// The archived workspace being read, if that is what the window is on.
     ///
     /// Read out of its live model rather than out of a list, because the archived list is loaded

--- a/Sources/Bloom/Views/Chrome/Window/DetailSplitViewController.swift
+++ b/Sources/Bloom/Views/Chrome/Window/DetailSplitViewController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import BloomCore
 import SwiftUI
 import QuartzCore
 
@@ -135,12 +136,12 @@ final class DetailSplitViewController: NSSplitViewController {
     static let inspectorMinimum: CGFloat = 280
     private static let inspectorMaximum: CGFloat = 760
 
-    /// The narrowest the detail half of the window can be drawn, divider included.
-    ///
-    /// Public because the window's own minimum has to be built out of it. These are hard AppKit
-    /// constraints: below this the split view stops laying out and starts clipping, and nothing
-    /// above it in SwiftUI negotiates the difference away.
-    static var minimumWidth: CGFloat { detailMinimum + inspectorMinimum + 1 }
+    // The narrowest this half of the window can be drawn is `BloomApp.widths.detailHalf`, and it
+    // is not a constant here any more, because it is not a constant: a collapsed inspector takes no
+    // room and the window should not be held to a width for it. The two numbers above are what that
+    // is built out of, and they are hard AppKit constraints rather than preferences: below the sum
+    // of them the split view stops laying out and starts clipping, and nothing above it in SwiftUI
+    // negotiates the difference away.
 
     private static let autosaveName = "bloom.detail.split"
 
@@ -255,6 +256,7 @@ final class DetailSplitViewController: NSSplitViewController {
 
         let shouldCollapse = !isInspectorPresented
         guard inspectorItem.isCollapsed != shouldCollapse else { return }
+        if !shouldCollapse { makeRoomForInspector(animated: animated) }
         // The animated setter runs a layout pass on every frame of the transition, and layout churn
         // is the condition this window has crashed under, so Reduce Motion turns it off rather than
         // merely shortening it.
@@ -290,6 +292,50 @@ final class DetailSplitViewController: NSSplitViewController {
             publishInspectorWidth(collapsed: shouldCollapse, sliding: true)
         }
     }
+
+    /// Widens the window, if it has to be widened, for a pane that is about to arrive in it.
+    ///
+    /// **This is what makes a conditional minimum honest rather than a trap.** The window's minimum
+    /// drops by 281 points while the inspector is away, which is the whole point of the change, and
+    /// the user is then free to drag the window down to it. Raising the minimum back up does not
+    /// move a window: `NSWindow` applies a new minimum to what the USER does next, not to where the
+    /// window already is. So without this the inspector would open into 281 points that do not
+    /// exist, and the split view would lay out wider than its container and clip, which is exactly
+    /// the defect the flat 1122 was introduced to stop.
+    ///
+    /// Growing the window is the same answer Notes and Freeform give to opening a sidebar in a
+    /// window too small for one. What happens when the screen cannot afford it is
+    /// `WindowWidths.presenting`'s decision rather than this method's: the window takes what the
+    /// screen has and the first column gives up the rest, because a list of rows survives being
+    /// narrow and a transcript and a diff do not.
+    ///
+    /// Inside the caller's animation context rather than before it, so the window grows over the
+    /// same quarter of a second the pane slides in over. `setFrame(_:display:animate:)` would be
+    /// the other way to animate it and it is the wrong one: it spins its own run loop and blocks
+    /// the main thread for the length of the animation, in the middle of a collapse this window
+    /// has crashed under layout churn during.
+    private func makeRoomForInspector(animated: Bool) {
+        guard let window = view.window, let screen = window.screen ?? NSScreen.main else { return }
+        let content = window.contentRect(forFrameRect: window.frame).width
+        let fit = BloomApp.widths.presenting(
+            windowWidth: content, screenWidth: screen.visibleFrame.width
+        )
+        guard let wanted = fit.windowWidth else { return }
+
+        var frame = window.frame
+        frame.size.width += wanted - content
+        // Grow to the right where there is room, and pull the leading edge in where there is not.
+        // A window that grew off the side of the screen would be one whose inspector had arrived
+        // somewhere the user cannot see, which is worse than the width it was opened at.
+        if frame.maxX > screen.visibleFrame.maxX {
+            frame.origin.x = max(screen.visibleFrame.minX, screen.visibleFrame.maxX - frame.width)
+        }
+        if animated {
+            window.animator().setFrame(frame, display: true)
+        } else {
+            window.setFrame(frame, display: true)
+        }
+    }
 }
 
 /// Puts the split controller above back into the SwiftUI tree, at the detail position of the
@@ -318,15 +364,18 @@ struct DetailSplitView: NSViewControllerRepresentable {
     /// leading edge and the inspector's Create Pull Request button off the trailing one, at the
     /// window's own minimum size. Measured on this branch at 1000x700.
     ///
-    /// The honest minimum is the sum of the two panes' minimum thicknesses, which is a constant.
+    /// The honest minimum is the sum of the panes that are ON SCREEN, which is not a constant: a
+    /// collapsed inspector occupies nothing, so reporting its 281 points anyway is what held the
+    /// window 281 points wider than it needed to be while two panes were showing. Same source as
+    /// the window's own minimum, so the two cannot drift. See `WindowWidths`.
     func sizeThatFits(
         _ proposal: ProposedViewSize,
         nsViewController: DetailSplitViewController,
         context: Context
     ) -> CGSize? {
-        CGSize(
-            width: max(proposal.width ?? DetailSplitViewController.minimumWidth,
-                       DetailSplitViewController.minimumWidth),
+        let minimum = BloomApp.widths.detailHalf(withInspector: isInspectorPresented)
+        return CGSize(
+            width: max(proposal.width ?? minimum, minimum),
             height: proposal.height ?? 0
         )
     }

--- a/Sources/Bloom/Views/RootView.swift
+++ b/Sources/Bloom/Views/RootView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import BloomCore
 
@@ -58,8 +59,16 @@ struct RootView: View {
                 // is survivable while both columns are the system's own white, and it is not once
                 // they are two steps of a ramp, because then the two panes simply run into each other.
                 .overlay(alignment: .trailing) { Hairline(axis: .vertical) }
+                // The ceiling is not always the reserve. On a display too narrow to hold all
+                // three panes at their minimums, the sidebar is the one that gives, because it is
+                // a list of rows that truncate where the other two hold a transcript and a diff
+                // that do not. `WindowWidths.sidebarMaximum` is that decision, and it answers with
+                // the plain 420 reserve on every display that can afford it, which is every Mac
+                // one. A nil is a screen with no room for a sidebar at all, and the column folds.
                 .navigationSplitViewColumnWidth(
-                    min: 200, ideal: Metrics.sidebarWidth, max: BloomApp.sidebarMaximumWidth
+                    min: BloomApp.sidebarMinimumWidth,
+                    ideal: Metrics.sidebarWidth,
+                    max: sidebarCeiling ?? BloomApp.sidebarMinimumWidth
                 )
             } detail: {
                 // An `NSSplitViewController`, not `.inspector()` and not `HSplitView`.
@@ -166,6 +175,15 @@ struct RootView: View {
             // Marks this scene as the main window, so the menu items that act on a workspace grey out
             // while Settings or a project settings window is key. See `MainWindowFocus`.
             .focusedSceneValue(\.isMainWindowFocused, true)
+
+            // A display with no room for a sidebar folds it rather than clipping it. The other two
+            // panes cannot fold and cannot truncate, so this is the only pane there is a decision
+            // to take about. It stays folded when the room comes back: unfolding a column the user
+            // has not asked for is a window rearranging itself behind them, and the toggle and its
+            // Command key are both a keystroke away. See `WindowWidths.sidebarMaximum`.
+            .onChange(of: sidebarCeiling == nil, initial: true) { _, folds in
+                if folds { columnVisibility = .detailOnly }
+            }
 
             // Bottom trailing, out of the way of the sidebar and of the composer's send button.
             .overlay(alignment: .bottomTrailing) {
@@ -422,10 +440,23 @@ struct RootView: View {
     /// points back to Home's list, which is what keeps a workspace name, its diff counts and its
     /// age on one line without truncating any of them.
     ///
-    /// Keyed on `selectedWorkspace` rather than on `selection`, because `DetailColumn` already
-    /// falls back to Home when a selected id no longer resolves to a workspace.
-    private var isInspectorPresented: Bool {
-        app.isInspectorVisible && app.selectedWorkspace != nil
+    /// It is the model's, because the window's own minimum width depends on the same answer and
+    /// `BloomApp` cannot read a private computed property on a view. See `AppModel`.
+    private var isInspectorPresented: Bool { app.isInspectorPresented }
+
+    /// What the first column may be dragged out to on the display this window is on, or nil when
+    /// there is no room for one at all. See `WindowWidths.sidebarMaximum`.
+    ///
+    /// `NSScreen.main` is the screen holding the key window, which is this one whenever anybody is
+    /// dragging anything. It is read rather than observed, so moving the window to a narrower
+    /// display leaves this a redraw behind; the consequence of being late is a sidebar that could
+    /// have been dragged 98 points wider than it was, on a display Bloom is unlikely to meet, and
+    /// the consequence of not reading it at all is a clipped window on that display.
+    private var sidebarCeiling: CGFloat? {
+        BloomApp.widths.sidebarMaximum(
+            sharing: NSScreen.main?.visibleFrame.width ?? .greatestFiniteMagnitude,
+            withInspector: isInspectorPresented
+        )
     }
 
     // MARK: - Actions

--- a/Sources/BloomCore/Presentation/WindowWidths.swift
+++ b/Sources/BloomCore/Presentation/WindowWidths.swift
@@ -1,0 +1,159 @@
+import CoreGraphics
+
+/// The thicknesses the main window's minimum width is built out of, and what has to move when the
+/// inspector opens in a window too narrow for it.
+///
+/// # Why the arithmetic left the window
+///
+/// It was one line in `BloomApp`: the sidebar's maximum, plus the detail half's minimum, plus a
+/// divider. 420 + 701 + 1 = 1122, a constant, correct in every state and therefore correct in none
+/// of them. It is not wrong as arithmetic. It is wrong as a STATEMENT: it says this window always
+/// needs room for three panes, while two of them are showing. On a laptop those 281 points are the
+/// difference between two windows side by side and one.
+///
+/// So the minimum is conditional now, and the moment a minimum is conditional it stops being
+/// arithmetic and becomes a rule with a hole in it. **The hole is that a minimum going UP does not
+/// move a window.** `NSWindow` does not resize itself when its minimum size is raised above what it
+/// currently is, so a window at 841 points that is handed a minimum of 1122 stays at 841 and the
+/// split view lays out 281 points more than it was given, which is the clipped sidebar rows and the
+/// clipped Create Pull Request button that `BloomApp`'s old comment is about. `presenting` is the
+/// answer to that and `minimum` is only half the story without it.
+///
+/// Four numbers, a condition, and one number out is exactly the shape that should not live in a
+/// view, which is why it is here.
+///
+/// # What the sidebar's number is, and why it is the maximum
+///
+/// `sidebar` is what the window RESERVES for the first column, and it is that column's maximum
+/// rather than the width it happens to be at. `NavigationSplitView` does not shrink its sidebar to
+/// satisfy the detail column's minimum, measured, so a window sized against a 260 point sidebar
+/// clips the moment the sidebar is dragged out to 420.
+///
+/// **Using the column's real width instead is worth up to 220 more points and it is deliberately
+/// not done.** It moves the hole above onto a control the owner drags constantly: every sidebar
+/// drag would raise a minimum under a window that will not grow, so every drag would need the same
+/// companion the inspector now has, on a gesture rather than on a click. One risky change at a
+/// time, and this is the smaller prize of the two.
+public struct WindowWidths: Equatable, Sendable {
+    /// What the window reserves for the first column: its MAXIMUM. See the note above.
+    public let sidebar: CGFloat
+
+    /// The narrowest the first column may be squeezed to before it should fold away instead.
+    public let sidebarMinimum: CGFloat
+
+    /// The centre column's own minimum thickness, which is a hard AppKit constraint on the split
+    /// view rather than something SwiftUI negotiates away.
+    public let detail: CGFloat
+
+    /// The inspector's, the same way.
+    public let inspector: CGFloat
+
+    /// One divider. Counted once per boundary: one between the sidebar and the detail half, and
+    /// one more inside it when the inspector is on screen.
+    public let divider: CGFloat
+
+    public init(
+        sidebar: CGFloat,
+        sidebarMinimum: CGFloat,
+        detail: CGFloat,
+        inspector: CGFloat,
+        divider: CGFloat
+    ) {
+        self.sidebar = sidebar
+        self.sidebarMinimum = sidebarMinimum
+        self.detail = detail
+        self.inspector = inspector
+        self.divider = divider
+    }
+
+    /// The narrowest the window's CONTENT may be drawn, which is what a `.frame(minWidth:)` on the
+    /// scene's root sets and what `NSWindow.contentMinSize` ends up holding.
+    public func minimum(withInspector: Bool) -> CGFloat {
+        sidebar + divider + detailHalf(withInspector: withInspector)
+    }
+
+    /// The narrowest the detail HALF may be drawn: the centre column, plus the inspector and the
+    /// divider between them while the inspector is on screen.
+    ///
+    /// The other half of the same rule as `minimum`, and here rather than beside the split view so
+    /// that the two cannot drift: what the representable reports as its fitting size and what the
+    /// window refuses to go below are the same statement about the same panes.
+    public func detailHalf(withInspector: Bool) -> CGFloat {
+        withInspector ? detail + divider + inspector : detail
+    }
+
+    /// What the first column may be dragged out to when there are `total` points to share, or nil
+    /// when not even its minimum fits and it should fold away instead.
+    ///
+    /// `total` is the screen's width where this is asked before a window exists to measure, and the
+    /// window's own width where it is asked after `presenting` has grown it as far as it can. Those
+    /// are the same number in the case that matters, and where they differ the window's is the one
+    /// the panes are actually laid out in.
+    ///
+    /// **This is the answer to "the window is already as wide as the screen and the inspector is
+    /// opened".** Clipping is not an answer and refusing to open the inspector is worse, so the
+    /// sidebar is what gives: it is the only pane of the three whose content survives being narrow,
+    /// because it is a list of rows that truncate, where the centre column holds a transcript and
+    /// the inspector holds a diff and a button that do not. Below `sidebarMinimum` there is nothing
+    /// left worth showing and folding it is honest, which is a state this window already has and
+    /// already puts a New Workspace button in the toolbar for.
+    ///
+    /// On any screen that can afford the reserve, which is every Mac display, this answers with the
+    /// reserve and nothing moves. It is the small external display and the Sidecar iPad that reach
+    /// the rest of it.
+    public func sidebarMaximum(sharing total: CGFloat, withInspector: Bool) -> CGFloat? {
+        let room = total - divider - detailHalf(withInspector: withInspector)
+        if room >= sidebar { return sidebar }
+        if room >= sidebarMinimum { return room }
+        return nil
+    }
+
+    /// What has to move for the inspector to open in a window this wide on a screen this wide.
+    ///
+    /// The window grows before the sidebar shrinks, because growing a window takes nothing away
+    /// from the user and narrowing the sidebar takes rows. It never shrinks the window: a window
+    /// wider than its screen is one the user has dragged there, and the inspector opening is not
+    /// the moment to argue with that.
+    public func presenting(windowWidth: CGFloat, screenWidth: CGFloat) -> InspectorFit {
+        let needed = minimum(withInspector: true)
+        guard windowWidth < needed else { return .settled }
+
+        let grown = max(windowWidth, min(needed, screenWidth))
+        let widened = grown > windowWidth ? grown : nil
+        guard grown < needed else {
+            return InspectorFit(windowWidth: widened, sidebarWidth: nil, foldsSidebar: false)
+        }
+
+        // The screen cannot afford the reserve, so the sidebar gives up the difference.
+        guard let room = sidebarMaximum(sharing: grown, withInspector: true) else {
+            return InspectorFit(windowWidth: widened, sidebarWidth: nil, foldsSidebar: true)
+        }
+        return InspectorFit(windowWidth: widened, sidebarWidth: room, foldsSidebar: false)
+    }
+}
+
+/// What opening the inspector costs the window it is opening in. See `WindowWidths.presenting`.
+public struct InspectorFit: Equatable, Sendable {
+    /// The content width the window has to be given, or nil while it is already wide enough.
+    public let windowWidth: CGFloat?
+
+    /// The width the first column has to come down to, or nil while it can keep what it has.
+    public let sidebarWidth: CGFloat?
+
+    /// Whether even the first column's minimum does not fit, and it has to fold away.
+    public let foldsSidebar: Bool
+
+    /// Nothing moves. The overwhelmingly common answer, and the one every window on a normal
+    /// display gets.
+    public static let settled = InspectorFit(
+        windowWidth: nil, sidebarWidth: nil, foldsSidebar: false
+    )
+
+    public init(windowWidth: CGFloat?, sidebarWidth: CGFloat?, foldsSidebar: Bool) {
+        self.windowWidth = windowWidth
+        self.sidebarWidth = sidebarWidth
+        self.foldsSidebar = foldsSidebar
+    }
+
+    public var isSettled: Bool { self == .settled }
+}

--- a/Tests/BloomCoreTests/WindowWidthsTests.swift
+++ b/Tests/BloomCoreTests/WindowWidthsTests.swift
@@ -1,0 +1,118 @@
+import Testing
+@testable import BloomCore
+
+/// How narrow the window may be, and what opening the inspector costs it.
+///
+/// The window's minimum used to be a constant that assumed three panes while two were showing, and
+/// making it conditional is only safe if opening the inspector can never ask for more room than
+/// the window can be given. `openingTheInspectorCannotClip` is that, written down.
+@Suite struct WindowWidthsTests {
+    /// Bloom's own numbers, which is the case every other one is a variation of.
+    private let widths = WindowWidths(
+        sidebar: 420, sidebarMinimum: 200, detail: 420, inspector: 280, divider: 1
+    )
+
+    @Test func theWindowGivesBackTheInspectorsRoomWhenItIsNotShowing() {
+        #expect(widths.minimum(withInspector: true) == 1122)
+        #expect(widths.minimum(withInspector: false) == 841)
+    }
+
+    @Test func openingTheInspectorCannotClip() {
+        // The case that bit last time. Whatever the collapsed minimum is, adding the inspector and
+        // its divider has to land exactly on the presented one: a presented minimum that asked for
+        // more than that would be a window the split view overflows the moment the pane arrives.
+        #expect(
+            widths.minimum(withInspector: false) + widths.inspector + widths.divider
+                == widths.minimum(withInspector: true)
+        )
+        #expect(
+            widths.detailHalf(withInspector: false) + widths.inspector + widths.divider
+                == widths.detailHalf(withInspector: true)
+        )
+    }
+
+    @Test func theDetailHalfIsTheWindowMinimumLessTheSidebarAndItsDivider() {
+        for showing in [true, false] {
+            #expect(
+                widths.minimum(withInspector: showing) - widths.sidebar - widths.divider
+                    == widths.detailHalf(withInspector: showing)
+            )
+        }
+    }
+
+    // MARK: - What opening it costs
+
+    @Test func aWindowAlreadyWideEnoughIsLeftAlone() {
+        #expect(widths.presenting(windowWidth: 1122, screenWidth: 1800).isSettled)
+        #expect(widths.presenting(windowWidth: 1500, screenWidth: 1800).isSettled)
+    }
+
+    @Test func aNarrowWindowOnARoomyScreenIsWidenedAndNothingElseMoves() {
+        let fit = widths.presenting(windowWidth: 841, screenWidth: 1800)
+        #expect(fit.windowWidth == 1122)
+        #expect(fit.sidebarWidth == nil)
+        #expect(!fit.foldsSidebar)
+    }
+
+    @Test func aScreenThatCannotAffordItGrowsTheWindowAsFarAsItGoesAndTheSidebarGivesTheRest() {
+        // 1024 points is a small external display. The window takes the screen, and the sidebar
+        // comes down from its 420 reserve to what is left: 1024 less a divider and the detail half.
+        let fit = widths.presenting(windowWidth: 900, screenWidth: 1024)
+        #expect(fit.windowWidth == 1024)
+        #expect(fit.sidebarWidth == 322)
+        #expect(!fit.foldsSidebar)
+    }
+
+    @Test func aWindowAtTheScreensWidthAlreadyOnlyMovesTheSidebar() {
+        // The question this was written to answer: the window cannot grow, so the sidebar is what
+        // gives, and it is the only one of the three whose content survives being narrow.
+        let fit = widths.presenting(windowWidth: 1024, screenWidth: 1024)
+        #expect(fit.windowWidth == nil)
+        #expect(fit.sidebarWidth == 322)
+        #expect(!fit.foldsSidebar)
+    }
+
+    @Test func aScreenTooNarrowEvenForTheSidebarsMinimumFoldsItAway() {
+        // A Sidecar iPad in portrait is 768 points. 768 less a divider and 701 leaves 66, and 66
+        // points of workspace rows is not a sidebar.
+        let fit = widths.presenting(windowWidth: 768, screenWidth: 768)
+        #expect(fit.foldsSidebar)
+        #expect(fit.sidebarWidth == nil)
+    }
+
+    @Test func aWindowWiderThanItsScreenIsNeverShrunk() {
+        // Dragged half off the display, which is the user's business and not the inspector's.
+        let fit = widths.presenting(windowWidth: 1100, screenWidth: 1000)
+        #expect(fit.windowWidth == nil)
+        #expect(fit.sidebarWidth == 398)
+    }
+
+    @Test func whatIsAskedForIsAlwaysSomethingTheWindowCanBeGiven() {
+        // The property behind every case above: after presenting, the panes at their minimums plus
+        // the sidebar it is left with never exceed the width the window ends up at.
+        for window in stride(from: 600.0, through: 2000, by: 37) {
+            for screen in [768.0, 1024, 1280, 1440, 1800, 3008] {
+                let fit = widths.presenting(windowWidth: window, screenWidth: screen)
+                let settled = fit.windowWidth ?? window
+                #expect(settled >= window)
+                let sidebar = fit.foldsSidebar ? 0 : (fit.sidebarWidth ?? widths.sidebar)
+                #expect(sidebar + widths.divider + widths.detailHalf(withInspector: true) <= settled)
+            }
+        }
+    }
+
+    // MARK: - The sidebar's own ceiling
+
+    @Test func theSidebarKeepsItsReserveOnAnyScreenThatCanAffordIt() {
+        #expect(widths.sidebarMaximum(sharing: 1122, withInspector: true) == 420)
+        #expect(widths.sidebarMaximum(sharing: 3008, withInspector: true) == 420)
+        // And with the inspector away there is 281 points more of it to go round.
+        #expect(widths.sidebarMaximum(sharing: 841, withInspector: false) == 420)
+    }
+
+    @Test func theSidebarsCeilingComesDownBeforeItFolds() {
+        #expect(widths.sidebarMaximum(sharing: 1024, withInspector: true) == 322)
+        #expect(widths.sidebarMaximum(sharing: 902, withInspector: true) == 200)
+        #expect(widths.sidebarMaximum(sharing: 901, withInspector: true) == nil)
+    }
+}

--- a/Tests/BloomCoreTests/WindowWidthsTests.swift
+++ b/Tests/BloomCoreTests/WindowWidthsTests.swift
@@ -22,20 +22,24 @@ import Testing
         // its divider has to land exactly on the presented one: a presented minimum that asked for
         // more than that would be a window the split view overflows the moment the pane arrives.
         //
-        // One line each, and that is not a style choice. A `#expect` whose operator starts a
-        // continuation line reported `1122.0 == 1122.0` as a failure on CI: swift-testing folds the
-        // operators of a broken `SequenceExpr` itself to find the one to split on, and it split
-        // this on the wrong one. Both sides printed the same number in the failure message, which
-        // is the tell. Keep a comparison on one line here.
-        let inspectorAndItsDivider = widths.inspector + widths.divider
-        #expect(widths.minimum(withInspector: false) + inspectorAndItsDivider == widths.minimum(withInspector: true))
-        #expect(widths.detailHalf(withInspector: false) + inspectorAndItsDivider == widths.detailHalf(withInspector: true))
+        // The comparison is made before `#expect` sees it, and that is not a style choice. Written
+        // as `#expect(a + b == c)` this reported `1122.0 == 1122.0` as a FAILURE on CI, twice, with
+        // both sides printing the same number, which is a comparison swift-testing took apart and
+        // put back together wrong rather than an inequality. Every expectation in this file that
+        // compares a computed width to another computed width does it this way; the ones that
+        // compare against a literal are fine as they are.
+        let step = widths.inspector + widths.divider
+        let windowLandsExactly = widths.minimum(withInspector: false) + step == widths.minimum(withInspector: true)
+        let halfLandsExactly = widths.detailHalf(withInspector: false) + step == widths.detailHalf(withInspector: true)
+        #expect(windowLandsExactly)
+        #expect(halfLandsExactly)
     }
 
     @Test func theDetailHalfIsTheWindowMinimumLessTheSidebarAndItsDivider() {
         for showing in [true, false] {
             let half = widths.minimum(withInspector: showing) - widths.sidebar - widths.divider
-            #expect(half == widths.detailHalf(withInspector: showing))
+            let agrees = half == widths.detailHalf(withInspector: showing)
+            #expect(agrees)
         }
     }
 
@@ -93,9 +97,11 @@ import Testing
             for screen in [768.0, 1024, 1280, 1440, 1800, 3008] {
                 let fit = widths.presenting(windowWidth: window, screenWidth: screen)
                 let settled = fit.windowWidth ?? window
-                #expect(settled >= window)
+                let neverShrinks = settled >= window
+                #expect(neverShrinks)
                 let sidebar = fit.foldsSidebar ? 0 : (fit.sidebarWidth ?? widths.sidebar)
-                #expect(sidebar + widths.divider + widths.detailHalf(withInspector: true) <= settled)
+                let panesFit = sidebar + widths.divider + widths.detailHalf(withInspector: true) <= settled
+                #expect(panesFit)
             }
         }
     }

--- a/Tests/BloomCoreTests/WindowWidthsTests.swift
+++ b/Tests/BloomCoreTests/WindowWidthsTests.swift
@@ -21,22 +21,21 @@ import Testing
         // The case that bit last time. Whatever the collapsed minimum is, adding the inspector and
         // its divider has to land exactly on the presented one: a presented minimum that asked for
         // more than that would be a window the split view overflows the moment the pane arrives.
-        #expect(
-            widths.minimum(withInspector: false) + widths.inspector + widths.divider
-                == widths.minimum(withInspector: true)
-        )
-        #expect(
-            widths.detailHalf(withInspector: false) + widths.inspector + widths.divider
-                == widths.detailHalf(withInspector: true)
-        )
+        //
+        // One line each, and that is not a style choice. A `#expect` whose operator starts a
+        // continuation line reported `1122.0 == 1122.0` as a failure on CI: swift-testing folds the
+        // operators of a broken `SequenceExpr` itself to find the one to split on, and it split
+        // this on the wrong one. Both sides printed the same number in the failure message, which
+        // is the tell. Keep a comparison on one line here.
+        let inspectorAndItsDivider = widths.inspector + widths.divider
+        #expect(widths.minimum(withInspector: false) + inspectorAndItsDivider == widths.minimum(withInspector: true))
+        #expect(widths.detailHalf(withInspector: false) + inspectorAndItsDivider == widths.detailHalf(withInspector: true))
     }
 
     @Test func theDetailHalfIsTheWindowMinimumLessTheSidebarAndItsDivider() {
         for showing in [true, false] {
-            #expect(
-                widths.minimum(withInspector: showing) - widths.sidebar - widths.divider
-                    == widths.detailHalf(withInspector: showing)
-            )
+            let half = widths.minimum(withInspector: showing) - widths.sidebar - widths.divider
+            #expect(half == widths.detailHalf(withInspector: showing))
         }
     }
 


### PR DESCRIPTION
The window's minimum was 1122 in every state: the sidebar's maximum, the centre column's minimum, the inspector's minimum and two dividers. Correct arithmetic, wrong statement, and 281 points of it were for a pane that is often not on screen.

It follows the inspector now, 1122 with it and 841 without. The arithmetic is `WindowWidths` in the core, tested, including the property that makes it safe: the collapsed minimum plus the inspector and its divider must land exactly on the presented one, or opening the pane asks for room the window was never made to have.

The companion is what stops the conditional minimum being a trap. A raised minimum applies to what the user does next, not to where the window already is, so `makeRoomForInspector` grows the window inside the animation context the pane slides in over. Where the screen cannot afford it, the sidebar gives up the difference and folds below its own minimum, decided in the same core function rather than by whichever view notices first.

Reserving the sidebar's real width rather than its maximum is worth another 220 points and is deliberately not in here; the reason is written down in `WindowWidths` and pointed at from `sidebarMaximumWidth`.