### PR TITLE
Forgive a branch prefix that already ends in a slash

### DIFF
--- a/Sources/BloomCore/Git/Git+Naming.swift
+++ b/Sources/BloomCore/Git/Git+Naming.swift
@@ -6,6 +6,10 @@ import Foundation
 /// tests drive them without a repository on disk. Whether the result is a name git will accept
 /// is a separate question, and `isValidBranchName` in `Git.swift` is what answers it.
 extension Git {
+    /// What is trimmed off both ends of a branch prefix. See `prefixed`.
+    private static let prefixEdges = CharacterSet.whitespacesAndNewlines
+        .union(CharacterSet(charactersIn: "/"))
+
     private static let stopWords: Set<String> = [
         "the", "a", "an", "and", "or", "but", "to", "of", "in", "on", "for", "with",
         "please", "can", "you", "i", "we", "it", "this", "that", "is", "are", "be",
@@ -111,13 +115,28 @@ extension Git {
     /// `WorkspaceNaming.cleanBranch` where a model's suggestion is prefixed, and in the app where
     /// a claimed sea's slug is. The third carried a comment saying it applied the same rule as the
     /// second, which it did by writing it out again, under a comment on this one warning about
-    /// exactly that. What a prefix means, which is a slash and no trimming, is decided here.
+    /// exactly that. What a prefix means is decided here, and only here.
     ///
     /// An empty prefix is no prefix. A project that has never set one and one that set it to ""
     /// are the same project.
+    ///
+    /// The prefix is normalised before the slash is added, because a prefix ending in one
+    /// produced `feature//test`, which the create window printed under the name box and which
+    /// `git branch` then refused with "'feature//test' is not a valid branch name": an empty
+    /// component between two slashes is not a ref. A prefix is a prefix whether or not somebody
+    /// wrote the separator themselves, and people write it, so whitespace and slashes at either
+    /// end come off and a prefix that was nothing but those is no prefix rather than a leading
+    /// slash. Normalising here rather than at the settings field is what matters: a `feature/`
+    /// already sitting in a project's `.bloom/settings.toml` is never seen by that field again.
+    ///
+    /// Only the edges. A prefix with a space or a colon in the middle of it is still a prefix git
+    /// will refuse, and silently rewriting the owner's own text into something else is a larger
+    /// decision than repairing a separator that was going to be supplied anyway.
     public static func prefixed(_ slug: String, with prefix: String?) -> String {
-        guard let prefix, !prefix.isEmpty else { return slug }
-        return "\(prefix)/\(slug)"
+        guard let prefix else { return slug }
+        let trimmed = prefix.trimmingCharacters(in: prefixEdges)
+        guard !trimmed.isEmpty else { return slug }
+        return "\(trimmed)/\(slug)"
     }
 
     public static func uniqueBranch(_ desired: String, taken: Set<String>) -> String {

--- a/Tests/BloomCoreTests/WorkspaceNamingTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceNamingTests.swift
@@ -302,3 +302,86 @@ struct BranchPrefixTests {
         #expect(suggested == WorkspaceNaming.prefixedBranch("dark-mode", prefix: "freek"))
     }
 }
+
+/// A prefix ending in a slash used to be joined to the slug with another one. Typing `feature/`
+/// into a project's Branch prefix field and then `test` into the create window printed
+/// `feature//test` under the box, and Create failed with "'feature//test' is not a valid branch
+/// name", because git takes no empty path component in a ref. The trailing slash is now trimmed
+/// off the prefix instead, so a prefix means the same thing whether or not the separator was
+/// typed with it, and a prefix already saved in a `.bloom/settings.toml` is forgiven rather than
+/// needing to be edited.
+@Suite("Branch prefix separators")
+struct BranchPrefixSeparatorTests {
+    @Test("a prefix that already ends in a slash does not get a second one")
+    func trailingSlash() {
+        #expect(Git.prefixed("test", with: "feature/") == "feature/test")
+        #expect(Git.prefixed("test", with: "feature//") == "feature/test")
+        #expect(Git.prefixed("test", with: "feature") == "feature/test")
+    }
+
+    /// A prefix pasted from a ref somebody copied, which reads as a leading slash git refuses too.
+    @Test("a prefix that starts with a slash loses it")
+    func leadingSlash() {
+        #expect(Git.prefixed("test", with: "/feature") == "feature/test")
+        #expect(Git.prefixed("test", with: "/feature/") == "feature/test")
+    }
+
+    /// A nested prefix is a real thing to want, and only the ends are touched.
+    @Test("slashes inside a prefix are left alone")
+    func nestedPrefix() {
+        #expect(Git.prefixed("test", with: "team/feature/") == "team/feature/test")
+    }
+
+    @Test("a prefix of nothing but slashes or whitespace is no prefix")
+    func emptyAfterTrimming() {
+        #expect(Git.prefixed("test", with: "") == "test")
+        #expect(Git.prefixed("test", with: nil) == "test")
+        #expect(Git.prefixed("test", with: "/") == "test")
+        #expect(Git.prefixed("test", with: "///") == "test")
+        #expect(Git.prefixed("test", with: "   ") == "test")
+        #expect(Git.prefixed("test", with: " / ") == "test")
+    }
+
+    /// The field is typed into by hand, and a trailing space survived the old join as surely as a
+    /// trailing slash did. Both ends, and both characters, in one pass.
+    @Test("whitespace around a prefix comes off with the slashes")
+    func surroundingWhitespace() {
+        #expect(Git.prefixed("test", with: " feature ") == "feature/test")
+        #expect(Git.prefixed("test", with: " feature/ ") == "feature/test")
+        #expect(Git.prefixed("test", with: "\tfeature/\n") == "feature/test")
+    }
+
+    /// The whole complaint, end to end: what the create window prints under the name box and what
+    /// `WorkspaceManager.cut` hands to git are the one string, and git will now take it.
+    @Test("the branch a prefix with a slash produces is one git accepts")
+    func gitAcceptsTheResult() {
+        let stem = Git.branchStem(prompt: "test", prefix: "feature/")
+
+        #expect(stem == "feature/test")
+        #expect(Git.isValidBranchName(stem))
+        // The string the alert quoted, so the test fails if `isValidBranchName` ever stops
+        // minding it and this suite starts proving nothing.
+        #expect(!Git.isValidBranchName("feature//test"))
+    }
+
+    /// The two names that come from somewhere other than the prompt take the same route, so a
+    /// model's suggestion and a claimed sea are forgiven the same trailing slash.
+    @Test("a suggested branch and a sea's slug are forgiven the same slash")
+    func suggestionsAgree() throws {
+        #expect(WorkspaceNaming.prefixedBranch("dark-mode", prefix: "feature/") == "feature/dark-mode")
+
+        let suggested = try #require(WorkspaceNaming.cleanBranch("dark mode", prefix: "feature/"))
+        #expect(suggested == "feature/dark-mode")
+    }
+
+    /// Deliberately not fixed here, and recorded so the next person knows it was a decision. A
+    /// prefix with a space or a colon in it is a prefix git refuses, and the answer to that is
+    /// either to say so at the settings field or to rewrite the owner's text, which is a larger
+    /// change than repairing a separator this function was going to supply anyway.
+    @Test("a prefix git refuses for a reason other than the separator still refuses")
+    func middleOfThePrefixIsUntouched() {
+        #expect(Git.prefixed("test", with: "my feature") == "my feature/test")
+        #expect(!Git.isValidBranchName(Git.prefixed("test", with: "my feature")))
+        #expect(WorkspaceNaming.prefixedBranch("test", prefix: "my feature") == nil)
+    }
+}


### PR DESCRIPTION
A prefix of `feature/` was joined to the slug with another slash, so the create window printed `feature//test` under the name box and Create failed with "'feature//test' is not a valid branch name". Git takes no empty component in a ref.

`Git.prefixed` is the one join every branch name goes through, the chip and `WorkspaceManager.cut` included, so the trimming goes there: whitespace and slashes come off both ends, and a prefix that was nothing but those is no prefix rather than a leading slash. Fixing it at the join rather than at the settings field is what matters, because a `feature/` already saved in a project's `.bloom/settings.toml` is never seen by that field again.

There is no shipped default prefix to correct: `RepoSettings.branchPrefix` is nil and nothing writes one, so a `feature/` can only have come from a settings file (`~/.conductor/settings.toml`, `~/.bloom/settings.toml` or the repo's own).

Only the ends are touched. A prefix with a space or a colon inside it is still one git refuses, which is a separate question from a separator this function was going to supply anyway.