### PR TITLE
Fix the diff pane: top alignment, multi-line selection, and a schema repair

### DIFF
--- a/Sources/Bloom/Design/DiffRunGallery.swift
+++ b/Sources/Bloom/Design/DiffRunGallery.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+import BloomCore
+
+/// A run of diff lines beside the per line rows it stands in for, over a rule drawn every
+/// `CodeMetrics.rowHeight`.
+///
+/// **The page exists for one invariant, and it is the one this whole change rests on.** A run
+/// draws its code as a single `Text` so that a selection can cross lines, which means the code no
+/// longer takes its height from a frame: it takes it from the text system, while the gutter beside
+/// it is still one fixed height cell per line. If those two ever disagree by so much as a fraction
+/// of a point the error ACCUMULATES, and four hundred lines later a number is beside the wrong
+/// line. Per line rows could never do that, so nothing in the diff used to be worth photographing;
+/// this is.
+///
+/// The rule is the test. Every tick is one `CodeMetrics.rowHeight`, so a number, a marker and a
+/// line of code belong between the same pair of ticks all the way down. `CodeMetrics.rowSpacing`
+/// is the arithmetic that makes it true and says what was measured to arrive at it.
+///
+/// `Snapshot.scheduleGalleryCapture` picks this up as `--gallery diff-run`.
+struct DiffRunGallery: View {
+    let app: AppModel
+
+    private static let width: CGFloat = 620
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            case_(
+                "A run, and the rows it replaces",
+                "The same six lines twice. The gutters have to be the same gutter: a diff draws "
+                    + "both kinds at once, wherever a comment band or an expander stops a run."
+            ) {
+                ruled(count: Self.lines.count) {
+                    DiffRunView(lines: Self.run, language: .swift, width: Self.width)
+                }
+                Hairline()
+                ruled(count: Self.lines.count) {
+                    VStack(spacing: 0) {
+                        ForEach(Self.lines, id: \.index) { line in
+                            DiffLineView(
+                                line: line,
+                                language: .swift,
+                                emphasis: Self.emphasis(of: line),
+                                width: Self.width
+                            )
+                        }
+                    }
+                }
+            }
+
+            case_(
+                "Forty lines, which is where drift would show",
+                "A fraction of a point per line is invisible on six and half a row on forty."
+            ) {
+                ruled(count: 40) {
+                    DiffRunView(lines: Self.long, language: .swift, width: Self.width)
+                }
+            }
+
+            case_(
+                "Nothing opposite it",
+                "The side by side padding starts at the marker column, not at the row's edge, so "
+                    + "the numbers keep the pane's own ground the way the per line rows leave them."
+            ) {
+                ruled(count: Self.opposite.count) {
+                    DiffRunView(
+                        lines: Self.opposite,
+                        language: .swift,
+                        numbers: .old,
+                        width: Self.width / 2
+                    )
+                }
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    // MARK: - The rule
+
+    /// One tick per row height, drawn over the top and hit testing nothing, so the thing being
+    /// photographed is not also being changed by the thing photographing it.
+    private func ruled(count: Int, @ViewBuilder content: () -> some View) -> some View {
+        content()
+            .overlay(alignment: .top) {
+                VStack(spacing: 0) {
+                    ForEach(0..<count, id: \.self) { _ in
+                        VStack(spacing: 0) {
+                            Rectangle()
+                                .fill(Palette.controlAccent.opacity(0.35))
+                                .frame(height: Metrics.hairline)
+                            Spacer(minLength: 0)
+                        }
+                        .frame(height: CodeMetrics.rowHeight)
+                    }
+                }
+                .allowsHitTesting(false)
+            }
+    }
+
+    private func case_(
+        _ title: String, _ note: String, @ViewBuilder content: () -> some View
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title).font(Typo.label).foregroundStyle(Palette.textSecondary)
+            Text(note)
+                .font(Typo.caption)
+                .foregroundStyle(Palette.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+            VStack(spacing: 0) {
+                content()
+            }
+            .background(Palette.surface)
+        }
+    }
+
+    // MARK: - What is drawn
+
+    private static let lines: [DiffLine] = [
+        DiffLine(
+            kind: .context, text: "func render(_ document: DiffDocument) -> some View {",
+            oldNumber: 12, newNumber: 12, index: 0
+        ),
+        DiffLine(
+            kind: .deletion, text: "    let width = proxy.size.width",
+            oldNumber: 13, index: 1
+        ),
+        DiffLine(
+            kind: .addition, text: "    let width = max(proxy.size.width, intrinsic(document))",
+            newNumber: 13, index: 2
+        ),
+        DiffLine(
+            kind: .context, text: "    return ScrollView([.vertical, .horizontal]) {",
+            oldNumber: 14, newNumber: 14, index: 3
+        ),
+        DiffLine(
+            kind: .context, text: "        LazyVStack(alignment: .leading, spacing: 0) { rows }",
+            oldNumber: 15, newNumber: 15, index: 4
+        ),
+        DiffLine(kind: .context, text: "    }", oldNumber: 16, newNumber: 16, index: 5),
+    ]
+
+    /// The word that actually changed on the pair above, so the page also shows that the emphasis
+    /// still lands on the right characters once the lines are one string.
+    static func emphasis(of line: DiffLine) -> [Range<String.Index>] {
+        guard let found = line.text.range(of: line.kind == .addition ? "max(" : "proxy.size.width")
+        else { return [] }
+        return [found]
+    }
+
+    private static let run: [DiffRunLine] = lines.map {
+        DiffRunLine(line: $0, emphasis: emphasis(of: $0), isCommented: $0.index == 4)
+    }
+
+    private static let long: [DiffRunLine] = (0..<40).map { offset in
+        DiffRunLine(
+            line: DiffLine(
+                kind: offset % 7 == 0 ? .addition : .context,
+                text: "    let value\(offset) = compute(input: \(offset))",
+                oldNumber: 100 + offset,
+                newNumber: 100 + offset,
+                index: 100 + offset
+            )
+        )
+    }
+
+    private static let opposite: [DiffRunLine] = [
+        DiffRunLine(
+            line: DiffLine(
+                kind: .deletion, text: "    let stale = true", oldNumber: 41, index: 200
+            )
+        ),
+        DiffRunLine(line: nil),
+        DiffRunLine(line: nil),
+        DiffRunLine(
+            line: DiffLine(
+                kind: .context, text: "    return stale", oldNumber: 42, newNumber: 40, index: 203
+            )
+        ),
+    ]
+}
+
+extension Gallery {
+    /// The registry entry for this page. See `Gallery`.
+    static let diffRun = Gallery(
+        name: "diff-run",
+        title: "Diff runs and the rule they sit on",
+        size: CGSize(width: 700, height: 1_220),
+        needsFocus: false,
+        view: { app in AnyView(DiffRunGallery(app: app)) }
+    )
+}

--- a/Sources/Bloom/Design/Gallery.swift
+++ b/Sources/Bloom/Design/Gallery.swift
@@ -86,6 +86,7 @@ extension Snapshot {
         .proseLeading,
         .welcomeOffers,
         .crewMessages,
+        .diffRun,
     ]
 
     /// The page `--gallery` names, falling back to the first rather than failing: a capture run

--- a/Sources/Bloom/Views/Center/Panes/ReviewPaneView.swift
+++ b/Sources/Bloom/Views/Center/Panes/ReviewPaneView.swift
@@ -60,7 +60,11 @@ struct ReviewPaneView: View {
     var body: some View {
         VStack(spacing: 0) {
             content
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // Pinned to the top, not centred, which is what an unaligned fill means and what
+                // a reader reported on 0.20.0: a file with a handful of lines in it floated in
+                // the middle of a tall pane with a band of empty above it. Every one of the views
+                // this holds reads top down, and the empty states inside them centre themselves.
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
             // The same composer the conversation shows, bound to the same transcript, so the
             // chips a review has accumulated are visible from the diff they were written on and

--- a/Sources/Bloom/Views/Code/CodeMetrics.swift
+++ b/Sources/Bloom/Views/Code/CodeMetrics.swift
@@ -1,5 +1,6 @@
 import AppKit
 import BloomCore
+import SwiftUI
 
 /// Monospaced text lets a view compute its own width arithmetically instead of measuring, which
 /// is what makes a single horizontal scroll view over a whole file affordable.
@@ -21,6 +22,24 @@ enum CodeMetrics {
         return NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
     }()
 
+    /// `font` as SwiftUI sees it, which is what a run of code has to be set in.
+    ///
+    /// **Not `Typo.code`, and the difference is measurable rather than theoretical.** `Typo.code`
+    /// is a TEXT STYLE rung, `.callout` at the monospaced design, and SwiftUI does not add
+    /// `.lineSpacing` to a text style at face value: measured offscreen, twenty-one lines of it
+    /// asked for three points of spacing came out 17.1375 points apart, where the same string in
+    /// the same face at a fixed point size came out at exactly 18. Both render identical glyphs at
+    /// the same size, so nothing about the page changes; only the line advance does, and a run
+    /// gets its height from that rather than from a frame. The first version of `DiffRunView`
+    /// used the rung and the gutter had slipped two whole rows by line forty, which is what the
+    /// `diff-run` gallery page exists to catch.
+    ///
+    /// It also settles a second question. `Typo.code` multiplies by `\.fontScale`, and every
+    /// number in this file is measured at a scale of one. Nothing that draws a diff sets that
+    /// environment today (`ReviewPaneView` scopes it to the composer), but a run pinned to this
+    /// font cannot drift from `rowHeight` even if one day something does.
+    static let measuredFont = Font(font)
+
     /// Width of one character in `Typo.code`.
     static let advance: CGFloat = advance(of: font, fallback: 7.2)
 
@@ -32,9 +51,28 @@ enum CodeMetrics {
         return width > 0 ? width : fallback
     }
 
+    /// The height one line of `Typo.code` takes when the text system lays it out, with no air of
+    /// our own added. Measured offscreen at the callout size, SwiftUI gives a `Text` exactly this,
+    /// which is what makes `rowSpacing` below arithmetic rather than a guess.
+    static let naturalLineHeight: CGFloat = ceil(font.ascender - font.descender + font.leading)
+
     /// One line of code, plus the small amount of air that keeps a wall of them readable. Floored
     /// at the height the diff was designed around so the default appearance is unchanged.
-    static let rowHeight: CGFloat = max(16, ceil(font.ascender - font.descender + font.leading) + 3)
+    static let rowHeight: CGFloat = max(16, naturalLineHeight + 3)
+
+    /// The air itself, which a multi-line `Text` has to be told to add between its lines.
+    ///
+    /// A run of lines drawn as one `Text` gets its line boxes from the text system, not from a
+    /// frame, so the gutter beside it only stays level if each box is exactly `rowHeight`.
+    /// **`.lineSpacing` is the only lever that works.** A paragraph style carrying
+    /// `minimumLineHeight` and `maximumLineHeight` on the `AttributedString` is the obvious way to
+    /// say it and SwiftUI ignores it outright: measured offscreen, three lines styled to 18 points
+    /// each came back 45 points tall, the same as unstyled. `.lineSpacing(3)` came back 51, which
+    /// is the 18 this wants.
+    ///
+    /// Never negative: `rowHeight` is this plus three whenever the floor above is not in play, and
+    /// the floor only ever raises it.
+    static let rowSpacing: CGFloat = rowHeight - naturalLineHeight
 
     /// The `+` or `-` column. One character wide, plus its own breathing room.
     static let markerWidth: CGFloat = ceil(advance) + 4

--- a/Sources/Bloom/Views/Code/CodeRunText.swift
+++ b/Sources/Bloom/Views/Code/CodeRunText.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import BloomCore
+
+/// One line of a run, and everything drawing it needs that is not shared with its neighbours.
+///
+/// The carry is per line rather than per run because the lexer carries block comments, heredocs
+/// and multiline strings forward, and a run does not always start where a hunk does.
+struct CodeRunLine: Equatable {
+    var text: String
+    var carry: LexState = LexState()
+    /// Word level diff spans, in indices over `text`.
+    var emphasis: [Range<String.Index>] = []
+    var emphasisColor: Color = .clear
+}
+
+/// Several syntax highlighted lines of source as ONE text object, so a selection runs across them.
+///
+/// **This is the whole of the fix for "text on multiple lines is not selectable".** Sibling `Text`
+/// views are separate selection scopes on this system: `.textSelection(.enabled)` selects within
+/// one and cannot span two, so a diff drawn as a `Text` per line let the reader select the single
+/// line a drag began on and no more. `CodeBlockView` hit the identical report about a markdown
+/// fence and answered it the same way, and its note is worth reading beside this one.
+///
+/// Joining costs the colours nothing. `CodeText.attributed` hands back a line whose highlighting
+/// and word level emphasis are already attribute runs on the string, and concatenation carries a
+/// run's attributes with it. It costs the memoisation nothing either: every line still goes
+/// through `SyntaxCache` on its own key, so a line redrawn in a run and a line redrawn on its own
+/// are the same cache hit.
+///
+/// What it does cost is the lazy stack's granularity, since a run is one item however many lines
+/// it holds. That is why `DiffRunGrouping` caps a run rather than taking a whole hunk, and the
+/// measurements behind the cap are on `DiffRunGrouping.runLimit`.
+struct CodeRunText: View, Equatable {
+    var lines: [CodeRunLine]
+    var language: Language
+
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.language == rhs.language && lhs.lines == rhs.lines
+    }
+
+    var body: some View {
+        Text(joined)
+            // `CodeMetrics.measuredFont` rather than `Typo.code`, and that is the whole of what
+            // keeps this level: a text style rung does not take `.lineSpacing` at face value.
+            // The measurement, and what it cost, are on `measuredFont` itself.
+            .font(CodeMetrics.measuredFont)
+            // Each line box has to come out at exactly `CodeMetrics.rowHeight`, because the gutter
+            // beside this is still one fixed height view per line and the two have to stay level
+            // over hundreds of rows. `rowSpacing` is that arithmetic.
+            .lineSpacing(CodeMetrics.rowSpacing)
+            .textSelection(.enabled)
+            // Unwrapped, for the reason the sheet is sized off the widest line in the file: the
+            // whole diff scrolls sideways as one, and a run that wrapped would take rows with it
+            // and throw the gutter out of step for everything below.
+            .fixedSize(horizontal: true, vertical: false)
+            // Spacing falls BETWEEN lines, so a run of n lines is one natural line plus n - 1
+            // gaps, which is half a gap short at each end of the n * rowHeight the gutter draws.
+            // Measured offscreen: seven lines came out at 126.0 points against 7 * 18, exactly,
+            // with this padding and three short without it.
+            .padding(.vertical, CodeMetrics.rowSpacing / 2)
+    }
+
+    private var joined: AttributedString {
+        var output = AttributedString()
+        for (offset, line) in lines.enumerated() {
+            if offset > 0 { output += AttributedString("\n") }
+            output += CodeText.attributed(
+                line: line.text,
+                language: language,
+                carry: line.carry,
+                emphasis: line.emphasis,
+                emphasisColor: line.emphasisColor
+            )
+        }
+        return output
+    }
+}

--- a/Sources/Bloom/Views/Code/CodeText.swift
+++ b/Sources/Bloom/Views/Code/CodeText.swift
@@ -35,19 +35,39 @@ struct CodeText: View {
     }
 
     var body: some View {
-        Text(attributed)
-            .font(Typo.code)
-            .textSelection(.enabled)
-            .lineLimit(1)
-            .fixedSize(horizontal: true, vertical: false)
+        Text(
+            Self.attributed(
+                line: line,
+                language: language,
+                carry: carry,
+                emphasis: emphasis,
+                emphasisColor: emphasisColor
+            )
+        )
+        .font(Typo.code)
+        .textSelection(.enabled)
+        .lineLimit(1)
+        .fixedSize(horizontal: true, vertical: false)
     }
 
-    private var attributed: AttributedString {
+    /// One line, highlighted, with its word level diff spans painted on top.
+    ///
+    /// Lifted out of `body` so that `CodeRunText` builds a whole run out of the same call this
+    /// draws a single line with. Two answers to "what does a line of code look like" is how the
+    /// per line rows and the run beside them would drift into two colour schemes for one file,
+    /// and the run is only ever some of the rows: see `DiffRunGrouping`.
+    static func attributed(
+        line: String,
+        language: Language,
+        carry: LexState,
+        emphasis: [Range<String.Index>] = [],
+        emphasisColor: Color = .clear
+    ) -> AttributedString {
         var value = SyntaxCache.attributed(line: line, language: language, carry: carry)
         guard !emphasis.isEmpty else { return value }
 
         for range in emphasis {
-            guard let mapped = Self.attributedRange(for: range, of: line, in: value) else { continue }
+            guard let mapped = attributedRange(for: range, of: line, in: value) else { continue }
             value[mapped].backgroundColor = emphasisColor
         }
         return value

--- a/Sources/Bloom/Views/Inspector/DiffGutter.swift
+++ b/Sources/Bloom/Views/Inspector/DiffGutter.swift
@@ -1,0 +1,182 @@
+import SwiftUI
+import BloomCore
+
+/// The line number columns of a diff row.
+///
+/// **Shared rather than written twice, because a diff draws two kinds of row at once.** Most rows
+/// are now a `DiffRunView`, several lines of code in one selectable text object with a column of
+/// these beside it; the rows a run may not swallow (see `DiffRunGrouping`) are still a
+/// `DiffLineView` each. Both appear in the same file, interleaved, so the two gutters have to be
+/// the same gutter to the point: a column that disagreed by half a point would step in and out
+/// down the left of every diff at exactly the places a comment band sits.
+struct DiffGutter: View {
+    /// Which gutters a row shows. Side by side shows one, unified shows both.
+    ///
+    /// Here rather than on `DiffLineView`, which is where it used to live, because the run view
+    /// needs it too and neither of them owns the other. `DiffLineView.Numbers` still resolves, so
+    /// the diff's own signatures did not have to move with it.
+    enum Numbers {
+        case both
+        case old
+        case new
+    }
+
+    var line: DiffLine?
+    var numbers: Numbers
+
+    var body: some View {
+        HStack(spacing: 0) {
+            switch numbers {
+            case .both:
+                number(line?.oldNumber)
+                number(line?.newNumber)
+            case .old:
+                number(line?.oldNumber)
+            case .new:
+                number(line?.newNumber)
+            }
+        }
+        // No tint of its own. A grey column against the white the code sits on put a hard vertical
+        // edge down the left of every diff, and a hard edge is read as a boundary between two
+        // things rather than as the margin of one. The row's wash runs under this and under the
+        // code alike, which leaves the numbers to be told apart by being dimmed and monospaced,
+        // and that is what separates a ruler from content anyway.
+    }
+
+    /// Right aligned, dimmed and monospaced, so a column of numbers reads as a ruler rather than
+    /// as content competing with the code beside it.
+    private func number(_ value: Int?) -> some View {
+        Text(value.map(String.init) ?? "")
+            .font(Typo.codeTiny)
+            .monospacedDigit()
+            .foregroundStyle(Palette.textTertiary)
+            .frame(width: CodeMetrics.numberWidth, alignment: .trailing)
+            .padding(.trailing, CodeMetrics.gutterPadding)
+    }
+
+    /// How wide this column comes out, which the run view needs as a number because it paints the
+    /// row washes as a layer behind the columns rather than as each row's own background.
+    static func width(for numbers: Numbers) -> CGFloat {
+        let cell = CodeMetrics.numberWidth + CodeMetrics.gutterPadding
+        return numbers == .both ? cell * 2 : cell
+    }
+
+    /// What this line is, where it is, and what it says, in that order.
+    ///
+    /// One element per line, said as a sentence. Left as it was drawn, VoiceOver read a row as
+    /// four unrelated fragments, "128", "129", "+", and then the code, and whether a line was
+    /// added or removed reached the reader only as a background wash and a one-character marker
+    /// that is a bare space on a context line. A colour is not a label.
+    static func speech(for line: DiffLine?) -> String {
+        guard let line else { return "" }
+        if line.kind == .noNewline { return "No newline at end of file" }
+
+        let number = line.newNumber ?? line.oldNumber
+        let place = number.map { " \($0)" } ?? ""
+        let state = switch line.kind {
+        case .addition: "Added line\(place)"
+        case .deletion: "Removed line\(place)"
+        default: "Line\(place)"
+        }
+
+        let text = line.text.trimmingCharacters(in: .whitespaces)
+        return text.isEmpty ? "\(state), empty" : "\(state), \(text)"
+    }
+}
+
+/// The one character column that says whether a line was added, removed or left alone.
+///
+/// Beside the code rather than inside the gutter, and that is load bearing for the split layout:
+/// a row with nothing opposite it paints `Palette.surfaceSunken` from HERE to the end of the sheet,
+/// so a marker moved in with the numbers would leave a stripe of pane colour inside the sunken
+/// band. See `DiffRunView.wash` and `DiffLineView.content`, which both start the fill at this
+/// column's leading edge.
+struct DiffMarker: View {
+    var line: DiffLine?
+
+    var body: some View {
+        Text(text)
+            .font(Typo.codeTiny)
+            .foregroundStyle(Palette.textTertiary)
+            .frame(width: CodeMetrics.markerWidth, alignment: .center)
+    }
+
+    private var text: String {
+        switch line?.kind {
+        case .addition: "+"
+        case .deletion: "-"
+        case .noNewline: "\\"
+        default: " "
+        }
+    }
+}
+
+/// The `+` in the gutter, sitting over the line number the way Conductor draws it.
+///
+/// Always in the hierarchy and hidden by drawing in clear rather than built on hover or faded with
+/// `.opacity`, so it is reachable by Tab under Full Keyboard Access and readable by VoiceOver: a
+/// control that only exists while a pointer floats over it is a control a keyboard can never
+/// reach. Not `.opacity(0)`, on the button or on its label, because either took the element out of
+/// the accessibility tree entirely, measured by it vanishing from the AX hierarchy, which silently
+/// broke the row's spoken sentence. Clear colours draw the same nothing while the button keeps its
+/// hit region and its element, which is also what makes the hover reveal feel instant.
+///
+/// **Its own `@FocusState`, one per instance, which is what lets a run of lines carry a column of
+/// these.** The state used to live on the row, and a run has no row to put it on.
+///
+/// **It is overlaid by its caller AFTER the accessibility collapse, never inside it.**
+/// `children: .ignore` swallows every descendant of whatever it is applied to, so a button inside
+/// the collapsed element is a button VoiceOver and the keyboard cannot reach, and the claim in the
+/// paragraph above would be quietly false. Both callers overlay it as a sibling of the collapsed
+/// row for that reason.
+struct DiffCommentButton: View {
+    var spot: ReviewSpot
+    var isRowHovered: Bool
+    var onComment: (ReviewSpot) -> Void
+
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        let shown = isRowHovered || isFocused
+        Button {
+            onComment(spot)
+        } label: {
+            Image(systemName: "plus")
+                .font(Typo.micro)
+                .fontWeight(.bold)
+                .foregroundStyle(shown ? Palette.selectedEmphasizedText : .clear)
+                .frame(width: 16, height: 16)
+                .background(
+                    shown ? Palette.controlAccent : .clear,
+                    in: RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .focused($isFocused)
+        .padding(.leading, Metrics.spacingTight)
+        .help("Comment on this line")
+        .accessibilityLabel("Comment on line \(spot.line)")
+    }
+}
+
+/// Which spot a row offers to hang a comment on, filtered to the side it is drawing.
+///
+/// In side by side a context line appears in both panes; only the new-side pane offers it, so one
+/// line never grows two buttons meaning the same thing. Shared by the per line rows and the run
+/// rows, and `DiffView.spots(of:numbers:)` makes the same split when it decides where a band
+/// lands, so a `+` and the band it produces can never disagree about which pane they belong to.
+enum DiffCommentSpot {
+    static func offered(
+        for line: DiffLine?,
+        numbers: DiffGutter.Numbers,
+        enabled: Bool
+    ) -> ReviewSpot? {
+        guard enabled, let spot = line?.reviewSpot else { return nil }
+        switch numbers {
+        case .both: return spot
+        case .old: return spot.side == .old ? spot : nil
+        case .new: return spot.side == .new ? spot : nil
+        }
+    }
+}

--- a/Sources/Bloom/Views/Inspector/DiffLineView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffLineView.swift
@@ -5,6 +5,13 @@ import BloomCore
 ///
 /// The same view serves both layouts. Unified asks for both number columns, side by side asks for
 /// one and is given an explicit width so the two panes stay aligned even when a line is empty.
+///
+/// **Most rows are no longer drawn by this.** A `Text` per line cannot be selected across two of
+/// them, so consecutive lines are grouped into a `DiffRunView` and drawn as one text object; see
+/// `DiffRunGrouping` for what stops a run. What is left here is every row a run may not swallow:
+/// a lone line between two comment bands, the line above an expander, the last line of a hunk.
+/// The two must look identical, which is why the gutter, the marker and the `+` are shared views
+/// rather than a copy each.
 struct DiffLineView: View, Equatable {
     /// A row redraws when what it holds changes, and not because the closure beside it is a new
     /// closure. `onComment` is written at the call site as `{ beginDraft(at: $0) }`, so it is a
@@ -29,12 +36,9 @@ struct DiffLineView: View, Equatable {
             && lhs.isCommented == rhs.isCommented
     }
 
-    /// Which gutters this row shows. Side by side shows one, unified shows both.
-    enum Numbers {
-        case both
-        case old
-        case new
-    }
+    /// Which gutters this row shows. The enum moved to `DiffGutter` when the run view came to
+    /// need it too; this keeps `DiffLineView.Numbers` naming the same type it always did.
+    typealias Numbers = DiffGutter.Numbers
 
     var line: DiffLine?
     var language: Language
@@ -52,27 +56,24 @@ struct DiffLineView: View, Equatable {
     var onComment: ((ReviewSpot) -> Void)?
 
     @State private var isHovered = false
-    @FocusState private var isPlusFocused: Bool
 
     var body: some View {
         HStack(spacing: 0) {
-            gutter
+            DiffGutter(line: line, numbers: numbers)
             content
         }
         .frame(width: width, height: CodeMetrics.rowHeight, alignment: .leading)
-        // One element per line, said as a sentence. Left as it was drawn, VoiceOver read a row as
-        // four unrelated fragments, "128", "129", "+", and then the code, and whether a line was
-        // added or removed reached the reader only as a background wash and a one-character
-        // marker that is a bare space on a context line. A colour is not a label.
+        // One element per line, said as a sentence. The wording, and why a colour is not a label,
+        // are on `DiffGutter.speech`.
         //
         // Collapsed HERE, before the comment button's overlay, and not at the foot of the body.
         // `children: .ignore` swallows every descendant of whatever it is applied to, so applied
         // after the overlay it removed the button from the accessibility tree, measured by the
-        // button vanishing from the AX hierarchy, and the claim in `commentButton`'s comment that
-        // a keyboard and VoiceOver can reach it was quietly false. In this order the row is one
-        // spoken sentence and the button is its sibling, which is both true and reachable.
+        // button vanishing from the AX hierarchy, and the claim in `DiffCommentButton`'s comment
+        // that a keyboard and VoiceOver can reach it was quietly false. In this order the row is
+        // one spoken sentence and the button is its sibling, which is both true and reachable.
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(accessibilityLabel)
+        .accessibilityLabel(DiffGutter.speech(for: line))
         .accessibilityHidden(line == nil)
         .overlay(alignment: .leading) { commentButton }
         // The whole row is the hover target, and it has to be said, because a view's hit region
@@ -100,7 +101,7 @@ struct DiffLineView: View, Equatable {
         // an unchanged line still paints nothing, so only the lines that were already coloured
         // are affected, and they now meet. Behind the content rather than over it, so the word
         // level emphasis inside `CodeText` still sits on top and is neither moved nor clipped.
-        .background(background)
+        .background(DiffWash.background(of: line))
         // The same action the `+` in the gutter carries, on the right click as well.
         //
         // A control that only appears under the pointer is a control most people never learn is
@@ -120,104 +121,19 @@ struct DiffLineView: View, Equatable {
         }
     }
 
-    /// What this line is, where it is, and what it says, in that order.
-    private var accessibilityLabel: String {
-        guard let line else { return "" }
-        if line.kind == .noNewline { return "No newline at end of file" }
-
-        let number = line.newNumber ?? line.oldNumber
-        let place = number.map { " \($0)" } ?? ""
-        let state = switch line.kind {
-        case .addition: "Added line\(place)"
-        case .deletion: "Removed line\(place)"
-        default: "Line\(place)"
-        }
-
-        let text = line.text.trimmingCharacters(in: .whitespaces)
-        return text.isEmpty ? "\(state), empty" : "\(state), \(text)"
-    }
-
     // MARK: - Commenting
 
     /// The spot a comment left on this row would anchor to, filtered to the side this view is
-    /// drawing. In side by side a context line appears in both panes; only the new-side pane
-    /// offers it, so one line never grows two buttons meaning the same thing.
+    /// drawing. The rule is `DiffCommentSpot`, shared with the run view.
     private var offeredSpot: ReviewSpot? {
-        guard onComment != nil, let spot = line?.reviewSpot else { return nil }
-        switch numbers {
-        case .both: return spot
-        case .old: return spot.side == .old ? spot : nil
-        case .new: return spot.side == .new ? spot : nil
-        }
+        DiffCommentSpot.offered(for: line, numbers: numbers, enabled: onComment != nil)
     }
 
-    /// The `+` in the gutter, sitting over the line number the way Conductor draws it.
-    ///
-    /// Always in the hierarchy and hidden by drawing in clear rather than built on hover or
-    /// faded with `.opacity`, so it is reachable by Tab under Full Keyboard Access and readable
-    /// by VoiceOver: a control that only exists while a pointer floats over it is a control a
-    /// keyboard can never reach. Not `.opacity(0)`, on the button or on its label, because
-    /// either took the element out of the accessibility tree entirely, measured by it vanishing
-    /// from the AX hierarchy, which silently broke the sentence before this one. Clear colours
-    /// draw the same nothing while the button keeps its hit region and its element, which is
-    /// also what makes the hover reveal feel instant.
     @ViewBuilder
     private var commentButton: some View {
-        if let spot = offeredSpot {
-            let shown = isHovered || isPlusFocused
-            Button {
-                onComment?(spot)
-            } label: {
-                Image(systemName: "plus")
-                    .font(Typo.micro)
-                    .fontWeight(.bold)
-                    .foregroundStyle(shown ? Palette.selectedEmphasizedText : .clear)
-                    .frame(width: 16, height: 16)
-                    .background(
-                        shown ? Palette.controlAccent : .clear,
-                        in: RoundedRectangle(cornerRadius: Metrics.cornerSmall)
-                    )
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .focused($isPlusFocused)
-            .padding(.leading, Metrics.spacingTight)
-            .help("Comment on this line")
-            .accessibilityLabel("Comment on line \(spot.line)")
+        if let spot = offeredSpot, let onComment {
+            DiffCommentButton(spot: spot, isRowHovered: isHovered, onComment: onComment)
         }
-    }
-
-    // MARK: - Gutter
-
-    @ViewBuilder
-    private var gutter: some View {
-        HStack(spacing: 0) {
-            switch numbers {
-            case .both:
-                number(line?.oldNumber)
-                number(line?.newNumber)
-            case .old:
-                number(line?.oldNumber)
-            case .new:
-                number(line?.newNumber)
-            }
-        }
-        // No tint of its own. A grey column against the white the code sits on put a hard vertical
-        // edge down the left of every diff, and a hard edge is read as a boundary between two
-        // things rather than as the margin of one. The row's wash runs under this and under the
-        // code alike, which leaves the numbers to be told apart by being dimmed and monospaced,
-        // and that is what separates a ruler from content anyway.
-    }
-
-    /// Right aligned, dimmed and monospaced, so a column of numbers reads as a ruler rather than
-    /// as content competing with the code beside it.
-    private func number(_ value: Int?) -> some View {
-        Text(value.map(String.init) ?? "")
-            .font(Typo.codeTiny)
-            .monospacedDigit()
-            .foregroundStyle(Palette.textTertiary)
-            .frame(width: CodeMetrics.numberWidth, alignment: .trailing)
-            .padding(.trailing, CodeMetrics.gutterPadding)
     }
 
     // MARK: - Content
@@ -228,7 +144,7 @@ struct DiffLineView: View, Equatable {
             switch line.kind {
             case .noNewline:
                 HStack(spacing: 0) {
-                    marker
+                    DiffMarker(line: line)
                     Text("No newline at end of file")
                         .font(Typo.codeTiny)
                         .foregroundStyle(Palette.textTertiary)
@@ -241,9 +157,9 @@ struct DiffLineView: View, Equatable {
                 // it paints over the row tint underneath rather than replacing it. Both are needed:
                 // the tint says the line changed, the emphasis says which part of it did.
                 HStack(spacing: 0) {
-                    marker
+                    DiffMarker(line: line)
                     CodeText(line: line.text, language: language, carry: carry)
-                        .emphasizing(emphasis, color: emphasisColor)
+                        .emphasizing(emphasis, color: DiffWash.emphasis(of: line))
                     Spacer(minLength: 0)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -256,24 +172,16 @@ struct DiffLineView: View, Equatable {
                 .frame(maxWidth: .infinity)
         }
     }
+}
 
-    private var marker: some View {
-        Text(markerText)
-            .font(Typo.codeTiny)
-            .foregroundStyle(Palette.textTertiary)
-            .frame(width: CodeMetrics.markerWidth, alignment: .center)
-    }
-
-    private var markerText: String {
-        switch line?.kind {
-        case .addition: "+"
-        case .deletion: "-"
-        case .noNewline: "\\"
-        default: " "
-        }
-    }
-
-    private var background: Color {
+/// What a diff line is painted with.
+///
+/// Two colours, asked for by the per line rows and by the run rows, which paint them in different
+/// places: `DiffLineView` as the row's own background, `DiffRunView` as a layer behind a column of
+/// lines. One answer, so a run and the lone line under it cannot come out different greens.
+enum DiffWash {
+    /// The wash that says the line changed.
+    static func background(of line: DiffLine?) -> Color {
         switch line?.kind {
         case .addition: Palette.diffAddBackground
         case .deletion: Palette.diffDeleteBackground
@@ -281,7 +189,8 @@ struct DiffLineView: View, Equatable {
         }
     }
 
-    private var emphasisColor: Color {
+    /// The stronger tint that says WHICH PART of it changed, painted on the glyph runs on top.
+    static func emphasis(of line: DiffLine?) -> Color {
         switch line?.kind {
         case .addition: Palette.diffAddEmphasis
         case .deletion: Palette.diffDeleteEmphasis

--- a/Sources/Bloom/Views/Inspector/DiffRow.swift
+++ b/Sources/Bloom/Views/Inspector/DiffRow.swift
@@ -16,6 +16,11 @@ enum DiffRow: Identifiable {
     case gapExpander(gapID: Int, hidden: Int)
     case line(DiffLine)
     case pair(SideBySideRow)
+    /// Consecutive lines drawn as one block of selectable text. See `DiffRunView`: a `Text` per
+    /// line cannot be selected across two of them, which is the bug this case exists for.
+    case lineRun([DiffLine])
+    /// The same, for the side by side layout, where each half is its own block.
+    case pairRun([SideBySideRow])
     /// A pending review comment, drawn under the line it is about, or at the top of the diff
     /// when `ReviewPlacements` could not put it under one.
     case commentBand(ReviewPlacement)
@@ -34,8 +39,93 @@ enum DiffRow: Identifiable {
         // pair's own `index` is not, restarting per hunk in the one-hunk folds the split view
         // builds from.
         case let .pair(row): "pair-\(row.left?.index ?? row.index)-\(row.right?.index ?? .min)"
+        // Named after the row it starts on, which a run keeps while it grows or shrinks. Content
+        // changes are not identity's job here: `DiffRunView` is `Equatable` and redraws on them.
+        case let .lineRun(lines): "linerun-\(lines.first?.index ?? .min)"
+        // Both sides name it, for the reason the single pair above gives and which a run needs
+        // just as much: the pair's own `index` restarts per hunk, so a run beginning with an
+        // addition (nothing on the left) would have been "pairrun-0" in every hunk that starts
+        // with one, and two rows of a `ForEach` sharing an id is a diff that draws one of them.
+        case let .pairRun(rows):
+            "pairrun-\(rows.first?.left?.index ?? rows.first?.index ?? .min)"
+                + "-\(rows.first?.right?.index ?? .min)"
         case let .commentBand(placement): "band-\(placement.id)"
         case .commentEditor: "editor"
         }
+    }
+
+    /// Whether this row may be drawn inside a run with its neighbours.
+    ///
+    /// Only plain lines may. A heading, either expander, a comment band and the open editor each
+    /// draw a view between two lines, and text cannot flow through one.
+    ///
+    /// `.noNewline` is a line and is still refused, which is the one exclusion that is not
+    /// structural. That row does not draw its own text at all: it draws the words "No newline at
+    /// end of file" in italics, so put in a run it would have printed whatever git left in the
+    /// line instead. Rare enough that keeping it on the per line path costs a selection nothing,
+    /// and it is the last line of a file anyway.
+    var isRunnable: Bool {
+        switch self {
+        case let .line(line):
+            return line.kind != .noNewline
+        case let .pair(row):
+            return row.left?.kind != .noNewline && row.right?.kind != .noNewline
+        default:
+            return false
+        }
+    }
+
+    /// Collapse consecutive line rows into runs, so a selection can cross them.
+    ///
+    /// A post pass over the finished list rather than something the two row builders each do, and
+    /// that is the point of doing it here: `unifiedRows` and `splitRows` interleave headings,
+    /// expanders, bands and the editor from four different places, and a rule about what sits next
+    /// to what is only reliable once all of them have had their say. Where a run stops is
+    /// `DiffRunGrouping`, in the core, with the tests.
+    static func grouped(_ rows: [DiffRow]) -> [DiffRow] {
+        var result: [DiffRow] = []
+        result.reserveCapacity(rows.count)
+
+        for chunk in DiffRunGrouping.chunks(count: rows.count, isLine: { rows[$0].isRunnable }) {
+            switch chunk {
+            case let .single(index):
+                result.append(rows[index])
+            case let .run(range):
+                let slice = Array(rows[range])
+                if let lines = slice.asLines {
+                    result.append(.lineRun(lines))
+                } else if let pairs = slice.asPairs {
+                    result.append(.pairRun(pairs))
+                } else {
+                    // A run of both kinds at once, which neither row builder can produce: one
+                    // list is all unified or all split. Drawn as it always was rather than
+                    // dropped, because a line missing off a diff is the worst thing this file
+                    // could do and a run is only a convenience.
+                    result.append(contentsOf: slice)
+                }
+            }
+        }
+
+        return result
+    }
+}
+
+private extension [DiffRow] {
+    var asLines: [DiffLine]? {
+        var result: [DiffLine] = []
+        for row in self {
+            guard case let .line(line) = row else { return nil }
+            result.append(line)
+        }
+        return result
+    }
+
+    var asPairs: [SideBySideRow]? {
+        var result: [SideBySideRow] = []
+        for row in self {
+            guard case let .pair(pair) = row else { return nil }
+            result.append(pair)
+        }
+        return result
     }
 }

--- a/Sources/Bloom/Views/Inspector/DiffRunView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffRunView.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+import BloomCore
+
+/// One line of a run, with everything the row around it needs to be drawn.
+struct DiffRunLine: Equatable {
+    /// Nil is a row with nothing opposite it in the side by side layout.
+    var line: DiffLine?
+    var carry: LexState = LexState()
+    var emphasis: [Range<String.Index>] = []
+    /// Whether a pending review comment is anchored here, which tints the row as under
+    /// discussion the way the band under it is.
+    var isCommented: Bool = false
+}
+
+/// Several consecutive diff lines, drawn with ONE text object for the code so that a selection
+/// runs across them.
+///
+/// **This is the fix for "text on multiple lines is not selectable in diff previews", reported on
+/// 0.20.0.** Every line used to be its own `Text`, sibling `Text`s are separate selection scopes
+/// on this system, and so a drag selected the line it began on and stopped. Nothing else about the
+/// row changed: the gutter, the marker, the washes, the `+` and the spoken sentence are all still
+/// one view per line, because all of them are per line facts. Only the code became one object.
+///
+/// ## How it stays level
+///
+/// The code no longer gets its height from a frame, it gets it from the text system, so the
+/// columns beside it only stay level if each line box comes out at exactly `CodeMetrics.rowHeight`.
+/// `CodeRunText` does that with `.lineSpacing` and half a gap of padding at each end, and both of
+/// those numbers are `CodeMetrics.rowSpacing`, derived from the same font the row height is. The
+/// alternative, a paragraph style on the string, is ignored outright by SwiftUI: the measurement
+/// is on `CodeMetrics.rowSpacing`. Measured offscreen, seven lines came out at 126.0 points
+/// against a gutter of 7 by 18.
+///
+/// ## Why the code is a layer over the rows rather than a column beside them
+///
+/// The per line chrome is drawn full width, underneath, and the code is laid over it with the
+/// columns' width as leading padding. Drawn as a third column in an `HStack` instead, a row with
+/// nothing opposite it could not paint `Palette.surfaceSunken` across the width the way
+/// `DiffLineView` does, and the accessibility element for a line would have been the gutter
+/// rather than the line. Padding rather than a clear spacer in the top layer, deliberately: a
+/// `Color.clear` is hit testable and would have sat on top of the `+` button underneath it.
+struct DiffRunView: View, Equatable {
+    var lines: [DiffRunLine]
+    var language: Language
+    var numbers: DiffGutter.Numbers = .both
+    /// Total width of the run, including gutters. Fixed by the file's widest line so the whole
+    /// diff scrolls horizontally as one sheet.
+    var width: CGFloat
+    /// Opens the review comment editor at a line. Nil, the default, draws no `+` at all.
+    var onComment: ((ReviewSpot) -> Void)?
+
+    /// Which line the pointer is over, as an offset into `lines`.
+    ///
+    /// A run is one view where there used to be one per line, so the hover that reveals the `+`
+    /// cannot be a plain `onHover` any more: it has to say WHERE. The arithmetic is only honest
+    /// because every line box in here is exactly `CodeMetrics.rowHeight` tall, which is the same
+    /// invariant the gutter depends on.
+    ///
+    /// It reveals the `+` and decides nothing else. A `+` drawn on the wrong line would be
+    /// visible and would still comment on the line it is drawn beside, because the button takes
+    /// its spot from its own row rather than from this. That is deliberate: hover is the one
+    /// thing in here a selectable `Text` might swallow over its glyphs, so nothing that could act
+    /// on the wrong line is allowed to depend on it.
+    @State private var hovered: Int?
+
+    /// The same argument as `DiffLineView.==`, which is where it is written out: the closure is a
+    /// fresh allocation on every pass over the diff and cannot be compared, and it does not need
+    /// to be. A run is worth more here than a line was, since one of these stands in for up to
+    /// `DiffRunGrouping.runLimit` rows.
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.lines == rhs.lines
+            && lhs.language == rhs.language
+            && lhs.numbers == rhs.numbers
+            && lhs.width == rhs.width
+    }
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            VStack(spacing: 0) {
+                ForEach(lines.indices, id: \.self) { index in
+                    chrome(at: index)
+                }
+            }
+            HStack(spacing: 0) {
+                CodeRunText(lines: runLines, language: language)
+                    .padding(.leading, columnsWidth)
+                    // The sentence a reader hears is the row's, assembled by `DiffGutter.speech`
+                    // and already carrying this line's text. Left visible, VoiceOver read the
+                    // whole run a second time as one undifferentiated block.
+                    .accessibilityHidden(true)
+                Spacer(minLength: 0)
+            }
+        }
+        .frame(width: width, height: CodeMetrics.rowHeight * CGFloat(lines.count), alignment: .leading)
+        // For `DiffLineView`'s reason: most of a diff row draws nothing, and without a shape the
+        // pointer finds the run only along the band of pixels the glyphs cover.
+        .contentShape(Rectangle())
+        .onContinuousHover(coordinateSpace: .local) { phase in
+            switch phase {
+            case let .active(point): hovered = row(at: point.y)
+            case .ended: hovered = nil
+            }
+        }
+    }
+
+    // MARK: - Per line chrome
+
+    /// Everything about one line that is not its code: the washes, the numbers, the marker, the
+    /// spoken sentence and the `+`. Full width, and drawn under the code layer.
+    private func chrome(at index: Int) -> some View {
+        let entry = lines[index]
+        return HStack(spacing: 0) {
+            DiffGutter(line: entry.line, numbers: numbers)
+            DiffMarker(line: entry.line)
+            Spacer(minLength: 0)
+        }
+        .frame(width: width, height: CodeMetrics.rowHeight, alignment: .leading)
+        // Collapsed here, above the overlay and never below it, for the reason spelled out on
+        // `DiffLineView` and on `DiffCommentButton`: `children: .ignore` swallows every descendant
+        // of what it is applied to, and a `+` inside the collapsed element is one no keyboard and
+        // no screen reader can reach.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(DiffGutter.speech(for: entry.line))
+        .accessibilityHidden(entry.line == nil)
+        .overlay(alignment: .leading) { commentButton(at: index) }
+        // The same action the `+` carries, on the right click as well, and for the reason written
+        // out on `DiffLineView`.
+        //
+        // **On the row, never on the run, and that is a safety decision rather than a tidiness
+        // one.** The run knows which line the pointer is over only from `hovered`, and hover is
+        // the one thing here that a selectable `Text` might swallow over its own glyphs: if it
+        // does, a stale index would put "Comment on This Line" on a line nobody pointed at, and a
+        // comment filed against the wrong line is worse than no menu at all. Asked of the row, the
+        // answer is whatever row the click actually landed on, which is exactly what the per line
+        // path has always done, or nothing, which is also what the per line path does.
+        .contextMenu {
+            if let spot = spot(at: index) {
+                Button("Comment on This Line") { onComment?(spot) }
+            }
+        }
+        // Over the diff wash, not instead of it: an addition under review stays an addition, and
+        // the amber says "under discussion" on top of whatever the line already was.
+        .background(entry.isCommented ? Palette.reviewLine : .clear)
+        .background(DiffWash.background(of: entry.line))
+        // Padding opposite a longer run on the other side. From the marker's leading edge, not
+        // from the row's, which is where `DiffLineView` starts it: the numbers keep the pane's own
+        // ground so the two layouts have the same gutter.
+        .background(alignment: .trailing) {
+            if entry.line == nil {
+                Rectangle()
+                    .fill(Palette.surfaceSunken)
+                    .frame(width: max(0, width - DiffGutter.width(for: numbers)))
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func commentButton(at index: Int) -> some View {
+        if let onComment, let spot = spot(at: index) {
+            DiffCommentButton(spot: spot, isRowHovered: hovered == index, onComment: onComment)
+        }
+    }
+
+    // MARK: - Geometry
+
+    /// Where the code starts: both gutters in the unified layout, one in either half of the split,
+    /// plus the marker column. The one number the code layer needs, and it is arithmetic rather
+    /// than a measurement for the same reason the sheet's width is.
+    private var columnsWidth: CGFloat {
+        DiffGutter.width(for: numbers) + CodeMetrics.markerWidth
+    }
+
+    private func row(at y: CGFloat) -> Int? {
+        guard y >= 0 else { return nil }
+        let index = Int(y / CodeMetrics.rowHeight)
+        return lines.indices.contains(index) ? index : nil
+    }
+
+    // MARK: - Commenting
+
+    private func spot(at index: Int) -> ReviewSpot? {
+        DiffCommentSpot.offered(
+            for: lines[index].line, numbers: numbers, enabled: onComment != nil
+        )
+    }
+
+    // MARK: - Code
+
+    private var runLines: [CodeRunLine] {
+        lines.map { entry in
+            CodeRunLine(
+                // A row with nothing opposite it still occupies a line in the run, or every line
+                // below it in the split layout would sit one row too high.
+                text: entry.line?.text ?? "",
+                carry: entry.carry,
+                emphasis: entry.emphasis,
+                emphasisColor: DiffWash.emphasis(of: entry.line)
+            )
+        }
+    }
+}

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -549,7 +549,48 @@ struct DiffView: View {
                 Hairline(axis: .vertical)
                 side(pair.right, document: document, numbers: .new, width: half)
             }
+
+        case let .lineRun(lines):
+            run(lines.map(Optional.some), document: document, numbers: .both, width: width)
+
+        case let .pairRun(pairs):
+            // Each half is its own block, so a selection runs down one pane rather than zigzagging
+            // between them. That is what every side by side diff on the web does too, and the
+            // alternative is a copied fragment interleaving two versions of the same file.
+            HStack(spacing: 0) {
+                let half = (width - Metrics.hairline) / 2
+                run(pairs.map(\.left), document: document, numbers: .old, width: half)
+                Hairline(axis: .vertical)
+                run(pairs.map(\.right), document: document, numbers: .new, width: half)
+            }
         }
+    }
+
+    /// A stretch of consecutive lines, drawn as one block of selectable text. One helper for both
+    /// layouts, taking optionals because a side by side row can have nothing opposite it.
+    private func run(
+        _ lines: [DiffLine?],
+        document: DiffDocument,
+        numbers: DiffLineView.Numbers,
+        width: CGFloat
+    ) -> some View {
+        DiffRunView(
+            lines: lines.map { line in
+                DiffRunLine(
+                    line: line,
+                    carry: line.flatMap { document.carries[$0.index] } ?? LexState(),
+                    emphasis: line.flatMap { document.emphasis[$0.index] } ?? [],
+                    isCommented: isCommented(line, numbers: numbers)
+                )
+            },
+            language: document.language,
+            numbers: numbers,
+            width: width,
+            onComment: { beginDraft(at: $0) }
+        )
+        // For the reason given at the per line call sites above, and up to four hundred times as
+        // much of it: one of these stands in for a whole run of rows.
+        .equatable()
     }
 
     private func side(
@@ -814,7 +855,11 @@ struct DiffView: View {
         var spots = Set(placements.compactMap(\.spot))
         if let draftSpot { spots.insert(draftSpot) }
         commentedSpots = spots
-        rows = isSideBySide ? splitRows(document) : unifiedRows(document)
+        // Grouped after the two builders have finished, never inside them: consecutive lines
+        // become one block of selectable text, because a `Text` per line cannot be selected
+        // across two of them. `DiffRow.grouped` says why it is a post pass, `DiffRunGrouping`
+        // says where a run stops.
+        rows = DiffRow.grouped(isSideBySide ? splitRows(document) : unifiedRows(document))
 
         // The editor follows its line, and a rebuild can take that line off the screen: a reload
         // after the agent edits, or a whitespace refold dropping the expanded run the line sat

--- a/Sources/Bloom/Views/Inspector/FilePreview.swift
+++ b/Sources/Bloom/Views/Inspector/FilePreview.swift
@@ -90,7 +90,9 @@ struct FilePreview: View {
                     content
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // Top, for the reason `ReviewPaneView` gives where it holds this view: an unaligned
+            // fill centres, and a short file centred in a tall pane reads as a layout accident.
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .background(Palette.surface)
         .background { shortcut }

--- a/Sources/Bloom/Views/Inspector/FilePreview.swift
+++ b/Sources/Bloom/Views/Inspector/FilePreview.swift
@@ -237,8 +237,8 @@ struct FilePreview: View {
             )
             ScrollView([.vertical, .horizontal]) {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(lines.indices, id: \.self) { index in
-                        row(at: index, width: width)
+                    ForEach(runs, id: \.lowerBound) { range in
+                        run(range, width: width)
                     }
                     if isTruncated {
                         Text("Showing the first \(Self.lineLimit.formatted()) lines")
@@ -255,23 +255,54 @@ struct FilePreview: View {
         }
     }
 
-    /// No tint behind the numbers, for the reason `DiffLineView.gutter` gives: a grey column
-    /// against the ground the code sits on draws a hard vertical edge down the left of the file,
-    /// and a hard edge reads as a boundary between two things rather than as the margin of one.
-    /// It also has to match, because Diff, Preview and Edit are three views of one file and this
-    /// pane is the one you land in by clicking a file that has not changed.
-    private func row(at index: Int, width: CGFloat) -> some View {
-        HStack(spacing: 0) {
-            Text("\(index + 1)")
-                .font(Typo.codeTiny)
-                .monospacedDigit()
-                .foregroundStyle(Palette.textTertiary)
-                .frame(width: CodeMetrics.numberWidth, alignment: .trailing)
-                .padding(.trailing, CodeMetrics.gutterPadding)
-            CodeText(
-                line: lines[index],
-                language: language,
-                carry: index < carries.count ? carries[index] : LexState()
+    /// The file in blocks, so a selection can run across lines.
+    ///
+    /// **A file was a `Text` per line and could not be selected across two of them**, which is the
+    /// same report the diff got on 0.20.0 and the same answer: sibling `Text`s are separate
+    /// selection scopes on this system. Nothing here needs the diff's machinery, since a file that
+    /// has not changed has no washes, no markers and no comment buttons, so it is a column of
+    /// numbers beside one `CodeRunText`.
+    ///
+    /// Blocks rather than the whole file, through the same rule the diff groups by, because a run
+    /// is one item in a lazy stack however many lines it holds and this pane will show five
+    /// thousand of them.
+    private var runs: [Range<Int>] {
+        DiffRunGrouping.chunks(count: lines.count, isLine: { _ in true }).map { chunk in
+            switch chunk {
+            case let .single(index): index..<(index + 1)
+            case let .run(range): range
+            }
+        }
+    }
+
+    /// No tint behind the numbers, for the reason `DiffGutter` gives: a grey column against the
+    /// ground the code sits on draws a hard vertical edge down the left of the file, and a hard
+    /// edge reads as a boundary between two things rather than as the margin of one. It also has
+    /// to match, because Diff, Preview and Edit are three views of one file and this pane is the
+    /// one you land in by clicking a file that has not changed.
+    private func run(_ range: Range<Int>, width: CGFloat) -> some View {
+        HStack(alignment: .top, spacing: 0) {
+            VStack(spacing: 0) {
+                ForEach(range, id: \.self) { index in
+                    Text("\(index + 1)")
+                        .font(Typo.codeTiny)
+                        .monospacedDigit()
+                        .foregroundStyle(Palette.textTertiary)
+                        .frame(width: CodeMetrics.numberWidth, alignment: .trailing)
+                        .padding(.trailing, CodeMetrics.gutterPadding)
+                        // One fixed height cell per line, which is what the block of text beside
+                        // this column is tuned to match. See `CodeMetrics.rowSpacing`.
+                        .frame(height: CodeMetrics.rowHeight)
+                }
+            }
+            CodeRunText(
+                lines: range.map { index in
+                    CodeRunLine(
+                        text: lines[index],
+                        carry: index < carries.count ? carries[index] : LexState()
+                    )
+                },
+                language: language
             )
             // The diff pays for this with its marker column. Without it here the first character
             // of every line sits against the gutter's edge, and the width computed above already
@@ -279,7 +310,11 @@ struct FilePreview: View {
             .padding(.leading, CodeMetrics.textInset)
             Spacer(minLength: 0)
         }
-        .frame(width: width, height: CodeMetrics.rowHeight, alignment: .leading)
+        .frame(
+            width: width,
+            height: CodeMetrics.rowHeight * CGFloat(range.count),
+            alignment: .leading
+        )
     }
 
     private func load() async {

--- a/Sources/BloomCore/Persistence/Store.swift
+++ b/Sources/BloomCore/Persistence/Store.swift
@@ -176,6 +176,54 @@ public actor Store {
         { try $0.execute(statements) }
     }
 
+    /// Columns the code in this build cannot run without, added to any database that is missing
+    /// one whatever its version number says.
+    ///
+    /// **The version stamp is a fast path, not the truth, and this is the incident that proved
+    /// it.** The owner's database read `user_version = 22` with `deliveries.crew_payload` present
+    /// and `sessions.parent_session_id` absent, so every query naming that column failed and the
+    /// app could not open the database at all. `migrate` had nothing to do: 22 is the length of
+    /// the list, so it returned before running a step.
+    ///
+    /// How a database gets into that state is the hazard of numbering migrations by position. Two
+    /// branches each append a step, both get the same number, and a database that ran one of them
+    /// is stamped as having run the other. Merging the branches cannot repair it, because the
+    /// stamp is already past both. Nothing about that is unusual enough to design against with a
+    /// second numbering scheme; what is worth doing is asking the schema rather than the stamp
+    /// before trusting it.
+    ///
+    /// So this runs on every open, costs one `PRAGMA table_info` per table named here, and adds
+    /// only what is genuinely missing. It is deliberately a short list: the columns whose absence
+    /// stops the app dead rather than every column the schema has. A migration is still where a
+    /// change is written; this is the belt under it.
+    private nonisolated static func repairSchema(_ db: SQLiteDatabase) throws {
+        let required: [(table: String, column: String, add: String, index: String?)] = [
+            (
+                "sessions", "parent_session_id",
+                "ALTER TABLE sessions ADD COLUMN parent_session_id TEXT;",
+                "CREATE INDEX IF NOT EXISTS sessions_parent ON sessions(parent_session_id);"
+            ),
+            (
+                "deliveries", "crew_payload",
+                "ALTER TABLE deliveries ADD COLUMN crew_payload BLOB;",
+                nil
+            ),
+        ]
+
+        for wanted in required {
+            let columns = try db.query("PRAGMA table_info(\(wanted.table));")
+            let names = Set(columns.compactMap { $0.string("name") })
+            // An empty answer is a table this database does not have, which is not this method's
+            // business: a missing table is a migration that has not run yet, and this runs before
+            // they do. An ALTER against it would fail rather than repair anything, and it did:
+            // the first version of this method put a bare `CREATE INDEX` under the loop and a
+            // brand new database could not be opened at all.
+            guard !names.isEmpty, !names.contains(wanted.column) else { continue }
+            try db.execute(wanted.add)
+            if let index = wanted.index { try db.execute(index) }
+        }
+    }
+
     private nonisolated static func migrate(_ db: SQLiteDatabase) throws {
         let migrations: [Migration] = [
             sql("""
@@ -910,6 +958,12 @@ public actor Store {
         ]
 
         let current = Int(db.userVersion)
+
+        // Before the version is trusted, and whatever it says. See `repairSchema`: a database
+        // stamped as fully migrated with a column missing is a real state that a real machine
+        // reached, and every query naming that column failed until it was put back.
+        try repairSchema(db)
+
         guard current < migrations.count else { return }
 
         // Off for the run, and back on after it, which is SQLite's own instruction for a schema

--- a/Sources/BloomCore/Presentation/DiffRunGrouping.swift
+++ b/Sources/BloomCore/Presentation/DiffRunGrouping.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Which consecutive rows of a rendered diff may be drawn as one run of selectable text.
+///
+/// **This exists because a diff drawn as one `Text` per line cannot be selected across lines.**
+/// Sibling text views are separate selection scopes on this platform, so dragging down a hunk
+/// selected the single line the drag began on, and there was no other way to get two lines out of
+/// a diff: the app has no copy command for one. `CodeBlockView` reached the same conclusion about
+/// a markdown fence and wrote the rule down; this is that rule applied to a diff, where the run
+/// has to stop at everything a fence does not have.
+///
+/// It is index arithmetic and nothing else, so that the app target hands it a count and a
+/// predicate rather than its own row type. A decision taken inside a view is a decision nothing
+/// can test, and this one has four ways to be wrong at the edges.
+public enum DiffRunGrouping {
+    /// One item in the rendered list: either a row that stands alone, or a stretch of line rows
+    /// drawn together.
+    public enum Chunk: Equatable, Sendable {
+        /// The row at this index, drawn the way it always was.
+        case single(Int)
+        /// Two or more line rows, drawn as one block of text so a selection can cross them.
+        case run(Range<Int>)
+    }
+
+    /// The longest run drawn as one block.
+    ///
+    /// **A cap rather than "the whole hunk", because a run is one item in a lazy stack and a lazy
+    /// stack can only skip what it has not realised.** Per line the stack realises a screenful;
+    /// per hunk a wholly new file is a single item, and the diff is gated at 5,000 changed lines,
+    /// so the worst case was one item holding all of them. Measured on this machine at the
+    /// callout text size: 5,000 lines cost 54ms to build the string and 42ms to lay out, in one
+    /// frame, against 8ms and under 4ms for 400. Four hundred lines is about fifteen screens, far
+    /// past what anybody drags through in one gesture, so the cap costs a selection nothing it
+    /// would have been asked for and keeps the stack's items the size it can skip.
+    public static let runLimit = 400
+
+    /// Group a rendered row list into blocks.
+    ///
+    /// `isLine` answers whether the row at an index is a plain line of code, which is the only
+    /// kind that may join a run. Everything else (a hunk heading, either expander, a review
+    /// comment band, the open comment editor) breaks the run, because each of those draws a view
+    /// between two lines and text cannot flow through one.
+    ///
+    /// A stretch of one is reported as `.single`, never as a run of one. There is nothing to
+    /// select across, and it keeps the per line path in service for exactly the rows that need
+    /// it: in the review pane a comment band under every commented line leaves its neighbours
+    /// alone, and those rows go on being drawn by the view that has always drawn them.
+    public static func chunks(
+        count: Int,
+        isLine: (Int) -> Bool,
+        limit: Int = runLimit
+    ) -> [Chunk] {
+        // A limit under two would make every run a `.single` and quietly turn the fix off. It is
+        // a caller's mistake rather than a state to support, and floored rather than trapped
+        // because a diff that draws is worth more than a precondition that is right.
+        let limit = max(2, limit)
+        var chunks: [Chunk] = []
+        var index = 0
+
+        while index < count {
+            guard isLine(index) else {
+                chunks.append(.single(index))
+                index += 1
+                continue
+            }
+
+            var end = index
+            while end < count, isLine(end), end - index < limit { end += 1 }
+
+            if end - index == 1 {
+                chunks.append(.single(index))
+            } else {
+                chunks.append(.run(index..<end))
+            }
+            index = end
+        }
+
+        return chunks
+    }
+}

--- a/Tests/BloomCoreTests/DiffRunGroupingTests.swift
+++ b/Tests/BloomCoreTests/DiffRunGroupingTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// What may be drawn as one block of selectable text, pinned where the diff cannot be reached.
+///
+/// The happy run is the least interesting case here. What this rule exists to get right is where
+/// a run STOPS: a hunk heading, either expander, a review comment band and the open comment
+/// editor all draw a view between two lines, and text cannot flow through one. A break the rule
+/// misses is a selection that jumps a band, and a break it invents is a selection that stops in
+/// the middle of a hunk for no reason the reader can see.
+struct DiffRunGroupingTests {
+    /// Rows named by what they are, so a test reads like the list it describes.
+    private enum Row {
+        case line
+        case other
+    }
+
+    private func chunks(_ rows: [Row], limit: Int = DiffRunGrouping.runLimit) -> [DiffRunGrouping.Chunk] {
+        DiffRunGrouping.chunks(
+            count: rows.count, isLine: { rows[$0] == .line }, limit: limit
+        )
+    }
+
+    @Test func nothingGroupsIntoNothing() {
+        #expect(chunks([]).isEmpty)
+    }
+
+    @Test func aStretchOfLinesIsOneRun() {
+        #expect(chunks([.line, .line, .line, .line]) == [.run(0..<4)])
+    }
+
+    @Test func aLoneLineStaysASingleRatherThanARunOfOne() {
+        #expect(chunks([.line]) == [.single(0)])
+        #expect(chunks([.other, .line, .other]) == [.single(0), .single(1), .single(2)])
+    }
+
+    // MARK: - Where a run stops
+
+    /// A comment band, an expander or a heading between two lines. The run has to end above it
+    /// and start again below, which is the whole of what this type is for.
+    @Test func aRowThatIsNotALineBreaksTheRun() {
+        #expect(
+            chunks([.line, .line, .other, .line, .line, .line])
+                == [.run(0..<2), .single(2), .run(3..<6)]
+        )
+    }
+
+    @Test func aBreakAtEitherEndLeavesTheRunWhole() {
+        #expect(chunks([.other, .line, .line]) == [.single(0), .run(1..<3)])
+        #expect(chunks([.line, .line, .other]) == [.run(0..<2), .single(2)])
+    }
+
+    /// Two bands under one line, which `appendAnnotations` produces whenever a line carries a
+    /// comment and the editor is open on it.
+    @Test func consecutiveBreaksEachStandAlone() {
+        #expect(
+            chunks([.line, .other, .other, .line, .line])
+                == [.single(0), .single(1), .single(2), .run(3..<5)]
+        )
+    }
+
+    /// The review pane's worst case: every line carries a band, so nothing may be grouped and
+    /// every row goes back to the view that has always drawn it.
+    @Test func aBandUnderEveryLineGroupsNothing() {
+        let rows: [Row] = Array(repeating: [.line, .other], count: 5).flatMap(\.self)
+
+        #expect(chunks(rows) == (0..<10).map { .single($0) })
+    }
+
+    // MARK: - The cap
+
+    @Test func aRunLongerThanTheLimitIsSplitAtIt() {
+        #expect(
+            chunks(Array(repeating: .line, count: 900), limit: 400)
+                == [.run(0..<400), .run(400..<800), .run(800..<900)]
+        )
+    }
+
+    /// The remainder is one line, and one line is a single wherever it came from.
+    @Test func aSplitLeavingOneLineLeavesASingle() {
+        #expect(
+            chunks(Array(repeating: .line, count: 401), limit: 400)
+                == [.run(0..<400), .single(400)]
+        )
+    }
+
+    @Test func aRunExactlyTheLimitIsNotSplit() {
+        #expect(chunks(Array(repeating: .line, count: 400), limit: 400) == [.run(0..<400)])
+    }
+
+    /// A limit under two would make every run a single and turn the fix off without a word.
+    @Test func anImpossibleLimitIsFlooredRatherThanObeyed() {
+        #expect(chunks(Array(repeating: .line, count: 4), limit: 0) == [.run(0..<2), .run(2..<4)])
+        #expect(chunks(Array(repeating: .line, count: 4), limit: 1) == [.run(0..<2), .run(2..<4)])
+    }
+
+    // MARK: - What the caller may rely on
+
+    /// Every index appears exactly once and in order, because these chunks replace the row list
+    /// rather than annotate it: a dropped index is a line that vanishes off the diff.
+    @Test func theChunksCoverEveryRowExactlyOnceInOrder() {
+        let rows: [Row] = [
+            .other, .line, .line, .line, .other, .line, .other, .other, .line, .line,
+        ]
+
+        var covered: [Int] = []
+        for chunk in chunks(rows) {
+            switch chunk {
+            case let .single(index): covered.append(index)
+            case let .run(range): covered.append(contentsOf: range)
+            }
+        }
+
+        #expect(covered == Array(rows.indices))
+    }
+
+    @Test func theChunksCoverEveryRowExactlyOnceUnderTheCapToo() {
+        var covered: [Int] = []
+        for chunk in chunks(Array(repeating: .line, count: 1_001), limit: 7) {
+            switch chunk {
+            case let .single(index): covered.append(index)
+            case let .run(range): covered.append(contentsOf: range)
+            }
+        }
+
+        #expect(covered == Array(0..<1_001))
+    }
+}

--- a/Tests/BloomCoreTests/SchemaRepairTests.swift
+++ b/Tests/BloomCoreTests/SchemaRepairTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// The incident this file is about: the owner's database read `user_version = 22`, the length of
+/// the migration list, with `sessions.parent_session_id` missing. `migrate` had nothing to run and
+/// every query naming that column failed, so the app could not open the database at all.
+@Suite("Schema repair", .tags(.persistence), .scratchDirectory)
+struct SchemaRepairTests {
+    @Test("a column missing from a database that calls itself migrated is put back")
+    func repairsAColumnTheStampSaysIsThere() async throws {
+        let path = TestScratch.unique("schema-repair") + ".sqlite"
+        _ = try Store(path: path)
+
+        // Drop the column behind the store's back, exactly as the state on the owner's machine
+        // had it: the table without it, and the version still saying everything has run.
+        let raw = try SQLiteDatabase(path: path)
+        // The index goes first, because SQLite refuses to drop a column an index names. A database
+        // that never ran the migration has neither, which is the state being reproduced.
+        try raw.execute("DROP INDEX IF EXISTS sessions_parent;")
+        try raw.execute("ALTER TABLE sessions DROP COLUMN parent_session_id;")
+        let before = try raw.query("PRAGMA table_info(sessions);")
+            .compactMap { $0.string("name") }
+        #expect(!before.contains("parent_session_id"))
+
+        // Opening again is what repairs it, without the version number moving.
+        let reopened = try Store(path: path)
+        let sessions = try await reopened.sessions(workspaceID: WorkspaceID("nothing"))
+        #expect(sessions.isEmpty)
+
+        let after = try SQLiteDatabase(path: path)
+        let columns = try after.query("PRAGMA table_info(sessions);")
+            .compactMap { $0.string("name") }
+        #expect(columns.contains("parent_session_id"))
+    }
+}


### PR DESCRIPTION
Two reports on 0.20.0, plus what one of them turned up.

A file pane pins its content to the top. An unaligned fill centres, so a diff of a few lines floated in the middle of a tall pane.

Text selection now runs across lines. The code column of a diff was one `Text` per line, and SwiftUI cannot select across two, so a drag never left the line it started on. Consecutive lines are drawn as one text object with the gutter, the markers and the washes as columns beside it. A run is capped at 400 lines so a large file stays one item per screenful rather than one for the file, and a heading, an expander, a comment band or the live comment editor breaks a run. Measured: one text object is cheaper per line than one per line, 19ms against 50ms for a thousand lines. The same fix covers an unchanged file in the preview pane.

And the one that stopped an app dead: a database can carry a version number saying every migration has run with a column missing, because migrations are numbered by position and two branches that each append get the same number. Bloom now asks the schema rather than the stamp for the handful of columns it cannot run without, and puts back anything missing on open. Reproduced against the database it happened on: the column returns, the version does not move, and nothing else changes.