### PR TITLE
Keep Spotlight out of the worktrees

### DIFF
--- a/Sources/Bloom/State/AppModel.swift
+++ b/Sources/Bloom/State/AppModel.swift
@@ -353,6 +353,10 @@ final class AppModel {
             }.value
             self.store = store
             self.manager = WorkspaceManager(store: store)
+            // Every installation that predates this has a workspaces root with no marker in it,
+            // and nothing else ever revisits that directory. Two `stat` calls once a launch, and
+            // it says nothing when it fails. See `SpotlightExclusion`.
+            SpotlightExclusion.markWorkspacesRoot()
             try await store.resetRunningSessions()
             // The questions those sessions were blocked on. A pending ask whose agent is gone is
             // not a question, it is a row with four live buttons that answer nothing, so they are

--- a/Sources/BloomCore/System/SpotlightExclusion.swift
+++ b/Sources/BloomCore/System/SpotlightExclusion.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Keeping Spotlight out of the worktrees.
+///
+/// A workspace is a full checkout, and a checkout that has been built in holds `vendor/`,
+/// `node_modules/`, `.build/` and whatever else the project's toolchain unpacks: tens of thousands
+/// of files that nobody has ever searched for by content, rewritten every time a test run touches
+/// them. `mds` and `mdworker` re-read all of it, on a machine already running several agents, and
+/// the owner watched that cost turn up as CPU. Twenty worktrees multiply it by twenty.
+///
+/// The alternative offered was System Settings, Spotlight, Privacy, add `~/bloom/workspaces`. That
+/// works and it is a thing a person has to remember, on every Mac they use, after Bloom has
+/// already made the directory. Bloom made it, so Bloom marks it.
+///
+/// **`.metadata_never_index` inside an ordinary directory rather than `.noindex` on its name.**
+/// The suffix is the mechanism Apple documents, and it is unusable here twice over: the workspaces
+/// root's absolute path is stored in every `workspaces` row and in git's own worktree admin files,
+/// so renaming it would strand every checkout in it, and a worktree's own directory is named after
+/// its branch. The marker file is what is left, and it was measured before it was written rather
+/// than taken on trust: this Mac has carried one in `~/dev/code` since June, and against 3,236
+/// directories under it Spotlight returns nothing at all, for a name query, for a content query,
+/// and for everything created since. See `SpotlightExclusionTests` for what the marker's contract
+/// is here, which is the writing of it and not Spotlight's half.
+///
+/// **The root only, and never one per worktree.** Exclusion covers the whole subtree, which is the
+/// property the measurement above rests on, so a marker in each project's folder would be dozens
+/// of files saying what one already says. It also means a marker is in place before the first
+/// worktree is cut, rather than after each one has already been indexed.
+///
+/// **Nowhere else needs one.** The agent scratch is under `NSTemporaryDirectory()`, the database
+/// and the settings are under `~/Library/Application Support`, and macOS excludes both of those
+/// already; attachments live inside a worktree, so the root above covers them; and an archived
+/// workspace is a worktree that has been removed, with no directory of its own to mark.
+public enum SpotlightExclusion {
+    /// The marker Spotlight reads. Empty: only the name carries meaning.
+    public static let markerName = ".metadata_never_index"
+
+    /// What marking a directory did, so a test can tell "already there" from "just written" and
+    /// from "could not". Nothing acts on this: it is an optimisation reporting itself.
+    public enum Outcome: Equatable, Sendable {
+        case written
+        case alreadyMarked
+        case noSuchDirectory
+        case refused
+    }
+
+    public static func markerPath(in directory: String) -> String {
+        (directory as NSString).appendingPathComponent(markerName)
+    }
+
+    /// Puts the marker in `directory`, if it is not there already.
+    ///
+    /// **An existing file of that name is left exactly as it is**, whatever is in it. Somebody
+    /// may have put one there by hand, which is precisely what the owner did the day this was
+    /// asked for, and a marker Bloom overwrites is a file Bloom destroyed to write the same thing.
+    ///
+    /// **Failing is not an error anybody hears about.** A read-only home directory, a sandbox that
+    /// refuses the write, a directory owned by somebody else: every one of them ends with Spotlight
+    /// indexing worktrees the way it did before this existed, which is where the app was last week.
+    /// There is nothing for a person to do about it and nothing to interrupt them for, so the
+    /// outcome is returned for a test to read and discarded everywhere else.
+    ///
+    /// - Parameter creatingIt: make `directory` first. False at launch, where the point is to catch
+    ///   an installation that already has a workspaces root; true on the path that is about to fill
+    ///   it, so the marker lands before the files do rather than after.
+    @discardableResult
+    public static func mark(_ directory: String, creatingIt: Bool = false) -> Outcome {
+        let manager = FileManager.default
+        if creatingIt {
+            try? manager.createDirectory(atPath: directory, withIntermediateDirectories: true)
+        }
+
+        var isDirectory: ObjCBool = false
+        guard manager.fileExists(atPath: directory, isDirectory: &isDirectory), isDirectory.boolValue else {
+            return .noSuchDirectory
+        }
+
+        let marker = markerPath(in: directory)
+        if manager.fileExists(atPath: marker) { return .alreadyMarked }
+
+        // Not atomically. `write(toFile:atomically:)` writes a neighbour and renames it, which
+        // needs a name of its own in a directory whose entries are worktrees git is holding open.
+        // The file is empty and its content is never read, so there is nothing a half written one
+        // could say wrongly.
+        guard manager.createFile(atPath: marker, contents: Data()) else { return .refused }
+        return .written
+    }
+
+    /// The one directory on this Mac that gets it.
+    @discardableResult
+    public static func markWorkspacesRoot(creatingIt: Bool = false) -> Outcome {
+        mark(WorkspaceManager.workspacesRoot.path, creatingIt: creatingIt)
+    }
+}

--- a/Sources/BloomCore/Workspace/WorkspaceManager.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceManager.swift
@@ -195,6 +195,9 @@ public struct WorkspaceManager: Sendable {
         let finalBranch = Git.uniqueBranch(stem, taken: existingBranches)
 
         let directoryName = finalBranch.replacingOccurrences(of: "/", with: "-")
+        // Here rather than after the checkout, because a marker written once a worktree is already
+        // on disk arrives too late for everything in it. See `SpotlightExclusion`.
+        SpotlightExclusion.markWorkspacesRoot(creatingIt: true)
         let root = Self.workspacesRoot.appendingPathComponent(repo.name, isDirectory: true)
         // The suffix rule lives in `WorktreePath` because restoring an archived workspace needs
         // the same one: two places that each invent a free directory name are two places that can
@@ -284,6 +287,7 @@ public struct WorkspaceManager: Sendable {
         }
 
         let directoryName = branch.replacingOccurrences(of: "/", with: "-")
+        SpotlightExclusion.markWorkspacesRoot(creatingIt: true)
         let root = Self.workspacesRoot.appendingPathComponent(repo.name, isDirectory: true)
         let worktreePath = WorktreePath.free(
             preferred: root.appendingPathComponent(directoryName).path

--- a/Tests/BloomCoreTests/SpotlightExclusionTests.swift
+++ b/Tests/BloomCoreTests/SpotlightExclusionTests.swift
@@ -1,0 +1,124 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+/// The marker that keeps Spotlight out of the worktrees.
+///
+/// Whether `mds` honours the file is Apple's half and is not assertable from here, so this suite
+/// asserts Bloom's half, which is the half that can go wrong quietly: the file is written where it
+/// is meant to be, an existing one of that name survives untouched, and a directory that refuses
+/// the write is reported rather than thrown. Nothing here goes near the real workspaces root: every
+/// test builds its own directory under the temporary directory and removes it.
+@Suite("Marking a directory so Spotlight leaves it alone")
+struct SpotlightExclusionTests {
+    private func temporaryDirectory() -> String {
+        let base = NSTemporaryDirectory() + "bloom-spotlight-test-\(UUID().uuidString)"
+        try? FileManager.default.createDirectory(atPath: base, withIntermediateDirectories: true)
+        return base
+    }
+
+    @Test("the marker sits inside the directory, under the name Spotlight reads")
+    func markerPathIsInsideTheDirectory() {
+        #expect(SpotlightExclusion.markerPath(in: "/a/b") == "/a/b/.metadata_never_index")
+        #expect(SpotlightExclusion.markerName == ".metadata_never_index")
+    }
+
+    @Test("marking an unmarked directory writes an empty file")
+    func markingWritesIt() {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+
+        let outcome = SpotlightExclusion.mark(directory)
+
+        #expect(outcome == .written)
+        let marker = SpotlightExclusion.markerPath(in: directory)
+        #expect(FileManager.default.fileExists(atPath: marker))
+        #expect(try! Data(contentsOf: URL(filePath: marker)).isEmpty)
+    }
+
+    @Test("marking twice writes once")
+    func markingIsIdempotent() {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+
+        #expect(SpotlightExclusion.mark(directory) == .written)
+        #expect(SpotlightExclusion.mark(directory) == .alreadyMarked)
+
+        let entries = (try? FileManager.default.contentsOfDirectory(atPath: directory)) ?? []
+        #expect(entries == [SpotlightExclusion.markerName])
+    }
+
+    /// The rule this was written for. The owner made one of these by hand before asking Bloom to
+    /// do it, and a person who puts a file somewhere gets to keep it.
+    @Test("a marker somebody else wrote is left exactly as it was")
+    func anExistingMarkerIsNotOverwritten() {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(atPath: directory) }
+        let marker = SpotlightExclusion.markerPath(in: directory)
+        try! "put here by hand\n".write(toFile: marker, atomically: true, encoding: .utf8)
+
+        let outcome = SpotlightExclusion.mark(directory)
+
+        #expect(outcome == .alreadyMarked)
+        #expect(try! String(contentsOfFile: marker, encoding: .utf8) == "put here by hand\n")
+    }
+
+    /// The launch call. An installation with no workspaces root yet has nothing to mark and is not
+    /// given one, because a Bloom that has never cut a worktree should not be making directories in
+    /// somebody's home for a folder they may never use.
+    @Test("a directory that is not there is left absent rather than created")
+    func anAbsentDirectoryIsNotCreated() {
+        let directory = temporaryDirectory() + "/never-made"
+
+        let outcome = SpotlightExclusion.mark(directory)
+
+        #expect(outcome == .noSuchDirectory)
+        #expect(!FileManager.default.fileExists(atPath: directory))
+    }
+
+    /// The creation call, and the ordering it exists for: the marker has to be in place before the
+    /// first worktree lands, so this makes the directory rather than waiting for git to.
+    @Test("asked to, it makes the directory and marks it in one go")
+    func creatingItMakesTheDirectory() {
+        let base = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(atPath: base) }
+        let directory = base + "/bloom/workspaces"
+
+        let outcome = SpotlightExclusion.mark(directory, creatingIt: true)
+
+        #expect(outcome == .written)
+        #expect(FileManager.default.fileExists(atPath: SpotlightExclusion.markerPath(in: directory)))
+    }
+
+    /// It is an optimisation, so nothing it cannot do is allowed to become anybody's problem. A
+    /// path under `/dev/null` cannot be a directory on any Mac, and asking for one there has to
+    /// come back as a value rather than as a throw or a crash.
+    @Test("somewhere it cannot write comes back as an outcome, not as a failure")
+    func aRefusedWriteIsSwallowed() {
+        #expect(SpotlightExclusion.mark("/dev/null/nowhere") == .noSuchDirectory)
+        #expect(SpotlightExclusion.mark("/dev/null/nowhere", creatingIt: true) == .noSuchDirectory)
+    }
+
+    /// A file where the directory should be is the same answer, and it is worth its own case
+    /// because `fileExists` alone says yes to it.
+    @Test("a file wearing the directory's name is not marked")
+    func aFileIsNotADirectory() {
+        let base = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(atPath: base) }
+        let path = base + "/workspaces"
+        try! "not a directory".write(toFile: path, atomically: true, encoding: .utf8)
+
+        #expect(SpotlightExclusion.mark(path) == .noSuchDirectory)
+        #expect(try! String(contentsOfFile: path, encoding: .utf8) == "not a directory")
+    }
+
+    /// The live call names the root new worktrees are cut in, and nothing else. Asserted on the
+    /// path rather than by running it, because running it would write into the owner's own
+    /// `~/bloom/workspaces` from a test.
+    @Test("the directory this Mac marks is the workspaces root")
+    func theLiveDirectoryIsTheWorkspacesRoot() {
+        let expected = WorkspaceManager.workspacesRoot.path + "/.metadata_never_index"
+
+        #expect(SpotlightExclusion.markerPath(in: WorkspaceManager.workspacesRoot.path) == expected)
+    }
+}


### PR DESCRIPTION
Twenty workspaces are twenty copies of `vendor/`, `node_modules/` and `.build/` for `mds` to re-read every time a build or test run touches them, and nobody searches a worktree by content. The advice was to add `~/bloom/workspaces` to Spotlight's privacy list by hand, on every Mac, after Bloom had already made the directory.

`SpotlightExclusion` writes `.metadata_never_index` into the workspaces root: once before the first worktree is cut, and again at launch for installations that already have a root. The root only, since exclusion covers the subtree.

An existing file of that name is left exactly as it is, whatever is in it. A write that fails is swallowed and returns an outcome nobody acts on: it is an optimisation, and its failure case is the app as it was.

The measurement it rests on: this Mac has carried a marker in `~/dev/code` since June, and against 3,236 directories under it Spotlight returns nothing, for a name query, a content query, or anything created since. Existing index entries persist until something reindexes, so `~/bloom/workspaces` will keep answering `mdfind` for a while after the marker appears.