### PR TITLE
Fold errored actions, and a subagent's rows

### DIFF
--- a/Sources/Bloom/Views/Transcript/TranscriptFoldRowView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptFoldRowView.swift
@@ -9,6 +9,10 @@ struct TranscriptFoldRowView: View {
     var hiddenCount: Int
     var showsMore: Bool
     var isExpanded: Bool
+    /// Whether this stands for a subagent's own work, in which case it is drawn where those rows
+    /// are drawn: indented under the call that started them, behind the same rule. A line at the
+    /// margin standing for indented rows reads as work the main agent did.
+    var isNested = false
     var onToggle: () -> Void
 
     @State private var isHovered = false
@@ -36,6 +40,17 @@ struct TranscriptFoldRowView: View {
         .accessibilityLabel("\(hiddenCount) actions")
         .modifier(ExpandableRow(isHovered: isHovered))
         .onHover { isHovered = $0 }
+        // Outside the hover treatment, exactly as `TranscriptRowView` puts it outside a row's
+        // own: the highlight belongs to the line, not to the gutter the rule is drawn in.
+        .padding(.leading, isNested ? TranscriptLayout.nestIndent : 0)
+        .overlay(alignment: .leading) {
+            if isNested {
+                Rectangle()
+                    .fill(Palette.border)
+                    .frame(width: Metrics.hairline)
+                    .padding(.leading, TranscriptLayout.inset)
+            }
+        }
     }
 
 }

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -375,14 +375,21 @@ struct TranscriptListView: View {
                 TranscriptFold.Fact(
                     seq: $0.seq,
                     kind: $0.kind,
-                    // A refusal travels as `is_error` too, and both are the same fact here: a call
-                    // that did not do what it was asked is a call the reader is looking for.
+                    // A refusal travels as `is_error` too, and both are the same fact here: a
+                    // call that did not do what it was asked has said everything it is going to
+                    // say, which is all the fold needs of it. It is not held out of the fold for
+                    // it; see rule 2 in `TranscriptFold`.
                     failed: $0.isError || $0.refusal != nil,
                     featured: MediaShowRow.isCall($0.payload)
                         || CodexImageViewRow.isCall($0.payload),
                     drawsNothing: TranscriptNoise.isHidden($0)
                         || TranscriptRowInk.drawsNothing(kind: $0.kind, payload: $0.payload),
-                    settled: settled($0)
+                    settled: settled($0),
+                    // Only a call has an id a subagent's rows can name. Every other kind carries
+                    // `refID` for something else, and a stray match here would make an ordinary
+                    // row the header of a run it has nothing to do with.
+                    toolUseID: $0.kind == .toolUse ? $0.refID : nil,
+                    parentToolUseID: $0.parentToolUseID
                 )
             },
             extending: previous
@@ -574,6 +581,9 @@ struct TranscriptListView: View {
                         hiding: hidden > 0 ? would : work.rows.count,
                         showsMore: hidden > 0 && would < work.rows.count,
                         isFolded: hidden > 0,
+                        // A subagent's line is drawn where its rows are, under the call that
+                        // started it. See `TranscriptFold`, which is where the grouping is.
+                        isNested: work.isNested,
                         // A turn with nothing to hide gets no line: a control that answers nothing
                         // when it is pressed is worse than no control. Its entry stays in the list
                         // all the same, drawing nothing, because an entry that came and went in
@@ -819,6 +829,7 @@ struct TranscriptListView: View {
         hiding: Int,
         showsMore: Bool,
         isFolded: Bool,
+        isNested: Bool,
         shows: Bool,
         session: SessionID
     ) -> TranscriptTableEntry {
@@ -831,6 +842,7 @@ struct TranscriptListView: View {
                 $0.combine(hiding)
                 $0.combine(showsMore)
                 $0.combine(isFolded)
+                $0.combine(isNested)
                 $0.combine(shows)
             },
             // Not a guess. This entry draws nothing because it has been told to draw nothing, so
@@ -849,6 +861,7 @@ struct TranscriptListView: View {
                         hiddenCount: hiding,
                         showsMore: showsMore,
                         isExpanded: !isFolded,
+                        isNested: isNested,
                         onToggle: { toggleFold(firstSeq) }
                     )
                     // The same two insets every row in this list carries: one here, and one inside

--- a/Sources/BloomCore/Transcript/TranscriptFold.swift
+++ b/Sources/BloomCore/Transcript/TranscriptFold.swift
@@ -24,6 +24,26 @@ import Foundation
 /// live group. This distinction lets a live group refold when another log row arrives without ever
 /// taking prose away from the reader.
 ///
+/// # A subagent's rows are their own working
+///
+/// A row from inside a subagent carries the id of the call that started it, and it is drawn
+/// indented under that call. A change of that id closes the group, so a subagent's children fold
+/// among themselves and a fold can never span two of them or reach out to the work around one.
+/// The call itself is held out of the fold the moment a child of it appears, because an indented
+/// "16 actions" line hanging under a fold that swallowed the row saying which agent it was is
+/// worse than not folding at all.
+///
+/// **This is a bug rather than a feature that was missing.** Nested rows were scanned exactly like
+/// any other, so they were in a group with the call that started them, and that call has no result
+/// until the subagent has finished. Rule 1 then pinned the whole group open: a subagent that ran
+/// for four minutes drew every one of its sixteen or sixty rows in full, at the one moment folding
+/// them was worth most, and only folded once it was over. Grouping by the id fixes the cause
+/// rather than the symptom, since the children settle one by one as their own results land.
+///
+/// Two subagents running at once interleave their rows, so every group is a row or two long and
+/// nothing folds. That is the honest answer for a transcript whose next line is from a different
+/// agent, and it is what the old code did for the whole run anyway.
+///
 /// # What is never hidden
 ///
 /// Four things remain visible. Permanent outcomes split consecutive activity into a new fold;
@@ -33,9 +53,25 @@ import Foundation
 ///    that had to reveal a row it had hidden is a transcript rearranging itself under somebody who
 ///    is reading it. A tool call with no result yet, and a permission question nobody has answered
 ///    yet, are the same fact here.
-/// 2. **A failed call, and an error row.** A failed command is the one you are scrolling to find.
-///    It remains visible and divides the ordinary activity before and after it into separate
-///    compact groups.
+/// 2. **The agent stopping, and a row carrying content of its own.** An `error` row is the agent
+///    exiting in a way it did not choose, and inline media is deliberate content wearing an
+///    activity row's clothes. Both remain visible and divide the ordinary activity before and
+///    after them into separate compact groups.
+///
+///    **A failed tool call is not one of these, and it used to be.** This rule said that a failed
+///    command is the one you are scrolling to find, which read well and drew badly: an errored
+///    row was held out of the fold and left standing on its own, so a run of work came out as "7
+///    actions", one error, "42 actions", one error, "88 actions", and the transcript was chopped
+///    up by the very rows the reader was meant to notice. A tool that fails is ordinary. Agents
+///    probe with calls that are allowed to miss, the prose that ends the run says what actually
+///    went wrong, and a reader hunting for the failure opens the fold or arrives through rule 4,
+///    which pulls a searched row out of whatever fold it sits in. An agent that dies says nothing
+///    afterwards, which is why the `error` row above is still held out and a failed call is not.
+///
+///    **The line is not marked when it hides one either**, and that is the same argument. It is a
+///    count and says nothing else about what it holds, not which tools ran, not how long they
+///    took; a mark for failure would be the first exception, and it would be lit on most folds in
+///    an ordinary session, which teaches a reader nothing except to stop reading it.
 /// 3. **A permission question nobody has answered.** It is covered by 1, and it is written down
 ///    separately because burying a question the turn is stopped on would be the worst fault this
 ///    file could have. Answered, it folds away with the rest.
@@ -169,6 +205,9 @@ public enum TranscriptFold {
         public var kind: MessageKind
         /// The call reported an error or was refused. Both travel as `is_error`, so they are one
         /// fact here.
+        ///
+        /// **This settles a row rather than holding it out of the fold.** A failed call folds
+        /// away with the ordinary work around it; see rule 2 for why it stopped being a boundary.
         public var failed: Bool
         /// Deliberate content carried by an activity-shaped row, such as inline media. It remains
         /// visible and separates the ordinary implementation log on either side.
@@ -184,6 +223,14 @@ public enum TranscriptFold {
         /// than trusting the caller: a result writes `is_error` and the payload in one go, so a
         /// call that could fail after being hidden would be a fold that has to unfold.
         public var settled: Bool
+        /// This row's own call id, for a tool call, and what a child of it carries as its
+        /// `parentToolUseID`. Nil for every other kind.
+        public var toolUseID: String?
+        /// The call that started the subagent this row came from, or nil for a top level row.
+        ///
+        /// Only compared, never parsed. It is already on the row for the indent the view draws,
+        /// so the fold reads it for nothing.
+        public var parentToolUseID: String?
 
         public init(
             seq: Int,
@@ -191,7 +238,9 @@ public enum TranscriptFold {
             failed: Bool = false,
             featured: Bool = false,
             drawsNothing: Bool = false,
-            settled: Bool = true
+            settled: Bool = true,
+            toolUseID: String? = nil,
+            parentToolUseID: String? = nil
         ) {
             self.seq = seq
             self.kind = kind
@@ -199,6 +248,8 @@ public enum TranscriptFold {
             self.featured = featured
             self.drawsNothing = drawsNothing
             self.settled = settled
+            self.toolUseID = toolUseID
+            self.parentToolUseID = parentToolUseID
         }
 
         /// Whether this is a grey activity row that may belong to a compact group. Black prose and
@@ -213,7 +264,7 @@ public enum TranscriptFold {
         }
 
         /// Whether this row has to stay on screen once it is reached. See rule 2 in the header.
-        var mustShow: Bool { failed || featured || kind == .error }
+        var mustShow: Bool { featured || kind == .error }
     }
 
     /// One row of a turn's working: where it is, and what it is called.
@@ -241,9 +292,14 @@ public enum TranscriptFold {
         var row: Row
         /// Whether this row may be hidden: settled, and not one that has to stay.
         var ready: Bool
-        /// A permanent boundary inside a turn, such as a failed call. Activity after it starts a
-        /// fresh fold instead of remaining exposed for the rest of the turn.
+        /// A permanent boundary inside a turn, such as the agent exiting. Activity after it
+        /// starts a fresh fold instead of remaining exposed for the rest of the turn.
+        ///
+        /// Set as the scan runs as well as read off the row, because a call becomes the header of
+        /// a subagent only when a child of it turns up, which is after it was collected.
         var mustShow: Bool
+        var toolUseID: String?
+        var parentToolUseID: String?
     }
 
     /// One turn's working, as the list needs it.
@@ -262,6 +318,9 @@ public enum TranscriptFold {
         public var ready: Int
         /// Whether the turn has said its answer, so nothing of the working need stay on screen.
         public var hasAnswer: Bool
+        /// Whether this is a subagent's own work, so the line that stands for it is drawn indented
+        /// under the call that started it rather than at the transcript's margin.
+        public var isNested: Bool
 
         /// The fold's identity, which is the sequence number of the FIRST row of the working.
         ///
@@ -272,11 +331,14 @@ public enum TranscriptFold {
         /// row instead, the entry would move every time one arrived.
         public var firstSeq: Int { rows.first?.seq ?? 0 }
 
-        public init(span: Range<Int>, rows: [Row], ready: Int, hasAnswer: Bool) {
+        public init(
+            span: Range<Int>, rows: [Row], ready: Int, hasAnswer: Bool, isNested: Bool = false
+        ) {
             self.span = span
             self.rows = rows
             self.ready = ready
             self.hasAnswer = hasAnswer
+            self.isNested = isNested
         }
     }
 
@@ -389,7 +451,10 @@ public enum TranscriptFold {
                     span: first.row.index..<(last.row.index + 1),
                     rows: segment.map(\.row),
                     ready: ready,
-                    hasAnswer: hasAnswer
+                    hasAnswer: hasAnswer,
+                    // Every item in the buffer shares one parent, because a change of it is what
+                    // closed the group, so the first answers for the segment.
+                    isNested: first.parentToolUseID != nil
                 ))
             }
 
@@ -400,8 +465,22 @@ public enum TranscriptFold {
             appendSegment(endingAt: items.endIndex)
         }
 
+        /// The call that started a subagent stops being foldable the moment a child of it turns
+        /// up, and that is asked of every kind rather than only of activity: a subagent's first
+        /// row is often its own prose, which closes the group two lines below before the parent
+        /// check there could ever see it, leaving the header inside a group that goes on to fold.
+        ///
+        /// Only asked at a change of parent, so it costs one comparison per row rather than a
+        /// walk of the buffer.
+        func markHeader(of fact: Fact) {
+            guard let parent = fact.parentToolUseID, items.last?.parentToolUseID != parent,
+                  let header = items.lastIndex(where: { $0.toolUseID == parent }) else { return }
+            items[header].mustShow = true
+        }
+
         for offset in start..<count {
             let fact = facts[facts.index(facts.startIndex, offsetBy: offset)]
+            markHeader(of: fact)
             // A message and the footer settle everything above them. Neither belongs to an
             // activity group, and a crew row is a message: it is what another agent said to start
             // this turn, in the place a user row sits when a person started it.
@@ -420,6 +499,11 @@ public enum TranscriptFold {
             // whatever is folded around it and counted as nothing. See `TranscriptRowInk`.
             if fact.drawsNothing { continue }
             guard fact.isActivity else { continue }
+            // A subagent's rows are its own working. See the section above: the id changing is
+            // what ends a group, so a fold never spans two subagents or reaches out of one.
+            if let last = items.last, last.parentToolUseID != fact.parentToolUseID {
+                close(hasAnswer: false)
+            }
             items.append(Item(
                 row: Row(index: offset, seq: fact.seq),
                 // **A failure counts as settled whatever the caller said, and that is the invariant
@@ -428,7 +512,9 @@ public enum TranscriptFold {
                 // round, a row that is hidden has already settled and can therefore never turn into
                 // a failure afterwards.
                 ready: fact.settled || fact.failed,
-                mustShow: fact.mustShow
+                mustShow: fact.mustShow,
+                toolUseID: fact.toolUseID,
+                parentToolUseID: fact.parentToolUseID
             ))
         }
         // Whatever is left is live activity. Folding while the turn works is the point, and the

--- a/Tests/BloomCoreTests/TranscriptFoldErrorTests.swift
+++ b/Tests/BloomCoreTests/TranscriptFoldErrorTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// An errored action folds away with the ordinary work around it.
+///
+/// **The bug this is written against.** A row whose call had failed was held out of the fold and
+/// left standing on its own between two folded groups, so a single run of work was drawn as "7
+/// actions", one errored fetch, "42 actions", one errored search, "88 actions". The rows meant to
+/// be easy to find were chopping up the transcript instead, and there were enough of them to do it
+/// twice in one screenful. A tool that fails is ordinary: agents probe with calls that are allowed
+/// to miss, and the prose that ends the run says what actually went wrong.
+///
+/// **What did not change is the other half of the old rule.** An `error` row is the agent exiting
+/// in a way it did not choose, which is the one failure no later prose will explain because there
+/// is no later prose, and a `featured` row is deliberate content wearing an activity row's
+/// clothes. Both still divide the work around them, and the tests at the foot of this suite are
+/// the boundary the change was allowed to move up to and no further.
+@Suite("Folding an errored action")
+struct FoldingAnErroredActionTests {
+    private func tool(_ seq: Int, failed: Bool = false, settled: Bool = true) -> TranscriptFold.Fact {
+        TranscriptFold.Fact(seq: seq, kind: .toolUse, failed: failed, settled: settled)
+    }
+
+    private func media(_ seq: Int) -> TranscriptFold.Fact {
+        TranscriptFold.Fact(seq: seq, kind: .toolUse, featured: true)
+    }
+
+    private func agentExit(_ seq: Int) -> TranscriptFold.Fact {
+        TranscriptFold.Fact(seq: seq, kind: .error)
+    }
+
+    private func prose(_ seq: Int) -> TranscriptFold.Fact {
+        TranscriptFold.Fact(seq: seq, kind: .assistantText)
+    }
+
+    private func user(_ seq: Int) -> TranscriptFold.Fact {
+        TranscriptFold.Fact(seq: seq, kind: .user)
+    }
+
+    private let everything = 0..<1_000
+
+    private func hides(_ work: TranscriptFold.Work, revealed: Set<Int> = []) -> Int {
+        TranscriptFold.hides(work, revealed: revealed, drawn: everything)
+    }
+
+    private func only(_ facts: [TranscriptFold.Fact]) throws -> TranscriptFold.Work {
+        let folds = TranscriptFold.folds(in: facts)
+        #expect(folds.all.count == 1)
+        return try #require(folds.all.first)
+    }
+
+    // MARK: An error inside a run
+
+    @Test("a failed call in the middle of a run folds with the rest of it")
+    func aFailureInTheMiddleFolds() throws {
+        let facts = [user(0)] + (1..<10).map { tool($0, failed: $0 == 5) }
+        let work = try only(facts)
+        #expect(work.rows.count == 9)
+        #expect(hides(work) == 9)
+        // The errored row is inside the working rather than standing between two of them.
+        let folds = TranscriptFold.folds(in: facts)
+        #expect(folds.fold(containing: 5)?.firstSeq == 1)
+    }
+
+    /// The screenshot that started this, written down: three runs of ordinary work and the two
+    /// errors between them are one group, not five entries.
+    @Test("the reported transcript folds into a single group")
+    func theReportedTranscript() throws {
+        var facts = [user(0)]
+        facts += (1...7).map { tool($0) }
+        facts.append(tool(8, failed: true))
+        facts += (9...50).map { tool($0) }
+        facts.append(tool(51, failed: true))
+        facts += (52...139).map { tool($0) }
+        let work = try only(facts)
+        #expect(work.rows.count == 139)
+        #expect(hides(work) == 139)
+    }
+
+    @Test("a run that opens with a failed call folds from its first row")
+    func aFailureAtTheStartFolds() throws {
+        let work = try only([user(0), tool(1, failed: true), tool(2), tool(3), tool(4)])
+        #expect(work.rows.first?.seq == 1)
+        #expect(work.rows.count == 4)
+        #expect(hides(work) == 4)
+    }
+
+    @Test("a run that ends on a failed call folds through it")
+    func aFailureAtTheEndFolds() throws {
+        let work = try only([user(0), tool(1), tool(2), tool(3), tool(4, failed: true)])
+        #expect(work.rows.count == 4)
+        #expect(hides(work) == 4)
+    }
+
+    /// Two failures in a row are still one run, and the ordinary work on either side of them is
+    /// not split into three entries the way it was.
+    @Test("consecutive failures do not start a new group")
+    func consecutiveFailuresFoldTogether() throws {
+        let facts = [user(0)]
+            + (1..<41).map { tool($0) }
+            + [tool(41, failed: true), tool(42, failed: true)]
+            + (43..<63).map { tool($0) }
+        let work = try only(facts)
+        #expect(work.rows.count == 62)
+        #expect(hides(work) == 62)
+    }
+
+    /// A refusal travels as `is_error` too, so it is the same fact here and folds the same way.
+    /// The permission question it came from folds once it has been answered, and burying the
+    /// answer while leaving the refused call standing would be half a rule.
+    @Test("a refused call folds like any other settled row")
+    func aRefusalFolds() throws {
+        let work = try only([user(0)] + (1..<8).map { tool($0, failed: $0 == 3) })
+        #expect(hides(work) == 7)
+    }
+
+    // MARK: Nothing unfolds under the reader
+
+    /// **The property folding a failure could have broken.** A call is hidden before its result
+    /// comes back, and that result can say it failed. The failure no longer changes what may be
+    /// hidden, so a fold does not have to give a row back to say so.
+    @Test("a hidden call coming back a failure does not unfold anything")
+    func aLateFailureDoesNotUnfold() {
+        var facts = [user(0)]
+        var folds = TranscriptFold.Folds.none
+        var seen: [Int: Int] = [:]
+
+        for seq in 1..<12 {
+            for at in facts.indices where facts[at].kind == .toolUse && !facts[at].settled {
+                facts[at].settled = true
+                facts[at].failed = facts[at].seq == 5 || facts[at].seq == 9
+            }
+            facts.append(tool(seq, settled: false))
+            folds = TranscriptFold.folds(in: facts, extending: folds)
+            for work in folds.all {
+                let now = hides(work)
+                #expect(now >= (seen[work.firstSeq] ?? 0), "row \(seq) unfolded \(work.firstSeq)")
+                seen[work.firstSeq] = now
+            }
+        }
+        #expect(folds.all.count == 1)
+        // One group over the whole turn, with both failures inside it.
+        #expect(folds.all.first?.rows.count == 11)
+    }
+
+    /// **Why the fold's line is not marked when it hides a failure.** A reader who is looking for
+    /// one is not left to spot a badge: rule 4 pulls a row something is aiming at, a search hit or
+    /// an unread mark, out of whatever fold it sits in, and the disclosure opens the rest.
+    @Test("an errored row a reader is taken to is still not hidden")
+    func aFailureSomethingAimsAtIsDrawn() throws {
+        let work = try only([user(0)] + (1..<10).map { tool($0, failed: $0 == 5) })
+        #expect(hides(work) == 9)
+        #expect(hides(work, revealed: [5]) == 4)
+    }
+
+    /// And the line says only what it always said. The count is the whole of it, so a fold that
+    /// holds a failure reads the same as one that does not.
+    @Test("the line stays a plain count")
+    func theLineIsAPlainCount() {
+        #expect(TranscriptFold.label(hiding: 139) == "139 actions")
+    }
+
+    // MARK: The boundary the change stopped at
+
+    /// The agent exiting is not an action that failed, it is the turn dying, and nothing later
+    /// explains it because there is nothing later. It still divides the work around it.
+    @Test("an agent error row still separates two groups")
+    func anAgentErrorStillSeparates() {
+        let facts = [user(0)] + (1..<5).map { tool($0) } + [agentExit(5)]
+            + (6..<10).map { tool($0) }
+        let folds = TranscriptFold.folds(in: facts)
+        #expect(folds.all.count == 2)
+        #expect(folds.all.map(\.rows.count) == [4, 4])
+        #expect(folds.index(containing: 5) == nil)
+    }
+
+    /// Inline media is content the agent chose to show, not part of the implementation log, so it
+    /// stays visible for the same reason prose does.
+    @Test("a featured row still separates two groups")
+    func featuredContentStillSeparates() {
+        let facts = [user(0)] + (1..<5).map { tool($0) } + [media(5)] + (6..<10).map { tool($0) }
+        let folds = TranscriptFold.folds(in: facts)
+        #expect(folds.all.count == 2)
+        #expect(folds.all.map(\.rows.count) == [4, 4])
+        #expect(folds.index(containing: 5) == nil)
+    }
+
+    /// Prose is unchanged too: it closes the work above it as answered, and a failure inside that
+    /// work does not stop it doing so.
+    @Test("prose still closes a group that holds a failure")
+    func proseStillClosesAGroup() {
+        let facts = [user(0)] + (1..<5).map { tool($0, failed: $0 == 2) } + [prose(5)]
+            + (6..<10).map { tool($0) }
+        let folds = TranscriptFold.folds(in: facts)
+        #expect(folds.all.count == 2)
+        #expect(folds.all.map(\.rows.count) == [4, 4])
+        #expect(folds.all.map(\.hasAnswer) == [true, false])
+    }
+}

--- a/Tests/BloomCoreTests/TranscriptFoldNestingTests.swift
+++ b/Tests/BloomCoreTests/TranscriptFoldNestingTests.swift
@@ -1,0 +1,208 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// A subagent's rows fold the way a run of top level rows does.
+///
+/// **The bug this is written against.** Under a row reading "Agent: general-purpose", sixteen
+/// consecutive nested actions were drawn one per line, with no "N actions" among them, while the
+/// same run at the top level would have folded. Nested rows were scanned like any other, so they
+/// sat in a group with the call that started the subagent, and that call has no result until the
+/// subagent has finished. Rule 1 held the whole group open on it: the transcript uncollapsed for
+/// as long as the subagent ran, which is exactly when folding it is worth most, and folded only
+/// once it was over.
+///
+/// So the id a nested row carries is what ends a group, and the call that started the subagent is
+/// held out of the fold as soon as a child of it appears. The rest of this suite is the two ways
+/// that could go wrong: a fold swallowing the header, so an indented count hangs under a line that
+/// no longer says which agent it stands for, and a fold reaching across two subagents into work
+/// that is not the same agent's at all.
+@Suite("Folding a subagent's rows")
+struct FoldingASubagentsRowsTests {
+    /// The call that starts a subagent. Unsettled, because that is the whole of the bug: its
+    /// result does not come back until the subagent has finished.
+    private func task(_ seq: Int, id: String, settled: Bool = false) -> TranscriptFold.Fact {
+        TranscriptFold.Fact(seq: seq, kind: .toolUse, settled: settled, toolUseID: id)
+    }
+
+    private func nested(
+        _ seq: Int, under parent: String, failed: Bool = false, settled: Bool = true
+    ) -> TranscriptFold.Fact {
+        TranscriptFold.Fact(
+            seq: seq, kind: .toolUse, failed: failed, settled: settled, parentToolUseID: parent
+        )
+    }
+
+    private func nestedProse(_ seq: Int, under parent: String) -> TranscriptFold.Fact {
+        TranscriptFold.Fact(seq: seq, kind: .assistantText, parentToolUseID: parent)
+    }
+
+    private func tool(_ seq: Int) -> TranscriptFold.Fact {
+        TranscriptFold.Fact(seq: seq, kind: .toolUse)
+    }
+
+    private func user(_ seq: Int) -> TranscriptFold.Fact {
+        TranscriptFold.Fact(seq: seq, kind: .user)
+    }
+
+    private let everything = 0..<1_000
+
+    private func hides(_ work: TranscriptFold.Work) -> Int {
+        TranscriptFold.hides(work, revealed: [], drawn: everything)
+    }
+
+    // MARK: The run that was drawn in full
+
+    /// The screenshot, written down: a subagent that is still working, sixteen of its actions
+    /// below it, and one line standing for them.
+    @Test("a running subagent's rows fold while it is still running")
+    func aRunningSubagentFolds() throws {
+        let facts = [user(0), tool(1), tool(2), task(3, id: "a")]
+            + (4..<20).map { nested($0, under: "a") }
+        let folds = TranscriptFold.folds(in: facts)
+        let work = try #require(folds.all.last)
+        #expect(work.rows.count == 16)
+        #expect(work.isNested)
+        #expect(hides(work) == 16)
+    }
+
+    /// **The reason the header is held out rather than left to fold with the work around it.** An
+    /// indented "16 actions" hanging under a line that has folded away the row saying which agent
+    /// it was is worse than not folding at all.
+    @Test("the call that started the subagent is not swallowed by a fold")
+    func theHeaderStaysVisible() {
+        let facts = [user(0), tool(1), tool(2), task(3, id: "a")]
+            + (4..<20).map { nested($0, under: "a") }
+        let folds = TranscriptFold.folds(in: facts)
+        #expect(folds.index(containing: 3) == nil)
+    }
+
+    /// A subagent's first row is often its own prose, which closes the group before the grouping
+    /// by id would ever see the nesting. The header is held out on the sight of any child, which
+    /// is what stops the run above it from folding over the top of it.
+    @Test("the header stays visible when the subagent opens with prose")
+    func theHeaderSurvivesNestedProse() throws {
+        let facts = [user(0), tool(1), tool(2), tool(3), task(4, id: "a"), nestedProse(5, under: "a")]
+            + (6..<10).map { nested($0, under: "a") }
+        let folds = TranscriptFold.folds(in: facts)
+        #expect(folds.index(containing: 4) == nil)
+        // And the ordinary work above it folds without waiting for the subagent to finish.
+        let above = try #require(folds.all.first)
+        #expect(above.rows.count == 3)
+        #expect(hides(above) == 3)
+    }
+
+    /// Prose from inside a subagent divides that subagent's own log, for the reason prose divides
+    /// the log at the top level: it is what the agent found, not what it did.
+    @Test("a subagent's prose closes its own group")
+    func nestedProseClosesTheNestedGroup() throws {
+        let facts = [user(0), task(1, id: "a"), nested(2, under: "a"), nestedProse(3, under: "a")]
+            + (4..<7).map { nested($0, under: "a") }
+        let folds = TranscriptFold.folds(in: facts)
+        #expect(folds.all.count == 1)
+        let work = try #require(folds.all.first)
+        #expect(work.rows.map(\.seq) == [4, 5, 6])
+        #expect(work.isNested)
+    }
+
+    // MARK: One fold never spans two agents
+
+    @Test("two subagents in a row do not fold into one group")
+    func twoSubagentsStaySeparate() {
+        let facts = [user(0), task(1, id: "a")] + (2..<6).map { nested($0, under: "a") }
+            + [task(6, id: "b")] + (7..<11).map { nested($0, under: "b") }
+        let folds = TranscriptFold.folds(in: facts)
+        #expect(folds.all.count == 2)
+        #expect(folds.all.map(\.rows.count) == [4, 4])
+        #expect(folds.all.map(\.isNested) == [true, true])
+        #expect(folds.all.map(\.firstSeq) == [2, 7])
+        // Both headers are still standing.
+        #expect(folds.index(containing: 1) == nil)
+        #expect(folds.index(containing: 6) == nil)
+    }
+
+    @Test("work after a subagent is the main agent's own group again")
+    func topLevelWorkResumes() {
+        let facts = [user(0), task(1, id: "a")] + (2..<6).map { nested($0, under: "a") }
+            + (6..<10).map { tool($0) }
+        let folds = TranscriptFold.folds(in: facts)
+        #expect(folds.all.count == 2)
+        #expect(folds.all.map(\.isNested) == [true, false])
+        #expect(folds.all.map(\.rows.count) == [4, 4])
+    }
+
+    /// Two subagents running at once interleave their rows, so no run of either is long enough to
+    /// fold. That is the honest answer for a transcript whose next line is a different agent's,
+    /// and it is what the old code did for the whole run anyway.
+    @Test("interleaved subagents fold nothing rather than folding together")
+    func interleavedSubagentsDoNotFold() {
+        var facts = [user(0), task(1, id: "a"), task(2, id: "b")]
+        for step in 0..<6 {
+            facts.append(nested(3 + step * 2, under: "a"))
+            facts.append(nested(4 + step * 2, under: "b"))
+        }
+        let folds = TranscriptFold.folds(in: facts)
+        #expect(folds.all.allSatisfy { hides($0) == 0 })
+    }
+
+    // MARK: Errors fold there too
+
+    @Test("a failed call inside a subagent folds with the rest of its run")
+    func aNestedFailureFolds() throws {
+        let facts = [user(0), task(1, id: "a")]
+            + (2..<12).map { nested($0, under: "a", failed: $0 == 6) }
+        let folds = TranscriptFold.folds(in: facts)
+        #expect(folds.all.count == 1)
+        let work = try #require(folds.all.first)
+        #expect(work.rows.count == 10)
+        #expect(hides(work) == 10)
+    }
+
+    // MARK: Nothing unfolds
+
+    /// A subagent's rows arrive one at a time, each result landing as the next call is issued,
+    /// while the call that started it stays unsettled throughout. What is hidden may not go down
+    /// on any of those passes.
+    @Test("a subagent's fold only ever grows as its rows arrive")
+    func aNestedFoldIsMonotone() {
+        var facts = [user(0), task(1, id: "a")]
+        var folds = TranscriptFold.Folds.none
+        var seen: [Int: Int] = [:]
+
+        for seq in 2..<16 {
+            for at in facts.indices where facts[at].parentToolUseID != nil && !facts[at].settled {
+                facts[at].settled = true
+                facts[at].failed = facts[at].seq == 7
+            }
+            facts.append(nested(seq, under: "a", settled: false))
+            folds = TranscriptFold.folds(in: facts, extending: folds)
+            for work in folds.all {
+                let now = hides(work)
+                #expect(now >= (seen[work.firstSeq] ?? 0), "row \(seq) unfolded \(work.firstSeq)")
+                seen[work.firstSeq] = now
+            }
+            #expect(folds.index(containing: 1) == nil, "row \(seq) hid the subagent's header")
+        }
+    }
+
+    /// Rows are appended and never reordered, so a scan of a session with a subagent in it only
+    /// ever has to redo the last turn, and has to agree with a scan from nothing while it does.
+    @Test("extending a scan over nested rows matches a full scan")
+    func extendingMatchesAFullScan() {
+        var facts: [TranscriptFold.Fact] = []
+        var extended = TranscriptFold.Folds.none
+        let script: [TranscriptFold.Fact] = [
+            user(0), tool(1), tool(2), task(3, id: "a"), nested(4, under: "a"),
+            nested(5, under: "a"), nestedProse(6, under: "a"), nested(7, under: "a"),
+            nested(8, under: "a", failed: true), nested(9, under: "a"), tool(10), tool(11),
+            task(12, id: "b"), nested(13, under: "b"), nested(14, under: "b"), tool(15),
+        ]
+        for fact in script {
+            facts.append(fact)
+            extended = TranscriptFold.folds(in: facts, extending: extended)
+            let whole = TranscriptFold.folds(in: facts)
+            #expect(extended.all == whole.all, "after \(facts.count) rows")
+            #expect(extended.resumeIndex == whole.resumeIndex, "after \(facts.count) rows")
+        }
+    }
+}

--- a/Tests/BloomCoreTests/TranscriptFoldTests.swift
+++ b/Tests/BloomCoreTests/TranscriptFoldTests.swift
@@ -205,32 +205,9 @@ struct TranscriptFoldTests {
         #expect(hides(work) == 0)
     }
 
-    /// A failed command remains visible and divides the surrounding activity into two compact
-    /// groups. It must not expose every ordinary action that follows it.
-    @Test("a failed call separates consecutive activity groups")
-    func aFailureSeparatesGroups() {
-        let facts = [user(0)] + (1..<10).map { tool($0, failed: $0 == 5) }
-        let folds = TranscriptFold.folds(in: facts)
-        #expect(folds.all.count == 2)
-        #expect(folds.all.map(\.rows.count) == [4, 4])
-        #expect(folds.all.map { hides($0) } == [4, 4])
-        #expect(folds.index(containing: 5) == nil)
-    }
-
-    @Test("many ordinary rows after consecutive failures form another group")
-    func activityAfterFailuresFoldsAgain() {
-        let facts = [user(0)]
-            + (1..<41).map { tool($0) }
-            + [tool(41, failed: true), tool(42, failed: true)]
-            + (43..<63).map { tool($0) }
-        let folds = TranscriptFold.folds(in: facts)
-        #expect(folds.all.map(\.rows.count) == [40, 20])
-        #expect(folds.all.map { hides($0) } == [40, 20])
-        #expect(folds.index(containing: 41) == nil)
-        #expect(folds.index(containing: 42) == nil)
-    }
-
-    /// An error row is the turn itself failing, and it is treated the same way.
+    /// **Rule 2.** An error row is the agent exiting in a way it did not choose, which is the one
+    /// failure nothing later in the turn will explain, so it stays out of the fold. A failed tool
+    /// call does not: `FoldingAnErroredActionTests` is that half.
     @Test("an error row stops the fold")
     func anErrorStopsTheFold() throws {
         let facts = [user(0), tool(1), tool(2), tool(3), tool(4), failure(5), tool(6)]
@@ -278,8 +255,8 @@ struct TranscriptFoldTests {
     func aFailureIsSettled() throws {
         let facts = [user(0)] + (1..<7).map { tool($0, failed: $0 == 6, settled: $0 != 6) }
         let work = try only(facts)
-        #expect(work.ready == 5)
-        #expect(hides(work) == 5)
+        #expect(work.ready == 6)
+        #expect(hides(work) == 6)
     }
 
     // MARK: The window


### PR DESCRIPTION
Two runs of work that stayed drawn one line at a time.

An errored tool row was held out of the fold, so a run came out as "7 actions", one error, "42 actions", one error, "88 actions". A failed call folds with the work around it now. An agent error row still stands on its own: nothing later in the turn explains it, because there is nothing later. The fold's line is left as a plain count, unmarked, on the argument that a mark for failure would be lit on most folds in an ordinary session.

A subagent's rows were grouped with the call that started them, and that call has no result until the subagent has finished, so the whole run stayed open for as long as it ran. They are grouped by the id they carry now, so they fold among themselves, a fold never spans two subagents, and the call that started one is held out of the fold as soon as a child of it appears. Its line is drawn indented, under the rule its rows are drawn under.