### PR TITLE
Avoid welcome window constraint recursion

### DIFF
--- a/Sources/Bloom/Views/Chrome/Window/WelcomeHostingController.swift
+++ b/Sources/Bloom/Views/Chrome/Window/WelcomeHostingController.swift
@@ -1,0 +1,69 @@
+import AppKit
+import SwiftUI
+
+/// Hosts the welcome sequence without feeding SwiftUI's ideal size back into AppKit's constraint
+/// pass.
+///
+/// `NSHostingSizingOptions.preferredContentSize` updates the window while AppKit is resolving the
+/// hosting view's safe area. A content change can then invalidate that same constraint pass and
+/// recurse. Measuring after layout keeps the content-sized window while making the resize a new
+/// main-actor turn rather than part of the pass that requested it.
+@MainActor
+final class WelcomeHostingController<Content: View>: NSHostingController<Content> {
+    private let contentWidth: CGFloat
+    private var resizeIsScheduled = false
+
+    init(rootView: Content, contentWidth: CGFloat) {
+        self.contentWidth = contentWidth
+        super.init(rootView: rootView)
+        sizingOptions = []
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("not decoded from a nib") }
+
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        scheduleResize()
+    }
+
+    /// The size used before the controller has joined a window. It is measured from the same root
+    /// view that will be installed, so the first frame and every later frame share one rule.
+    func fittingContentSize() -> CGSize {
+        measuredContentSize()
+    }
+
+    private func scheduleResize() {
+        guard !resizeIsScheduled else { return }
+        resizeIsScheduled = true
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.resizeIsScheduled = false
+            self.resizeWindow()
+        }
+    }
+
+    private func resizeWindow() {
+        guard let window = view.window else { return }
+        let size = measuredContentSize()
+        let current = view.bounds.size
+        guard abs(current.width - size.width) > 0.5 || abs(current.height - size.height) > 0.5
+        else { return }
+
+        let oldFrame = window.frame
+        var newFrame = window.frameRect(forContentRect: NSRect(origin: .zero, size: size))
+        newFrame.origin.x = oldFrame.origin.x
+        newFrame.origin.y = oldFrame.maxY - newFrame.height
+        window.setFrame(newFrame, display: true)
+    }
+
+    private func measuredContentSize() -> CGSize {
+        let proposed = CGSize(width: contentWidth, height: .greatestFiniteMagnitude)
+        let measured = sizeThatFits(in: proposed)
+        guard measured.height.isFinite, measured.height > 0 else {
+            return CGSize(width: contentWidth, height: max(1, view.bounds.height))
+        }
+        return CGSize(width: contentWidth, height: ceil(measured.height))
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Window/WelcomeView.swift
+++ b/Sources/Bloom/Views/Chrome/Window/WelcomeView.swift
@@ -49,7 +49,8 @@ struct WelcomeView: View {
     /// Wide enough for `npm install -g @anthropic-ai/claude-code` to sit on one line in the mono
     /// face, which is the longest command this window can ever show, and no wider. A command that
     /// wrapped would be a command somebody copies wrong by hand.
-    private static let width: CGFloat = 520
+    static let contentWidth: CGFloat = 520
+    private static let width = contentWidth
     private static let markSize: CGFloat = 64
     /// The gutter the glyphs and the sounding line share.
     private static let gutter: CGFloat = 26

--- a/Sources/Bloom/Views/Chrome/Window/WelcomeWindow.swift
+++ b/Sources/Bloom/Views/Chrome/Window/WelcomeWindow.swift
@@ -85,7 +85,7 @@ enum WelcomeWindow {
         // first run is greeted, and the Help menu and a later broken launch open straight onto the
         // checks, because somebody who came back came back for the checks. Back is offered from
         // there either way, so the greeting is never a screen that has been taken away.
-        // A CONTROLLER, not a bare `NSHostingView`, and that is the whole of the sizing.
+        // A controller, not a bare `NSHostingView`, and that is the whole of the sizing.
         //
         // This was a hosting view with `.preferredContentSize` and one `setContentSize` at the
         // foot of this function, which is a one way ratchet: the call happens once, so the only
@@ -98,25 +98,29 @@ enum WelcomeWindow {
         // only have been a second ratchet pointing the other way, and wrong for every size change
         // nobody had thought to name.
         //
-        // A view controller's `preferredContentSize` is a value AppKit tracks for itself, and a
-        // window that is not resizable follows it in both directions. The size is a consequence of
-        // the content on every frame now, rather than of the two moments somebody measured it.
-        let host = NSHostingController(rootView: WelcomeView(
+        // Automatic preferred-content sizing used to make AppKit update the window from inside
+        // its own constraint pass. The welcome sequence changes height as probes settle and steps
+        // crossfade, so that feedback could re-enter the hosting view's safe-area update. The
+        // controller below measures after layout and coalesces those changes onto the next main
+        // actor turn instead.
+        let host = WelcomeHostingController(rootView: WelcomeView(
             inspection: model,
             registration: offer,
             start: OnboardingFlow.firstStep(trigger: trigger),
             onFinish: { close() }
-        ))
-        host.sizingOptions = [.preferredContentSize]
+        ), contentWidth: WelcomeView.contentWidth)
+        let size = host.fittingContentSize()
 
-        let window = NSWindow(contentViewController: host)
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
         // No `.resizable`: this is a column of fixed width whose height follows its content, and a
         // drag handle on it would only ever produce a worse version of it. `.fullSizeContentView`
         // is what lets the plinth run up behind the title bar, the alternative being a strip of
-        // flat window background above the gradient. Assigned rather than passed, because the
-        // initialiser that installs the tracking above is the one that takes a view controller and
-        // it picks the standard mask for itself.
-        window.styleMask = [.titled, .closable, .fullSizeContentView]
+        // flat window background above the gradient.
         window.isReleasedWhenClosed = false
         window.title = "Welcome to Bloom"
         window.titleVisibility = .hidden
@@ -124,6 +128,7 @@ enum WelcomeWindow {
         window.isMovableByWindowBackground = true
         window.standardWindowButton(.miniaturizeButton)?.isHidden = true
         window.standardWindowButton(.zoomButton)?.isHidden = true
+        window.contentViewController = host
         window.center()
         // Closing this window is how somebody says they have seen it. See
         // `WelcomeLaunch.recordDismissal`, which is where the reasoning is.


### PR DESCRIPTION
## What changed

- disable automatic preferred-content sizing for the welcome hosting controller
- measure the SwiftUI content after layout and coalesce window resizing onto a later main-actor turn
- preserve the window's top edge while its onboarding steps change height

This prevents dynamic onboarding content from feeding a window resize back into the AppKit constraint pass that requested it.

## Verification

- `./Tools/test-core.sh OnboardingFlow`
- `make build`
- `make lint`
- `make swiftlint`