### PR TITLE
Keep Spotlight out of the workspaces root

### DIFF
--- a/Sources/BloomCore/System/SpotlightExclusion.swift
+++ b/Sources/BloomCore/System/SpotlightExclusion.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// The marker that tells Spotlight to leave a directory tree alone.
+///
+/// **The workspaces root is dozens of checkouts of the same repository.** Every one of them grows
+/// a `vendor/`, a `node_modules/` or a `.build/`, all of it generated, none of it anything a
+/// person searches for, and all of it rewritten by whichever agent is building right now. `mds`
+/// wakes on those writes and reindexes them, which is real CPU spent on a copy of a tree it has
+/// already indexed under the project the worktree was cut from.
+///
+/// The alternative is System Settings, Spotlight, Search Privacy, which is a list the owner has
+/// to maintain by hand and which no fresh machine has. A file in the directory travels with the
+/// directory, so a new install gets it the first time a worktree is cut.
+///
+/// **The name is the whole mechanism.** `.metadata_never_index` is what `mds` looks for, and it
+/// excludes the directory it sits in and everything under it, so one at the root covers every
+/// project and every worktree ever cut below it. The file's contents are never read, which is why
+/// this writes an empty one.
+public enum SpotlightExclusion {
+    public static let markerName = ".metadata_never_index"
+
+    /// Make sure `directory` exists and carries the marker.
+    ///
+    /// Best effort by design, and the return value says which way it went so a caller that cares
+    /// can log it. Nothing here is worth failing a workspace creation over: the worst case of a
+    /// marker that could not be written is a directory that gets indexed, which is where every
+    /// machine starts anyway.
+    @discardableResult
+    public static func mark(_ directory: URL, using manager: FileManager = .default) -> Bool {
+        let marker = directory.appendingPathComponent(markerName, isDirectory: false)
+        if manager.fileExists(atPath: marker.path) { return true }
+        do {
+            try manager.createDirectory(at: directory, withIntermediateDirectories: true)
+            try Data().write(to: marker, options: .withoutOverwriting)
+            return true
+        } catch {
+            // A race with another Bloom window doing the same thing lands here with the marker
+            // already written, which is the outcome that was wanted.
+            return manager.fileExists(atPath: marker.path)
+        }
+    }
+}

--- a/Sources/BloomCore/Workspace/WorkspaceManager.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceManager.swift
@@ -51,6 +51,18 @@ public struct WorkspaceManager: Sendable {
         return home.appendingPathComponent("bloom/workspaces", isDirectory: true)
     }
 
+    /// `workspacesRoot`, with Spotlight told to leave it alone before anything is cut into it.
+    ///
+    /// Asked here rather than at launch because this is the only moment the answer is needed and
+    /// the only moment the directory is certain to be wanted: a copy of Bloom that never creates
+    /// a workspace should not create a directory either. `SpotlightExclusion` carries why the
+    /// marker is worth writing at all.
+    static func preparedWorkspacesRoot() -> URL {
+        let root = workspacesRoot
+        SpotlightExclusion.mark(root)
+        return root
+    }
+
     // MARK: - Repositories
 
     @discardableResult
@@ -195,7 +207,7 @@ public struct WorkspaceManager: Sendable {
         let finalBranch = Git.uniqueBranch(stem, taken: existingBranches)
 
         let directoryName = finalBranch.replacingOccurrences(of: "/", with: "-")
-        let root = Self.workspacesRoot.appendingPathComponent(repo.name, isDirectory: true)
+        let root = Self.preparedWorkspacesRoot().appendingPathComponent(repo.name, isDirectory: true)
         // The suffix rule lives in `WorktreePath` because restoring an archived workspace needs
         // the same one: two places that each invent a free directory name are two places that can
         // disagree about which names are free.
@@ -284,7 +296,7 @@ public struct WorkspaceManager: Sendable {
         }
 
         let directoryName = branch.replacingOccurrences(of: "/", with: "-")
-        let root = Self.workspacesRoot.appendingPathComponent(repo.name, isDirectory: true)
+        let root = Self.preparedWorkspacesRoot().appendingPathComponent(repo.name, isDirectory: true)
         let worktreePath = WorktreePath.free(
             preferred: root.appendingPathComponent(directoryName).path
         ) { FileManager.default.fileExists(atPath: $0) }

--- a/Tests/BloomCoreTests/SpotlightExclusionTests.swift
+++ b/Tests/BloomCoreTests/SpotlightExclusionTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// The workspaces root is dozens of checkouts of one repository, every one with a `vendor/` or a
+/// `.build/` in it, all of it rewritten by whatever is building right now. Spotlight reindexing
+/// that on every write costs CPU for a copy of a tree it has already indexed once.
+@Suite("Spotlight exclusion")
+struct SpotlightExclusionTests {
+    private func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("spotlight-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    /// The point of writing it rather than asking the owner to keep a list in System Settings: a
+    /// file travels with the directory, so a fresh machine gets it on the first worktree.
+    @Test("a directory that does not exist yet is made and marked")
+    func aMissingDirectoryIsMadeAndMarked() throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(SpotlightExclusion.mark(directory))
+
+        let marker = directory.appendingPathComponent(SpotlightExclusion.markerName)
+        #expect(FileManager.default.fileExists(atPath: marker.path))
+        // Empty on purpose: mds looks at the name and never reads the contents.
+        #expect(try Data(contentsOf: marker).isEmpty)
+    }
+
+    /// Called on every workspace creation, so it has to be free and silent the second time.
+    @Test("marking twice leaves the first marker alone")
+    func markingTwiceIsIdempotent() throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        #expect(SpotlightExclusion.mark(directory))
+        let marker = directory.appendingPathComponent(SpotlightExclusion.markerName)
+        try Data("not empty".utf8).write(to: marker)
+
+        #expect(SpotlightExclusion.mark(directory))
+        // Untouched rather than rewritten: a marker somebody edited is still a marker, and
+        // truncating a file this had no reason to open is how a helper starts losing things.
+        #expect(try Data(contentsOf: marker) == Data("not empty".utf8))
+    }
+
+    /// Best effort. A root that cannot be written is a directory that gets indexed, which is
+    /// where every machine starts, and it must not fail the workspace creation that asked.
+    @Test("an unwritable place is reported rather than thrown")
+    func anUnwritablePlaceIsReported() {
+        #expect(SpotlightExclusion.mark(URL(fileURLWithPath: "/dev/null/nope")) == false)
+    }
+
+    /// The name is the whole mechanism, so it is asserted rather than assumed.
+    @Test("the marker is the name mds looks for")
+    func theMarkerIsTheNameSpotlightLooksFor() {
+        #expect(SpotlightExclusion.markerName == ".metadata_never_index")
+    }
+}


### PR DESCRIPTION
The workspaces root is dozens of checkouts of the same repository, every one growing a `vendor/`, a `node_modules/` or a `.build/`. Spotlight wakes on those writes and reindexes a copy of a tree it has already indexed under the project the worktree was cut from, which is real CPU during a build.

The alternative is System Settings, Spotlight, Search Privacy, which is a list kept by hand that no fresh machine has. `.metadata_never_index` travels with the directory instead, and covers everything under it, so one at the root is enough.

Written when a worktree is about to be cut rather than at launch, so a copy of Bloom that never creates a workspace never creates the directory either. Best effort: a marker that cannot be written is a directory that gets indexed, which is where every machine starts.

A folder the owner picked for a new project is deliberately not marked. That one is theirs, not Bloom's generated-checkout area.