### PR TITLE
Draw a hunk's band only where the reader has landed

### DIFF
--- a/Sources/Bloom/Views/Inspector/DiffHunkHeaderView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffHunkHeaderView.swift
@@ -6,6 +6,9 @@ import SwiftUI
 /// The glyph is the enclosing scope, which is what the line says whenever git can name one. It
 /// used to be a left-and-right arrow, which on a band directly above a diff that really does
 /// scroll sideways read as a scrolling hint.
+///
+/// Which hunks get one at all is `DiffHunkHeading`, not this view: only the ones the reader
+/// reaches after lines the pane did not print.
 struct DiffHunkHeaderView: View {
     var text: String
     var width: CGFloat

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -759,7 +759,7 @@ struct DiffView: View {
 
         for (hunkIndex, hunk) in document.file.hunks.enumerated() {
             appendGap(&rows, document: document, hunkIndex: hunkIndex, hunk: hunk, split: false)
-            rows.append(.header(hunk: hunkIndex, text: Self.headerText(hunk)))
+            appendHeading(&rows, document: document, hunkIndex: hunkIndex)
 
             let lines = hunk.lines
             for chunk in Self.chunks(
@@ -788,7 +788,7 @@ struct DiffView: View {
 
         for (hunkIndex, hunk) in document.file.hunks.enumerated() {
             appendGap(&rows, document: document, hunkIndex: hunkIndex, hunk: hunk, split: true)
-            rows.append(.header(hunk: hunkIndex, text: Self.headerText(hunk)))
+            appendHeading(&rows, document: document, hunkIndex: hunkIndex)
 
             // Folding one hunk at a time keeps the boundaries that `sideBySide()` flattens away.
             var single = document.file
@@ -872,10 +872,20 @@ struct DiffView: View {
         }
     }
 
-    private static func headerText(_ hunk: DiffHunk) -> String {
-        let trimmed = hunk.header.trimmingCharacters(in: .whitespaces)
-        if !trimmed.isEmpty { return trimmed }
-        return "@@ -\(hunk.oldStart),\(hunk.oldCount) +\(hunk.newStart),\(hunk.newCount) @@"
+    /// The `@@` band, drawn only where it says something the numbers beside it do not.
+    ///
+    /// Both the rule and the text are `DiffHunkHeading`, in the core, so the two layouts cannot
+    /// end up showing different bands and so the rule has a test. It is asked here rather than in
+    /// `appendGap` because a hunk with no gap above it still comes through this line.
+    private func appendHeading(
+        _ rows: inout [DiffRow],
+        document: DiffDocument,
+        hunkIndex: Int
+    ) {
+        guard let text = DiffHunkHeading.text(
+            for: document.file.hunks, at: hunkIndex, revealed: revealedGaps[hunkIndex] ?? 0
+        ) else { return }
+        rows.append(.header(hunk: hunkIndex, text: text))
     }
 
     // MARK: Collapsing

--- a/Sources/BloomCore/Git/DiffHunkHeading.swift
+++ b/Sources/BloomCore/Git/DiffHunkHeading.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// The `@@` band above a hunk, and whether it is worth drawing at all.
+///
+/// **A grey strip reading `{} public function __construct(` sat between line 48 and line 49 with
+/// the numbering running straight through it.** The band is orientation: it tells a reader where
+/// they have landed after code the diff did not print. Between two lines that follow each other
+/// it names a scope the reader is already inside and marks a landing that never happened, and the
+/// row is a row of noise in the middle of a file somebody is reading.
+///
+/// So it is drawn exactly when the eye has jumped: when the lines printed above the hunk are not
+/// the lines that precede it in the file. That is `DiffGap` again, asked about what is **still**
+/// hidden rather than about the patch, and the difference matters. A gap is revealed upward from
+/// the hunk, so the moment one line of it is up, the line above the band is contiguous with the
+/// hunk. That is where the band in the report came from: git does not emit touching hunks at
+/// three lines of context (measured, and the arithmetic in `xdl_get_hunk` says so: changes closer
+/// than twice the context are merged into one hunk, which leaves at least one unprinted line
+/// between any two it does split), so contiguity in the pane is always the reader's own expander.
+///
+/// **A changed scope is deliberately not a case of its own.** It cannot arise alone: contiguity
+/// only ever comes from a fully revealed gap, and revealing the gap prints the very source line
+/// the band would have quoted, so the band would restate a line already on the screen.
+public enum DiffHunkHeading {
+    /// What the band above `hunks[index]` should read, or nothing when it would say nothing.
+    ///
+    /// `revealed` is how many lines of the gap above that hunk the reader has asked the expander
+    /// for. Both layouts go through this one call rather than deciding for themselves, because a
+    /// unified pane and a split pane disagreeing about which bands exist is a difference nobody
+    /// could read as anything but a bug.
+    public static func text(for hunks: [DiffHunk], at index: Int, revealed: Int) -> String? {
+        guard hunks.indices.contains(index) else { return nil }
+        guard let gap = DiffGap.between(hunks: hunks, at: index) else { return nil }
+        guard DiffGap.hidden(revealed, in: gap) > 0 else { return nil }
+        return text(of: hunks[index])
+    }
+
+    /// The enclosing scope git named, falling back to the hunk's own coordinates.
+    ///
+    /// Git leaves the name off whenever its funcname patterns find nothing above the hunk, which
+    /// is every hunk at the head of a file and every hunk of a file it has no patterns for. The
+    /// coordinates are kept rather than the band being dropped, because they are the only mark of
+    /// the jump left when the worktree copy could not be read: without it `DiffView.appendGap`
+    /// draws neither the expander nor a revealed line, and the rows would run from one part of
+    /// the file into another with nothing in between.
+    static func text(of hunk: DiffHunk) -> String {
+        let trimmed = hunk.header.trimmingCharacters(in: .whitespaces)
+        if !trimmed.isEmpty { return trimmed }
+        return "@@ -\(hunk.oldStart),\(hunk.oldCount) +\(hunk.newStart),\(hunk.newCount) @@"
+    }
+}

--- a/Tests/BloomCoreTests/DiffHunkHeadingTests.swift
+++ b/Tests/BloomCoreTests/DiffHunkHeadingTests.swift
@@ -1,0 +1,90 @@
+import Testing
+@testable import BloomCore
+
+/// The report: a grey band reading `{} public function __construct(` between line 48 and line 49,
+/// numbering contiguous either side of it. `DiffView` drew one for every hunk, so a reader who had
+/// expanded the gap above a hunk got a band naming the scope they were already sitting in.
+@Suite("Hunk headings")
+struct DiffHunkHeadingTests {
+    private func hunk(newStart: Int, newCount: Int, header: String = " func work()") -> DiffHunk {
+        DiffHunk(
+            oldStart: newStart, oldCount: newCount,
+            newStart: newStart, newCount: newCount,
+            header: header, lines: []
+        )
+    }
+
+    /// The case the band exists for: lines were skipped, so the reader needs telling where they
+    /// have landed.
+    @Test("a hunk reached over skipped lines gets a band")
+    func skippedLinesEarnABand() {
+        let hunks = [hunk(newStart: 1, newCount: 5), hunk(newStart: 40, newCount: 6)]
+        #expect(DiffHunkHeading.text(for: hunks, at: 1, revealed: 0) == "func work()")
+    }
+
+    /// The first hunk is the same question asked of the head of the file: everything above it is
+    /// skipped, and there is nothing above it to skip.
+    @Test("the first hunk is judged against the top of the file")
+    func theFirstHunkIsJudgedAgainstLineOne() {
+        #expect(DiffHunkHeading.text(for: [hunk(newStart: 48, newCount: 6)], at: 0, revealed: 0)
+            == "func work()")
+        #expect(DiffHunkHeading.text(for: [hunk(newStart: 1, newCount: 6)], at: 0, revealed: 0)
+            == nil)
+    }
+
+    /// The report, reproduced. The gap is revealed upward from the hunk, so its last revealed
+    /// line is always the one directly above the band, and once every line of it is up the
+    /// numbering runs straight through.
+    @Test("a fully revealed gap takes the band with it")
+    func aRevealedGapLosesItsBand() {
+        let hunks = [hunk(newStart: 1, newCount: 5), hunk(newStart: 49, newCount: 6)]
+        // 6..<49 is the gap, so 43 lines of it.
+        #expect(DiffHunkHeading.text(for: hunks, at: 1, revealed: 42) != nil)
+        #expect(DiffHunkHeading.text(for: hunks, at: 1, revealed: 43) == nil)
+        #expect(DiffHunkHeading.text(for: hunks, at: 1, revealed: 500) == nil)
+    }
+
+    /// Git does not emit touching hunks at three lines of context, so this is arithmetic the pane
+    /// should never see. It is stated anyway, because the rule must not depend on that being true.
+    @Test("touching hunks get nothing")
+    func touchingHunksGetNothing() {
+        let hunks = [hunk(newStart: 1, newCount: 9), hunk(newStart: 10, newCount: 3)]
+        #expect(DiffHunkHeading.text(for: hunks, at: 1, revealed: 0) == nil)
+    }
+
+    /// A scope that changed is not a case of its own: it can only show up once the gap is fully
+    /// revealed, and the revealed lines include the very line the band would have quoted.
+    @Test("a changed scope over contiguous lines still gets nothing")
+    func aChangedScopeOverContiguousLinesGetsNothing() {
+        let hunks = [
+            hunk(newStart: 1, newCount: 5, header: " func one()"),
+            hunk(newStart: 40, newCount: 6, header: " func two()"),
+        ]
+        #expect(DiffHunkHeading.text(for: hunks, at: 1, revealed: 34) == nil)
+    }
+
+    /// Git leaves the name off every hunk it cannot find a scope for, and the band was never
+    /// empty: it fell back to the coordinates. Kept, because with an unreadable worktree copy
+    /// there is no expander either and the band is the only mark of the jump.
+    @Test("an unnamed hunk falls back to its coordinates")
+    func anUnnamedHunkFallsBackToCoordinates() {
+        let hunks = [hunk(newStart: 1, newCount: 5, header: ""), hunk(newStart: 40, newCount: 6, header: "")]
+        #expect(DiffHunkHeading.text(for: hunks, at: 1, revealed: 0) == "@@ -40,6 +40,6 @@")
+    }
+
+    @Test("an index no hunk has gets nothing")
+    func anIndexNoHunkHasGetsNothing() {
+        #expect(DiffHunkHeading.text(for: [], at: 0, revealed: 0) == nil)
+        #expect(DiffHunkHeading.text(for: [hunk(newStart: 40, newCount: 6)], at: 3, revealed: 0)
+            == nil)
+        #expect(DiffHunkHeading.text(for: [hunk(newStart: 40, newCount: 6)], at: -1, revealed: 0)
+            == nil)
+    }
+
+    /// The header text is what the parser kept, with git's leading space taken off.
+    @Test("the band shows the scope git named")
+    func theBandShowsTheScopeGitNamed() {
+        #expect(DiffHunkHeading.text(of: hunk(newStart: 9, newCount: 2, header: " class A {"))
+            == "class A {")
+    }
+}


### PR DESCRIPTION
The `@@` band was drawn for every hunk in both layouts, so a reader who expanded the gap above one got a grey strip naming the scope they were already sitting in, between two lines whose numbering ran straight through it.

The rule is now `DiffHunkHeading` in the core, with a suite, and both `unifiedRows` and `splitRows` go through it: a band is drawn when lines above the hunk are still hidden, which is `DiffGap` asked about what is left rather than about the patch.

Worth noting for the report that started this: the hunks were never adjacent. Git merges changes closer than twice the context, so at the default `-U3` any two hunks it does split have at least one unprinted line between them (measured). Contiguity in the pane is always the reader's own expander, and since a gap reveals upward from the hunk, one revealed line is enough to produce the band in the screenshot.

A changed scope over contiguous lines is deliberately not a case of its own: it can only arise from a fully revealed gap, and revealing the gap prints the very source line the band would have quoted.

`headerText` moved with the rule. It never drew an empty band; git leaves the scope off every hunk at the head of a file, and the band fell back to `@@ -1,4 +1,4 @@`. Those are gone now under the gap rule, but the fallback is kept for a hunk after a real gap in a file git has no funcname patterns for, because with an unreadable worktree copy there is no expander either and the band is the only mark of the jump.