### PR TITLE
Find agent CLIs outside Finder's PATH

### DIFF
--- a/Sources/Bloom/System/FeedbackEnvironment.swift
+++ b/Sources/Bloom/System/FeedbackEnvironment.swift
@@ -159,15 +159,7 @@ enum FeedbackEnvironment {
     /// unusual is seen as present rather than missing. Read the same way `InstallPingService`
     /// reads them.
     static func executablePathOverrides(app: AppModel?) async -> [AgentKind: String] {
-        guard let store = app?.store else { return [:] }
-
-        var found: [AgentKind: String] = [:]
-        for kind in AgentKind.allCases {
-            guard let value = try? await store.setting(AgentCatalog.executablePathSettingKey(kind)) else { continue }
-            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty { found[kind] = trimmed }
-        }
-        return found
+        await AgentCatalog.executablePathOverrides(in: app?.store)
     }
 
     /// What the agent CLI answers `--version` with, from memory if it was asked today.

--- a/Sources/Bloom/System/InstallPingService.swift
+++ b/Sources/Bloom/System/InstallPingService.swift
@@ -142,15 +142,7 @@ final class InstallPingService {
     /// unusual is seen as present rather than missing. Empty when the store is not open yet, which
     /// only costs the accuracy of a custom path on the first ping after a launch.
     private func executablePathOverrides() async -> [AgentKind: String] {
-        guard let store = app?.store else { return [:] }
-
-        var found: [AgentKind: String] = [:]
-        for kind in AgentKind.allCases {
-            guard let value = try? await store.setting(AgentCatalog.executablePathSettingKey(kind)) else { continue }
-            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty { found[kind] = trimmed }
-        }
-        return found
+        await AgentCatalog.executablePathOverrides(in: app?.store)
     }
 
     /// What the server said, or that it said nothing. Every outcome is silent to the user.

--- a/Sources/Bloom/Views/Chrome/Settings/AgentsSettingsView.swift
+++ b/Sources/Bloom/Views/Chrome/Settings/AgentsSettingsView.swift
@@ -341,14 +341,7 @@ struct AgentsSettingsView: View {
     }
 
     private func loadOverrides() async -> [AgentKind: String] {
-        guard let store = app.store else { return [:] }
-        var found: [AgentKind: String] = [:]
-        for kind in AgentKind.allCases {
-            guard let value = try? await store.setting(Self.overrideKey(kind)) else { continue }
-            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty { found[kind] = trimmed }
-        }
-        return found
+        await AgentCatalog.executablePathOverrides(in: app.store)
     }
 
     /// Committing on submit and on focus loss rather than on every keystroke keeps a half-typed
@@ -369,7 +362,7 @@ struct AgentsSettingsView: View {
         Task {
             if let store = app.store {
                 do {
-                    try await store.setSetting(Self.overrideKey(kind), value)
+                    try await store.setSetting(AgentCatalog.executablePathSettingKey(kind), value)
                     saveFailure = nil
                 } catch {
                     saveFailure = "The executable path for \(kind.label) could not be stored."
@@ -384,10 +377,6 @@ struct AgentsSettingsView: View {
             self.catalog = catalog
             await read(from: catalog)
         }
-    }
-
-    private static func overrideKey(_ kind: AgentKind) -> String {
-        "agent.\(kind.rawValue).executablePath"
     }
 }
 

--- a/Sources/Bloom/Views/Chrome/Window/SetupInspection.swift
+++ b/Sources/Bloom/Views/Chrome/Window/SetupInspection.swift
@@ -58,9 +58,15 @@ final class SetupInspection {
     /// Detection results this window was handed rather than gathered. Debug builds only; see
     /// `SetupRehearsal`.
     private let rehearsal: SetupReport?
+    /// The same database-backed executable paths the Agents pane and the runners use.
+    private let agentOverrides: () async -> [AgentKind: String]
 
-    init(rehearsal: SetupReport? = nil) {
+    init(
+        rehearsal: SetupReport? = nil,
+        agentOverrides: @escaping () async -> [AgentKind: String] = { [:] }
+    ) {
         self.rehearsal = rehearsal
+        self.agentOverrides = agentOverrides
     }
 
     /// Looks again, from the top. Idempotent while a run is in flight, because the button that
@@ -122,7 +128,7 @@ final class SetupInspection {
         if let rehearsal {
             for check in rehearsal.checks { record(check) }
         } else {
-            let probe = SetupProbe(agentOverrides: Self.agentOverrides())
+            let probe = SetupProbe(agentOverrides: await agentOverrides())
             for await check in probe.run() {
                 if Task.isCancelled { return }
                 record(check)
@@ -162,17 +168,4 @@ final class SetupInspection {
         }
     }
 
-    /// The per-agent executable paths the Agents settings pane writes, read here so this window
-    /// looks for the same binary that pane was pointed at. Through the key `AgentCatalog` owns,
-    /// because two spellings of one key is how a wizard starts calling a working agent missing.
-    private static func agentOverrides() -> [AgentKind: String] {
-        var overrides: [AgentKind: String] = [:]
-        for kind in AgentKind.allCases {
-            let key = AgentCatalog.executablePathSettingKey(kind)
-            let value = UserDefaults.standard.string(forKey: key)?
-                .trimmingCharacters(in: .whitespaces) ?? ""
-            if !value.isEmpty { overrides[kind] = value }
-        }
-        return overrides
-    }
 }

--- a/Sources/Bloom/Views/Chrome/Window/WelcomeWindow.swift
+++ b/Sources/Bloom/Views/Chrome/Window/WelcomeWindow.swift
@@ -71,7 +71,10 @@ enum WelcomeWindow {
     }
 
     private static func make(trigger: OnboardingTrigger) -> NSWindow {
-        let model = SetupInspection(rehearsal: SetupRehearsal.report)
+        let model = SetupInspection(
+            rehearsal: SetupRehearsal.report,
+            agentOverrides: { await waitForAgentOverrides() }
+        )
         inspection = model
 
         // Read through a closure rather than captured, because the socket is bound in
@@ -140,6 +143,26 @@ enum WelcomeWindow {
         WindowRoles.mark(window, as: .utility)
         return window
     }
+
+    /// Wait briefly for bootstrap to open the database, then read the paths the Agents pane wrote.
+    ///
+    /// A first run opens this window from `applicationDidFinishLaunching` while `AppModel.bootstrap`
+    /// is still opening the store from the scene's task. Reading once would reproduce the old
+    /// UserDefaults bug in another form: the custom path would work on a later visit and not on the
+    /// launch where it matters.
+    fileprivate static func waitForAgentOverrides(
+        timeout: Duration = .seconds(3)
+    ) async -> [AgentKind: String] {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if let store = app?.store {
+                return await AgentCatalog.executablePathOverrides(in: store)
+            }
+            try? await Task.sleep(for: .milliseconds(150))
+            if Task.isCancelled { return [:] }
+        }
+        return await AgentCatalog.executablePathOverrides(in: app?.store)
+    }
 }
 
 // MARK: - Whether it opens on its own
@@ -168,7 +191,8 @@ enum WelcomeLaunch {
         Task {
             // Nothing is drawn for this, so it can take as long as four CLIs take. If the machine
             // is fine, which it nearly always is, the user never learns this happened.
-            let report = await SetupProbe().report()
+            let overrides = await WelcomeWindow.waitForAgentOverrides()
+            let report = await SetupProbe(agentOverrides: overrides).report()
             guard OnboardingGate.trigger(hasCompletedBefore: true, verdict: report.verdict) == .blocked
             else { return }
             WelcomeWindow.show(trigger: .blocked, mayActivate: false)

--- a/Sources/BloomCore/Agent/AgentCatalog.swift
+++ b/Sources/BloomCore/Agent/AgentCatalog.swift
@@ -206,6 +206,31 @@ public actor AgentCatalog {
         "agent.\(kind.rawValue).executablePath"
     }
 
+    /// The custom executable paths stored by the Agents pane.
+    ///
+    /// One reader for every consumer. The pane, onboarding, install ping and runner used to read
+    /// this table independently, and onboarding read a different persistence system altogether.
+    public static func executablePathOverrides(in store: Store?) async -> [AgentKind: String] {
+        guard let store else { return [:] }
+
+        var found: [AgentKind: String] = [:]
+        for kind in AgentKind.allCases {
+            guard let value = try? await store.setting(executablePathSettingKey(kind)) else { continue }
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { found[kind] = trimmed }
+        }
+        return found
+    }
+
+    /// The command a runner should launch for this agent.
+    ///
+    /// An explicit path wins even when it is currently missing. Falling back would make the
+    /// settings pane show one binary while a session silently launched another one from PATH.
+    public static func executable(for kind: AgentKind, override: String?) -> String {
+        let trimmed = override?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? kind.executableName : expandingTilde(trimmed)
+    }
+
     /// Which agent CLIs are present on this machine, by executable lookup alone.
     ///
     /// Deliberately much less than `detect`. No `--version` subprocess, no config file opened and

--- a/Sources/BloomCore/Agent/AgentRunner.swift
+++ b/Sources/BloomCore/Agent/AgentRunner.swift
@@ -86,6 +86,8 @@ public actor AgentRunner {
     /// is where the footer writes it. Re-read at the top of every turn, so toggling it takes
     /// effect on the next thing sent rather than on the next launch of the app.
     private var isFastMode = false
+    /// The executable selected in Settings, or the ordinary command name when none was selected.
+    private var configuredExecutable = AgentKind.claudeCode.executableName
     /// Which output style the composer's picker is on for this session, or nil for the default.
     ///
     /// Kept beside fast mode and read the same way, because it is the same kind of thing: a
@@ -295,7 +297,7 @@ public actor AgentRunner {
     /// only exists after the first run and a restart has to resume rather than begin again.
     public func launch() -> AgentLaunch {
         AgentLaunch(
-            executable: Self.executable,
+            executable: configuredExecutable,
             arguments: Self.argv(
                 session: session,
                 resume: session.agentSessionID,
@@ -348,10 +350,10 @@ public actor AgentRunner {
     /// asked for: see `SessionRunner.send(_:recording:)` for why what goes out and what is drawn
     /// are not the same string.
     public func send(_ text: String, recording: Data? = nil) async throws {
-        // The two settings reads come first, and that ordering is the whole of the fix.
+        // The settings reads come first, and that ordering is the whole of the fix.
         //
         // They were between the wait and the start, and each is a store round trip, so there were
-        // two suspensions in a window that must have none. `cancelNow()` is nonisolated, on
+        // suspensions in a window that must have none. `cancelNow()` is nonisolated, on
         // purpose, so it does not queue behind this actor: a Stop landing in that gap signals the
         // running process, `start()` then finds `handle.current` still non-nil because the child
         // has not exited yet, short-circuits, and the turn below is written into a process that
@@ -359,6 +361,7 @@ public actor AgentRunner {
         // nothing is lost by asking first.
         await refreshFastMode()
         await refreshOutputStyle()
+        await refreshExecutable()
         try await waitForCancelledRunToExit()
         start()
 
@@ -399,6 +402,11 @@ public actor AgentRunner {
     private func refreshOutputStyle() async {
         let stored = try? await store.setting(ComposerControls.outputStyleKey(sessionID: session.id))
         outputStyle = OutputStyle.isDefault(stored) ? nil : stored
+    }
+
+    private func refreshExecutable() async {
+        let stored = try? await store.setting(AgentCatalog.executablePathSettingKey(.claudeCode))
+        configuredExecutable = AgentCatalog.executable(for: .claudeCode, override: stored)
     }
 
     static func encodeTurn(_ text: String) throws -> String {

--- a/Sources/BloomCore/Agent/Codex/CodexRunner.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexRunner.swift
@@ -320,7 +320,9 @@ public actor CodexRunner: SessionRunner {
     private func connected() async throws -> CodexClient {
         if let client { return client }
 
+        let stored = try? await store.setting(AgentCatalog.executablePathSettingKey(.codex))
         let client = makeClient(CodexClient.Configuration(
+            executable: AgentCatalog.executable(for: .codex, override: stored),
             cwd: workspacePath,
             clientName: "Bloom",
             clientVersion: Self.clientVersion,

--- a/Sources/BloomCore/System/ExecutableSearchPath.swift
+++ b/Sources/BloomCore/System/ExecutableSearchPath.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// The directories a GUI-launched Bloom adds to the sparse PATH macOS gives it.
+///
+/// Package managers with one stable executable directory are named directly. Node version
+/// managers are different: nvm and fnm install each Node release into its own directory and add
+/// the selected release to PATH from shell startup files that Finder never reads. Walking those
+/// version directories lets Bloom find a CLI installed under any of them without running a login
+/// shell, whose startup files are arbitrary user code and may prompt, print or never return.
+public enum ExecutableSearchPath {
+    public static func additionalDirectories(
+        home: String = FileManager.default.homeDirectoryForCurrentUser.path
+    ) -> [String] {
+        additionalDirectories(home: home, childrenOf: directoryChildren)
+    }
+
+    static func additionalDirectories(
+        home: String,
+        childrenOf: (String) -> [String]
+    ) -> [String] {
+        let stable = [
+            "/opt/homebrew/bin",
+            "/opt/homebrew/sbin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin",
+            "\(home)/.local/bin",
+            "\(home)/.npm-packages/bin",
+            "\(home)/.volta/bin",
+            "\(home)/.yarn/bin",
+            "\(home)/.bun/bin",
+            "\(home)/.cargo/bin",
+            "\(home)/.composer/vendor/bin",
+            "\(home)/bin",
+            "\(home)/.local/share/mise/shims",
+            "\(home)/.asdf/shims",
+            "\(home)/.nodenv/shims",
+            "\(home)/Library/pnpm",
+            "\(home)/.local/share/pnpm",
+            "\(home)/.nix-profile/bin",
+            "/nix/var/nix/profiles/default/bin",
+        ]
+
+        let versioned = [
+            (root: "\(home)/.nvm/versions/node", suffix: "bin"),
+            (root: "\(home)/Library/Application Support/fnm/node-versions", suffix: "installation/bin"),
+            (root: "\(home)/.local/share/fnm/node-versions", suffix: "installation/bin"),
+        ].flatMap { root, suffix in
+            childrenOf(root)
+                .sorted { $0.compare($1, options: .numeric) == .orderedDescending }
+                .map { "\(root)/\($0)/\(suffix)" }
+        }
+
+        var seen = Set<String>()
+        return (stable + versioned).filter { seen.insert($0).inserted }
+    }
+
+    private static func directoryChildren(_ path: String) -> [String] {
+        (try? FileManager.default.contentsOfDirectory(atPath: path)) ?? []
+    }
+}

--- a/Sources/BloomCore/System/Shell.swift
+++ b/Sources/BloomCore/System/Shell.swift
@@ -37,29 +37,7 @@ public struct ShellError: Error, CustomStringConvertible {
 public enum Shell {
     /// Directories added to PATH for spawned processes, because GUI apps launched from Finder
     /// inherit a minimal PATH that lacks Homebrew, mise, fnm, and friends.
-    public static let extraPaths: [String] = {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        return [
-            "/opt/homebrew/bin",
-            "/opt/homebrew/sbin",
-            "/usr/local/bin",
-            "/usr/bin",
-            "/bin",
-            "/usr/sbin",
-            "/sbin",
-            "\(home)/.local/bin",
-            // Node installs put binaries wherever the user's package manager decided. `codex`
-            // lives in .npm-packages/bin on this machine, and a Finder launch would otherwise
-            // report it as not installed while a terminal launch found it.
-            "\(home)/.npm-packages/bin",
-            "\(home)/.volta/bin",
-            "\(home)/.yarn/bin",
-            "\(home)/.bun/bin",
-            "\(home)/.cargo/bin",
-            "\(home)/.composer/vendor/bin",
-            "\(home)/bin",
-        ]
-    }()
+    public static let extraPaths = ExecutableSearchPath.additionalDirectories()
 
     /// How many subprocesses this process has started since launch.
     ///

--- a/Tests/BloomCoreTests/AgentCatalogTests.swift
+++ b/Tests/BloomCoreTests/AgentCatalogTests.swift
@@ -278,6 +278,31 @@ struct AgentCatalogTests {
         #expect(status.details.contains { $0.label == "Problem" })
     }
 
+    @Test("reads trimmed executable overrides from the shared settings table")
+    func readsStoredOverrides() async throws {
+        let store = try makeTestStore("agent-executable-overrides")
+        try await store.setSetting(
+            AgentCatalog.executablePathSettingKey(.codex),
+            "  /tmp/tools/codex  "
+        )
+        try await store.setSetting(
+            AgentCatalog.executablePathSettingKey(.claudeCode),
+            "   "
+        )
+
+        let overrides = await AgentCatalog.executablePathOverrides(in: store)
+
+        #expect(overrides == [.codex: "/tmp/tools/codex"])
+        #expect(await AgentCatalog.executablePathOverrides(in: nil).isEmpty)
+    }
+
+    @Test("an override is the runner command and an empty value keeps the ordinary name")
+    func resolvesRunnerExecutable() {
+        #expect(AgentCatalog.executable(for: .codex, override: " /tmp/tools/codex ") == "/tmp/tools/codex")
+        #expect(AgentCatalog.executable(for: .codex, override: nil) == "codex")
+        #expect(AgentCatalog.executable(for: .claudeCode, override: "   ") == "claude")
+    }
+
     @Test("returns one status per kind, in order, and caches until invalidated")
     func cachesStatuses() async {
         let missing = TestScratch.unique("bloom-no-such-agent")

--- a/Tests/BloomCoreTests/AgentRunnerTests.swift
+++ b/Tests/BloomCoreTests/AgentRunnerTests.swift
@@ -764,6 +764,25 @@ struct AgentRunnerProcessTests {
         #expect(process.launch.arguments[index + 1] == #"{"outputStyle":"Concise"}"#)
     }
 
+    @Test("the stored executable reaches the process the runner spawns")
+    func spawnsWithTheStoredExecutable() async throws {
+        let store = try makeTestStore("agent-executable")
+        let session = try await makeSession(store)
+        try await store.setSetting(
+            AgentCatalog.executablePathSettingKey(.claudeCode),
+            "/tmp/tools/claude"
+        )
+
+        let recorder = ProcessRecorder()
+        let runner = AgentRunner(
+            workspacePath: "/tmp/w", session: session, store: store, makeProcess: recorder.factory
+        )
+
+        try await runner.send("hello")
+
+        #expect(try #require(recorder.last).launch.executable == "/tmp/tools/claude")
+    }
+
     /// The other half, and the one that matters more: a session nobody has set a style on spawns
     /// with no settings object at all, so a style the repository chose in its own
     /// `.claude/settings.json` is left standing.

--- a/Tests/BloomCoreTests/CodexRunnerTests.swift
+++ b/Tests/BloomCoreTests/CodexRunnerTests.swift
@@ -101,6 +101,21 @@ private func eventually(
         #expect(stored?.state == .running)
     }
 
+    @Test func startsTheStoredCodexExecutable() async throws {
+        let store = try makeTestStore("codex-runner-executable")
+        let (session, _) = try await makeCodexSession(store)
+        try await store.setSetting(
+            AgentCatalog.executablePathSettingKey(.codex),
+            "/tmp/tools/codex"
+        )
+        let box = scriptedBox()
+        let runner = makeRunner(store: store, session: session, box: box)
+
+        try await runner.send("hello")
+
+        #expect(box.process.launch.executable == "/tmp/tools/codex")
+    }
+
     /// A chat that has spoken before resumes rather than starting a second conversation.
     @Test func resumesAThreadItAlreadyHas() async throws {
         let store = try makeTestStore("codex-runner-resume")

--- a/Tests/BloomCoreTests/ExecutableSearchPathTests.swift
+++ b/Tests/BloomCoreTests/ExecutableSearchPathTests.swift
@@ -1,0 +1,49 @@
+import Testing
+@testable import BloomCore
+
+@Suite("Executable search path")
+struct ExecutableSearchPathTests {
+    @Test("includes stable package-manager and shim directories")
+    func includesStableDirectories() {
+        let home = "/Users/example"
+        let paths = ExecutableSearchPath.additionalDirectories(home: home, childrenOf: { _ in [] })
+
+        #expect(paths.contains("\(home)/.local/bin"))
+        #expect(paths.contains("\(home)/.local/share/mise/shims"))
+        #expect(paths.contains("\(home)/.asdf/shims"))
+        #expect(paths.contains("\(home)/Library/pnpm"))
+    }
+
+    @Test("finds every installed nvm version with the newest first")
+    func findsNVMVersions() {
+        let home = "/Users/example"
+        let root = "\(home)/.nvm/versions/node"
+        let paths = ExecutableSearchPath.additionalDirectories(home: home) { path in
+            path == root ? ["v9.11.2", "v22.18.0", "v20.19.4"] : []
+        }
+
+        let found = paths.filter { $0.hasPrefix(root) }
+        #expect(found == [
+            "\(root)/v22.18.0/bin",
+            "\(root)/v20.19.4/bin",
+            "\(root)/v9.11.2/bin",
+        ])
+    }
+
+    @Test("finds both fnm data locations")
+    func findsFNMVersions() {
+        let home = "/Users/example"
+        let library = "\(home)/Library/Application Support/fnm/node-versions"
+        let local = "\(home)/.local/share/fnm/node-versions"
+        let paths = ExecutableSearchPath.additionalDirectories(home: home) { path in
+            switch path {
+            case library: ["v22.18.0"]
+            case local: ["v20.19.4"]
+            default: []
+            }
+        }
+
+        #expect(paths.contains("\(library)/v22.18.0/installation/bin"))
+        #expect(paths.contains("\(local)/v20.19.4/installation/bin"))
+    }
+}


### PR DESCRIPTION
## What changed

- discover agent CLIs in common version-manager, shim, and package-manager locations
- read executable overrides from the shared settings store during onboarding
- launch Claude Code and Codex with their configured executable override

## Verification

- `./Tools/test-core.sh ExecutableSearchPath`
- `./Tools/test-core.sh AgentCatalog`
- `./Tools/test-core.sh AgentRunner`
- `./Tools/test-core.sh CodexRunner`
- `make build`
- `make lint`
- `make swiftlint`