### PR TITLE
Keep a subagent's row while it is still running

### DIFF
--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -156,12 +156,12 @@ final class TranscriptModel {
     /// tomorrow has the duration and no explanation, which is where it was before any of this.
     private(set) var recoveredRuns: [Int: RetryRun] = [:]
 
-    /// The subagents this turn has spawned, in the order it spawned them.
+    /// The subagents this session has spawned and not yet accounted for, in spawn order.
     ///
     /// One roster per session rather than per workspace, because a workspace with four chats runs
     /// four turns and the sidebar draws the active chat's. It is deliberately not stored: see
     /// `SubagentRoster` for the argument, which is that the longest one of these is meant to live
-    /// is a single turn and the CLI's own record of it is already on disk.
+    /// is a single session and the CLI's own record of it is already on disk.
     private(set) var subagents = SubagentRoster() {
         didSet { if let id = workspace?.id { app.noteSubagentsChanged(workspaceID: id) } }
     }
@@ -830,12 +830,13 @@ final class TranscriptModel {
         turnStartedAt = Date()
         wasStoppedByHand = false
         hasReportedTurnEnded = false
-        // **The clearing rule.** The last turn's subagents go here, at the one place a turn
-        // starts, and nowhere else. Clearing them when they finish is the option that reads well
-        // in a screenshot and badly in use: three rows leaving one by one take everything below
-        // them up the pane while you are still reading the third. Clearing them here means a
+        // **The clearing rule.** The last turn's FINISHED subagents go here, at the one place a
+        // turn starts, and nowhere else. Clearing them when they finish is the option that reads
+        // well in a screenshot and badly in use: three rows leaving one by one take everything
+        // below them up the pane while you are still reading the third. Clearing them here means a
         // finished subagent keeps its place, with its tick or its cross and what it answered, for
-        // as long as the turn it belongs to is the last thing that happened.
+        // as long as the turn it belongs to is the last thing that happened. One still running is
+        // not cleared at all, because it is still running. See `SubagentRoster.turnStarted`.
         subagents.turnStarted()
         setRunning(true)
         statusLabel = "Starting"
@@ -1211,7 +1212,9 @@ final class TranscriptModel {
             await appendLatestMessages()
             setRunning(false)
             statusLabel = nil
-            subagents.turnEnded()
+            // The process is gone, so every subagent under it went with it and nothing is left to
+            // report their endings. This is the case `agentExited` is named for.
+            subagents.agentExited()
             await refreshSession()
             app.alert = BloomAlert(
                 title: "The agent stopped in \(workspaceNow?.name ?? AskConversation.title)",
@@ -1241,9 +1244,17 @@ final class TranscriptModel {
             fileRecoveredRun()
             setRunning(false)
             statusLabel = nil
-            // Anything still breathing was killed with the turn, whatever the last line about it
-            // said. The rows stay, marked as stopped; they go when the next turn starts.
-            subagents.turnEnded()
+            // **A result is not news about a subagent, and assuming it was is what hid them.**
+            // `claude` runs for the whole session and the next turn is written into the same
+            // process, so an `Agent` call that answered "the agent is working in the background"
+            // is still working after this line and still going to report its own ending here.
+            // Marking everything stopped took its row away seconds after it was spawned, and the
+            // clear at the next turn's start then made sure it never came back: a workspace with
+            // a spinner and no children under it while two agents were six minutes in.
+            //
+            // A turn the owner stopped is the other case, and there the process really was
+            // signalled, so the children genuinely died with it.
+            if wasStoppedByHand { subagents.agentExited() }
             // Token counts, cost and state are all written by the runner as part of handling the
             // same result. Reading them back keeps one writer and avoids double counting.
             await refreshSession()

--- a/Sources/BloomCore/Transcript/Subagent.swift
+++ b/Sources/BloomCore/Transcript/Subagent.swift
@@ -17,8 +17,9 @@ import Foundation
 /// - `system/task_notification` is the only line carrying `output_file`, and it arrives for a
 ///   failed subagent as readily as for one that worked.
 ///
-/// Nothing here is stored. A subagent lives for seconds and the row it draws is cleared by the
-/// next turn, so there is no table and nothing to migrate. See `SubagentRoster`.
+/// Nothing here is stored. A subagent outlives nothing but the session it was spawned in, and the
+/// row it draws is cleared once it has finished, so there is no table and nothing to migrate. See
+/// `SubagentRoster`.
 public enum SubagentSignal: Sendable, Hashable {
     case started(SubagentStart)
     case progressed(SubagentProgress)

--- a/Sources/BloomCore/Transcript/SubagentLifecycle.swift
+++ b/Sources/BloomCore/Transcript/SubagentLifecycle.swift
@@ -19,8 +19,8 @@ public enum SubagentState: String, Sendable, Hashable, CaseIterable, Codable {
     /// It stopped without answering. The API refusing it ten times running is this, and on the
     /// night this was measured it was all three subagents in the capture.
     case failed
-    /// Killed rather than finished: by the parent turn ending, by the owner, or by the CLI's own
-    /// limits. Kept apart from `failed` because nothing went wrong, and a cross beside a row
+    /// Killed rather than finished: by the agent process going away, by the owner, or by the
+    /// CLI's own limits. Kept apart from `failed` because nothing went wrong, and a cross beside a row
     /// nobody's code broke is a lie that costs somebody ten minutes.
     case stopped
 
@@ -41,10 +41,17 @@ public enum SubagentLifecycleEvent: Sendable, Hashable {
     /// the CLI spelled it. Reading it is `SubagentState.init(reported:)`'s job, and a word nobody
     /// recognises is refused rather than guessed at.
     case reported(status: String)
-    /// The turn that owned this subagent ended without the CLI saying what became of it. Sent by
-    /// the roster when a result line lands, so a row cannot breathe for ever behind a finished
-    /// turn: the process that would have told us is gone.
-    case turnEnded
+    /// The `claude` process died without the CLI saying what became of this subagent. Sent by
+    /// the roster when the agent exits, so a row cannot breathe for ever behind a session that
+    /// has gone: the process that would have told us is not there any more.
+    ///
+    /// **Not the end of a turn, and that rename is the bug.** It used to be sent on every result
+    /// line, on the reasoning that the reporter had gone away. The reporter had not: `claude`
+    /// runs for the length of the session and `AgentRunner.send` writes the next turn into the
+    /// same process, so a result says nothing about a subagent. An `Agent` call that comes back
+    /// with "the agent is working in the background" outlives the turn that made it by minutes,
+    /// and this event was marking it stopped seconds after it started.
+    case agentExited
 }
 
 extension SubagentState {
@@ -88,8 +95,8 @@ extension SubagentState {
     /// `running` likewise: the CLI sends `task_updated` for things other than an ending, and a
     /// machine that fired on the ordinary case is a machine somebody routes around.
     ///
-    /// `turnEnded` is the one event that is legal from `running` and says nothing about it having
-    /// worked, which is why it lands on `stopped` rather than on `failed`.
+    /// `agentExited` is the one event that is legal from `running` and says nothing about it
+    /// having worked, which is why it lands on `stopped` rather than on `failed`.
     public func transition(on event: SubagentLifecycleEvent) -> StateTransition<SubagentState> {
         switch event {
         case .spawned:
@@ -106,7 +113,7 @@ extension SubagentState {
             }
             return reported == .running ? .unchanged : .moves(to: reported)
 
-        case .turnEnded:
+        case .agentExited:
             guard self == .running else { return .unchanged }
             return .moves(to: .stopped)
         }

--- a/Sources/BloomCore/Transcript/SubagentRetention.swift
+++ b/Sources/BloomCore/Transcript/SubagentRetention.swift
@@ -32,8 +32,10 @@ import Foundation
 /// seconds is a flicker of its own, and the tick is the confirmation that the work landed. See
 /// `lingerSeconds`.
 ///
-/// The backstop is unchanged and is what keeps all three bounded: `SubagentRoster.turnStarted`
-/// clears everything when the next turn begins.
+/// The backstop is what keeps all three bounded: `SubagentRoster.turnStarted` clears every
+/// finished subagent when the next turn begins. A subagent still working is not cleared and keeps
+/// its row across the turn boundary, because an `Agent` call launched into the background runs for
+/// minutes after the turn that made it has ended and the row is the only sign of it.
 public enum SubagentRetention: Sendable {
     /// How long a finished row is held before it leaves.
     ///

--- a/Sources/BloomCore/Transcript/SubagentRoster.swift
+++ b/Sources/BloomCore/Transcript/SubagentRoster.swift
@@ -142,12 +142,21 @@ public struct Subagent: Sendable, Hashable, Identifiable {
     }
 }
 
-/// Every subagent this turn has spawned, in the order they were spawned, for the length of the
-/// turn and no longer.
+/// Every subagent this session has spawned that has not yet been accounted for, in the order they
+/// were spawned.
 ///
-/// **The clearing rule, which is the backstop.** A row appears on `task_started` and is removed at
-/// the latest when the NEXT turn starts. Not for ever, because then the sidebar accumulates a
-/// morning's worth of dead work under every workspace.
+/// **The clearing rule, which is the backstop.** A row appears on `task_started` and a FINISHED
+/// row is removed at the latest when the next turn starts. Not for ever, because then the sidebar
+/// accumulates a morning's worth of dead work under every workspace.
+///
+/// **A subagent that is still running survives the turn that spawned it, and that is the bug this
+/// paragraph records.** The `Agent` tool answers "Async agent launched successfully. The agent is
+/// working in the background", the turn's result line lands while the subagent is minutes from
+/// finishing, and `claude` keeps running for the whole session, so the ending still arrives on the
+/// same stream under the same `task_id`. Clearing a running subagent here threw away the only
+/// thing that could receive that line, and the sidebar drew a workspace with a spinner and no
+/// children while the transcript said two agents were still going. So finished rows are cleared
+/// and running ones are kept, and only the process going away ends one Bloom was not told about.
 ///
 /// Most rows go sooner than that: a tick is held briefly and then leaves, and only a failure, or a
 /// row somebody has opened, stays for the whole turn. That is `SubagentRetention`'s to decide and
@@ -157,7 +166,7 @@ public struct Subagent: Sendable, Hashable, Identifiable {
 ///
 /// **Nothing here is stored.** `Store`'s rule is that `upsert` creates and `update` modifies, and
 /// the question in front of it is whether a subagent should have a row at all. It should not. The
-/// longest a subagent's row is meant to live is one turn; the CLI's own record of it is on disk
+/// longest a subagent's row is meant to live is one session; the CLI's own record of it is on disk
 /// already and Bloom does not own that file; and a table would mean a migration, a delete pass and
 /// a decision about what a subagent row means once its session is closed. A relaunch clears the
 /// pane, which is what the rule says happens at the start of the next turn anyway, only sooner.
@@ -196,22 +205,29 @@ public struct SubagentRoster: Sendable, Hashable {
     /// to summarise the children it is drawing.
     public var isWorking: Bool { subagents.contains { $0.state == .running } }
 
-    /// The next turn has started, so the last turn's children go, rows and all. The backstop
-    /// under `SubagentRetention`, and the only thing that clears a failure.
+    /// The next turn has started, so the last turn's FINISHED children go, rows and all. The
+    /// backstop under `SubagentRetention`, and the only thing that clears a failure.
+    ///
+    /// Anything still running stays. It is not the last turn's child in any sense that matters:
+    /// it is work in flight, it is still going to report its own ending on this session's stream,
+    /// and the row is the only place anybody can see it. See the type's doc comment.
     public mutating func turnStarted() {
-        subagents = []
-        byToolUse = [:]
+        subagents.removeAll { $0.state.isFinished }
+        let living = Set(subagents.map(\.id))
+        byToolUse = byToolUse.filter { living.contains($0.value) }
         refusals = 0
     }
 
-    /// The turn ended. Anything still running was killed with it, whatever the last line said.
+    /// The agent process died. Anything still running was killed with it, whatever the last line
+    /// said.
     ///
-    /// Sent on the result line rather than inferred, because the process that would have reported
-    /// these endings is the one that just went away: without this a subagent whose notification
-    /// was lost breathes on the row until the owner sends the next message.
-    public mutating func turnEnded(now: Date = Date()) {
+    /// Sent when `claude` itself goes away rather than when a turn ends, because the process is
+    /// what reports these endings and it lives for the whole session: a turn finishing is not news
+    /// about a subagent. Without this a subagent whose notification can never arrive, because the
+    /// process that would have sent it was signalled, breathes on the row for ever.
+    public mutating func agentExited(now: Date = Date()) {
         for index in subagents.indices {
-            apply(.turnEnded, at: index, now: now)
+            apply(.agentExited, at: index, now: now)
         }
     }
 

--- a/Tests/BloomCoreTests/SubagentRetentionTests.swift
+++ b/Tests/BloomCoreTests/SubagentRetentionTests.swift
@@ -242,11 +242,11 @@ import Foundation
         #expect(roster[SubagentID("1")]?.finishedAt == first)
     }
 
-    @Test func aTurnEndingTimesWhateverItStopped() {
+    @Test func theAgentExitingTimesWhateverItStopped() {
         var roster = SubagentRoster()
         roster.apply(.started(SubagentStart(id: SubagentID("1"), toolUseID: "t")), now: Self.start)
         let end = Self.start.addingTimeInterval(30)
-        roster.turnEnded(now: end)
+        roster.agentExited(now: end)
         #expect(roster[SubagentID("1")]?.state == .stopped)
         #expect(roster[SubagentID("1")]?.finishedAt == end)
     }
@@ -264,7 +264,6 @@ import Foundation
             now = now.addingTimeInterval(0.1)
             switch event {
             case .subagent(let signal): roster.apply(signal, now: now)
-            case .result: roster.turnEnded(now: now)
             default: break
             }
         }

--- a/Tests/BloomCoreTests/SubagentTests.swift
+++ b/Tests/BloomCoreTests/SubagentTests.swift
@@ -23,7 +23,6 @@ import Foundation
         for event in try events() {
             switch event {
             case .subagent(let signal): roster.apply(signal)
-            case .result: roster.turnEnded()
             default: break
             }
         }
@@ -183,13 +182,13 @@ import Foundation
         #expect(SubagentState(reported: "in_progress") == .running)
     }
 
-    @Test func aTurnEndingStopsWhateverWasStillRunning() {
+    @Test func theAgentExitingStopsWhateverWasStillRunning() {
         // The process that would have reported the ending is the one that just went away.
         var roster = SubagentRoster()
         roster.apply(.started(SubagentStart(id: SubagentID("a"))))
         roster.apply(.started(SubagentStart(id: SubagentID("b"))))
         roster.apply(.reported(SubagentReport(id: SubagentID("b"), status: "completed")))
-        roster.turnEnded()
+        roster.agentExited()
         #expect(roster[SubagentID("a")]?.state == .stopped)
         #expect(roster[SubagentID("b")]?.state == .completed)
         #expect(!roster.isWorking)
@@ -204,7 +203,6 @@ import Foundation
         var roster = SubagentRoster()
         roster.apply(.started(SubagentStart(id: SubagentID("a"), description: "One")))
         roster.apply(.reported(SubagentReport(id: SubagentID("a"), status: "completed")))
-        roster.turnEnded()
         return roster
     }
 
@@ -225,6 +223,113 @@ import Foundation
         roster.turnStarted()
         roster.apply(.progressed(SubagentProgress(parentToolUseID: "", elapsedSeconds: 9)))
         #expect(roster.isEmpty)
+    }
+}
+
+// MARK: - Subagents that outlive the turn that spawned them
+
+/// **"Seems like some subagents are not displayed."** A workspace drew three subagent rows while
+/// its turn ran, and minutes later drew a spinner and no children at all while the transcript said
+/// two of them were still going, six minutes in.
+///
+/// Nothing was wrong with the parsing. The `Agent` tool answers "Async agent launched
+/// successfully. The agent is working in the background", so the turn's result line lands while
+/// the subagent has minutes left; `SubagentRoster.turnEnded` then marked every running subagent
+/// `stopped`, retention took the rows off two and a half seconds later, and the next turn's
+/// `turnStarted` emptied the roster, so the `task_notification` that would have ended them had
+/// nothing left to land on. `claude` runs for the whole session, which is why the ending was
+/// always still coming and why nothing had the right to declare these subagents finished.
+@Suite struct SubagentsOutlivingTheirTurnTests {
+    private func spawned() -> SubagentRoster {
+        var roster = SubagentRoster()
+        roster.apply(.started(SubagentStart(
+            id: SubagentID("live"), toolUseID: "toolu_live", description: "Prototype exploration",
+            isBackgrounded: true, taskType: "local_agent"
+        )))
+        roster.apply(.started(SubagentStart(
+            id: SubagentID("done"), toolUseID: "toolu_done", description: "Study conventions",
+            taskType: "local_agent"
+        )))
+        roster.apply(.reported(SubagentReport(
+            id: SubagentID("done"), status: "completed", summary: "Read it"
+        )))
+        return roster
+    }
+
+    @Test func aTurnEndingSaysNothingAboutASubagentStillWorking() {
+        // The result line used to stop everything. `claude` is still there and so is the subagent.
+        var roster = spawned()
+        roster.turnStarted()
+        #expect(roster[SubagentID("live")]?.state == .running)
+        #expect(roster.isWorking)
+    }
+
+    @Test func theNextTurnKeepsARunningRowAndDropsAFinishedOne() {
+        var roster = spawned()
+        roster.turnStarted()
+        #expect(roster.subagents.map(\.id) == [SubagentID("live")])
+
+        let rows = SubagentRetention.rows(roster, now: Date())
+        #expect(rows.map(\.title) == ["Prototype exploration"])
+        #expect(rows.first?.mark == .working)
+    }
+
+    @Test func theEndingStillLandsAfterTheTurnBoundary() {
+        // The whole point of keeping the row: the `task_notification` arrives in a later turn,
+        // under the same `task_id`, and there has to be something for it to land on.
+        var roster = spawned()
+        roster.turnStarted()
+        roster.apply(.reported(SubagentReport(
+            id: SubagentID("live"), status: "completed", summary: "Explored", outputFile: "/tmp/a"
+        )))
+        #expect(roster[SubagentID("live")]?.state == .completed)
+        #expect(roster[SubagentID("live")]?.outputFile == "/tmp/a")
+        #expect(roster.refusals == 0)
+    }
+
+    @Test func theToolUseMapSurvivesForTheRowsThatDo() {
+        // A tick names the subagent by its parent's `tool_use_id` and by nothing else, so a map
+        // cleared with the turn would leave a kept row unable to count.
+        var roster = spawned()
+        roster.turnStarted()
+        roster.apply(.progressed(SubagentProgress(parentToolUseID: "toolu_live", elapsedSeconds: 400)))
+        #expect(roster[SubagentID("live")]?.elapsedSeconds == 400)
+
+        // And the finished one's entry goes with it, or the next turn's ticks find a dead row.
+        roster.apply(.progressed(SubagentProgress(parentToolUseID: "toolu_done", elapsedSeconds: 9)))
+        #expect(roster[SubagentID("done")] == nil)
+        #expect(roster.subagents.count == 1)
+    }
+
+    @Test func onlyTheAgentGoingAwayStopsOne() {
+        var roster = spawned()
+        roster.turnStarted()
+        roster.agentExited()
+        #expect(roster[SubagentID("live")]?.state == .stopped)
+        #expect(!roster.isWorking)
+    }
+
+    @Test func aBackgroundAgentStillHasARowMinutesIntoALaterTurn() {
+        // The owner's own reading: three rows counting up while the turn ran, and a spinner with
+        // nothing under it once two more turns had been and gone.
+        let start = Date(timeIntervalSince1970: 1_000_000)
+        var roster = SubagentRoster()
+        roster.apply(
+            .started(SubagentStart(
+                id: SubagentID("a"), toolUseID: "t", description: "there-there conventions sweep",
+                isBackgrounded: true, taskType: "local_agent"
+            )),
+            now: start
+        )
+        // Two turns end and two more begin while it works.
+        roster.turnStarted()
+        roster.turnStarted()
+
+        let sixMinutesIn = start.addingTimeInterval(6 * 60)
+        let rows = SubagentRetention.rows(roster, now: sixMinutesIn)
+        #expect(rows.count == 1)
+        #expect(rows.first?.detail == .elapsed(seconds: 360))
+        #expect(rows.first?.detail.text == "6m 0s")
     }
 }
 


### PR DESCRIPTION
A workspace drew three subagent rows during a turn and, minutes later, a spinner with no children while the transcript said two agents were still going six minutes in.

The Agent tool answers "Async agent launched successfully. The agent is working in the background", so a turn's result lands while its subagents have minutes left. `SubagentRoster.turnEnded` marked every running one stopped, retention took the rows off 2.5s later, and the next turn's `turnStarted` emptied the roster, so the `task_notification` that would have ended them had nothing to land on. It rested on the reporting process having gone away, and it has not: `claude` runs for the whole session and the next turn is written into the same process.

`turnStarted` now clears only the finished subagents, and `turnEnded` is `agentExited`, sent when the process really does die (the agent erroring out, or a turn the owner stopped).