### PR TITLE
Replace the toolbar search field with a Cmd+K panel

### DIFF
--- a/Sources/Bloom/Design/Theme.swift
+++ b/Sources/Bloom/Design/Theme.swift
@@ -877,13 +877,14 @@ extension View {
 enum Motion {
     static let pane: Animation = .easeOut(duration: 0.18)
 
-    /// The inspector column arriving and leaving, the pull request band arriving with it, and the
-    /// window's search field moving over to make room.
+    /// The inspector column arriving and leaving, and the pull request band arriving with it.
     ///
-    /// Three parts of one movement, and no two of them are drawn by the same thing. The column is
-    /// an `NSSplitViewItem` under AppKit's animator. The band along the top of it is a title bar
-    /// accessory, because it sits in the title bar rather than inside the pane. The field is an
-    /// `NSSearchToolbarItem`, packed by `NSToolbar` into whatever width that accessory leaves it.
+    /// It was three parts of one movement, drawn by three different things, and it is two now: the
+    /// window's search field was the third and it is a panel rather than a toolbar item. The
+    /// column is an `NSSplitViewItem` under AppKit's animator. The band along the top of it is a
+    /// title bar accessory, because it sits in the title bar rather than inside the pane. The
+    /// field was an `NSSearchToolbarItem`, packed by `NSToolbar` into whatever width that
+    /// accessory left it.
     /// That is why they used to arrive at different times: the band was drawn or it was not, with
     /// nothing in between, so it appeared whole on the frame the toolbar button was pressed while
     /// the column spent a quarter of a second sliding in underneath it (the owner's words were "bit

--- a/Sources/Bloom/State/AppModel.swift
+++ b/Sources/Bloom/State/AppModel.swift
@@ -178,26 +178,29 @@ final class AppModel {
     /// keystroke handler is a mid-update mutation this file avoids everywhere else.
     @ObservationIgnored var transcriptSearchTask: Task<Void, Never>?
     @ObservationIgnored var transcriptBackfillTask: Task<Void, Never>?
-    /// What Home's list is narrowed to: what was typed into the window's search field, which chip
-    /// is lit, which projects are listed.
+    /// What Home's list is narrowed to: the query, which chip is lit, which projects are listed.
     ///
     /// Here rather than in `HomeView`'s `@State`, because `HomeView` is destroyed and rebuilt
     /// every time the selection leaves Home and comes back, so a filter held in the view is
     /// silently cleared by opening any workspace at all. A user who narrows the list to one
     /// project, opens something from it and comes back to a list of everything has been overruled
-    /// by the app without being told. The query has the same problem twice over: the field is in
-    /// the window's toolbar and stays on screen when Home does not.
+    /// by the app without being told.
+    ///
+    /// **Only one thing writes the query now**, which is the search panel's "search Home for this"
+    /// row. There was a field in the window's toolbar and it is gone, because typing into it set
+    /// the selection to Home. What says the query is there at all is `HomeBar.queryChip`.
     ///
     /// Deliberately not persisted to disk. A scope is something you click to get through a long
     /// list, not a preference, and an app that starts up with a third of the machine's work
     /// missing because of something you did last Tuesday has to be worked out rather than read.
     var homeFilter = HomeFilter()
-    /// Whether the window's search field is first responder.
+    /// Whether a field in the window's chrome has the keyboard, which is the search panel's now
+    /// that the toolbar has no field.
     ///
-    /// Mirrored off `RootView`'s `@FocusState` because a `@FocusState` is private to the view that
-    /// declares it, and the pane that has to read this is Home's list, three view controllers down
-    /// inside the detail column. What it is read for is the one thing a list must never do, which
-    /// is take the keyboard off somebody who is mid word. See `HomeListKeyboard`.
+    /// Mirrored here because the pane that has to read it is Home's list, three view controllers
+    /// down inside the detail column, and the panel is an overlay on the window. What it is read
+    /// for is the one thing a list must never do, which is take the keyboard off somebody who is
+    /// mid word. See `HomeListKeyboard`, and `SearchPanelOverlay` for the one writer.
     var isSearchFieldFocused = false
     var isCreatingWorkspace = false
 

--- a/Sources/Bloom/Views/Center/Composer/MenuSearchField.swift
+++ b/Sources/Bloom/Views/Center/Composer/MenuSearchField.swift
@@ -31,9 +31,27 @@ struct MenuSearchField: NSViewRepresentable {
     /// search field gets, where every other caller here is a line in a floating panel. Absent by
     /// default, so a panel keeps the system size it has always had.
     var font: NSFont?
+    /// Shift+Tab. Its own way in rather than a case on `ComposerKey` for the reason `onHorizontal`
+    /// gives above: that enum is the keys **the composer** answers, and every one of its seven
+    /// handlers would have to answer a question only the search panel asks.
+    var onBacktab: (@MainActor () -> Bool)?
+    /// Backspace pressed with nothing in the field, which is how the search panel backs out of a
+    /// mode. Only then: a Backspace with text in front of it belongs to the field editor, always.
+    var onDeleteEmpty: (@MainActor () -> Bool)?
+    /// The right arrow, with whether the caret was at the very end of the text. The panel pushes
+    /// into a row with it from the end and leaves it to the caret anywhere else, and which of the
+    /// two that is stays a rule in the core rather than a condition written here.
+    var onRight: (@MainActor (Bool) -> Bool)?
+    /// Bumped by a caller to select everything in the field, which is what a second press of the
+    /// key that opened the panel does. A counter rather than a flag, because the same request
+    /// arriving twice has to be honoured twice.
+    var selectAllToken = 0
 
     func makeNSView(context: Context) -> NSTextField {
-        let field = NSTextField()
+        let field = MenuSearchFieldView()
+        field.onCommandReturn = { [weak coordinator = context.coordinator] in
+            coordinator?.onKey(.commandReturn) ?? false
+        }
         field.delegate = context.coordinator
         field.placeholderString = placeholder
         field.isBordered = false
@@ -50,6 +68,9 @@ struct MenuSearchField: NSViewRepresentable {
     func updateNSView(_ field: NSTextField, context: Context) {
         context.coordinator.onKey = onKey
         context.coordinator.onHorizontal = onHorizontal
+        context.coordinator.onBacktab = onBacktab
+        context.coordinator.onDeleteEmpty = onDeleteEmpty
+        context.coordinator.onRight = onRight
         context.coordinator.text = $text
         // Written on every pass, not just at `makeNSView`. The icon picker changes it when its tab
         // changes, and set once the Emojis tab was captioned "Search icons".
@@ -62,6 +83,7 @@ struct MenuSearchField: NSViewRepresentable {
         // line above was written to fix, one field along.
         let resolved = font ?? .systemFont(ofSize: NSFont.systemFontSize)
         if field.font != resolved { field.font = resolved }
+        context.coordinator.selectAll(field, token: selectAllToken)
         // Asked for again here, and it is not belt and braces: the panel is made before its window
         // exists, so the first attempt has nothing to be first responder in. The coordinator only
         // ever succeeds once, so a field somebody has since tabbed out of is left alone.
@@ -76,6 +98,12 @@ struct MenuSearchField: NSViewRepresentable {
         var text: Binding<String>
         var onKey: @MainActor (ComposerKey) -> Bool
         var onHorizontal: (@MainActor (Int) -> Bool)?
+        var onBacktab: (@MainActor () -> Bool)?
+        var onDeleteEmpty: (@MainActor () -> Bool)?
+        var onRight: (@MainActor (Bool) -> Bool)?
+        /// The last `selectAllToken` acted on, so a redraw with the same number does not drag the
+        /// selection back over a word somebody has since started retyping.
+        private var selectedToken = 0
         /// Whether the keyboard has been claimed once already. The panel opens because somebody
         /// clicked the control it hangs off and the next thing they do is type, so it is claimed;
         /// claiming it again on a later pass would drag the caret back out of wherever they had
@@ -103,6 +131,18 @@ struct MenuSearchField: NSViewRepresentable {
             }
         }
 
+        /// Selects everything, once per token.
+        @MainActor
+        func selectAll(_ field: NSTextField, token: Int) {
+            guard token != selectedToken else { return }
+            selectedToken = token
+            // Only when the field has the keyboard. `selectText` takes first responder as a side
+            // effect, and a panel that stole the caret back on a redraw would be a field nobody
+            // could leave.
+            guard field.window?.firstResponder === field.currentEditor() else { return }
+            field.selectText(nil)
+        }
+
         func controlTextDidChange(_ notification: Notification) {
             guard let field = notification.object as? NSTextField else { return }
             text.wrappedValue = field.stringValue
@@ -118,6 +158,21 @@ struct MenuSearchField: NSViewRepresentable {
                 default: break
                 }
             }
+            if let onRight, selector == #selector(NSResponder.moveRight(_:)) {
+                // Whether the caret is at the very end with nothing selected. Reading the event is
+                // the app target's half; what "the end" then means is the caller's rule.
+                let selection = textView.selectedRange()
+                let atEnd = selection.length == 0
+                    && selection.location == (textView.string as NSString).length
+                if onRight(atEnd) { return true }
+            }
+            if let onBacktab, selector == #selector(NSResponder.insertBacktab(_:)) {
+                if onBacktab() { return true }
+            }
+            if let onDeleteEmpty, selector == #selector(NSResponder.deleteBackward(_:)),
+               textView.string.isEmpty {
+                if onDeleteEmpty() { return true }
+            }
             let key: ComposerKey? = switch selector {
             case #selector(NSResponder.moveUp(_:)): .up
             case #selector(NSResponder.moveDown(_:)): .down
@@ -129,5 +184,33 @@ struct MenuSearchField: NSViewRepresentable {
             guard let key else { return false }
             return onKey(key)
         }
+    }
+}
+
+/// The field itself, which exists only to catch Cmd+Return.
+///
+/// A field editor turns most keys into a `doCommandBySelector`, which is where everything else
+/// here is answered, and it turns Cmd+Return into nothing at all: the standard key bindings map
+/// Option+Return to `insertNewlineIgnoringFieldEditor:` and leave the Command version unbound. A
+/// key equivalent is offered to the key window's view tree before the menu bar, so a `Button` with
+/// that shortcut somewhere in the panel would fire, but it would fire for a row the field has
+/// already moved off. This is the one place the press and the state it is about are the same
+/// moment.
+final class MenuSearchFieldView: NSTextField {
+    var onCommandReturn: (@MainActor () -> Bool)?
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            .subtracting([.capsLock, .function, .numericPad])
+        guard modifiers == .command,
+              let scalar = event.charactersIgnoringModifiers?.unicodeScalars.first,
+              Int(scalar.value) == 0x0D,
+              // Only while this field has the keyboard, or a panel left in the hierarchy would
+              // answer a key aimed at whatever the user is really looking at.
+              window?.firstResponder === currentEditor(),
+              let onCommandReturn else {
+            return super.performKeyEquivalent(with: event)
+        }
+        return onCommandReturn() ? true : super.performKeyEquivalent(with: event)
     }
 }

--- a/Sources/Bloom/Views/Center/Composer/SlashCommandRow.swift
+++ b/Sources/Bloom/Views/Center/Composer/SlashCommandRow.swift
@@ -60,33 +60,16 @@ struct SlashCommandRow: View {
     /// The name, with the characters the query actually matched carried at full weight and colour
     /// and the rest stepped back.
     ///
-    /// Ranges rather than characters, so a run reads as a word: typing `revi` lights the `revi`
-    /// inside `security-review` rather than the stray `r` of `secu(r)ity`, because the matcher
-    /// reports the run it scored rather than the first letters it could reach.
-    ///
-    /// Built by interpolating one styled `Text` per run, which is what macOS 26 leaves once `+` on
-    /// two `Text`s is deprecated. An `AttributedString` would be the shorter spelling and is the
-    /// wrong one here: its SwiftUI scope carries `font` and no `fontWeight`, so bolding a run
-    /// would mean naming a whole font and the row would stop inheriting the menu's own.
+    /// The drawing itself is `MatchedRuns`, because the search panel draws a workspace name and a
+    /// command title exactly the same way and two copies of it would be two answers to "which
+    /// characters matched". What stays here is the `/`, which is this menu's alone, and the two
+    /// colours, which depend on whether the row is a skill.
     private var name: Text {
         var runs = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 0)
         runs.appendInterpolation(Text("/").foregroundStyle(quiet))
-        guard !match.highlights.isEmpty else {
-            runs.appendInterpolation(Text(command.name).foregroundStyle(loud))
-            return Text(LocalizedStringKey(stringInterpolation: runs))
-        }
-
-        let characters = Array(command.name)
-        let hits = Set(match.highlights)
-        var index = 0
-        while index < characters.count {
-            let isHit = hits.contains(index)
-            var end = index
-            while end < characters.count, hits.contains(end) == isHit { end += 1 }
-            let run = Text(String(characters[index..<end]))
-            runs.appendInterpolation(isHit ? run.fontWeight(.bold).foregroundStyle(loud) : run.foregroundStyle(quiet))
-            index = end
-        }
+        MatchedRuns.append(
+            command.name, highlights: match.highlights, loud: loud, quiet: quiet, to: &runs
+        )
         return Text(LocalizedStringKey(stringInterpolation: runs))
     }
 

--- a/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
+++ b/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
@@ -275,6 +275,19 @@ struct BloomCommands: Commands {
             // which is what somebody in a terminal needs it to mean. Cmd+F still lands here
             // whenever nothing in front can find, so the key that used to open the Search screen
             // still reaches the search.
+            // The panel, on a key nothing else in the bar spends. Directly above Search because
+            // the two open the same card: this one on the resting list, Search with the
+            // Transcripts chip already chosen.
+            //
+            // A shell keeps Cmd+K to clear its scrollback, which is iTerm's binding and
+            // Terminal's, and a focused view is offered a key equivalent before the menu bar is.
+            // That is deliberate rather than a gap: somebody inside a terminal reaches the panel
+            // with Shift+Cmd+F, which has always meant the whole search. See
+            // `MenuBarCatalogueTests.theKeysTheViewsOwn`, which records every such overlap.
+            MenuCommand(.quickSearch) {
+                SearchPanelModel.shared.open(app: model)
+            }
+
             MenuCommand(.search) {
                 NotificationCenter.default.post(name: .bloomFocusSearch, object: nil)
             }

--- a/Sources/Bloom/Views/Chrome/App/MainMenuActions.swift
+++ b/Sources/Bloom/Views/Chrome/App/MainMenuActions.swift
@@ -1,0 +1,85 @@
+import AppKit
+import BloomCore
+
+/// Running a menu bar item from somewhere that is not the menu bar, and asking which of them could
+/// be run at all.
+///
+/// **The search panel presses the app's own menu rather than carrying a second copy of every
+/// action.** `BloomCommands` is a `Commands` body holding fifty-eight closures, each reaching state
+/// only that body can see: a focused value, an `openWindow` bound to a scene, an `@Observable` read
+/// for the greying. Handing all of that to a second caller would mean lifting every one of those
+/// closures out of the view they are declared in, and the copy left behind would be free to drift.
+/// Sending the real item is the same press the user would make with the pointer, so there is
+/// exactly one implementation and no way for the panel to offer something the menu does not.
+///
+/// It answers the greying for free too. `MenuBarCatalogue.availability` says what KIND of thing has
+/// to be true and deliberately holds no rule; the live answer is `NSMenuItem.isEnabled` after the
+/// menu has been `update()`d, which is exactly what a person sees when they open the menu.
+/// `MenuActionProbe` measured that this works with the menu never opened, which is the state the
+/// panel is in.
+///
+/// **Matched by title, because a SwiftUI `Commands` body publishes no identifier onto the items it
+/// makes.** The titles come from `MenuBarCatalogue` on both sides, so the only way a lookup can
+/// miss is an item drawn under a title the table does not know, which is what `MenuCommand` exists
+/// to make impossible.
+@MainActor
+enum MainMenuActions {
+    /// Every item the bar will actually fire right now.
+    ///
+    /// One walk of the six menus rather than one per row: the panel asks this once when its list
+    /// changes, and asking per row would `update()` each menu fifty-eight times inside a draw pass.
+    ///
+    /// **An item with a submenu is not in the set, and that is a fact rather than a policy.**
+    /// AppKit never fires the action of an item that has one, so Split Right, Go to Tab, Focus
+    /// Pane, Colour and Run open a list in the menu bar and have nothing to send here. They stay
+    /// in the panel, greyed, with the reason on the row, because a list that hides what it cannot
+    /// do teaches nothing. That is the rule the menu bar itself keeps.
+    static func runnable() -> Set<MenuBarAction> {
+        var byTitle: [String: MenuBarAction] = [:]
+        for row in MenuBarCatalogue.commands {
+            byTitle[row.title] = row.action
+            if let alternate = row.alternateTitle { byTitle[alternate] = row.action }
+        }
+
+        var found: Set<MenuBarAction> = []
+        for top in NSApp.mainMenu?.items ?? [] {
+            guard let submenu = top.submenu else { continue }
+            submenu.update()
+            for item in submenu.items {
+                guard let action = byTitle[item.title], item.isEnabled, !item.hasSubmenu else {
+                    continue
+                }
+                found.insert(action)
+            }
+        }
+        return found
+    }
+
+    /// Presses one item.
+    ///
+    /// - Returns: false when the bar carries no such item, when it is greyed, or when it is a
+    ///   submenu, so a caller can say nothing happened rather than pretending something did.
+    @discardableResult
+    static func perform(_ action: MenuBarAction) -> Bool {
+        guard let found = item(for: action) else { return false }
+        let item = found.menu.items[found.index]
+        guard item.isEnabled, !item.hasSubmenu else { return false }
+        found.menu.performActionForItem(at: found.index)
+        return true
+    }
+
+    /// Both titles are tried, because a two-state item wears whichever half its state calls for:
+    /// Pin is "Unpin" on a pinned workspace, and the table knows both spellings.
+    private static func item(for action: MenuBarAction) -> (menu: NSMenu, index: Int)? {
+        let row = MenuBarCatalogue[action]
+        let titles = [row.title, row.alternateTitle].compactMap { $0 }
+        for top in NSApp.mainMenu?.items ?? [] {
+            guard let submenu = top.submenu else { continue }
+            submenu.update()
+            if let index = submenu.items.firstIndex(where: { titles.contains($0.title) }) {
+                return (submenu, index)
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Search/MatchedRuns.swift
+++ b/Sources/Bloom/Views/Chrome/Search/MatchedRuns.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// Text with the characters a fuzzy match hit carried at full weight and colour, and the rest
+/// stepped back.
+///
+/// **Runs rather than characters, so a hit reads as a word.** Typing `revi` lights the `revi`
+/// inside `security-review` rather than the stray `r` of `secu(r)ity`, because the matcher reports
+/// the run it scored rather than the first letters it could reach.
+///
+/// **Built by interpolating one styled `Text` per run**, which is what macOS 26 leaves once `+` on
+/// two `Text`s is deprecated. An `AttributedString` would be the shorter spelling and is the wrong
+/// one here: its SwiftUI scope carries `font` and no `fontWeight`, so bolding a run would mean
+/// naming a whole font and the row would stop inheriting the list's own.
+///
+/// It was `SlashCommandRow`'s, privately, and it is here because the search panel draws a workspace
+/// name and a command title exactly the same way. Two copies of this would be two answers to
+/// "which characters matched", drawn an inch apart.
+enum MatchedRuns {
+    static func text(_ string: String, highlights: [Int], loud: Color, quiet: Color) -> Text {
+        var runs = LocalizedStringKey.StringInterpolation(literalCapacity: 0, interpolationCount: 0)
+        append(string, highlights: highlights, loud: loud, quiet: quiet, to: &runs)
+        return Text(LocalizedStringKey(stringInterpolation: runs))
+    }
+
+    /// The same, appended to an interpolation a caller has already started, which is what lets the
+    /// slash menu draw its `/` in the quiet colour before the name.
+    static func append(
+        _ string: String,
+        highlights: [Int],
+        loud: Color,
+        quiet: Color,
+        to runs: inout LocalizedStringKey.StringInterpolation
+    ) {
+        guard !highlights.isEmpty else {
+            runs.appendInterpolation(Text(string).foregroundStyle(loud))
+            return
+        }
+
+        let characters = Array(string)
+        let hits = Set(highlights)
+        var index = 0
+        while index < characters.count {
+            let isHit = hits.contains(index)
+            var end = index
+            while end < characters.count, hits.contains(end) == isHit { end += 1 }
+            let run = Text(String(characters[index..<end]))
+            runs.appendInterpolation(
+                isHit ? run.fontWeight(.bold).foregroundStyle(loud) : run.foregroundStyle(quiet)
+            )
+            index = end
+        }
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelActivation.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelActivation.swift
@@ -1,0 +1,146 @@
+import AppKit
+import SwiftUI
+import BloomCore
+
+/// What Return does to the highlighted row.
+///
+/// **Every one of these is a route the app already has.** A workspace goes through the selection,
+/// an archived one through `openArchived`, a transcript hit through `AppModel.open`, which already
+/// picks the session and scrolls to the row, and a command through the real menu item. Nothing
+/// here is a second implementation of anything, which is what keeps the panel a faster route
+/// rather than a parallel app.
+///
+/// **The panel closes before the row is opened.** A menu item is validated against the responder
+/// chain, and the panel's field is first responder while it is up, so an item pressed from an open
+/// panel would be validated against a text field rather than against the window it is meant to act
+/// on. Closing first is also what makes the transition read as one movement rather than as a card
+/// that lingers over the thing it just opened.
+@MainActor
+enum SearchPanelActivation {
+    static func open(
+        _ row: SearchPanelRow, panel: SearchPanelModel, app: AppModel
+    ) {
+        let mode = panel.field.mode
+        panel.close(app: app)
+
+        switch row {
+        case .workspace(let hit):
+            open(hit, app: app)
+
+        case .transcript(let hit):
+            // The best match rather than the workspace, so Return lands on the sentence that was
+            // drawn under the row. `AppModel.open` carries the session and the sequence number.
+            guard let match = hit.result.best else { return }
+            Task { await app.open(match) }
+
+        case .command(let hit):
+            run(hit.item.action, mode: mode, panel: panel, app: app)
+
+        case .fallback(let fallback):
+            run(fallback, app: app)
+        }
+    }
+
+    private static func open(_ hit: SearchPanelWorkspaceHit, app: AppModel) {
+        if hit.isArchived {
+            // The reader, which is the same split Home's rows make: an archived workspace has no
+            // worktree, so it opens for reading rather than for working in.
+            app.openArchived(hit.workspace)
+        } else {
+            app.selection = .workspace(hit.workspace.id)
+        }
+    }
+
+    /// Runs a command row.
+    ///
+    /// In an action list the row is aimed at the workspace that was pushed into, which is not
+    /// necessarily the one the Workspace menu is about: the menu acts on the selection or on the
+    /// focused row, and the panel can be pointed at neither. So the action list goes through
+    /// `SearchPanelWorkspaceCommands`, which takes the workspace as an argument. Everywhere else
+    /// the menu bar's own item is the one pressed.
+    private static func run(
+        _ action: MenuBarAction, mode: SearchPanelMode, panel: SearchPanelModel, app: AppModel
+    ) {
+        if let id = mode.workspaceID,
+           let workspace = app.workspaces.first(where: { $0.id == id })
+               ?? panel.archived.first(where: { $0.id == id }),
+           let workspaceAction = SearchPanelActions.workspaceAction(for: action) {
+            SearchPanelWorkspaceCommands.perform(workspaceAction, on: workspace, app: app)
+            return
+        }
+
+        // On the next turn of the run loop, because the panel is closing on this one and the item
+        // is validated against whatever is first responder when it fires.
+        DispatchQueue.main.async {
+            MainMenuActions.perform(action)
+        }
+    }
+
+    /// The two rows under a search that matched nothing.
+    ///
+    /// The start row carries the name through to the create window, so the row's own words are
+    /// true in the two modes that have a name field. Chat mode names a workspace from the prompt
+    /// the model is given, so there it is a starting point rather than the name.
+    private static func run(_ fallback: SearchPanelFallback, app: AppModel) {
+        switch fallback {
+        case .startWorkspace(let name):
+            CreateWorkspaceOpening.shared.askForName(name)
+            NotificationCenter.default.post(name: .bloomNewWorkspace, object: nil)
+
+        case .searchHome(let query):
+            // Home's own field is what this hands the query to, so a long browse carries on in the
+            // pane built for one. The scope settles the same way the field settled it.
+            app.homeFilter.query = query
+            app.homeFilter.scope = HomeScope.settle(app.homeFilter.scope, searching: true)
+            app.selection = .home
+        }
+    }
+}
+
+/// One workspace's own menu, performed against that workspace rather than against whatever the
+/// Workspace menu happens to be about.
+///
+/// It is the same work `WorkspaceMenuItems` does on a right click, reached the same way: `Reveal`,
+/// `Clipboard` and the three writes on `AppModel`. Written out here rather than shared with that
+/// view because a `View`'s buttons are closures inside a `body` and there is nothing to call.
+@MainActor
+enum SearchPanelWorkspaceCommands {
+    /// Switched over the whole enum, so an item added to `WorkspaceMenuAction` has to be answered
+    /// here or the build fails.
+    static func perform(_ action: WorkspaceMenuAction, on workspace: Workspace, app: AppModel) {
+        switch action {
+        case .openInEditor:
+            Reveal.inEditor(workspace.path, repo: workspace.repoID)
+        case .revealInFinder:
+            Reveal.inFinder(workspace.path)
+        case .copyName:
+            Clipboard.copy(workspace.name)
+        case .copyBranchName:
+            Clipboard.copy(workspace.branch)
+        case .pin:
+            Task { await app.togglePinned(workspace) }
+        case .unreadMark:
+            guard let mark = WorkspaceUnreadMark.action(for: workspace) else { return }
+            Task { await app.setUnread(workspace, mark.unread) }
+        case .rename:
+            // The one item with no work of its own: the field belongs to whichever list is drawing
+            // the row, so this is the post the menu bar's own Rename makes.
+            NotificationCenter.default.post(
+                name: .bloomRenameWorkspace, object: nil,
+                userInfo: [Notification.bloomWorkspaceIDKey: workspace.id.rawValue]
+            )
+        case .archive:
+            // Straight through, with no dialog of its own, exactly as the row's menu does it:
+            // whether an archive needs confirming depends on what is uncommitted, what is running
+            // and what GitHub says, and `AppModel.archive` is where all three come together.
+            Task { await app.archive(workspace) }
+        case .restore:
+            Task { await app.restore(workspace) }
+        case .colour:
+            // A submenu of ten swatches rather than an action. `SearchPanelActions.order` does not
+            // offer it, so this case is unreachable and is here because the switch is exhaustive
+            // on purpose: an item added to the enum has to be classified.
+            break
+        }
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelCommandRow.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelCommandRow.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import BloomCore
+
+/// One menu bar item in the panel: what it is called, and which key it carries.
+///
+/// **Every row prints its key, and "no key" is printed rather than left blank.** Bloom has
+/// thirty-nine items carrying a shortcut nobody has memorised and nineteen with none at all, and
+/// this is the cheapest teaching surface the app will ever get. A blank slot would say nothing
+/// about which of the two a row is.
+///
+/// **An item that cannot be pressed right now is greyed rather than hidden**, which is the rule the
+/// menu bar already keeps and for the same reason: a list that hides what is unavailable teaches
+/// nothing about what the app can do. Whether it can be pressed is the live menu's answer, not a
+/// rule restated here. See `MainMenuActions`.
+struct SearchPanelCommandRow: View {
+    var hit: SearchPanelCommandHit
+    var isEnabled: Bool
+    var isSelected: Bool
+    var onPick: @MainActor () -> Void
+    var onHover: @MainActor () -> Void
+
+    @Environment(\.controlActiveState) private var activeState
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onPick) {
+            HStack(spacing: Metrics.spacingWide) {
+                title
+                    .font(Typo.body)
+                    .lineLimit(1)
+
+                Spacer(minLength: Metrics.gutter)
+
+                Text(hit.item.keyText)
+                    .font(Typo.caption)
+                    .foregroundStyle(keyColour)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, Metrics.inset)
+            .padding(.vertical, Metrics.spacingSmall)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .accessibilityLabel(hit.item.title)
+        .accessibilityValue(hit.item.key == nil ? SearchPanelCommands.noKey : hit.item.keyText)
+        .rowBackground(isSelected: isSelected, isHovered: isHovered, isFocused: true)
+        .onHoverChange { hovering in
+            isHovered = hovering
+            if hovering { onHover() }
+        }
+    }
+
+    private var title: Text {
+        MatchedRuns.text(hit.item.title, highlights: hit.highlights, loud: loud, quiet: quiet)
+    }
+
+    private var loud: Color {
+        if !isEnabled { return Palette.textDisabled }
+        return isEmphasized ? Palette.selectedEmphasizedText : Palette.textPrimary
+    }
+
+    private var quiet: Color {
+        if !isEnabled { return Palette.textDisabled }
+        return isEmphasized ? Palette.selectedEmphasizedText.opacity(0.76) : Palette.textSecondary
+    }
+
+    /// The key is one step quieter than the title in every state, because it is a reminder rather
+    /// than the thing being read.
+    private var keyColour: Color {
+        isEnabled ? quiet : Palette.textDisabled
+    }
+
+    private var isEmphasized: Bool {
+        isSelected && activeState != .inactive
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelFallbackRow.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelFallbackRow.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+import BloomCore
+
+/// One of the two rows under a search that matched nothing.
+///
+/// It prints the key of the menu item it is a shortcut to, exactly as a command row does, because
+/// it is one: Start a Workspace is Cmd+N in File and Search is Shift+Cmd+F in Edit. Nothing in the
+/// panel is reachable only from the panel.
+struct SearchPanelFallbackRow: View {
+    var fallback: SearchPanelFallback
+    var isSelected: Bool
+    var onPick: @MainActor () -> Void
+    var onHover: @MainActor () -> Void
+
+    @Environment(\.controlActiveState) private var activeState
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onPick) {
+            HStack(spacing: Metrics.spacingWide) {
+                Image(systemName: symbol)
+                    .font(Typo.labelEmphasis)
+                    .foregroundStyle(quiet)
+                    .frame(width: Metrics.repoIcon)
+
+                Text(fallback.title)
+                    .font(Typo.body)
+                    .foregroundStyle(loud)
+                    .lineLimit(1)
+
+                Spacer(minLength: Metrics.gutter)
+
+                Text(MenuBarCatalogue[fallback.action].keyText)
+                    .font(Typo.caption)
+                    .foregroundStyle(quiet)
+            }
+            .padding(.horizontal, Metrics.inset)
+            .padding(.vertical, Metrics.spacingSmall)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(fallback.title)
+        .rowBackground(isSelected: isSelected, isHovered: isHovered, isFocused: true)
+        .onHoverChange { hovering in
+            isHovered = hovering
+            if hovering { onHover() }
+        }
+    }
+
+    private var symbol: String {
+        switch fallback {
+        case .startWorkspace: "plus.square.on.square"
+        case .searchHome: "house"
+        }
+    }
+
+    private var loud: Color {
+        isEmphasized ? Palette.selectedEmphasizedText : Palette.textPrimary
+    }
+
+    private var quiet: Color {
+        isEmphasized ? Palette.selectedEmphasizedText.opacity(0.76) : Palette.textSecondary
+    }
+
+    private var isEmphasized: Bool {
+        isSelected && activeState != .inactive
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelFooter.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelFooter.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import BloomCore
+
+/// The strip along the bottom of the card: what the keys do, and how many results there are.
+///
+/// **The count sits on the right, where it does not compete with the keys.** The keys are what
+/// somebody reads once and never again; the count is what changes while they type.
+struct SearchPanelFooter: View {
+    var keys: [SearchPanelFooterKey]
+    var summary: String?
+
+    var body: some View {
+        HStack(spacing: Metrics.gutter) {
+            ForEach(keys) { key in
+                HStack(spacing: Metrics.spacingSmall) {
+                    Text(key.key)
+                        .font(Typo.caption)
+                        .foregroundStyle(Palette.textSecondary)
+                        .padding(.horizontal, Metrics.chipInsetH)
+                        .padding(.vertical, Metrics.chipInsetV)
+                        .background(
+                            RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+                                .fill(Palette.hover)
+                        )
+
+                    Text(key.label)
+                        .font(Typo.caption)
+                        .foregroundStyle(Palette.textTertiary)
+                }
+            }
+
+            Spacer(minLength: Metrics.spacingWide)
+
+            if let summary {
+                Text(summary)
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textTertiary)
+            }
+        }
+        .padding(.horizontal, Metrics.inset)
+        .padding(.vertical, Metrics.spacingSmall)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .overlay(alignment: .top) { Hairline() }
+        // Read as one line, not as a row of controls: nothing here is pressable, so nothing here
+        // should be reachable by a pointer or announced as a target.
+        .accessibilityHidden(true)
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelModel.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelModel.swift
@@ -167,6 +167,57 @@ final class SearchPanelModel {
 
     // MARK: - The keyboard
 
+    #if DEBUG
+    /// Opens the panel for a capture run, which cannot press a key equivalent.
+    ///
+    /// Debug builds only, and it draws nothing on its own: it is how `--snapshot-window` gets the
+    /// window into the state this feature is about, exactly as `--create-sheet` does for the
+    /// window that starts a workspace. Without it the panel is reachable only by Cmd+K and by a
+    /// glyph in the title bar, and a synthetic press of either is an event sent to whatever the
+    /// owner is really looking at.
+    ///
+    ///     Bloom --snapshot-window /tmp/panel.png [--search-panel-query docs]
+    ///           [--search-panel-scope transcripts] [--search-panel-drill] --search-panel
+    ///
+    /// **`--search-panel` goes last, after every flag that carries a value**, and that is not a
+    /// style preference. A bare token left over at the end of argv is taken by AppKit as a file to
+    /// open, and the app then never brings its window up at all: `--search-panel --window-size
+    /// 1400x900` is fine, `--search-panel --search-panel-query review` leaves `review` stray and
+    /// the capture reports "no window to capture" with nothing else to go on. Snapshot's own
+    /// `--settings` carries the same warning for the neighbouring reason.
+    ///
+    /// The wait is for the same beat every capture flag waits for: the sidebar is drawn from the
+    /// database and the resting list is the workspaces that database has not loaded yet.
+    func presentIfRequested(app: AppModel) {
+        let arguments = CommandLine.arguments
+        guard arguments.contains("--search-panel") else { return }
+
+        func value(_ flag: String) -> String? {
+            guard let index = arguments.firstIndex(of: flag), index + 1 < arguments.count else {
+                return nil
+            }
+            return arguments[index + 1]
+        }
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2))
+            let scope = value("--search-panel-scope").flatMap(HomeScope.init(rawValue:)) ?? .all
+            open(scope: scope, app: app)
+            if let query = value("--search-panel-query") {
+                type(query, app: app)
+                // The transcript half is a hop onto the store behind a debounce, so a picture
+                // taken before it lands is a picture of the fast half alone.
+                try? await Task.sleep(for: .seconds(2))
+                rebuild(app: app)
+            }
+            if arguments.contains("--search-panel-drill") {
+                highlighted = 0
+                drill(app: app)
+            }
+        }
+    }
+    #endif
+
     var keyContext: SearchPanelKeyContext {
         SearchPanelKeyContext(
             mode: field.mode,

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelModel.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelModel.swift
@@ -1,0 +1,182 @@
+import AppKit
+import SwiftUI
+import BloomCore
+
+/// Whether the panel is open, what is in its field, and which row is highlighted.
+///
+/// **A shared object rather than `@State` in the window**, for the same reason `FeedbackPresenter`
+/// and `SetupRunAlert` are: a `Commands` body is not a view and cannot reach a `@State`, and the
+/// two keys that open this are menu items. It is also what lets the toolbar's magnifying glass and
+/// the Edit menu open the same panel rather than two.
+///
+/// Everything it decides is in the core. What is here is the state those decisions are taken
+/// against, and the wiring to `AppModel`: the archived list, the transcript search and the two
+/// ways a row is opened.
+@MainActor
+@Observable
+final class SearchPanelModel {
+    static let shared = SearchPanelModel()
+
+    private(set) var isOpen = false
+    private(set) var field = SearchPanelField()
+    var scope: HomeScope = .all
+    /// An index into `listing.rows`, never into a section. See `SearchPanelListing.rows`.
+    var highlighted: Int?
+    private(set) var listing = SearchPanelListing.empty
+    /// Which menu bar items the bar would actually fire right now, read once per rebuild. See
+    /// `MainMenuActions.runnable`.
+    private(set) var runnable: Set<MenuBarAction> = []
+    /// Bumped when Cmd+K is pressed at an already open panel, which is the platform's answer to
+    /// pressing a find key twice: select what is in the field rather than opening a second one.
+    private(set) var selectAllToken = 0
+    /// The archived workspaces, loaded when the panel opens. Old work is most of what the search
+    /// half is for, so the list is not complete without them.
+    private(set) var archived: [Workspace] = []
+    /// Where the caret is, which is what decides whether the right arrow pushes into a row or
+    /// moves the caret one character. See `SearchPanelKeys`.
+    var caretAtEnd = true
+
+    private init() {}
+
+    // MARK: - Opening and closing
+
+    /// - Parameter scope: the chip to open on. Shift+Cmd+F opens on Transcripts, which is what that
+    ///   key has always meant, and Cmd+K opens on Everything.
+    func open(scope: HomeScope = .all, app: AppModel) {
+        if isOpen {
+            // The platform's rule for pressing a find key at an open find: select what is there,
+            // so the next character replaces the query rather than extending it.
+            selectAllToken &+= 1
+        } else {
+            isOpen = true
+            field = SearchPanelField()
+            highlighted = nil
+            listing = .empty
+        }
+        self.scope = HomeScope.settle(scope, searching: true)
+        Task { archived = await app.archivedWorkspaces() }
+        rebuild(app: app)
+    }
+
+    /// Closing leaves the window exactly where it was. Nothing about the selection, the scroll or
+    /// the sidebar moves, which is the whole difference between this and the field it replaced.
+    func close(app: AppModel) {
+        guard isOpen else { return }
+        isOpen = false
+        field = SearchPanelField()
+        scope = .all
+        highlighted = nil
+        listing = .empty
+        // The store's half is cleared with it, or the next search would open on the answer to the
+        // last one for as long as the debounce takes.
+        app.searchTranscripts("")
+    }
+
+    // MARK: - Typing
+
+    func type(_ text: String, app: AppModel) {
+        let before = field.mode
+        field.type(text)
+        // Only when it moved. `searchTranscripts` cancels whatever is running, so calling it on a
+        // keystroke that changed no query would throw away an answer that was about to land.
+        if before != field.mode || field.mode == .things {
+            app.searchTranscripts(field.mode == .things ? field.query : "")
+        }
+        rebuild(app: app)
+    }
+
+    /// Pushes into the highlighted row's own menu, if it has one.
+    @discardableResult
+    func drill(app: AppModel) -> Bool {
+        guard let row = listing.row(at: highlighted), let id = row.drillable else { return false }
+        guard field.enterActions(on: id) else { return false }
+        app.searchTranscripts("")
+        rebuild(app: app)
+        return true
+    }
+
+    @discardableResult
+    func leaveMode(app: AppModel) -> Bool {
+        guard field.leaveMode() else { return false }
+        app.searchTranscripts(field.mode == .things ? field.query : "")
+        rebuild(app: app)
+        return true
+    }
+
+    func clearQuery(app: AppModel) {
+        field.clear()
+        app.searchTranscripts("")
+        rebuild(app: app)
+    }
+
+    func setScope(_ scope: HomeScope, app: AppModel) {
+        self.scope = scope
+        rebuild(app: app)
+    }
+
+    // MARK: - Building the list
+
+    /// One pass, on the same inputs Home builds its list from, called when those inputs move
+    /// rather than while drawing.
+    func rebuild(app: AppModel) {
+        guard isOpen else { return }
+        switch field.mode {
+        case .things:
+            listing = field.isEmpty
+                ? SearchPanelResting.build(
+                    workspaces: app.workspaces,
+                    repos: app.repos,
+                    activity: HomeActivity(
+                        running: app.runningWorkspaceIDs, waiting: app.waitingWorkspaceIDs
+                    )
+                )
+                : SearchPanelResults.build(
+                    query: field.query,
+                    repos: app.repos,
+                    workspaces: app.workspaces,
+                    archived: archived,
+                    transcripts: app.transcriptResults,
+                    scope: scope,
+                    hasProjects: !app.repos.isEmpty
+                )
+        case .commands:
+            listing = SearchPanelListing(
+                sections: SearchPanelCommands.sections(SearchPanelCommands.rank(field.query)),
+                isSearching: !field.isEmpty
+            )
+        case .actions(let id):
+            listing = SearchPanelListing(sections: SearchPanelActions.sections(for: subject(id)))
+        }
+
+        runnable = MainMenuActions.runnable()
+        // The highlight follows the list rather than the list following the highlight. A row index
+        // held over a rebuild is how a panel opens the workspace above the one being looked at.
+        highlighted = listing.rows.isEmpty ? nil : min(highlighted ?? 0, listing.rows.count - 1)
+    }
+
+    /// Which kind of subject a drilled workspace is, which decides what it can be asked to do.
+    private func subject(_ id: WorkspaceID) -> WorkspaceMenuSubject {
+        archived.contains { $0.id == id } ? .archived(id) : .live(id)
+    }
+
+    /// The workspace an action list is about, for the pill in the field.
+    func drilledWorkspace(app: AppModel) -> Workspace? {
+        guard let id = field.mode.workspaceID else { return nil }
+        return app.workspaces.first { $0.id == id } ?? archived.first { $0.id == id }
+    }
+
+    // MARK: - The keyboard
+
+    var keyContext: SearchPanelKeyContext {
+        SearchPanelKeyContext(
+            mode: field.mode,
+            rowCount: listing.rows.count,
+            highlighted: highlighted,
+            isQueryEmpty: field.isEmpty,
+            scope: scope,
+            scopes: HomeScope.offered(searching: true),
+            canDrill: listing.row(at: highlighted)?.drillable != nil,
+            caretAtEnd: caretAtEnd
+        )
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelOverlay.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelOverlay.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+import BloomCore
+
+/// Where the panel sits, what happens to the window behind it, and when its list is rebuilt.
+///
+/// **The window is dimmed and it does not move.** Spotlight and Raycast float over the screen;
+/// VS Code and Sublime pin their panel to the top of the window, and that is what this is, because
+/// the panel acts on this window's contents. Dimmed rather than blurred: a blur costs a live
+/// backdrop filter over the whole window for a card that is up for two seconds, and what the dim
+/// has to say is only "this is in front".
+///
+/// **Clicking outside closes it, and nothing is lost.** The click is taken by the dim rather than
+/// by the window under it, so the pointer cannot select a sidebar row on its way out of the panel.
+struct SearchPanelOverlay: ViewModifier {
+    let app: AppModel
+    @Bindable var panel: SearchPanelModel
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// How far below the top of the window the card hangs.
+    ///
+    /// Near the top rather than against it: a card flush with the title bar reads as part of the
+    /// chrome, and this is a thing in front of the window rather than a thing attached to it.
+    private static let topInset: CGFloat = 56
+
+    /// Enough to say the window behind is not the thing being used, and not so much that a person
+    /// cannot read the workspace name they were looking at. Black in both appearances, because
+    /// what it does is take light out of the ground rather than tint it.
+    private static let dim = 0.22
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .top) {
+                if panel.isOpen {
+                    ZStack(alignment: .top) {
+                        Color.black.opacity(Self.dim)
+                            .ignoresSafeArea()
+                            .contentShape(Rectangle())
+                            .onTapGesture { panel.close(app: app) }
+                            .accessibilityHidden(true)
+
+                        SearchPanelView(app: app, panel: panel)
+                            .padding(.top, Self.topInset)
+                    }
+                    .transition(.opacity)
+                }
+            }
+            .animation(reduceMotion ? nil : Motion.pane, value: panel.isOpen)
+            // Home's list must not take the keyboard off a field somebody is typing in, and this
+            // is the flag it reads. The panel's field is a field in the window exactly as the
+            // toolbar's was. See `HomeListKeyboard`.
+            .onChange(of: panel.isOpen) { _, open in
+                app.isSearchFieldFocused = open
+            }
+            // The list is rebuilt when its inputs move rather than while drawing, which is the
+            // same rule Home's `rebuild` keeps and for the same reason: it runs over every
+            // workspace on the machine.
+            .onChange(of: app.workspaces) { _, _ in panel.rebuild(app: app) }
+            .onChange(of: app.repos) { _, _ in panel.rebuild(app: app) }
+            .onChange(of: app.transcriptResults) { _, _ in panel.rebuild(app: app) }
+            // The two halves of the running state, watched separately because they move
+            // separately: a turn starting and a turn stopping to ask are different moments, and
+            // both change what the resting list leads with.
+            .onChange(of: app.runningWorkspaceIDs) { _, _ in panel.rebuild(app: app) }
+            .onChange(of: app.waitingWorkspaceIDs) { _, _ in panel.rebuild(app: app) }
+    }
+}
+
+extension View {
+    /// The panel, over this window.
+    func searchPanel(app: AppModel) -> some View {
+        modifier(SearchPanelOverlay(app: app, panel: SearchPanelModel.shared))
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelScopes.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelScopes.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+import BloomCore
+
+/// The chips at the head of the panel's list: Everything, Workspaces, Transcripts, Archived, each
+/// with its count.
+///
+/// **Home's own control, not a second one.** It is the same segmented picker over the same
+/// `HomeScope.offered(searching:)` with the same `HomeScopeCounts.badge`, so the two surfaces
+/// cannot offer different chips or different numbers for one machine. They split the answer by
+/// what kind of thing matched rather than filtering rows, which is the distinction Home already
+/// draws between browsing and searching.
+///
+/// Tab and Shift+Tab step them, which is why the picker is never given the keyboard: the field
+/// keeps it, and `SearchPanelKeys` decides what Tab means. See `MenuSearchField`.
+struct SearchPanelScopes: View {
+    var counts: HomeScopeCounts
+    @Binding var scope: HomeScope
+
+    var body: some View {
+        Picker("Scope", selection: $scope) {
+            ForEach(HomeScope.offered(searching: true), id: \.self) { scope in
+                Text(title(for: scope))
+                    .tag(scope)
+                    .accessibilityLabel(accessibilityLabel(for: scope))
+            }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .controlSize(.small)
+        .padding(.horizontal, Metrics.inset)
+        .padding(.bottom, Metrics.spacingSmall)
+        .help("Choose which kind of thing the answer is narrowed to")
+    }
+
+    /// Every chip carries its own number here, where Home's strip prints only two of them.
+    ///
+    /// **That is a difference from Home and it is deliberate.** On Home the numbers were five
+    /// figures across a strip somebody was reading past; here there are four chips, they exist
+    /// only while a search is running, and the number is the reason to press one: "Transcripts 14"
+    /// is what tells you the answer you want is in the half not on screen.
+    private func title(for scope: HomeScope) -> String {
+        let label = scope.label(searching: true)
+        let count = counts.count(of: scope, searching: true)
+        return count == 0 ? label : "\(label) \(count)"
+    }
+
+    private func accessibilityLabel(for scope: HomeScope) -> String {
+        let label = scope.label(searching: true)
+        let count = counts.count(of: scope, searching: true)
+        return count == 0 ? label : "\(label), \(count)"
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelTranscriptRow.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelTranscriptRow.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+import BloomCore
+
+/// One workspace whose transcript matched, with the best line under it.
+///
+/// **Drawn differently from a name match, because it is a different fact.** A name match is a
+/// subsequence, so the characters that hit are bold and the rest step back. A transcript match is a
+/// phrase in a sentence, so it gets the sentence, with the matched words carried at weight and at
+/// full colour. That is what the FTS5 snippet already returns, marked, and `TranscriptSearch`
+/// already reads it back into segments.
+///
+/// One row per workspace rather than per message, which is `TranscriptSearch.group`'s decision: a
+/// workspace where the agent said the word forty times would otherwise take the whole panel and
+/// bury the three others that are the actual answer. Return opens the best of them at its own line.
+struct SearchPanelTranscriptRow: View {
+    var hit: SearchPanelTranscriptHit
+    var isSelected: Bool
+    var onPick: @MainActor () -> Void
+    var onHover: @MainActor () -> Void
+
+    @Environment(\.controlActiveState) private var activeState
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onPick) {
+            HStack(alignment: .top, spacing: Metrics.spacingWide) {
+                RepoIcon(repo: hit.repo)
+
+                VStack(alignment: .leading, spacing: Metrics.spacingHair) {
+                    HStack(spacing: Metrics.spacingSmall) {
+                        Text(hit.workspace?.name ?? "Unknown workspace")
+                            .font(Typo.bodyEmphasis)
+                            .foregroundStyle(loud)
+                            .lineLimit(1)
+
+                        Text(detail)
+                            .font(Typo.caption)
+                            .foregroundStyle(quiet)
+                            .lineLimit(1)
+                    }
+
+                    if let snippet = hit.result.best?.snippet, !snippet.isEmpty {
+                        Text(marked(snippet))
+                            .font(Typo.caption)
+                            .foregroundStyle(quiet)
+                            .lineLimit(2)
+                            .multilineTextAlignment(.leading)
+                    }
+                }
+
+                Spacer(minLength: Metrics.spacingWide)
+            }
+            .padding(.horizontal, Metrics.inset)
+            .padding(.vertical, Metrics.spacingSmall)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint("Opens the workspace at this point in the transcript.")
+        .rowBackground(isSelected: isSelected, isHovered: isHovered, isFocused: true)
+        .onHoverChange { hovering in
+            isHovered = hovering
+            if hovering { onHover() }
+        }
+    }
+
+    private var detail: String {
+        var parts = [hit.repo?.name ?? "Unknown project"]
+        if hit.isArchived { parts.append("archived") }
+        parts.append(hit.result.total == 1 ? "1 match" : "\(hit.result.total) matches")
+        return parts.joined(separator: " \u{00B7} ")
+    }
+
+    private var accessibilityLabel: String {
+        "\(hit.workspace?.name ?? "Unknown workspace"), \(detail)"
+    }
+
+    /// One `AttributedString` rather than concatenated `Text`, which is the API that would read
+    /// better and is deprecated on macOS 26. The matched run gets weight and the loud colour
+    /// rather than a highlight plate: a wash behind two words in a caption sized line, four lines
+    /// to a panel, was the loudest thing on the card by some way when Home tried it.
+    private func marked(_ snippet: TranscriptSnippet) -> AttributedString {
+        var built = AttributedString()
+        for segment in snippet.segments {
+            var run = AttributedString(segment.text)
+            if segment.isMatch {
+                run.inlinePresentationIntent = .stronglyEmphasized
+                run.foregroundColor = loud
+            }
+            built.append(run)
+        }
+        return built
+    }
+
+    private var loud: Color {
+        isEmphasized ? Palette.selectedEmphasizedText : Palette.textPrimary
+    }
+
+    private var quiet: Color {
+        isEmphasized ? Palette.selectedEmphasizedText.opacity(0.76) : Palette.textSecondary
+    }
+
+    private var isEmphasized: Bool {
+        isSelected && activeState != .inactive
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelView.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelView.swift
@@ -1,0 +1,300 @@
+import SwiftUI
+import BloomCore
+
+/// The card: a field, the chips, the list, and a strip of keys along the bottom.
+///
+/// **The same card the composer's two menus already sit in**, which is `MenuPanel`: one definition
+/// of the glass, the rim, the corner and the shadow, so a third floating list cannot drift from the
+/// two that were there first.
+///
+/// **Pinned near the top of the window rather than centred on the display.** The panel acts on this
+/// window's contents, so it should visibly belong to this window; centring it on the screen is what
+/// a system service does and Bloom is not one. See `SearchPanelOverlay` for the dimming and the
+/// placement.
+struct SearchPanelView: View {
+    var app: AppModel
+    @Bindable var panel: SearchPanelModel
+
+    /// Wide enough for a workspace name, its project and an age on one line, and narrow enough that
+    /// the eye does not have to travel to read a row. The composer's slash menu is 440 and holds a
+    /// command name; this holds a sentence out of a transcript.
+    static let width: CGFloat = 560
+
+    /// Four rows and a bit, which is what a person reads before pressing Return. A taller list
+    /// would be a pane, and a pane is Home.
+    private static let listHeight: CGFloat = 310
+
+    var body: some View {
+        MenuPanel {
+            field
+            Hairline()
+
+            if panel.field.mode.showsScopes, !panel.field.isEmpty {
+                SearchPanelScopes(counts: panel.listing.counts, scope: scopeBinding)
+                    .padding(.top, Metrics.spacingSmall)
+            }
+
+            list
+
+            SearchPanelFooter(
+                keys: SearchPanelKeys.footer(
+                    for: panel.field.mode, isSearching: !panel.field.isEmpty
+                ),
+                summary: panel.listing.isEmpty ? nil : panel.listing.summary
+            )
+        }
+        .frame(width: Self.width)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Quick Search")
+    }
+
+    // MARK: - The field
+
+    /// The glyph, the mode's pill, the field itself, and what is being acted on.
+    ///
+    /// The pill is what tells you which mode you are in, and Backspace on an empty field is what
+    /// takes it off again. That is GitHub's scope model rather than an invention: you narrow
+    /// forwards and widen backwards.
+    private var field: some View {
+        HStack(spacing: Metrics.spacing) {
+            Image(systemName: "magnifyingglass")
+                .font(Typo.labelEmphasis)
+                .foregroundStyle(Palette.textTertiary)
+
+            if let pill = modePill {
+                Chip(text: pill)
+            }
+
+            MenuSearchField(
+                text: textBinding,
+                placeholder: placeholder,
+                onKey: key(_:),
+                onBacktab: { handle(.backTab) },
+                onDeleteEmpty: { handle(.backspaceOnEmpty) },
+                onRight: { atEnd in
+                    panel.caretAtEnd = atEnd
+                    return handle(.right)
+                },
+                selectAllToken: panel.selectAllToken
+            )
+            .frame(height: Metrics.controlHeight)
+
+            if let subject = commandSubject {
+                Text("on \(subject)")
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textTertiary)
+                    .lineLimit(1)
+            }
+        }
+        .padding(.horizontal, Metrics.inset)
+        .padding(.vertical, Metrics.spacingWide)
+    }
+
+    /// The word in the pill. An action list names the workspace it is about, because "Action" on
+    /// its own would be a label with nothing in it.
+    private var modePill: String? {
+        switch panel.field.mode {
+        case .things: nil
+        case .commands: SearchPanelMode.commands.pill
+        case .actions: panel.drilledWorkspace(app: app)?.name ?? SearchPanelMode.actions(WorkspaceID("")).pill
+        }
+    }
+
+    /// What the commands mode is aimed at, drawn on the trailing edge so a person can see which
+    /// workspace Archive would take before they press it.
+    private var commandSubject: String? {
+        guard panel.field.mode == .commands else { return nil }
+        return app.menuWorkspace?.name
+    }
+
+    private var placeholder: String {
+        switch panel.field.mode {
+        case .things: "Search workspaces, transcripts and commands"
+        case .commands: "Run a command"
+        case .actions: "Act on this workspace"
+        }
+    }
+
+    // MARK: - The list
+
+    @ViewBuilder
+    private var list: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(panel.listing.sections) { section in
+                        if let title = section.title {
+                            // In the scroll rather than stuck to the top, because a sticky heading
+                            // inside a list this tall eats one of the four rows you can see.
+                            Text(title)
+                                .font(Typo.micro)
+                                .foregroundStyle(Palette.textTertiary)
+                                .textCase(.uppercase)
+                                .tracking(Typo.microTracking)
+                                .padding(.horizontal, Metrics.inset)
+                                .padding(.top, Metrics.spacingWide)
+                                .padding(.bottom, Metrics.spacingTight)
+                        }
+
+                        ForEach(section.rows) { row in
+                            self.row(row)
+                                .id(row.id)
+                        }
+                    }
+
+                    notice
+                }
+                .padding(.vertical, Metrics.spacingSmall)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxHeight: Self.listHeight)
+            // No anchor, so the arrows scroll the least they can get away with. Pinning would
+            // throw the highlighted row to the far edge every time somebody stepped upwards, which
+            // no Mac list does.
+            .onChange(of: panel.highlighted) { _, index in
+                guard let row = panel.listing.row(at: index) else { return }
+                proxy.scrollTo(row.id)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func row(_ row: SearchPanelRow) -> some View {
+        let index = panel.listing.rows.firstIndex { $0.id == row.id }
+        let isSelected = index != nil && index == panel.highlighted
+
+        switch row {
+        case .workspace(let hit):
+            SearchPanelWorkspaceRow(
+                hit: hit,
+                isSelected: isSelected,
+                onPick: { open(row) },
+                onHover: { panel.highlighted = index }
+            )
+
+        case .transcript(let hit):
+            SearchPanelTranscriptRow(
+                hit: hit,
+                isSelected: isSelected,
+                onPick: { open(row) },
+                onHover: { panel.highlighted = index }
+            )
+
+        case .command(let hit):
+            SearchPanelCommandRow(
+                hit: hit,
+                isEnabled: isRunnable(hit),
+                isSelected: isSelected,
+                onPick: { open(row) },
+                onHover: { panel.highlighted = index }
+            )
+
+        case .fallback(let fallback):
+            SearchPanelFallbackRow(
+                fallback: fallback,
+                isSelected: isSelected,
+                onPick: { open(row) },
+                onHover: { panel.highlighted = index }
+            )
+        }
+    }
+
+    /// An action list is performed against the workspace that was pushed into rather than against
+    /// whatever the Workspace menu is about, so the live menu's greying does not apply to it: the
+    /// row is offered because `WorkspaceMenuSubject` allows it, which is the same rule Home's own
+    /// menu for that workspace keeps.
+    private func isRunnable(_ hit: SearchPanelCommandHit) -> Bool {
+        panel.field.mode.workspaceID != nil || panel.runnable.contains(hit.item.action)
+    }
+
+    /// The two things drawn under the list, and neither of them is an error.
+    ///
+    /// A search here cannot fail in a way worth drawing: `TranscriptSearch.matchExpression` quotes
+    /// every token before it reaches FTS5, so the store either answers or the task was cancelled by
+    /// the next keystroke. What is left is the one honest condition, the index still being built,
+    /// stated as a fact under the list rather than as a failure across it.
+    @ViewBuilder
+    private var notice: some View {
+        if panel.listing.isEmpty, !panel.field.isEmpty {
+            VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
+                Text(SearchPanelFallback.summary(for: panel.field.query))
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textSecondary)
+            }
+            .padding(.horizontal, Metrics.inset)
+            .padding(.vertical, Metrics.spacingWide)
+        }
+
+        if !panel.field.isEmpty, panel.field.mode == .things,
+           let sentence = SearchPanelFallback.indexNotice(isIndexing: app.isTranscriptIndexIncomplete) {
+            Label(sentence, systemImage: "clock")
+                .font(Typo.caption)
+                .foregroundStyle(Palette.textTertiary)
+                .padding(.horizontal, Metrics.inset)
+                .padding(.vertical, Metrics.spacingSmall)
+        }
+    }
+
+    // MARK: - Bindings and keys
+
+    private var textBinding: Binding<String> {
+        Binding(
+            get: { panel.field.text },
+            set: { panel.type($0, app: app) }
+        )
+    }
+
+    private var scopeBinding: Binding<HomeScope> {
+        Binding(
+            get: { panel.scope },
+            set: { panel.setScope($0, app: app) }
+        )
+    }
+
+    private func open(_ row: SearchPanelRow) {
+        SearchPanelActivation.open(row, panel: panel, app: app)
+    }
+
+    /// The keys the field hands over, mapped onto the enum the core answers.
+    private func key(_ key: ComposerKey) -> Bool {
+        switch key {
+        case .up: handle(.up)
+        case .down: handle(.down)
+        case .tab: handle(.tab)
+        case .returnKey: handle(.returnKey)
+        case .commandReturn: handle(.commandReturn)
+        case .escape: handle(.escape)
+        }
+    }
+
+    /// - Returns: whether the field should keep the key. False hands it back to the field editor,
+    ///   which is what leaves Tab moving the focus in a mode that has no chips.
+    private func handle(_ key: SearchPanelKey) -> Bool {
+        switch SearchPanelKeys.outcome(for: key, in: panel.keyContext) {
+        case .move(let index):
+            panel.highlighted = index
+            return true
+        case .open:
+            guard let row = panel.listing.row(at: panel.highlighted) else { return true }
+            open(row)
+            return true
+        case .drill:
+            return panel.drill(app: app)
+        case .scope(let scope):
+            panel.setScope(scope, app: app)
+            return true
+        case .leaveMode:
+            return panel.leaveMode(app: app)
+        case .clearQuery:
+            panel.clearQuery(app: app)
+            return true
+        case .close:
+            panel.close(app: app)
+            return true
+        case .handled:
+            return true
+        case .ignored:
+            return false
+        }
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelView.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelView.swift
@@ -122,6 +122,15 @@ struct SearchPanelView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
+                    if let summary = panel.listing.summaryLine {
+                        Text(summary)
+                            .font(Typo.caption)
+                            .foregroundStyle(Palette.textSecondary)
+                            .padding(.horizontal, Metrics.inset)
+                            .padding(.top, Metrics.spacingWide)
+                            .padding(.bottom, Metrics.spacingSmall)
+                    }
+
                     ForEach(panel.listing.sections) { section in
                         if let title = section.title {
                             // In the scroll rather than stuck to the top, because a sticky heading
@@ -215,16 +224,6 @@ struct SearchPanelView: View {
     /// stated as a fact under the list rather than as a failure across it.
     @ViewBuilder
     private var notice: some View {
-        if panel.listing.isEmpty, !panel.field.isEmpty {
-            VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
-                Text(SearchPanelFallback.summary(for: panel.field.query))
-                    .font(Typo.caption)
-                    .foregroundStyle(Palette.textSecondary)
-            }
-            .padding(.horizontal, Metrics.inset)
-            .padding(.vertical, Metrics.spacingWide)
-        }
-
         if !panel.field.isEmpty, panel.field.mode == .things,
            let sentence = SearchPanelFallback.indexNotice(isIndexing: app.isTranscriptIndexIncomplete) {
             Label(sentence, systemImage: "clock")

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelWorkspaceRow.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelWorkspaceRow.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import BloomCore
+
+/// One workspace in the panel: its name with the matched characters lit, its project, and one
+/// short fact about where it has got to.
+///
+/// **The name leads and everything else is one quiet line under it**, which is the shape the
+/// sidebar's hover card and Home's rows already have. A panel row is read in the half second
+/// between typing and pressing Return, so there is room for exactly one line of context and the
+/// choice of what goes in it is the whole design of the row: what is waiting on you at rest, and
+/// how long ago it happened in a search.
+struct SearchPanelWorkspaceRow: View {
+    var hit: SearchPanelWorkspaceHit
+    var isSelected: Bool
+    var onPick: @MainActor () -> Void
+    var onHover: @MainActor () -> Void
+
+    @Environment(\.controlActiveState) private var activeState
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onPick) {
+            HStack(spacing: Metrics.spacingWide) {
+                RepoIcon(repo: hit.repo)
+
+                VStack(alignment: .leading, spacing: Metrics.spacingHair) {
+                    name
+                        .font(Typo.bodyEmphasis)
+                        .lineLimit(1)
+                    detail
+                        .font(Typo.caption)
+                        .foregroundStyle(quiet)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: Metrics.spacingWide)
+            }
+            .padding(.horizontal, Metrics.inset)
+            .padding(.vertical, Metrics.spacingSmall)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+        // Focused, because the panel's field really does hold the keyboard while the arrows walk
+        // this list, which is the one case AppKit paints in the accent.
+        .rowBackground(isSelected: isSelected, isHovered: isHovered, isFocused: true)
+        .onHoverChange { hovering in
+            isHovered = hovering
+            if hovering { onHover() }
+        }
+    }
+
+    private var name: Text {
+        MatchedRuns.text(hit.workspace.name, highlights: hit.highlights, loud: loud, quiet: quiet)
+    }
+
+    /// The project, then the one fact worth a row's second line.
+    ///
+    /// In the resting list that is why the workspace is waiting; in a search it is what matched
+    /// when the name did not, because a row matched on its branch would otherwise look unrelated
+    /// to what was typed. The age is last in both, because it is the fact people scan for and the
+    /// trailing edge is where the eye ends up.
+    private var detail: Text {
+        var parts: [String] = [hit.repo?.name ?? "Unknown project"]
+        if hit.isArchived { parts.append("archived") }
+        if let waiting = hit.waiting { parts.append(waiting.label) }
+        if let match = hit.match { parts.append(match) }
+        parts.append(
+            hit.workspace.lastActivityAt.formatted(
+                .relative(presentation: .numeric, unitsStyle: .narrow)
+            )
+        )
+        return Text(parts.joined(separator: " \u{00B7} "))
+    }
+
+    private var accessibilityLabel: String {
+        var parts = [hit.workspace.name]
+        if let repo = hit.repo { parts.append("in \(repo.name)") }
+        if hit.isArchived { parts.append("archived") }
+        if let waiting = hit.waiting { parts.append(waiting.label) }
+        if let match = hit.match { parts.append("matched \(match)") }
+        return parts.joined(separator: ", ")
+    }
+
+    private var loud: Color {
+        isEmphasized ? Palette.selectedEmphasizedText : Palette.textPrimary
+    }
+
+    private var quiet: Color {
+        isEmphasized ? Palette.selectedEmphasizedText.opacity(0.76) : Palette.textSecondary
+    }
+
+    /// See `FileMentionRow`: the labels set their own colour, so they have to know when the row
+    /// underneath them has gone accent coloured or they stay unreadable on it.
+    private var isEmphasized: Bool {
+        isSelected && activeState != .inactive
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Window/BloomWindowToolbar.swift
+++ b/Sources/Bloom/Views/Chrome/Window/BloomWindowToolbar.swift
@@ -79,21 +79,19 @@ struct BloomWindowToolbar: ToolbarContent {
             }
         }
 
-        // The elastic middle of the bar, and the whole reason the search field sits at the
-        // window's trailing edge rather than beside the name.
+        // The elastic middle of the bar. It was put here for the search field, which used to be
+        // the last item in the toolbar: `.searchable` contributed an `NSSearchToolbarItem` after
+        // everything written above, and an `NSToolbar` packs from the leading edge with no gap
+        // unless something between the items can stretch. What usually stretches is AppKit's own
+        // title item, and `RootView` takes that away with `.toolbar(removing: .title)` because the
+        // name is drawn here instead, so removing the second title also removed the toolbar's only
+        // slack. Measured offscreen at 1440 points: without this the field's capsule started at
+        // x=416, a third of the way across the bar, and with it at x=727.
         //
-        // `.searchable` contributes an `NSSearchToolbarItem` after everything written here, and an
-        // `NSToolbar` packs its items from the leading edge with no gap unless something between
-        // them can stretch. What usually stretches is AppKit's own title item, and `RootView`
-        // takes that away with `.toolbar(removing: .title)` because the name is drawn here
-        // instead, so removing the second title also removed the toolbar's only piece of slack.
-        //
-        // Measured in an offscreen window 1440 points wide, with the same 380 point accessory:
-        // without this the field's capsule starts at x=416, eight points from the title's own and
-        // a third of the way across the bar, which is what the owner was looking at; with it, at
-        // x=727, hard against the pull request band. The band is beyond the toolbar rather than
-        // in it, so the two do not compete for the edge: the field takes the toolbar's trailing
-        // end, the band takes the window's. See `TitleBarStrip`.
+        // **The field has gone to a panel and the spacer stays**, because what it does now is hold
+        // these items against the leading edge rather than letting a toolbar with nothing at its
+        // other end lay them out somewhere else. The window's search is a glyph in the title bar
+        // accessory now: see `SearchToolbarButton` and `TitleBarStrip`.
         ToolbarSpacer(.flexible, placement: .navigation)
 
         // The worktree's menu is not here any more. It was a trailing toolbar item, pinned to the

--- a/Sources/Bloom/Views/Chrome/Window/SearchToolbarButton.swift
+++ b/Sources/Bloom/Views/Chrome/Window/SearchToolbarButton.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import BloomCore
+
+/// The magnifying glass in the title bar, which opens the search panel.
+///
+/// **Twenty-six points of glyph where there were two hundred and six of glass.** The window's
+/// search was an `NSSearchToolbarItem` contributed by `.searchable`: a capsule with the system's
+/// drop shadow, packed against the trailing end of the toolbar by a flexible spacer, sharing an
+/// edge with nothing. The shadow and the glass were macOS 26's and could not be turned off while
+/// the item was a toolbar item. This is the same search, in chrome that fits what it actually
+/// does.
+///
+/// **It is a `WindowPaneToggle` in everything but name**, drawn on the same 32 point slot with the
+/// same hover plate and the same quiet ink, because it sits directly beside the inspector's toggle
+/// and two controls an inch apart that are drawn differently read as two unrelated things. It is
+/// not that type because that type says whether a pane is open, and this opens a card that closes
+/// itself.
+///
+/// **A glyph and not the field, and something is lost with it.** A field in a toolbar teaches
+/// itself and a panel behind a key does not; this is the mitigation and it is only a partial one.
+/// What it does keep is that the search is still visible to somebody who has never pressed Cmd+K.
+struct SearchToolbarButton: View {
+    var action: @MainActor () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Label("Search", systemImage: "magnifyingglass")
+                .labelStyle(.iconOnly)
+                .font(Typo.labelEmphasis)
+                .foregroundStyle(Palette.textSecondary)
+                // Inside the label, which is the whole of the bug `WindowPaneToggle` records: a
+                // `.plain` Button takes its clicks inside its label, so a frame around the
+                // finished Button only centres a glyph-sized target in a 32 point box.
+                .frame(width: Metrics.barHeight, height: Metrics.barHeight)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHoverChange { isHovered = $0 }
+        .background {
+            if isHovered {
+                RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+                    .fill(Palette.hover)
+                    .padding(Metrics.spacingTight)
+            }
+        }
+        .accessibilityLabel("Search")
+        .help("Search workspaces, transcripts and commands")
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Window/TitleBarStrip.swift
+++ b/Sources/Bloom/Views/Chrome/Window/TitleBarStrip.swift
@@ -26,10 +26,14 @@ import BloomCore
 /// branch: with a 132 point intrinsic size the container kept the one point frame it was given. So
 /// the frame is set by hand, and this is what says when.
 ///
-/// **That frame is also the window's search field's x, which is why the accessory travels rather
-/// than jumps.** The toolbar gets what the trailing accessory leaves it, and `.searchable`'s
-/// `NSSearchToolbarItem` is packed against the end of it by `BloomWindowToolbar`'s flexible
-/// spacer. See `TitleBarStripController.resize` and `InspectorSlide`.
+/// **That frame used to be the window's search field's x as well, which is why the accessory
+/// travels rather than jumps.** The toolbar gets what the trailing accessory leaves it, and
+/// `.searchable`'s `NSSearchToolbarItem` was packed against the end of it by
+/// `BloomWindowToolbar`'s flexible spacer, so a frame set in one step moved the field 379 points
+/// on one frame. The field is a panel now and there is nothing left in the toolbar for the
+/// accessory to drag, but the travelling stays: what it is really for is the band, which has to
+/// end exactly where the pane under it ends on every frame of the slide. See
+/// `TitleBarStripController.resize` and `InspectorSlide`.
 @MainActor
 @Observable
 final class InspectorGeometry {
@@ -166,26 +170,40 @@ struct TitleBarStrip: View {
     /// in a 1440 point window. So the toggle now stops where the sidebar toggle at the other end
     /// of the bar would stop, rather than at a number chosen for looking about right.
     ///
-    /// It is on the toggle rather than on the strip, and it is constant rather than conditional,
-    /// for the same reason: `PullRequestBar` is the heading of the pane below it and has to end
-    /// exactly where that pane ends, so the gap goes between the two and the accessory is asked
-    /// for these ten points on top of the pane's width in every state. Conditional on the band
-    /// being there, it would arrive as a ten point jump halfway through the inspector's slide.
+    /// It is on the controls rather than on the strip, and it is constant rather than
+    /// conditional, for the same reason: `PullRequestBar` is the heading of the pane below it and
+    /// has to end exactly where that pane ends, so the gap goes between the two and the accessory
+    /// is asked for these ten points on top of the pane's width in every state. Conditional on the
+    /// band being there, it would arrive as a ten point jump halfway through the inspector's
+    /// slide.
     static let trailingInset: CGFloat = 10
 
     var body: some View {
         HStack(spacing: 0) {
-            if inspector.hasWorkspace {
-                WindowPaneToggle(
-                    edge: .trailing,
-                    isVisible: app.isInspectorVisible
-                ) {
-                    app.isInspectorVisible.toggle()
+            // The window's controls: the search, which used to be 206 points of glass at the
+            // other end of the toolbar, and the inspector's toggle. On one 32 point rhythm, so
+            // the trailing end of the bar is two small controls rather than a capsule and a
+            // glyph. See `SearchToolbarButton`.
+            //
+            // See `trailingInset` for the clearance. It is on the pair rather than on either of
+            // them, because which one ends up last depends on whether there is a workspace, and
+            // on the pair rather than on the strip, because the band beside them has to keep the
+            // window's edge.
+            HStack(spacing: 0) {
+                SearchToolbarButton {
+                    SearchPanelModel.shared.open(app: app)
                 }
-                // See `trailingInset`. On the toggle rather than on the strip, because the band
-                // beside it has to keep the window's edge.
-                .padding(.trailing, Self.trailingInset)
+
+                if inspector.hasWorkspace {
+                    WindowPaneToggle(
+                        edge: .trailing,
+                        isVisible: app.isInspectorVisible
+                    ) {
+                        app.isInspectorVisible.toggle()
+                    }
+                }
             }
+            .padding(.trailing, Self.trailingInset)
 
             if let model = shown, inspector.isVisible {
                 PullRequestBar(model: model)
@@ -251,9 +269,10 @@ struct TitleBarStrip: View {
         // edge towards that corner and the band goes with it, clipped as it passes the edge, which
         // is exactly what the pane below is doing. A `.transition(.offset)` on top of that would be
         // the same distance travelled twice: the band left in the first half of the slide and
-        // arrived in the second. Gluing the band to the edge the accessory gives back also glues it
-        // to the search field, which is packed against that same edge from the other side, so the
-        // two things in the title bar cannot drift apart no matter what clock either is on.
+        // arrived in the second. Gluing the band to the edge the accessory gives back is what
+        // kept it in step with the window's search field while that was a toolbar item packed
+        // against the same edge from the other side; the field has gone to a panel, and the rule
+        // stays because it is what keeps the band over its own pane.
         .frame(maxWidth: .infinity, alignment: .leading)
         .frame(height: height)
         // The model's identity rather than its row: a workspace row is rewritten every six seconds
@@ -343,8 +362,9 @@ final class TitleBarStripController: NSTitlebarAccessoryViewController {
     /// sleeping display or closed halfway through a slide therefore stops the clock, and what is
     /// left behind is an accessory frozen part way between one point and 380. That is not a
     /// cosmetic leftover. A trailing accessory INDENTS the toolbar's items, per
-    /// `NSTitlebarAccessoryViewController.h`, so a frozen one parks the search field at a width
-    /// nothing on screen explains and leaves it there until the inspector is next opened or closed.
+    /// `NSTitlebarAccessoryViewController.h`, so a frozen one parks the band at a width nothing on
+    /// screen explains and leaves it there until the inspector is next opened or closed. It used
+    /// to park the window's search field there too, which is how the fault was found.
     ///
     /// The version this replaced could not have that fault, because its whole mechanism was a
     /// `Task.sleep` that always ran. Losing that guarantee was not part of the trade, so it is back
@@ -418,8 +438,13 @@ final class TitleBarStripController: NSTitlebarAccessoryViewController {
         // The slot the toggle is drawn in plus the clearance it keeps on its trailing side, which
         // the accessory has to be asked for or the band would give it up. See
         // `TitleBarStrip.trailingInset`.
-        let toggleWidth = geometry.hasWorkspace ? Metrics.barHeight + TitleBarStrip.trailingInset : 0
-        let target = max(geometry.width + toggleWidth, 1)
+        // The magnifying glass is always drawn and the inspector's toggle only when there is a
+        // workspace to toggle one for, and the clearance on the trailing side is kept in both
+        // states, because there is always a control on that edge now.
+        let controls = Metrics.barHeight
+            + (geometry.hasWorkspace ? Metrics.barHeight : 0)
+            + TitleBarStrip.trailingInset
+        let target = max(geometry.width + controls, 1)
         // A view with no window has no display to take a link from, and a slide whose clock never
         // ticks is an accessory stuck at the width it set off from. Nothing can be watching such a
         // window anyway, so it lands rather than travels. This is also the first call, from `init`.

--- a/Sources/Bloom/Views/CreateWorkspace/CreateWorkspaceView.swift
+++ b/Sources/Bloom/Views/CreateWorkspace/CreateWorkspaceView.swift
@@ -248,6 +248,16 @@ struct CreateWorkspaceView: View {
             guard CreateWorkspaceOpening.shared.consumePullRequestAsk() else { return }
             raisePullRequestBox()
         }
+        // The name the search panel's fallback row was named after, taken once, the same shape as
+        // the flag above. See `CreateWorkspaceOpening.suggestedName`.
+        .task {
+            guard let suggested = CreateWorkspaceOpening.shared.consumeName() else { return }
+            typedName = suggested
+        }
+        .onChange(of: CreateWorkspaceOpening.shared.suggestedName) { _, _ in
+            guard let suggested = CreateWorkspaceOpening.shared.consumeName() else { return }
+            typedName = suggested
+        }
         // The already-open case. No `initial`, deliberately: a window built with the flag already
         // set sees no change and is served by the task above, which runs after `load` and so keeps
         // the keyboard the task would otherwise have taken back.

--- a/Sources/Bloom/Views/CreateWorkspace/CreateWorkspaceWindow.swift
+++ b/Sources/Bloom/Views/CreateWorkspace/CreateWorkspaceWindow.swift
@@ -110,4 +110,24 @@ final class CreateWorkspaceOpening {
         wantsPullRequest = false
         return true
     }
+
+    /// A name to open the window with, set by the search panel's "start a workspace called this"
+    /// row and by nothing else.
+    ///
+    /// Somebody who searched for a workspace that does not exist has just said what they want it
+    /// called, and asking them to type it again is the panel throwing that away. It lands in the
+    /// name field, which the two modes that run no agent draw; chat mode has no such field because
+    /// it names the workspace from the prompt, so there this is what the field would have held if
+    /// they change their mind about the mode.
+    private(set) var suggestedName: String?
+
+    func askForName(_ name: String) {
+        suggestedName = name
+    }
+
+    /// Once, like the pull request ask above.
+    func consumeName() -> String? {
+        defer { suggestedName = nil }
+        return suggestedName
+    }
 }

--- a/Sources/Bloom/Views/Home/HomeBar.swift
+++ b/Sources/Bloom/Views/Home/HomeBar.swift
@@ -4,12 +4,17 @@ import BloomCore
 /// The one strip of chrome above Home's list: which chip is lit, and which projects are listed.
 ///
 /// **What came off it.** It used to hold a hand built search field with a hand drawn focus ring, a
-/// project menu, a "Hide archived" toggle and a readout of what the list added up to. The field is
-/// gone: the window has a real `NSSearchToolbarItem` in its toolbar, which is where Finder and Mail
-/// publish search. The toggle is gone into `HomeScope.live`, because a narrowing switch beside a
-/// set of narrowing chips is two mechanisms for one question. And the readout is gone down to
-/// `HomeStatusBar` at the foot of the pane: a count belongs beside the thing it counts, and this
-/// bar was carrying five chips, a picker and a sentence at one weight, so nothing on it led.
+/// project menu, a "Hide archived" toggle and a readout of what the list added up to. The field
+/// went to the window's toolbar as a real `NSSearchToolbarItem`, and then off the toolbar
+/// altogether: the search is a panel on Cmd+K now, because typing into a field in the title bar
+/// set the selection to Home and took the reader off whatever they were reading. The toggle is
+/// gone into `HomeScope.live`, because a narrowing switch beside a set of narrowing chips is two
+/// mechanisms for one question. And the readout is gone down to `HomeStatusBar` at the foot of the
+/// pane: a count belongs beside the thing it counts, and this bar was carrying five chips, a
+/// picker and a sentence at one weight, so nothing on it led.
+///
+/// What arrived with the panel is `queryChip`, which is the one thing the strip has to say now
+/// that no field on screen holds the query.
 ///
 /// **What went on it.** One control, and only under the Archived chip: whether that list is in
 /// date order or in size order. It is the last piece of the Settings > Storage pane, whose
@@ -52,6 +57,8 @@ struct HomeBar: View {
                 .fixedSize()
                 .help("Choose which work Home lists")
 
+                queryChip
+
                 Spacer(minLength: Metrics.gutter)
 
                 HStack(spacing: Metrics.spacing) {
@@ -79,6 +86,53 @@ struct HomeBar: View {
     private func accessibilityLabel(for scope: HomeScope) -> String {
         let label = scope.label(searching: isSearching)
         return counts.badge(of: scope, searching: isSearching).map { "\(label), \($0)" } ?? label
+    }
+
+    // MARK: - The query
+
+    /// What Home is being searched for, as a chip that can be taken off.
+    ///
+    /// **The strip needs this because the field that used to hold the query is gone.** It was an
+    /// `NSSearchToolbarItem` in the window's toolbar, and it went with the search panel: the
+    /// panel's "search Home for this" row is the one thing left that writes `HomeFilter.query`. A
+    /// list narrowed by a query with no control on screen saying so is how somebody files a bug
+    /// about their workspaces having disappeared, and it is the exact failure `projectLabel` a few
+    /// lines down exists to prevent for the other filter.
+    ///
+    /// Absent when there is nothing to say, rather than an empty field kept for symmetry: the
+    /// strip is two chips and a menu most of the time, and a permanently empty box on it would be
+    /// a thing to read past on every visit to the first screen the app opens.
+    @ViewBuilder
+    private var queryChip: some View {
+        if isSearching {
+            HStack(spacing: Metrics.spacingSmall) {
+                Image(systemName: "magnifyingglass")
+                    .font(Typo.micro)
+                    .imageScale(.small)
+
+                Text(filter.query)
+                    .font(Typo.caption)
+                    .lineLimit(1)
+
+                Button {
+                    filter.query = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(Typo.micro)
+                        .imageScale(.medium)
+                }
+                .buttonStyle(.plain)
+                .help("Clear the search")
+                .accessibilityLabel("Clear the search")
+            }
+            .foregroundStyle(Palette.textSecondary)
+            .padding(.horizontal, Metrics.chipInsetH)
+            .padding(.vertical, Metrics.chipInsetV)
+            .background(Palette.hover, in: RoundedRectangle(cornerRadius: Metrics.cornerSmall))
+            .padding(.leading, Metrics.spacing)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Searching for \(filter.query)")
+        }
     }
 
     // MARK: - Order

--- a/Sources/Bloom/Views/RootView.swift
+++ b/Sources/Bloom/Views/RootView.swift
@@ -171,6 +171,9 @@ struct RootView: View {
             // Debug builds only, and only when asked for on the command line: raises one of the two
             // Help menu sheets so a capture run can look at it. See `FeedbackPresenter`.
             .task { FeedbackPresenter.shared.presentIfRequested() }
+            // The same, for the search panel, which is otherwise reachable only by a key
+            // equivalent and a glyph. See `SearchPanelModel.presentIfRequested`.
+            .task { presentSearchPanelIfRequested() }
             // Send Feedback and Submit a Prompt, raised from the Help menu. Here rather than at the
             // menu item, because a `Commands` body is not a view and cannot present anything, and
             // because what was typed into either of them belongs to the app rather than to the sheet:
@@ -304,13 +307,18 @@ struct RootView: View {
                 // explanation. See `AppModel.open(workspaceID:)`.
                 Task { await app.open(workspaceID: id) }
             }
-            // Shift+Cmd+F, and Cmd+F where nothing in front can find. A `Commands` body is not a view
-            // and cannot reach a `@FocusState`, so the menu item posts and this listens.
-            //
-            // The centre pane goes to Home with it. The field is in the toolbar, so it is on screen
-            // while a workspace is open, and a search whose answer is drawn in a pane nobody is
-            // looking at would be a field that does nothing.
+            // Shift+Cmd+F, and Cmd+F where nothing in front can find, are handled in
+            // `windowWiring` below, and they open the panel rather than putting a keyboard
+            // anywhere in the window.
         )
+    }
+
+    /// Debug builds only. In a method of its own so `body` carries one call rather than a
+    /// conditional compilation block, which the type checker in there can do without.
+    private func presentSearchPanelIfRequested() {
+        #if DEBUG
+        SearchPanelModel.shared.presentIfRequested(app: app)
+        #endif
     }
 
     /// The window's notification wiring, in a method rather than in `body`.

--- a/Sources/Bloom/Views/RootView.swift
+++ b/Sources/Bloom/Views/RootView.swift
@@ -27,9 +27,6 @@ struct RootView: View {
 
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
     @State private var isStartingFreshAskConversation = false
-    /// Whether the window's search field has the keyboard. Shift+Cmd+F, and Cmd+F where nothing in
-    /// front can find, put it here. See `FindCommand`.
-    @FocusState private var isSearchFocused: Bool
 
     var body: some View {
         @Bindable var app = app
@@ -98,43 +95,22 @@ struct RootView: View {
                     // title item is not a thing reading the interface settles. The window came up
                     // wearing its name twice once already. Both, until a picture says which one did it.
                     .toolbar(removing: .title)
-                    // The window's search field, on the trailing edge of the toolbar, which is where
-                    // Finder and Mail publish search on this platform.
+                    // **There is no `.searchable` here any more, and the reason is a defect rather
+                    // than a matter of taste.** The window carried an `NSSearchToolbarItem`, 206
+                    // points of the system's glass with the system's drop shadow, packed against
+                    // the toolbar's trailing end by a flexible spacer and sharing an edge with
+                    // nothing. That was survivable. What was not is that typing one character into
+                    // it set the selection to Home: a search that takes the page away from you is
+                    // a search people stop using, and getting back meant clearing the field and
+                    // clicking the workspace again.
                     //
-                    // Which edge it lands on is not this modifier's to say. `SearchFieldPlacement` on
-                    // macOS offers `automatic`, `toolbar`, `toolbarPrincipal` and `sidebar`, and none
-                    // of them names an edge: the item is appended after the toolbar's own items and
-                    // goes wherever the packing leaves it. What puts it at the end is the
-                    // `ToolbarSpacer` in `BloomWindowToolbar`, and without that it sits against the
-                    // window's name a third of the way across.
-                    //
-                    // `.searchable` rather than the hand built field this replaced, and that is the
-                    // whole reason it moved. An `NSSearchToolbarItem` is compact at rest, expands over
-                    // the toolbar when it is focused, draws the system's glass and the system's focus
-                    // ring, and answers Escape, none of which a `TextField` in a `RoundedRectangle`
-                    // with a hand drawn stroke ever quite did.
-                    //
-                    // `HomeBar` used to argue against exactly this, on the grounds that a field in the
-                    // toolbar would look like it searched the transcript and the inspector too. That
-                    // was right while the field was a filter for one list. It searches every workspace
-                    // on the Mac and the full text of every transcript now, so the objection became
-                    // the case for it: this belongs to the window rather than to a column. Finding a
-                    // word in what you are reading is still Cmd+F and still the pane's own, which is
-                    // Xcode's split. See `FindCommand`.
-                    .searchable(
-                        text: $app.homeFilter.query,
-                        placement: .toolbar,
-                        prompt: Text("Search")
-                    )
-                    .searchFocused($isSearchFocused)
+                    // The same search is a panel now, opened on Cmd+K and from the magnifying
+                    // glass in the title bar, and it moves nothing: no selection, no scroll, no
+                    // column. Nothing it could reach was taken away with the field, which is the
+                    // whole point of relocating it rather than replacing it. See `SearchPanelView`
+                    // for the card and `SearchToolbarButton` for the glyph.
                     .onChange(of: app.selectedWorkspace != nil, initial: true) { _, available in
                         InspectorGeometry.shared.setWorkspaceAvailable(available)
-                    }
-                    // Published to the model, because the pane that needs the answer cannot see a
-                    // `@FocusState` declared up here and Home's list was taking the keyboard off this
-                    // field mid word. See `HomeListKeyboard` for the sequence that did it.
-                    .onChange(of: isSearchFocused) { _, focused in
-                        app.isSearchFieldFocused = focused
                     }
             }
             // As well as heading the toolbar (see BloomApp), the title names the window in the
@@ -349,22 +325,28 @@ struct RootView: View {
     /// `@State` and `@FocusState`, and a modifier is a separate type that can see neither.
     private func windowWiring(_ content: some View) -> some View {
         content
-        .onReceive(NotificationCenter.default.publisher(for: .bloomFocusSearch)) { _ in
-            app.selection = .home
-            isSearchFocused = true
-        }
-        // Typing into the field is the same act as pressing the key that focuses it, so it lands
-        // in the same place. Only on the way IN: clearing the field must not navigate anywhere,
-        // because clearing it is how somebody gets back to the list they were reading.
+        // The search panel, over the whole window rather than over one column: it reaches every
+        // workspace on the Mac and the full text of every transcript, so it belongs to the window.
+        .searchPanel(app: app)
+        // Shift+Cmd+F, and Cmd+F wherever nothing in front can find. Both have always meant "the
+        // whole search", and both open the panel on the Transcripts chip, because what neither of
+        // them can be is find-in-place: that is the pane's own and stays there.
         //
-        // The scope settles here too, because this is where the two sets of chips cross. See
-        // `HomeScope.settle`.
+        // **Nothing here navigates any more.** This used to set the selection to Home and put the
+        // keyboard in the toolbar's field, which is what took the reader off the conversation they
+        // were in. The panel opens over the window and closes leaving it exactly where it was.
+        .onReceive(NotificationCenter.default.publisher(for: .bloomFocusSearch)) { _ in
+            SearchPanelModel.shared.open(scope: .transcripts, app: app)
+        }
+        // The scope settles when Home's own query moves, because that is where the two sets of
+        // chips cross. See `HomeScope.settle`. It no longer navigates: the only thing that writes
+        // this query now is the panel's "search Home for this" row, which is already on its way to
+        // Home, and clearing it is how somebody gets back to the list they were reading.
         .onChange(of: app.homeFilter.query) { old, new in
             let was = !WorkspaceSearch.needle(old).isEmpty
             let now = !WorkspaceSearch.needle(new).isEmpty
             guard was != now else { return }
             app.homeFilter.scope = HomeScope.settle(app.homeFilter.scope, searching: now)
-            if now { app.selection = .home }
         }
         .onReceive(NotificationCenter.default.publisher(for: .bloomToggleSidebar)) { _ in
             toggleSidebar()
@@ -482,9 +464,12 @@ extension Notification.Name {
     // its own name private so nothing can post an id down it untyped. These two carry no id and
     // are only ever posted by views, so they live here.
     static let bloomToggleSidebar = Notification.Name("bloom.toggleSidebar")
-    /// Puts the keyboard in the window's search field. Posted by the Edit menu's Search item and
-    /// by Cmd+F falling through, neither of which can reach a `@FocusState` from a `Commands`
-    /// body.
+    /// Opens the search panel on the Transcripts chip. Posted by the Edit menu's Search item and
+    /// by Cmd+F falling through, both of which mean "the whole search" rather than find-in-place.
+    ///
+    /// The name is older than the panel and is kept rather than churned: it is the same door, and
+    /// what it used to open was a field in the toolbar. It no longer puts a keyboard anywhere in
+    /// the window, which is the defect the panel exists to fix.
     static let bloomFocusSearch = Notification.Name("bloom.focusSearch")
     /// Asks for the create window. Still a notification rather than an `openWindow` at each of
     /// the four controls that can ask, because which project is meant depends on what this window

--- a/Sources/BloomCore/Presentation/FindCommand.swift
+++ b/Sources/BloomCore/Presentation/FindCommand.swift
@@ -16,15 +16,16 @@ import Foundation
 /// somebody who wants it from inside a terminal has a key that always means it.
 ///
 /// **The one thing that changed when the Search screen went.** The fall through lands in the
-/// window's own search field rather than on a sidebar destination. Nothing about either key
-/// moved: this enum already said "the pane in front, or the workspace search", and the workspace
-/// search is now a field in the toolbar and a state of Home rather than a screen beside it.
+/// window's own search rather than on a sidebar destination. Nothing about either key has moved
+/// since: this enum has always said "the pane in front, or the workspace search", and the
+/// workspace search has been a screen, then a field in the toolbar, and is a panel over the window
+/// now. Which of those it is is the app target's business; the rule is the same one either way.
 public enum FindCommand {
     public enum Target: Equatable, Sendable {
         /// The pane in front answers, through its own find bar.
         case findInPlace
-        /// The window's search field, which searches names, branches, projects and the full text
-        /// of every transcript on the machine.
+        /// The window's search, which reaches names, branches, projects and the full text of every
+        /// transcript on the machine. See `SearchPanelResults`.
         case workspaceSearch
     }
 

--- a/Sources/BloomCore/Presentation/MenuBarCatalogue.swift
+++ b/Sources/BloomCore/Presentation/MenuBarCatalogue.swift
@@ -94,6 +94,16 @@ public enum MenuBarCatalogue {
         MenuBarItem(.find, in: .edit, "Find…", key: .command("f")),
         MenuBarItem(.findNext, in: .edit, "Find Next", key: .command("g")),
         MenuBarItem(.findPrevious, in: .edit, "Find Previous", key: .init("g", .command, .shift)),
+        // The panel, on the one Command key no Mac app has spent on anything else. Directly above
+        // Search because the two open the same card: this one on the resting list, Search with the
+        // Transcripts chip already chosen. See `SearchPanelMode`.
+        //
+        // **A terminal pane keeps Cmd+K, and that is deliberate rather than a gap.**
+        // `TerminalView.performKeyEquivalent` claims it to clear the scrollback, and AppKit offers
+        // a key equivalent to the key window's view tree before the main menu, so a shell with the
+        // keyboard answers it exactly as iTerm and Terminal do. Somebody inside a shell reaches
+        // the panel with Shift+Cmd+F, which already means the whole search and always has.
+        MenuBarItem(.quickSearch, in: .edit, "Quick Search…", key: .command("k")),
         MenuBarItem(.search, in: .edit, "Search", key: .init("f", .command, .shift), availability: .needsProject),
 
         // MARK: View
@@ -220,6 +230,7 @@ public enum MenuBarAction: String, CaseIterable, Sendable {
     case find
     case findNext
     case findPrevious
+    case quickSearch
     case search
 
     case splitRight

--- a/Sources/BloomCore/Presentation/MenuShortcutText.swift
+++ b/Sources/BloomCore/Presentation/MenuShortcutText.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// A key equivalent written the way the menu bar writes it, for a surface that has to print one
+/// itself.
+///
+/// The menu bar never needs this: `keyboardShortcut` hands `MenuShortcut` to AppKit and AppKit
+/// draws the glyphs. The search panel does, because it prints the key beside every command row so
+/// the reader learns the shortcut for next time. That is Superhuman's argument, taken with
+/// Linear's correction: a palette teaches only the shortcuts somebody already went looking for,
+/// which is why the menus keep theirs.
+///
+/// It is here rather than beside the panel because it is a spelling of the same table
+/// `MenuBarCatalogue` holds, and a second spelling of a shortcut is how one surface ends up
+/// teaching a key the bar does not have.
+extension MenuShortcut {
+    /// The modifiers in the order macOS draws them, then the key.
+    ///
+    /// Control, Option, Shift, Command, which is the order in every menu on the platform and is
+    /// not the order the `OptionSet` happens to be declared in.
+    public var display: String {
+        var text = ""
+        if modifiers.contains(.control) { text += "\u{2303}" }
+        if modifiers.contains(.option) { text += "\u{2325}" }
+        if modifiers.contains(.shift) { text += "\u{21E7}" }
+        if modifiers.contains(.command) { text += "\u{2318}" }
+        return text + Self.glyph(for: trigger)
+    }
+
+    /// The key itself. The five that are not characters get the glyph a menu draws for them, and a
+    /// letter is drawn in upper case, which is what a menu does whether or not Shift is in the
+    /// combination.
+    static func glyph(for trigger: Trigger) -> String {
+        switch trigger {
+        case .character(let character): String(character).uppercased()
+        case .upArrow: "\u{2191}"
+        case .downArrow: "\u{2193}"
+        case .leftArrow: "\u{2190}"
+        case .rightArrow: "\u{2192}"
+        // Backspace, which is what Archive Workspace takes. The forward delete glyph is a
+        // different character and would be a different key.
+        case .delete: "\u{232B}"
+        case .return: "\u{21A9}"
+        case .comma: ","
+        }
+    }
+}
+
+extension MenuBarItem {
+    /// What the panel prints on this row's trailing edge, which is the key or the words "no key".
+    ///
+    /// A blank slot would say nothing about which of the two a row is, and nineteen items in the
+    /// bar carry no shortcut at all. See `SearchPanelCommands.noKey`.
+    public var keyText: String { key?.display ?? SearchPanelCommands.noKey }
+}

--- a/Sources/BloomCore/Presentation/SearchPanelActions.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelActions.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// The list Cmd+Return pushes into: one workspace's own menu, which is the menu the sidebar, Home
+/// and the menu bar already offer on that row.
+///
+/// **Nothing new, and nothing that has to be listed at the top level.** Raycast opens an action
+/// menu inside a result and Linear drills into sub lists; here the sub list already exists as
+/// `WorkspaceMenuAction`, gated by `WorkspaceMenuSubject.allows`, so an archived workspace is
+/// offered exactly what Home's menu offers it and the two cannot drift.
+///
+/// **Two of the Workspace menu's items are deliberately not reachable from here.** Colour is a
+/// submenu of ten swatches rather than an action, so a row that ran it would have nothing to run;
+/// and Merge is not a `WorkspaceMenuAction` at all, because landing a branch is published by the
+/// pull request band for the workspace on screen and cannot be aimed at an arbitrary row. Both are
+/// still in the Workspace menu and both are still reachable through `>`.
+public enum SearchPanelActions {
+    /// The rows for one workspace, in the order the row's own menu draws them.
+    ///
+    /// The order is `WorkspaceMenuItems`': what the checkout is, then what the row is, then the
+    /// one that destroys it. Restore takes Archive's place on a workspace that has already been
+    /// archived, which is what Home's shorter menu does.
+    public static let order: [WorkspaceMenuAction] = [
+        .openInEditor,
+        .revealInFinder,
+        .copyName,
+        .copyBranchName,
+        .pin,
+        .unreadMark,
+        .rename,
+        .restore,
+        .archive,
+    ]
+
+    /// What can be pressed against this workspace, as menu bar items so every row prints the same
+    /// title and the same key the menu bar prints.
+    public static func rows(for subject: WorkspaceMenuSubject) -> [SearchPanelCommandHit] {
+        order
+            .filter { subject.allows($0) }
+            .map { SearchPanelCommandHit(item: MenuBarCatalogue[menuBarAction(for: $0)]) }
+    }
+
+    /// One section, headed by nothing: the pill in the field already names what is being acted on,
+    /// and a heading repeating it would be the same words twice on one card.
+    public static func sections(for subject: WorkspaceMenuSubject) -> [SearchPanelSection] {
+        let rows = rows(for: subject)
+        guard !rows.isEmpty else { return [] }
+        return [SearchPanelSection(id: "actions", title: nil, rows: rows.map { .command($0) })]
+    }
+
+    /// The row in the table each of these items is, so the panel and the menu bar cannot word one
+    /// action two ways or print two different keys for it.
+    ///
+    /// Switched over the whole enum rather than through a dictionary, so an item added to
+    /// `WorkspaceMenuAction` has to be given a row here or the build fails.
+    public static func menuBarAction(for action: WorkspaceMenuAction) -> MenuBarAction {
+        switch action {
+        case .archive: .archive
+        case .restore: .restore
+        case .openInEditor: .openInEditor
+        case .revealInFinder: .revealInFinder
+        case .copyBranchName: .copyBranchName
+        case .rename: .renameWorkspace
+        case .pin: .pin
+        case .unreadMark: .unreadMark
+        case .colour: .colour
+        case .copyName: .copyName
+        }
+    }
+
+    /// The other direction, for the app target's one switch that performs a row.
+    public static func workspaceAction(for action: MenuBarAction) -> WorkspaceMenuAction? {
+        WorkspaceMenuAction.allCases.first { menuBarAction(for: $0) == action }
+    }
+}

--- a/Sources/BloomCore/Presentation/SearchPanelCommands.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelCommands.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// The command half of the panel: `MenuBarCatalogue` ranked against what was typed and grouped by
+/// the menu each item lives in.
+///
+/// **A table read rather than a list written.** Every command in the panel is already in a menu,
+/// with its title, its key and its menu named in one place, so there is nothing here to keep in
+/// step with the menu bar and no way to add a command that only the panel has. That is the rule
+/// the whole feature rests on: the panel is a faster route, never the only one.
+///
+/// **Grouped by menu, because the palette should teach where a thing is rather than replace the
+/// place it is.** A flat ranked list would be quicker to write and would leave the reader no
+/// better at finding the item again with the pointer.
+///
+/// There are no aliases here, so "delete" does not find Archive Workspace. That is worth having
+/// and it is a content exercise over fifty-eight items rather than a change to this file, so it is
+/// deliberately left out rather than half done. `FuzzyMatch` over the titles is what there is.
+public enum SearchPanelCommands {
+    /// How many command rows a search of things is allowed to show before the reader is asked to
+    /// type `>`.
+    ///
+    /// The panel's first question is "which workspace was it", and a menu bar that could take the
+    /// whole list would answer a question nobody asked. Four is a hint that the commands are there
+    /// and a nudge towards the prefix that shows all of them.
+    public static let inlineLimit = 4
+
+    /// Below this a search of things shows no commands at all. One letter matches most of the menu
+    /// bar, and a list of fifty-eight items under two workspaces is not a hint.
+    public static let inlineMinimumQueryLength = 2
+
+    /// Every item that matched, best first.
+    ///
+    /// An empty query answers with the whole catalogue in table order, which is what the command
+    /// mode shows the moment `>` is typed: the menus, in the order the bar draws them.
+    public static func rank(_ query: String, in commands: [MenuBarItem] = MenuBarCatalogue.commands) -> [SearchPanelCommandHit] {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else {
+            return commands.map { SearchPanelCommandHit(item: $0) }
+        }
+        return commands
+            .compactMap { item in
+                guard let hit = FuzzyMatch.hit(item.title, query: trimmed) else { return nil }
+                return SearchPanelCommandHit(item: item, highlights: hit.positions, score: hit.score)
+            }
+            // Stably, so two items on the same score keep the order the menu bar draws them in
+            // rather than swapping about between keystrokes.
+            .enumerated()
+            .sorted { left, right in
+                left.element.score == right.element.score
+                    ? left.offset < right.offset
+                    : left.element.score > right.element.score
+            }
+            .map(\.element)
+    }
+
+    /// The ranked hits, cut into one section per menu, in the order the menu bar draws the menus.
+    ///
+    /// Within a menu the rows keep the ranked order rather than the table's, because a section
+    /// that reordered itself back to the menu's own order would put the best match under two worse
+    /// ones and the reader would have to read all three.
+    public static func sections(_ hits: [SearchPanelCommandHit]) -> [SearchPanelSection] {
+        MenuBarMenu.allCases.compactMap { menu in
+            let rows = hits.filter { $0.item.menu == menu }
+            guard !rows.isEmpty else { return nil }
+            return SearchPanelSection(
+                id: "menu-\(menu.rawValue)",
+                title: title(of: menu),
+                rows: rows.map { SearchPanelRow.command($0) }
+            )
+        }
+    }
+
+    /// What the menu is called at the top of the screen, which is what the heading has to say for
+    /// the row under it to teach anything.
+    public static func title(of menu: MenuBarMenu) -> String {
+        switch menu {
+        case .bloom: "Bloom"
+        case .file: "File"
+        case .edit: "Edit"
+        case .view: "View"
+        case .workspace: "Workspace"
+        case .help: "Help"
+        }
+    }
+
+    /// What a row prints on its trailing edge.
+    ///
+    /// **"no key" is printed rather than left blank.** Nineteen items in the bar carry no shortcut
+    /// at all, and a blank slot says nothing about which of the two a row is. Superhuman prints the
+    /// key beside every command and says out loud that the palette exists to teach you out of
+    /// itself; this is the half of that which is honest about the items it cannot teach.
+    public static let noKey = "no key"
+}

--- a/Sources/BloomCore/Presentation/SearchPanelFallback.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelFallback.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// The rows under a search that matched nothing.
+///
+/// **Two, and no more.** Raycast puts configurable fallback commands under an empty result and
+/// hands them the text that matched nothing, so "ask this as a question" is a real ending for any
+/// string. That is worth taking sparingly: somebody who searched for a workspace that does not
+/// exist has just told you what to call it, which is the same argument the quick prompt panel
+/// already makes for its "new quick prompt" row. A third row would be a menu.
+///
+/// Both are already in a menu, which is the rule the whole panel keeps: New Workspace is Cmd+N in
+/// File and Search is Shift+Cmd+F in Edit. Nothing here is reachable only from the panel.
+public enum SearchPanelFallback: Equatable, Sendable, Identifiable {
+    /// Start a workspace named after what was typed.
+    case startWorkspace(String)
+    /// Hand the query to Home, which is where a long browse goes.
+    case searchHome(String)
+
+    public var id: String {
+        switch self {
+        case .startWorkspace: "start-workspace"
+        case .searchHome: "search-home"
+        }
+    }
+
+    public var query: String {
+        switch self {
+        case .startWorkspace(let query), .searchHome(let query): query
+        }
+    }
+
+    public var title: String {
+        switch self {
+        case .startWorkspace(let query): "Start a workspace called \(query)"
+        case .searchHome(let query): "Search Home for \(query)"
+        }
+    }
+
+    /// The item in the menu bar this row is a shortcut to, so the row can print the same key that
+    /// menu prints and cannot drift from it.
+    public var action: MenuBarAction {
+        switch self {
+        case .startWorkspace: .newWorkspace
+        case .searchHome: .search
+        }
+    }
+
+    /// The two rows, in the order they are drawn.
+    ///
+    /// - Parameter hasProjects: whether a workspace can be started at all. With no project added
+    ///   there is nothing to cut a worktree from, so the row would be a promise the app cannot
+    ///   keep.
+    public static func rows(for query: String, hasProjects: Bool) -> [SearchPanelFallback] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        return (hasProjects ? [.startWorkspace(trimmed)] : []) + [.searchHome(trimmed)]
+    }
+
+    /// The sentence under the empty state, or nothing.
+    ///
+    /// **Only while the backfill is actually running.** The transcript index is built after launch,
+    /// and until it finishes a "nothing matched" about work the user knows they did can be wrong.
+    /// At any other time the same sentence would be an excuse rather than a fact, which is why it
+    /// is keyed on the flag rather than printed always.
+    public static func indexNotice(isIndexing: Bool) -> String? {
+        isIndexing
+            ? "The transcript index is still building, so older conversations are not searchable yet."
+            : nil
+    }
+
+    /// The line above the two rows.
+    public static func summary(for query: String) -> String {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        return "No workspace, transcript or command matches \(trimmed)."
+    }
+}

--- a/Sources/BloomCore/Presentation/SearchPanelField.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelField.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// The field at the head of the panel: what has been typed, which mode that put the panel in, and
+/// what typing had been done before a mode was entered.
+///
+/// It is a value rather than three properties on the view because the three move together and
+/// getting them out of step is the whole class of bug here: a `>` left in the text as well as in
+/// the pill searches for a workspace called "> merge", and a mode left behind by an empty field
+/// searches the menu bar for a workspace name.
+///
+/// **`>` counts only as the first character.** Anywhere else it is a character like any other,
+/// because a branch called `feature>thing` is a thing somebody can have and a search that refused
+/// to look for it would be a search with a secret.
+///
+/// **Leaving a mode puts the earlier query back.** Pushing into a workspace's own menu from a
+/// search for `docs` and then backing out to an empty field would make Backspace a way of losing
+/// what you typed, and the panel is a place people back out of constantly.
+public struct SearchPanelField: Equatable, Sendable {
+    public private(set) var mode: SearchPanelMode = .things
+    public private(set) var text: String = ""
+    /// What was in the field before a mode was entered, restored when the mode is left.
+    private var stashed = ""
+
+    public init() {}
+
+    /// The character that switches to commands, as the first thing typed.
+    public static let commandPrefix: Character = ">"
+
+    /// What the field says after somebody has typed into it.
+    ///
+    /// The prefix is read only while the panel is searching things, so a command called
+    /// "> something" cannot put an already-open command list into itself.
+    public mutating func type(_ typed: String) {
+        guard mode == .things, let first = typed.first, first == Self.commandPrefix else {
+            text = typed
+            return
+        }
+        stashed = ""
+        mode = .commands
+        // The one space after the prefix goes with it, so `> merge` and `>merge` are the same
+        // query rather than two, the second of which matches nothing.
+        var rest = String(typed.dropFirst())
+        if rest.first == " " { rest.removeFirst() }
+        text = rest
+    }
+
+    /// Pushes into one workspace's own menu. False when the panel is already in a mode, because a
+    /// list of actions has no rows to push into and a command has no workspace of its own.
+    public mutating func enterActions(on workspaceID: WorkspaceID) -> Bool {
+        guard mode == .things else { return false }
+        stashed = text
+        mode = .actions(workspaceID)
+        text = ""
+        return true
+    }
+
+    /// Backspace with nothing in the field. False when there is no mode to leave, which hands the
+    /// key back so it can do what Backspace does everywhere else.
+    public mutating func leaveMode() -> Bool {
+        guard mode != .things else { return false }
+        mode = .things
+        text = stashed
+        stashed = ""
+        return true
+    }
+
+    /// Escape's first press, and the Clear button on the field.
+    public mutating func clear() {
+        text = ""
+    }
+
+    public var isEmpty: Bool { text.isEmpty }
+
+    /// What the transcript half and the name half are actually asked, which is the text with the
+    /// prefix already taken off it by `type`.
+    public var query: String { text }
+}

--- a/Sources/BloomCore/Presentation/SearchPanelKeys.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelKeys.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+/// A key press the panel has to answer, once the event has been read.
+///
+/// Reading an `NSEvent` is the only part that has to happen in the app target. What each key means
+/// is a rule, and a rule taken inside a view is a rule nothing can test.
+public enum SearchPanelKey: Equatable, Sendable {
+    case up
+    case down
+    /// Next scope chip.
+    case tab
+    /// Previous scope chip.
+    case backTab
+    case returnKey
+    /// Cmd+Return, which pushes into the highlighted row's own menu.
+    case commandReturn
+    /// The right arrow, which means the same as Cmd+Return but only from the end of the field.
+    case right
+    case escape
+    /// Backspace with nothing in the field.
+    case backspaceOnEmpty
+}
+
+/// What a key press turns out to mean.
+///
+/// `handled` and `ignored` are not the same answer, for the reason `ListKeyOutcome` gives: a key
+/// the panel ignored goes back to the field editor, where it still moves the caret or types a
+/// character, and a key the panel handled and had nothing to do with is finished.
+public enum SearchPanelOutcome: Equatable, Sendable {
+    case move(Int)
+    /// Open the highlighted row: a workspace, a transcript hit at its own line, or a fallback.
+    case open
+    /// Push into the highlighted row's own menu.
+    case drill
+    case scope(HomeScope)
+    /// Backspace out of commands, or out of an action list, back to searching things.
+    case leaveMode
+    /// Escape's first press with something in the field.
+    case clearQuery
+    case close
+    case handled
+    case ignored
+}
+
+/// Everything a key handler needs to know about the panel, as a value, so the whole keyboard can
+/// be asserted without a window.
+public struct SearchPanelKeyContext: Equatable, Sendable {
+    public var mode: SearchPanelMode
+    public var rowCount: Int
+    public var highlighted: Int?
+    public var isQueryEmpty: Bool
+    public var scope: HomeScope
+    /// The chips on offer, which is `HomeScope.offered(searching:)`. Handed in rather than derived
+    /// so the panel and the strip cannot be offered two different sets.
+    public var scopes: [HomeScope]
+    /// Whether the highlighted row has a menu of its own. See `SearchPanelRow.drillable`.
+    public var canDrill: Bool
+    /// Whether the caret is at the end of the field, which is what makes the right arrow mean
+    /// "push in" rather than "move the caret one character".
+    public var caretAtEnd: Bool
+
+    public init(
+        mode: SearchPanelMode = .things,
+        rowCount: Int = 0,
+        highlighted: Int? = nil,
+        isQueryEmpty: Bool = true,
+        scope: HomeScope = .all,
+        scopes: [HomeScope] = HomeScope.offered(searching: true),
+        canDrill: Bool = false,
+        caretAtEnd: Bool = true
+    ) {
+        self.mode = mode
+        self.rowCount = rowCount
+        self.highlighted = highlighted
+        self.isQueryEmpty = isQueryEmpty
+        self.scope = scope
+        self.scopes = scopes
+        self.canDrill = canDrill
+        self.caretAtEnd = caretAtEnd
+    }
+}
+
+/// The panel's whole keyboard.
+///
+/// **The arrows stop at both ends rather than wrapping**, which is `ListNavigation`'s rule and the
+/// platform's: Down on the last row of a table stays on the last row. `MenuRows` wraps and is not
+/// what this is, because this list is three sections of results a person is reading down rather
+/// than a menu of six items they are cycling.
+///
+/// **Escape clears before it closes.** Somebody who typed a query and wants a different one should
+/// not have to reopen the panel to get an empty field, and somebody who wants out presses it
+/// twice. Every editor on the platform does the first half of this.
+public enum SearchPanelKeys {
+    public static func outcome(
+        for key: SearchPanelKey, in context: SearchPanelKeyContext
+    ) -> SearchPanelOutcome {
+        switch key {
+        case .up, .down:
+            guard let index = ListNavigation.destination(
+                for: key == .down ? .down : .up,
+                from: context.highlighted,
+                count: context.rowCount
+            ) else {
+                // Nothing to move to, and the key is still the panel's: an arrow handed back would
+                // scroll whatever is behind the card.
+                return .handled
+            }
+            return index == context.highlighted ? .handled : .move(index)
+
+        case .tab, .backTab:
+            // The chips split an answer about workspaces and transcripts. Commands and an action
+            // list have no such answer, so Tab goes back to the field editor and moves the focus
+            // the way it does everywhere else.
+            guard context.mode.showsScopes, !context.scopes.isEmpty else { return .ignored }
+            let step = key == .tab ? 1 : -1
+            let current = context.scopes.firstIndex(of: context.scope) ?? 0
+            // Wrapped, unlike the arrows, because a row of four chips is a cycle rather than a
+            // list being read: Tab off the end of it has nowhere else to go.
+            let next = (current + step + context.scopes.count) % context.scopes.count
+            return .scope(context.scopes[next])
+
+        case .returnKey:
+            return context.highlighted == nil ? .handled : .open
+
+        case .commandReturn:
+            return context.canDrill ? .drill : .handled
+
+        case .right:
+            // Only from the end of the field. Mid word the right arrow is the caret's, and a
+            // panel that took it would make the field unusable for correcting a typo.
+            guard context.caretAtEnd else { return .ignored }
+            return context.canDrill ? .drill : .ignored
+
+        case .escape:
+            return context.isQueryEmpty ? .close : .clearQuery
+
+        case .backspaceOnEmpty:
+            return context.mode == .things ? .ignored : .leaveMode
+        }
+    }
+
+    /// The keys printed in the footer, which change with the mode because the two that matter
+    /// most do.
+    public static func footer(
+        for mode: SearchPanelMode, isSearching: Bool
+    ) -> [SearchPanelFooterKey] {
+        switch mode {
+        case .things:
+            var keys = [
+                SearchPanelFooterKey(key: "\u{21A9}", label: "Open"),
+                SearchPanelFooterKey(key: "\u{2318}\u{21A9}", label: "Actions"),
+            ]
+            // The prefix is advertised at rest and the chips are advertised in a search, because
+            // at rest there are no chips and in a search the reader has already found the field.
+            keys.append(
+                isSearching
+                    ? SearchPanelFooterKey(key: "\u{21E5}", label: "Scope")
+                    : SearchPanelFooterKey(key: ">", label: "Commands")
+            )
+            keys.append(SearchPanelFooterKey(key: "esc", label: "Close"))
+            return keys
+        case .commands:
+            return [
+                SearchPanelFooterKey(key: "\u{21A9}", label: "Run"),
+                SearchPanelFooterKey(key: "\u{232B}", label: "Leave commands"),
+                SearchPanelFooterKey(key: "esc", label: "Close"),
+            ]
+        case .actions:
+            return [
+                SearchPanelFooterKey(key: "\u{21A9}", label: "Run"),
+                SearchPanelFooterKey(key: "\u{232B}", label: "Back"),
+                SearchPanelFooterKey(key: "esc", label: "Close"),
+            ]
+        }
+    }
+}
+
+/// One pair in the footer: the glyph, and what pressing it does.
+public struct SearchPanelFooterKey: Equatable, Sendable, Identifiable {
+    public var key: String
+    public var label: String
+
+    public var id: String { label }
+
+    public init(key: String, label: String) {
+        self.key = key
+        self.label = label
+    }
+}

--- a/Sources/BloomCore/Presentation/SearchPanelListing.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelListing.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// A run of rows under one heading.
+///
+/// **Headings stay in the scroll rather than sticking.** A sticky header inside a list three
+/// hundred points tall eats one of the four rows you can see, and the panel's whole argument is
+/// that the answer is on screen before you have finished typing.
+public struct SearchPanelSection: Equatable, Sendable, Identifiable {
+    public var id: String
+    /// Nil for a section that needs no heading, which is the action list: the pill in the field
+    /// already names what is being acted on.
+    public var title: String?
+    public var rows: [SearchPanelRow]
+
+    public init(id: String, title: String?, rows: [SearchPanelRow]) {
+        self.id = id
+        self.title = title
+        self.rows = rows
+    }
+}
+
+/// Everything the panel is showing, in one value.
+///
+/// `rows` is the same rows as `sections` flattened, and it is held rather than derived at every
+/// keystroke because it is what the arrow keys walk: the highlight is an index into this, so a
+/// listing that recomputed it and a key handler that recomputed it differently would be two lists
+/// disagreeing about which row Return opens. See `SearchPanelKeys`.
+public struct SearchPanelListing: Equatable, Sendable {
+    public var sections: [SearchPanelSection]
+    /// Drawn order, headings taken out. The arrows walk this, so they skip the headings for free.
+    public var rows: [SearchPanelRow]
+    /// What each chip says, worked out in the same pass. Home's own counts, so the two surfaces
+    /// cannot disagree about how much archived work there is.
+    public var counts: HomeScopeCounts
+    /// Whether there is a query behind this listing, which is what decides the chips on offer and
+    /// whether the fallback rows can appear at all.
+    public var isSearching: Bool
+
+    public init(
+        sections: [SearchPanelSection],
+        counts: HomeScopeCounts = HomeScopeCounts(),
+        isSearching: Bool = false
+    ) {
+        self.sections = sections
+        self.rows = sections.flatMap(\.rows)
+        self.counts = counts
+        self.isSearching = isSearching
+    }
+
+    public static let empty = SearchPanelListing(sections: [])
+
+    public var isEmpty: Bool { rows.isEmpty }
+
+    /// The row at an index the highlight is holding, or nothing when the list has moved under it.
+    public func row(at index: Int?) -> SearchPanelRow? {
+        guard let index, rows.indices.contains(index) else { return nil }
+        return rows[index]
+    }
+
+    /// The count in the footer, on the right, where it does not compete with the keys.
+    public var summary: String {
+        let count = rows.count
+        return count == 1 ? "1 result" : "\(count) results"
+    }
+}

--- a/Sources/BloomCore/Presentation/SearchPanelListing.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelListing.swift
@@ -35,16 +35,25 @@ public struct SearchPanelListing: Equatable, Sendable {
     /// Whether there is a query behind this listing, which is what decides the chips on offer and
     /// whether the fallback rows can appear at all.
     public var isSearching: Bool
+    /// The sentence over the fallback rows, and nil whenever something matched.
+    ///
+    /// It is here rather than derived in the view from `rows.isEmpty`, because by the time the
+    /// fallbacks are in the list the list is not empty: the two rows ARE rows, arrowable and
+    /// openable like any other. Only the builder knows that nothing matched, so only the builder
+    /// can say so.
+    public var summaryLine: String?
 
     public init(
         sections: [SearchPanelSection],
         counts: HomeScopeCounts = HomeScopeCounts(),
-        isSearching: Bool = false
+        isSearching: Bool = false,
+        summaryLine: String? = nil
     ) {
         self.sections = sections
         self.rows = sections.flatMap(\.rows)
         self.counts = counts
         self.isSearching = isSearching
+        self.summaryLine = summaryLine
     }
 
     public static let empty = SearchPanelListing(sections: [])

--- a/Sources/BloomCore/Presentation/SearchPanelMode.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelMode.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Which of the three things the panel is searching, and how a person gets between them.
+///
+/// **One prefix, and no sigil zoo.** VS Code has `>`, `@`, `#`, `:` and `?` plus word prefixes,
+/// and almost nobody gets past the first. Here `@` and `/` already mean a file mention and a slash
+/// command in the composer, and teaching a second meaning for either is how a keystroke stops
+/// being reflexive. So there is exactly one prefix, `>`, and everything else that would have been
+/// a sigil is a scope chip: Home already draws those, already names them and already tests them.
+///
+/// A mode is entered by typing and left with Backspace on an empty field, which is GitHub's scope
+/// model rather than an invention: you narrow forwards and widen backwards, and the chip in the
+/// field is what tells you which of the two you are in.
+public enum SearchPanelMode: Equatable, Sendable {
+    /// Workspaces, transcripts and, quietly under them, the commands whose names match.
+    case things
+    /// The menu bar, grouped by the menu each item lives in.
+    case commands
+    /// One workspace's own menu, pushed into from its row. See `SearchPanelActions`.
+    case actions(WorkspaceID)
+
+    /// The word drawn in the pill at the head of the field. Nothing at rest, because a pill saying
+    /// "Everything" would be a label on the state you are in most of the time.
+    public var pill: String? {
+        switch self {
+        case .things: nil
+        case .commands: "Commands"
+        // The workspace's name is the app target's to look up, so the pill for an action list is
+        // completed there. This says only that there is one.
+        case .actions: "Action"
+        }
+    }
+
+    /// Whether the scope chips are drawn. They split an answer about workspaces and transcripts,
+    /// and neither of the other two modes has one to split.
+    public var showsScopes: Bool { self == .things }
+
+    public var workspaceID: WorkspaceID? {
+        if case .actions(let id) = self { return id }
+        return nil
+    }
+}

--- a/Sources/BloomCore/Presentation/SearchPanelResting.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelResting.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// What the panel shows before anything has been typed.
+///
+/// **It is not recents and it is not everything.** Slack's quick switcher shows only unread
+/// conversations, capped at twenty-four, having found that listing every channel was crushing on a
+/// large team. Bloom has a better version of that finding available to it: it knows not merely
+/// that something is unread but whether an agent has stopped to ask a question. Somebody running
+/// eight agents opens this panel already wanting to know which one wants them, so that is answered
+/// first, under a heading, and what they last had open comes second.
+///
+/// **It caps itself, which a full list does not.** The panel is three hundred points of list. A
+/// scrollable index of the machine put at the top of it would be a worse Home, reached by a key.
+public enum SearchPanelResting {
+    /// How many workspaces the first section can hold.
+    ///
+    /// Five, because a person with more than five agents wanting them has a problem the panel
+    /// cannot solve by listing it, and because the second section has to be visible without
+    /// scrolling for the panel to read as two answers rather than one long one.
+    public static let waitingCap = 5
+
+    /// How many of the recently open follow.
+    public static let recentCap = 5
+
+    /// The resting list, in drawn order.
+    ///
+    /// - Parameters:
+    ///   - workspaces: the live ones, which is what "waiting" and "what you last had open" are
+    ///     both about. An archived workspace is neither: it cannot be waiting on anybody and it is
+    ///     not open. It is still reachable by typing its name, which is the point of the search
+    ///     half.
+    ///   - repos: for the project name each row carries, because the panel is flat and a row is
+    ///     the only place its project can be said.
+    ///   - activity: which agents are running and which have stopped to ask. Handed in for the
+    ///     reason `HomeActivity` gives: it lives in the app's memory and moves without the row
+    ///     moving.
+    public static func build(
+        workspaces: [Workspace],
+        repos: [Repo],
+        activity: HomeActivity
+    ) -> SearchPanelListing {
+        var byID: [RepoID: Repo] = [:]
+        byID.reserveCapacity(repos.count)
+        for repo in repos { byID[repo.id] = repo }
+
+        // Most recent first in both sections, which is the order every other list of workspaces in
+        // the app is in. Sorted once and split, rather than sorted twice.
+        let recent = workspaces.sorted { $0.lastActivityAt > $1.lastActivityAt }
+
+        let waiting = recent
+            .compactMap { workspace -> SearchPanelWorkspaceHit? in
+                guard let reason = reason(for: workspace, activity: activity) else { return nil }
+                return SearchPanelWorkspaceHit(
+                    workspace: workspace, repo: byID[workspace.repoID], waiting: reason
+                )
+            }
+            .prefix(waitingCap)
+
+        let taken = Set(waiting.map(\.id))
+        let opened = recent
+            .filter { !taken.contains($0.id) }
+            .prefix(recentCap)
+            .map { SearchPanelWorkspaceHit(workspace: $0, repo: byID[$0.repoID]) }
+
+        var sections: [SearchPanelSection] = []
+        if !waiting.isEmpty {
+            sections.append(
+                SearchPanelSection(
+                    id: "waiting", title: "Waiting on you",
+                    rows: waiting.map { .workspace($0) }
+                )
+            )
+        }
+        if !opened.isEmpty {
+            sections.append(
+                SearchPanelSection(
+                    id: "recent", title: sections.isEmpty ? "Recent" : "Recently open",
+                    rows: opened.map { .workspace($0) }
+                )
+            )
+        }
+        return SearchPanelListing(sections: sections)
+    }
+
+    /// Which of the two kinds of waiting a workspace is in, or neither.
+    ///
+    /// The question is asked in the order a person would want answering: an agent blocked on an
+    /// answer needs them now, where a finished turn is only unread. Both come from
+    /// `HomeActivity.needsYou`, which is the same rule Home's rows and the sidebar's glyphs draw,
+    /// so a workspace cannot be waiting here and quiet there.
+    public static func reason(
+        for workspace: Workspace, activity: HomeActivity
+    ) -> SearchPanelWaiting? {
+        guard activity.needsYou(workspace) else { return nil }
+        return activity.waiting.contains(workspace.id) ? .askedAQuestion : .turnFinished
+    }
+}

--- a/Sources/BloomCore/Presentation/SearchPanelResults.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelResults.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+/// What the panel shows once something has been typed: the workspaces, then the handful of
+/// commands whose names match, then the transcripts.
+///
+/// **Workspaces lead, because "which workspace was it" is the question people open this with.**
+/// They are also the only half that is free: the names and branches are matched over an array
+/// already in memory, so they are on screen before the query has left the main actor, while the
+/// transcript half is a hop onto the store, an FTS5 match and a join. The two halves are therefore
+/// built from two arguments here rather than from one fetch, and `transcripts` is empty until the
+/// slower half answers. The panel fills that section in underneath rather than holding the fast
+/// half back. See `AppModel.searchTranscripts` for the debounce and the replacement.
+///
+/// **Names are matched fuzzily and the matched characters are reported.** `WorkspaceSearch` is a
+/// substring test and stays the rule for whether a row is in the list at all, because that is what
+/// Home uses and a search that found a workspace in one surface and not the other would be worse
+/// than either. What is added on top is `FuzzyMatch` over the name, which both ranks the answer
+/// and says which characters to draw bold: typing `docs` should find `rewrite-documentation-site`
+/// and then show why it did.
+public enum SearchPanelResults {
+    /// The listing for one query.
+    ///
+    /// - Parameters:
+    ///   - transcripts: what the full text index said, already folded one row per workspace by
+    ///     `TranscriptSearch.group`. Empty until the store answers, and empty when the query is
+    ///     too short for it to be worth asking.
+    ///   - hasProjects: whether a workspace can be started, which decides one of the two fallback
+    ///     rows. See `SearchPanelFallback`.
+    public static func build(
+        query: String,
+        repos: [Repo],
+        workspaces: [Workspace],
+        archived: [Workspace],
+        transcripts: [TranscriptWorkspaceMatches],
+        scope: HomeScope,
+        commands: [MenuBarItem] = MenuBarCatalogue.commands,
+        hasProjects: Bool
+    ) -> SearchPanelListing {
+        let needle = WorkspaceSearch.needle(query)
+        guard !needle.isEmpty else { return .empty }
+
+        var byID: [RepoID: Repo] = [:]
+        byID.reserveCapacity(repos.count)
+        for repo in repos { byID[repo.id] = repo }
+
+        var counts = HomeScopeCounts()
+        var matched: [SearchPanelWorkspaceHit] = []
+        matched.reserveCapacity(workspaces.count)
+
+        func consider(_ workspace: Workspace, isArchived: Bool) {
+            let repo = byID[workspace.repoID]
+            // **Two rules, and a row is in the list if either answers.** The subsequence over the
+            // name is what makes `docs` find `rewrite-documentation-site` and is what says which
+            // characters to draw bold. `WorkspaceSearch` is the substring rule Home uses, and it
+            // stays because it reaches the branch and the project as well: a search that found a
+            // workspace on Home and not here would be worse than either rule on its own.
+            let hit = FuzzyMatch.hit(workspace.name, query: needle)
+            let field = WorkspaceSearch.match(workspace: workspace, repo: repo, needle: needle)
+            guard hit != nil || field != nil else { return }
+            matched.append(
+                SearchPanelWorkspaceHit(
+                    workspace: workspace,
+                    repo: repo,
+                    highlights: hit?.positions ?? [],
+                    // Only when the name was not what put it there, since the row already draws
+                    // the name and the characters that hit in it.
+                    match: hit == nil && field != workspace.name ? field : nil,
+                    isArchived: isArchived,
+                    // A name match outranks a branch or project match, always: a workspace called
+                    // what you typed is the answer, and one whose project happens to contain the
+                    // letters is a near miss.
+                    score: hit?.score ?? 0
+                )
+            )
+            if isArchived { counts.archived += 1 } else { counts.live += 1 }
+        }
+
+        for workspace in workspaces { consider(workspace, isArchived: false) }
+        for workspace in archived { consider(workspace, isArchived: true) }
+        counts.workspaces = matched.count
+
+        let archivedIDs = Set(archived.map(\.id))
+        let known = Set(workspaces.map(\.id)).union(archivedIDs)
+        // A result whose workspace has been deleted since the index was written has nothing to
+        // open, so it is dropped rather than drawn as a row that does nothing.
+        let hits = transcripts.filter { known.contains($0.workspaceID) }
+        for hit in hits {
+            counts.transcripts += hit.total
+            counts.transcriptWorkspaces += 1
+            if archivedIDs.contains(hit.workspaceID) { counts.archived += hit.total }
+        }
+
+        let shownWorkspaces = matched
+            .filter { hit in
+                scope.showsWorkspaces && scope.includes(
+                    HomeRow(workspace: hit.workspace, repo: hit.repo), activity: HomeActivity()
+                )
+            }
+            .sorted { left, right in
+                if left.score != right.score { return left.score > right.score }
+                return left.workspace.lastActivityAt > right.workspace.lastActivityAt
+            }
+
+        let shownTranscripts = hits
+            .filter { scope.includesTranscript(isArchived: archivedIDs.contains($0.workspaceID)) }
+            .map { result in
+                let workspace = workspaces.first { $0.id == result.workspaceID }
+                    ?? archived.first { $0.id == result.workspaceID }
+                return SearchPanelTranscriptHit(
+                    result: result,
+                    workspace: workspace,
+                    repo: workspace.flatMap { byID[$0.repoID] },
+                    isArchived: archivedIDs.contains(result.workspaceID)
+                )
+            }
+
+        let shownCommands = inlineCommands(needle, scope: scope, commands: commands)
+
+        var sections: [SearchPanelSection] = []
+        if !shownWorkspaces.isEmpty {
+            sections.append(
+                SearchPanelSection(
+                    id: "workspaces", title: "Workspaces",
+                    rows: shownWorkspaces.map { .workspace($0) }
+                )
+            )
+        }
+        if !shownCommands.isEmpty {
+            sections.append(
+                SearchPanelSection(
+                    id: "commands", title: "Commands",
+                    rows: shownCommands.map { .command($0) }
+                )
+            )
+        }
+        if !shownTranscripts.isEmpty {
+            sections.append(
+                SearchPanelSection(
+                    id: "transcripts", title: "Transcripts",
+                    rows: shownTranscripts.map { .transcript($0) }
+                )
+            )
+        }
+
+        if sections.isEmpty {
+            let rows = SearchPanelFallback.rows(for: query, hasProjects: hasProjects)
+            if !rows.isEmpty {
+                sections.append(
+                    SearchPanelSection(id: "fallback", title: nil, rows: rows.map { .fallback($0) })
+                )
+            }
+        }
+
+        return SearchPanelListing(sections: sections, counts: counts, isSearching: true)
+    }
+
+    /// The few commands a search of things is allowed to show.
+    ///
+    /// **Under the Everything chip alone.** The other three chips name a kind of thing that
+    /// matched, and a menu item is neither a workspace nor a transcript, so a command row under
+    /// Workspaces would be a row the chip above it says is not there.
+    ///
+    /// They are deliberately not in `counts`. The chips are Home's and they count workspaces and
+    /// transcript matches; adding a third kind to the Everything number would make the two
+    /// surfaces disagree about how much there is, over rows that are a hint rather than the
+    /// answer. Typing `>` is what asks for the whole menu bar.
+    private static func inlineCommands(
+        _ needle: String, scope: HomeScope, commands: [MenuBarItem]
+    ) -> [SearchPanelCommandHit] {
+        guard scope == .all, needle.count >= SearchPanelCommands.inlineMinimumQueryLength else {
+            return []
+        }
+        return Array(SearchPanelCommands.rank(needle, in: commands).prefix(SearchPanelCommands.inlineLimit))
+    }
+}

--- a/Sources/BloomCore/Presentation/SearchPanelResults.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelResults.swift
@@ -142,7 +142,9 @@ public enum SearchPanelResults {
             )
         }
 
+        var summaryLine: String?
         if sections.isEmpty {
+            summaryLine = SearchPanelFallback.summary(for: query)
             let rows = SearchPanelFallback.rows(for: query, hasProjects: hasProjects)
             if !rows.isEmpty {
                 sections.append(
@@ -151,7 +153,9 @@ public enum SearchPanelResults {
             }
         }
 
-        return SearchPanelListing(sections: sections, counts: counts, isSearching: true)
+        return SearchPanelListing(
+            sections: sections, counts: counts, isSearching: true, summaryLine: summaryLine
+        )
     }
 
     /// The few commands a search of things is allowed to show.

--- a/Sources/BloomCore/Presentation/SearchPanelRow.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelRow.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// One line of the panel, whatever kind of thing it names.
+///
+/// Four cases and one flat array, because the arrow keys walk the drawn order rather than four
+/// lists that would each need their own end. The section headings are not rows: they are not
+/// selectable, so putting them in the same array would mean every key handler skipping them, which
+/// is the rule `SearchPanelListing` keeps by holding both shapes rather than deriving one from the
+/// other.
+public enum SearchPanelRow: Equatable, Sendable, Identifiable {
+    case workspace(SearchPanelWorkspaceHit)
+    case transcript(SearchPanelTranscriptHit)
+    case command(SearchPanelCommandHit)
+    case fallback(SearchPanelFallback)
+
+    /// Namespaced by kind, because a workspace row and the transcript row for the same workspace
+    /// are two rows in one list and a shared id would make a `ForEach` draw one of them twice.
+    public var id: String {
+        switch self {
+        case .workspace(let hit): "workspace:\(hit.workspace.id.rawValue)"
+        case .transcript(let hit): "transcript:\(hit.result.workspaceID.rawValue)"
+        case .command(let hit): "command:\(hit.item.action.rawValue)"
+        case .fallback(let fallback): "fallback:\(fallback.id)"
+        }
+    }
+
+    /// The workspace this row would push into on Cmd+Return, or nothing when it has no menu of
+    /// its own. A transcript hit answers with its workspace: the row names one, and the menu on it
+    /// is the same menu the sidebar offers.
+    public var drillable: WorkspaceID? {
+        switch self {
+        case .workspace(let hit): hit.isArchived ? nil : hit.workspace.id
+        case .transcript(let hit): hit.isArchived ? nil : hit.result.workspaceID
+        case .command, .fallback: nil
+        }
+    }
+}
+
+/// A workspace that matched, and why it is in the list.
+public struct SearchPanelWorkspaceHit: Equatable, Sendable, Identifiable {
+    public var workspace: Workspace
+    public var repo: Repo?
+    /// Character offsets into `workspace.name` that the query matched, ascending, drawn the way
+    /// `SlashCommandRow` draws them. Empty when something other than the name matched, and empty
+    /// when the offsets could not be trusted: see `FuzzyMatch.Hit.positions`.
+    public var highlights: [Int]
+    /// The text that put this row in the list when it was not the name, so a row matched on its
+    /// branch says so rather than looking unrelated to what was typed.
+    public var match: String?
+    public var isArchived: Bool
+    /// Why this row is in the resting list. Nil in a search, where the query is the reason.
+    public var waiting: SearchPanelWaiting?
+    public var score: Int
+
+    public var id: WorkspaceID { workspace.id }
+
+    public init(
+        workspace: Workspace,
+        repo: Repo? = nil,
+        highlights: [Int] = [],
+        match: String? = nil,
+        isArchived: Bool = false,
+        waiting: SearchPanelWaiting? = nil,
+        score: Int = 0
+    ) {
+        self.workspace = workspace
+        self.repo = repo
+        self.highlights = highlights
+        self.match = match
+        self.isArchived = isArchived
+        self.waiting = waiting
+        self.score = score
+    }
+}
+
+/// The two ways a workspace can be waiting on a person, which the resting list leads with.
+///
+/// Slack's quick switcher shows unread conversations and caps them, having found that listing
+/// every channel was crushing on a large team. Bloom knows something better than unread: whether
+/// the agent stopped to ask a question, or whether it finished and nobody has read it. Somebody
+/// running eight agents opens this panel already wanting to know which one wants them.
+public enum SearchPanelWaiting: String, Equatable, Sendable {
+    /// The agent is blocked on an answer.
+    case askedAQuestion
+    /// The turn ended and the transcript has not been read.
+    case turnFinished
+
+    public var label: String {
+        switch self {
+        case .askedAQuestion: "asked a question"
+        case .turnFinished: "turn finished"
+        }
+    }
+}
+
+/// A workspace whose transcript matched, with the best few lines already folded into it by
+/// `TranscriptSearch.group`.
+public struct SearchPanelTranscriptHit: Equatable, Sendable, Identifiable {
+    public var result: TranscriptWorkspaceMatches
+    /// Nil when the workspace has been deleted since the index was written, which is a row the
+    /// builder drops rather than draws.
+    public var workspace: Workspace?
+    public var repo: Repo?
+    public var isArchived: Bool
+
+    public var id: WorkspaceID { result.workspaceID }
+
+    public init(
+        result: TranscriptWorkspaceMatches,
+        workspace: Workspace?,
+        repo: Repo?,
+        isArchived: Bool
+    ) {
+        self.result = result
+        self.workspace = workspace
+        self.repo = repo
+        self.isArchived = isArchived
+    }
+}
+
+/// One menu bar item that matched, with the characters the query hit.
+///
+/// Whether it can be pressed right now is not here, for the reason `MenuBarCatalogue` gives about
+/// `availability`: it depends on the live pane tree, on a running turn and on the responder chain,
+/// none of which the core can hold. The app target asks the real menu and greys the row.
+public struct SearchPanelCommandHit: Equatable, Sendable, Identifiable {
+    public var item: MenuBarItem
+    /// Offsets into `item.title`, as `SearchPanelWorkspaceHit.highlights` are into a name.
+    public var highlights: [Int]
+    public var score: Int
+
+    public var id: MenuBarAction { item.action }
+
+    public init(item: MenuBarItem, highlights: [Int] = [], score: Int = 0) {
+        self.item = item
+        self.highlights = highlights
+        self.score = score
+    }
+}

--- a/Sources/BloomCore/Presentation/SearchPanelRow.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelRow.swift
@@ -27,10 +27,14 @@ public enum SearchPanelRow: Equatable, Sendable, Identifiable {
     /// The workspace this row would push into on Cmd+Return, or nothing when it has no menu of
     /// its own. A transcript hit answers with its workspace: the row names one, and the menu on it
     /// is the same menu the sidebar offers.
+    ///
+    /// **An archived workspace has one too**, and it is the shorter menu Home already draws for
+    /// one: Copy Name, Copy Branch Name, Restore. Which items that is is
+    /// `WorkspaceMenuSubject.allows`, so nothing here has to know that a worktree is gone.
     public var drillable: WorkspaceID? {
         switch self {
-        case .workspace(let hit): hit.isArchived ? nil : hit.workspace.id
-        case .transcript(let hit): hit.isArchived ? nil : hit.result.workspaceID
+        case .workspace(let hit): hit.workspace.id
+        case .transcript(let hit): hit.result.workspaceID
         case .command, .fallback: nil
         }
     }

--- a/Tests/BloomCoreTests/MenuBarCatalogueTests.swift
+++ b/Tests/BloomCoreTests/MenuBarCatalogueTests.swift
@@ -164,8 +164,11 @@ struct MenuBarCatalogueTests {
             // review, and nothing in the app says which you are about to get.
             MenuShortcut("d", .command): nil,
             MenuShortcut("d", .command, .shift): .showChanges,
-            // It clears itself with this one, which nothing in the bar claims and no menu shows.
-            MenuShortcut("k", .command): nil,
+            // Deliberate, and the shape the search panel was designed around: a shell clears its
+            // scrollback with this, which is iTerm's binding and Terminal's, and the panel opens
+            // on it everywhere else. Somebody inside a shell reaches the panel with Shift+Cmd+F,
+            // which already means the whole search.
+            MenuShortcut("k", .command): .quickSearch,
             // Deliberate: the pane in a shell, the tab everywhere else.
             MenuShortcut("w", .command): .closeTab,
             // Deliberate: the same action reached two ways.

--- a/Tests/BloomCoreTests/SearchPanelActionsTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelActionsTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// The list Cmd+Return pushes into: one workspace's own menu, gated by the same rule the sidebar,
+/// Home and the menu bar are gated by.
+@Suite("Search panel actions")
+struct SearchPanelActionsTests {
+    /// Fourteen items for free, and none of them has to be listed at the top level.
+    @Test("a live workspace is offered its whole row menu, in the row menu's order")
+    func aLiveWorkspace() {
+        let rows = SearchPanelActions.rows(for: .live(WorkspaceID("w1")))
+        #expect(rows.map(\.item.action) == [
+            .openInEditor, .revealInFinder, .copyName, .copyBranchName,
+            .pin, .unreadMark, .renameWorkspace, .archive,
+        ])
+    }
+
+    /// Opening an editor on a path that is not there means nothing, and neither does archiving
+    /// what is already archived. `WorkspaceMenuSubject` is the one table that says so.
+    @Test("an archived workspace is offered what Home offers it and nothing more")
+    func anArchivedWorkspace() {
+        let rows = SearchPanelActions.rows(for: .archived(WorkspaceID("w1")))
+        #expect(rows.map(\.item.action) == [.copyName, .copyBranchName, .restore])
+    }
+
+    /// The pill in the field already names what is being acted on, and a heading repeating it
+    /// would be the same words twice on one card.
+    @Test("the action list is one section with no heading")
+    func oneSectionNoHeading() {
+        let sections = SearchPanelActions.sections(for: .live(WorkspaceID("w1")))
+        #expect(sections.count == 1)
+        #expect(sections[0].title == nil)
+    }
+
+    /// Every row is a menu bar row, so the panel and the bar cannot word one action two ways or
+    /// print two different keys for it.
+    @Test("every workspace menu action names a row in the catalogue, and the map goes both ways")
+    func theMapIsComplete() {
+        for action in WorkspaceMenuAction.allCases {
+            let menuBar = SearchPanelActions.menuBarAction(for: action)
+            #expect(MenuBarCatalogue[menuBar].menu == .workspace)
+            #expect(SearchPanelActions.workspaceAction(for: menuBar) == action)
+        }
+    }
+
+    /// Colour is a submenu of ten swatches rather than an action, so a row that ran it would have
+    /// nothing to run. It is still in the Workspace menu and still reachable through `>`.
+    @Test("the colour submenu is not offered as a row")
+    func colourIsNotARow() {
+        let offered = SearchPanelActions.rows(for: .live(WorkspaceID("w1"))).map(\.item.action)
+        #expect(!offered.contains(.colour))
+        #expect(!SearchPanelActions.order.contains(.colour))
+    }
+}

--- a/Tests/BloomCoreTests/SearchPanelCommandsTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelCommandsTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// The command half of the panel: the menu bar table ranked, grouped by menu, and the key each row
+/// prints.
+///
+/// Everything here is read off `MenuBarCatalogue` rather than written beside it, which is the rule
+/// the feature rests on: there is no command in the panel that is not also in a menu.
+@Suite("Search panel commands")
+struct SearchPanelCommandsTests {
+    /// Nothing typed yet, which is the state the moment `>` is pressed: the whole bar, in the
+    /// order the menus draw it.
+    @Test("an empty query is the whole catalogue in table order")
+    func anEmptyQueryIsTheWholeBar() {
+        let ranked = SearchPanelCommands.rank("")
+        #expect(ranked.count == MenuBarCatalogue.commands.count)
+        #expect(ranked.map(\.item.action) == MenuBarCatalogue.commands.map(\.action))
+    }
+
+    @Test("a query ranks by the same subsequence score the slash menu uses, and reports the hits")
+    func rankingAndHighlights() {
+        let ranked = SearchPanelCommands.rank("archive")
+        #expect(ranked.first?.item.action == .archive)
+        #expect(ranked.first?.highlights == [0, 1, 2, 3, 4, 5, 6])
+        #expect(!ranked.contains { $0.item.action == .about })
+    }
+
+    /// The palette should teach where a thing is rather than replace the place it is.
+    @Test("rows are grouped by the menu they live in, in the bar's own order")
+    func groupedByMenu() {
+        let sections = SearchPanelCommands.sections(SearchPanelCommands.rank(""))
+        #expect(sections.map(\.title) == ["Bloom", "File", "Edit", "View", "Workspace", "Help"])
+        #expect(sections.allSatisfy { $0.rows.allSatisfy { $0.drillable == nil } })
+    }
+
+    /// A section that reordered itself back to the menu's order would put the best match under two
+    /// worse ones and the reader would have to read all three.
+    @Test("within a menu the rows keep the ranked order")
+    func rankedInsideASection() {
+        let sections = SearchPanelCommands.sections(SearchPanelCommands.rank("tab"))
+        guard let view = sections.first(where: { $0.title == "View" }) else {
+            Issue.record("expected a View section")
+            return
+        }
+        let scores = view.rows.compactMap { row -> Int? in
+            guard case .command(let hit) = row else { return nil }
+            return hit.score
+        }
+        #expect(scores == scores.sorted(by: >))
+    }
+
+    @Test("a menu with nothing in it is not a heading over nothing")
+    func emptyMenusAreDropped() {
+        let sections = SearchPanelCommands.sections(SearchPanelCommands.rank("postcard"))
+        #expect(sections.map(\.title) == ["Help"])
+    }
+
+    /// Nineteen items in the bar carry no shortcut at all, and a blank slot says nothing about
+    /// which of the two a row is.
+    @Test("a row prints its key, or the words no key")
+    func everyRowPrintsAKey() {
+        #expect(MenuBarCatalogue[.archive].keyText == "\u{2318}\u{232B}")
+        #expect(MenuBarCatalogue[.merge].keyText == "no key")
+        #expect(MenuBarCatalogue[.nextChangedFile].keyText == "\u{2325}\u{2318}J")
+        #expect(MenuBarCatalogue[.projectSettings].keyText == "\u{21E7}\u{2318},")
+        #expect(MenuBarCatalogue[.zoomPane].keyText == "\u{21E7}\u{2318}\u{21A9}")
+        #expect(MenuBarCatalogue[.nextWorkspace].keyText == "\u{2325}\u{2318}\u{2193}")
+        #expect(MenuBarCatalogue[.closePane].keyText == "\u{2303}\u{2318}W")
+    }
+
+    /// Control, Option, Shift, Command, which is the order in every menu on the platform and not
+    /// the order the `OptionSet` happens to be declared in.
+    @Test("the modifiers are drawn in the platform's order")
+    func modifierOrder() {
+        let all = MenuShortcut("x", .command, .shift, .option, .control)
+        #expect(all.display == "\u{2303}\u{2325}\u{21E7}\u{2318}X")
+    }
+
+    /// The one key the panel opens on has to be in the bar, or the panel would be a surface with a
+    /// keystroke and no map.
+    @Test("the panel itself is a menu item, on a key nothing else claims")
+    func thePanelIsInTheBar() {
+        let item = MenuBarCatalogue[.quickSearch]
+        #expect(item.menu == .edit)
+        #expect(item.key == .command("k"))
+        let others = MenuBarCatalogue.commands.filter { $0.action != .quickSearch }
+        #expect(!others.contains { $0.key == .command("k") })
+    }
+}

--- a/Tests/BloomCoreTests/SearchPanelFieldTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelFieldTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// The panel's field: which mode what was typed puts it in, what is left of the text once the
+/// prefix has been taken off, and what backing out of a mode restores.
+///
+/// The whole of this exists because the three move together. A `>` left in the text as well as in
+/// the pill searches for a workspace called "> merge", and a mode left behind by an empty field
+/// searches the menu bar for a workspace name.
+@Suite("Search panel field")
+struct SearchPanelFieldTests {
+    @Test("a leading > switches to commands and is taken off the query")
+    func theePrefixIsConsumed() {
+        var field = SearchPanelField()
+        field.type(">")
+        #expect(field.mode == .commands)
+        #expect(field.text.isEmpty)
+
+        field.type("merge")
+        #expect(field.mode == .commands)
+        #expect(field.query == "merge")
+    }
+
+    /// `>merge` and `> merge` are the same query. One space after the prefix goes with it, and a
+    /// second one is the user's.
+    @Test("one space after the prefix goes with the prefix")
+    func oneSpaceIsEaten() {
+        var typed = SearchPanelField()
+        typed.type("> merge")
+        #expect(typed.query == "merge")
+
+        var tight = SearchPanelField()
+        tight.type(">merge")
+        #expect(tight.query == "merge")
+
+        var padded = SearchPanelField()
+        padded.type(">  merge")
+        #expect(padded.query == " merge")
+    }
+
+    /// A branch called `feature>thing` is a thing somebody can have, and a search that refused to
+    /// look for it would be a search with a secret.
+    @Test("a > that is not the first character is a character like any other")
+    func onlyTheFirstCharacterCounts() {
+        var field = SearchPanelField()
+        field.type("feature>thing")
+        #expect(field.mode == .things)
+        #expect(field.query == "feature>thing")
+    }
+
+    @Test("a > typed inside commands is a character, not a second mode")
+    func theePrefixIsReadOnceOnly() {
+        var field = SearchPanelField()
+        field.type(">")
+        field.type(">merge")
+        #expect(field.mode == .commands)
+        #expect(field.query == ">merge")
+    }
+
+    @Test("backspace on an empty field leaves commands, and does nothing at rest")
+    func backspaceLeavesTheMode() {
+        var field = SearchPanelField()
+        // Lifted out of `#expect`, which rewrites its argument into a closure taking the value
+        // immutably. See CLAUDE.md: a mutating call inside the macro does not compile.
+        let atRest = field.leaveMode()
+        #expect(atRest == false)
+
+        field.type(">")
+        let left = field.leaveMode()
+        #expect(left)
+        #expect(field.mode == .things)
+    }
+
+    /// Backspace out of an action list must not be a way of losing what you typed to find the row
+    /// you pushed into.
+    @Test("leaving an action list puts the earlier query back")
+    func leavingRestoresTheQuery() {
+        var field = SearchPanelField()
+        field.type("docs")
+        let entered = field.enterActions(on: WorkspaceID("w1"))
+        #expect(entered)
+        #expect(field.mode == .actions(WorkspaceID("w1")))
+        #expect(field.text.isEmpty)
+
+        let left = field.leaveMode()
+        #expect(left)
+        #expect(field.mode == .things)
+        #expect(field.query == "docs")
+    }
+
+    /// A command has no workspace of its own and an action list has no rows to push into, so
+    /// neither can be pushed into again.
+    @Test("only a search of things can be pushed into")
+    func actionsAreEnteredFromThingsAlone() {
+        var field = SearchPanelField()
+        field.type(">")
+        let entered = field.enterActions(on: WorkspaceID("w1"))
+        #expect(entered == false)
+        #expect(field.mode == .commands)
+    }
+
+    @Test("clearing empties the text and keeps the mode")
+    func clearingKeepsTheMode() {
+        var field = SearchPanelField()
+        field.type(">")
+        field.type("merge")
+        field.clear()
+        #expect(field.mode == .commands)
+        #expect(field.isEmpty)
+    }
+
+    /// The chips split an answer about workspaces and transcripts, and neither of the other two
+    /// modes has one to split.
+    @Test("the scope chips are drawn while searching things and never in a mode")
+    func onlyThingsHaveScopes() {
+        #expect(SearchPanelMode.things.showsScopes)
+        #expect(!SearchPanelMode.commands.showsScopes)
+        #expect(!SearchPanelMode.actions(WorkspaceID("w1")).showsScopes)
+        #expect(SearchPanelMode.things.pill == nil)
+        #expect(SearchPanelMode.commands.pill == "Commands")
+    }
+}

--- a/Tests/BloomCoreTests/SearchPanelKeysTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelKeysTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// Every key the panel answers, and the two answers that are not the same: a key it handled and a
+/// key it ignored. An ignored key goes back to the field editor, where it still moves the caret or
+/// types a character.
+@Suite("Search panel keys")
+struct SearchPanelKeysTests {
+    private func context(
+        mode: SearchPanelMode = .things,
+        rows: Int = 5,
+        highlighted: Int? = 0,
+        isQueryEmpty: Bool = false,
+        scope: HomeScope = .all,
+        canDrill: Bool = true,
+        caretAtEnd: Bool = true
+    ) -> SearchPanelKeyContext {
+        SearchPanelKeyContext(
+            mode: mode,
+            rowCount: rows,
+            highlighted: highlighted,
+            isQueryEmpty: isQueryEmpty,
+            scope: scope,
+            scopes: HomeScope.offered(searching: true),
+            canDrill: canDrill,
+            caretAtEnd: caretAtEnd
+        )
+    }
+
+    /// `ListNavigation`'s rule and the platform's: Down on the last row stays on the last row. A
+    /// list that jumped back to the top would move the reader's eye the height of the card on a
+    /// keystroke that means "one more".
+    @Test("the arrows stop at both ends rather than wrapping")
+    func arrowsDoNotWrap() {
+        #expect(SearchPanelKeys.outcome(for: .down, in: context(highlighted: 0)) == .move(1))
+        #expect(SearchPanelKeys.outcome(for: .down, in: context(highlighted: 4)) == .handled)
+        #expect(SearchPanelKeys.outcome(for: .up, in: context(highlighted: 0)) == .handled)
+        #expect(SearchPanelKeys.outcome(for: .up, in: context(highlighted: 3)) == .move(2))
+    }
+
+    /// An arrow handed back would scroll whatever is behind the card, which is the window the
+    /// panel is supposed to leave exactly where it was.
+    @Test("an arrow with nowhere to go is still the panel's")
+    func arrowsAreNeverHandedBack() {
+        #expect(SearchPanelKeys.outcome(for: .down, in: context(rows: 0, highlighted: nil)) == .handled)
+    }
+
+    @Test("with nothing highlighted, an arrow enters the list from the edge it came from")
+    func arrowsEnterFromTheEdge() {
+        #expect(SearchPanelKeys.outcome(for: .down, in: context(highlighted: nil)) == .move(0))
+        #expect(SearchPanelKeys.outcome(for: .up, in: context(highlighted: nil)) == .move(4))
+    }
+
+    @Test("Tab steps the chips forward and Shift+Tab back, wrapping")
+    func tabWalksTheChips() {
+        let scopes = HomeScope.offered(searching: true)
+        #expect(SearchPanelKeys.outcome(for: .tab, in: context(scope: .all)) == .scope(scopes[1]))
+        #expect(SearchPanelKeys.outcome(for: .backTab, in: context(scope: .all)) == .scope(scopes[3]))
+        #expect(SearchPanelKeys.outcome(for: .tab, in: context(scope: scopes[3])) == .scope(scopes[0]))
+    }
+
+    /// Commands and an action list have no answer to split, so Tab goes back to the field editor
+    /// and moves the focus the way it does everywhere else.
+    @Test("Tab is not the panel's in a mode")
+    func tabIsHandedBackInAMode() {
+        #expect(SearchPanelKeys.outcome(for: .tab, in: context(mode: .commands)) == .ignored)
+        #expect(
+            SearchPanelKeys.outcome(
+                for: .tab, in: context(mode: .actions(WorkspaceID("w1")))
+            ) == .ignored
+        )
+    }
+
+    @Test("Return opens the highlighted row, and does nothing when there is none")
+    func returnOpens() {
+        #expect(SearchPanelKeys.outcome(for: .returnKey, in: context()) == .open)
+        #expect(SearchPanelKeys.outcome(for: .returnKey, in: context(highlighted: nil)) == .handled)
+    }
+
+    @Test("Cmd+Return pushes into a row that has a menu, and is swallowed by one that has not")
+    func commandReturnDrills() {
+        #expect(SearchPanelKeys.outcome(for: .commandReturn, in: context()) == .drill)
+        #expect(
+            SearchPanelKeys.outcome(for: .commandReturn, in: context(canDrill: false)) == .handled
+        )
+    }
+
+    /// Mid word the right arrow is the caret's. A panel that took it would make the field unusable
+    /// for correcting a typo.
+    @Test("the right arrow pushes in only from the end of the field")
+    func rightNeedsTheCaretAtTheEnd() {
+        #expect(SearchPanelKeys.outcome(for: .right, in: context()) == .drill)
+        #expect(SearchPanelKeys.outcome(for: .right, in: context(caretAtEnd: false)) == .ignored)
+        #expect(SearchPanelKeys.outcome(for: .right, in: context(canDrill: false)) == .ignored)
+    }
+
+    /// Somebody who typed a query and wants a different one should not have to reopen the panel to
+    /// get an empty field, and somebody who wants out presses it twice.
+    @Test("Escape clears a full field and closes an empty one")
+    func escapeClearsThenCloses() {
+        #expect(SearchPanelKeys.outcome(for: .escape, in: context(isQueryEmpty: false)) == .clearQuery)
+        #expect(SearchPanelKeys.outcome(for: .escape, in: context(isQueryEmpty: true)) == .close)
+    }
+
+    @Test("Backspace on an empty field leaves a mode and is otherwise the field's")
+    func backspaceLeavesAMode() {
+        #expect(SearchPanelKeys.outcome(for: .backspaceOnEmpty, in: context()) == .ignored)
+        #expect(
+            SearchPanelKeys.outcome(for: .backspaceOnEmpty, in: context(mode: .commands)) == .leaveMode
+        )
+        #expect(
+            SearchPanelKeys.outcome(
+                for: .backspaceOnEmpty, in: context(mode: .actions(WorkspaceID("w1")))
+            ) == .leaveMode
+        )
+    }
+
+    /// The two footers that differ are the ones that matter: at rest the prefix is advertised
+    /// because there are no chips to advertise, and Backspace is named in both modes because it is
+    /// the only way out of one.
+    @Test("the footer names the way out of every mode")
+    func theFooterNamesTheWayOut() {
+        let resting = SearchPanelKeys.footer(for: .things, isSearching: false)
+        #expect(resting.contains { $0.key == ">" })
+        let searching = SearchPanelKeys.footer(for: .things, isSearching: true)
+        #expect(searching.contains { $0.label == "Scope" })
+        #expect(SearchPanelKeys.footer(for: .commands, isSearching: true).contains { $0.label == "Leave commands" })
+        #expect(
+            SearchPanelKeys.footer(for: .actions(WorkspaceID("w1")), isSearching: true)
+                .contains { $0.label == "Back" }
+        )
+    }
+}

--- a/Tests/BloomCoreTests/SearchPanelRestingTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelRestingTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// What the panel shows before anything has been typed: what is waiting on you, then what you last
+/// had open, both capped.
+///
+/// The dates here are built rather than read off the clock, for the reason `HomeListTests` gives:
+/// a suite that says "an hour ago" against `Date()` is a suite whose ordering is decided by when
+/// it ran.
+@Suite("Search panel resting list")
+struct SearchPanelRestingTests {
+    private func workspace(
+        _ name: String,
+        at activity: Date,
+        unread: Bool = false,
+        repoID: RepoID = RepoID("repo")
+    ) -> Workspace {
+        Workspace(
+            id: WorkspaceID(name),
+            repoID: repoID,
+            name: name,
+            branch: "feature/\(name)",
+            path: "/tmp/\(name)",
+            baseBranch: "main",
+            lastActivityAt: activity,
+            unread: unread
+        )
+    }
+
+    private func date(_ minutesAgo: Int) -> Date {
+        Date(timeIntervalSince1970: 1_700_000_000 - Double(minutesAgo) * 60
+        )
+    }
+
+    private let repo = Repo(id: RepoID("repo"), name: "bloom", path: "/tmp/repo")
+
+    /// Somebody running eight agents opens this panel already wanting to know which one wants
+    /// them, so that question is answered before they type.
+    @Test("the workspaces waiting on you lead, under their own heading")
+    func waitingLeads() {
+        let asking = workspace("docs chapters", at: date(4))
+        let finished = workspace("appcast signing", at: date(26), unread: true)
+        let quiet = workspace("pill caps", at: date(1))
+
+        let listing = SearchPanelResting.build(
+            workspaces: [quiet, asking, finished],
+            repos: [repo],
+            activity: HomeActivity(waiting: [asking.id])
+        )
+
+        #expect(listing.sections.map(\.title) == ["Waiting on you", "Recently open"])
+        #expect(listing.sections[0].rows.map(\.id) == [
+            "workspace:docs chapters", "workspace:appcast signing",
+        ])
+        #expect(listing.sections[1].rows.map(\.id) == ["workspace:pill caps"])
+    }
+
+    /// The two kinds are drawn apart because they mean different things: an agent blocked on an
+    /// answer needs you now, where a finished turn is only unread.
+    @Test("a blocked agent and a finished turn are told apart")
+    func theTwoKindsOfWaiting() {
+        let asking = workspace("asking", at: date(1))
+        let finished = workspace("finished", at: date(2), unread: true)
+        let activity = HomeActivity(waiting: [asking.id])
+
+        #expect(SearchPanelResting.reason(for: asking, activity: activity) == .askedAQuestion)
+        #expect(SearchPanelResting.reason(for: finished, activity: activity) == .turnFinished)
+        #expect(SearchPanelResting.reason(for: workspace("quiet", at: date(3)), activity: activity) == nil)
+        #expect(SearchPanelWaiting.askedAQuestion.label == "asked a question")
+        #expect(SearchPanelWaiting.turnFinished.label == "turn finished")
+    }
+
+    /// A row cannot be in both sections. Slack's finding is that listing everything is crushing;
+    /// listing the same thing twice is worse.
+    @Test("a workspace that is waiting is not repeated under what you last had open")
+    func noRowAppearsTwice() {
+        let asking = workspace("asking", at: date(1))
+        let other = workspace("other", at: date(2))
+        let listing = SearchPanelResting.build(
+            workspaces: [asking, other], repos: [repo], activity: HomeActivity(waiting: [asking.id])
+        )
+        #expect(listing.rows.count == 2)
+        #expect(Set(listing.rows.map(\.id)).count == 2)
+    }
+
+    /// The panel is three hundred points of list. An index of the machine put at the top of it
+    /// would be a worse Home, reached by a key.
+    @Test("both sections cap themselves")
+    func bothSectionsCap() {
+        let waiting = (0..<9).map { workspace("waiting-\($0)", at: date($0), unread: true) }
+        let quiet = (0..<9).map { workspace("quiet-\($0)", at: date(100 + $0)) }
+        let listing = SearchPanelResting.build(
+            workspaces: waiting + quiet, repos: [repo], activity: HomeActivity()
+        )
+        #expect(listing.sections[0].rows.count == SearchPanelResting.waitingCap)
+        #expect(listing.sections[1].rows.count == SearchPanelResting.recentCap)
+    }
+
+    /// With nothing waiting there is only one section, and it says "Recent" rather than "Recently
+    /// open", because "open" only means something against the heading that is not there.
+    @Test("a quiet machine gets one section")
+    func aQuietMachineGetsOneSection() {
+        let listing = SearchPanelResting.build(
+            workspaces: [workspace("one", at: date(1))], repos: [repo], activity: HomeActivity()
+        )
+        #expect(listing.sections.map(\.title) == ["Recent"])
+        #expect(!listing.isSearching)
+    }
+
+    @Test("a machine with nothing on it draws nothing rather than an empty heading")
+    func nothingAtAll() {
+        let listing = SearchPanelResting.build(workspaces: [], repos: [], activity: HomeActivity())
+        #expect(listing.isEmpty)
+        #expect(listing.sections.isEmpty)
+    }
+
+    /// The project travels with the row because the panel is flat: a row is the only place its
+    /// project can be said.
+    @Test("a row carries its project")
+    func aRowCarriesItsProject() {
+        let listing = SearchPanelResting.build(
+            workspaces: [workspace("one", at: date(1))], repos: [repo], activity: HomeActivity()
+        )
+        guard case .workspace(let hit)? = listing.rows.first else {
+            Issue.record("expected a workspace row")
+            return
+        }
+        #expect(hit.repo?.name == "bloom")
+    }
+}

--- a/Tests/BloomCoreTests/SearchPanelResultsTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelResultsTests.swift
@@ -216,6 +216,12 @@ struct SearchPanelResultsTests {
         }
         #expect(start.title == "Start a workspace called houdini")
         #expect(start.action == .newWorkspace)
+        // Said by the builder rather than derived from an empty list, because by the time the
+        // fallbacks are in the list the list is not empty.
+        #expect(listing.summaryLine == "No workspace, transcript or command matches houdini.")
+
+        let matched = build("docs", workspaces: [workspace("docs chapters")])
+        #expect(matched.summaryLine == nil)
     }
 
     /// With no project added there is nothing to cut a worktree from, so the row would be a
@@ -271,9 +277,10 @@ struct SearchPanelResultsTests {
         #expect(listing.summary == "2 results")
     }
 
-    /// A workspace's own menu acts on a worktree that is there. An archived row has none, and a
-    /// command has no workspace at all.
-    @Test("only a live workspace's row can be pushed into")
+    /// Every row that names a workspace can be pushed into, archived ones included: what an
+    /// archived workspace can be asked to do is `WorkspaceMenuSubject.allows`, and it is the same
+    /// shorter menu Home already draws for one. A command has no workspace at all.
+    @Test("a row that names a workspace can be pushed into, whether or not it is archived")
     func whatCanBeDrilled() {
         let listing = build(
             "docs",
@@ -285,7 +292,7 @@ struct SearchPanelResultsTests {
             uniqueKeysWithValues: listing.rows.map { ($0.id, $0.drillable) }
         )
         #expect(drillable["workspace:docs chapters"] == WorkspaceID("docs chapters"))
-        #expect(drillable["workspace:docs import"] == .some(nil))
+        #expect(drillable["workspace:docs import"] == WorkspaceID("docs import"))
         #expect(drillable["transcript:docs chapters"] == WorkspaceID("docs chapters"))
     }
 }

--- a/Tests/BloomCoreTests/SearchPanelResultsTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelResultsTests.swift
@@ -1,0 +1,291 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// What the panel shows once something has been typed: which rows are in the list, in what order,
+/// under which headings, and what each chip says.
+///
+/// The transcript half arrives a moment after the name half, so every test here that cares about
+/// ordering hands the transcripts in separately, which is the shape the app is really in: the
+/// names are on screen before the store has answered.
+@Suite("Search panel results")
+struct SearchPanelResultsTests {
+    private func workspace(
+        _ name: String,
+        branch: String? = nil,
+        repoID: RepoID = RepoID("repo"),
+        state: WorkspaceState = .active,
+        at activity: Date = Date(timeIntervalSince1970: 1_700_000_000)
+    ) -> Workspace {
+        Workspace(
+            id: WorkspaceID(name),
+            repoID: repoID,
+            name: name,
+            branch: branch ?? "feature/\(name)",
+            path: "/tmp/\(name)",
+            baseBranch: "main",
+            state: state,
+            lastActivityAt: activity
+        )
+    }
+
+    private let repo = Repo(id: RepoID("repo"), name: "runbloom", path: "/tmp/repo")
+
+    private func transcriptResult(_ workspace: String, matches: Int) -> TranscriptWorkspaceMatches {
+        TranscriptWorkspaceMatches(
+            workspaceID: WorkspaceID(workspace),
+            matches: [
+                TranscriptMatch(
+                    messageID: 1,
+                    workspaceID: WorkspaceID(workspace),
+                    sessionID: SessionID("s-\(workspace)"),
+                    sessionTitle: "Session",
+                    seq: 7,
+                    kind: .assistantText,
+                    createdAt: Date(timeIntervalSince1970: 0),
+                    snippet: TranscriptSnippet(segments: []),
+                    score: -1
+                ),
+            ],
+            total: matches
+        )
+    }
+
+    private func build(
+        _ query: String,
+        workspaces: [Workspace] = [],
+        archived: [Workspace] = [],
+        transcripts: [TranscriptWorkspaceMatches] = [],
+        scope: HomeScope = .all,
+        commands: [MenuBarItem] = [],
+        hasProjects: Bool = true
+    ) -> SearchPanelListing {
+        SearchPanelResults.build(
+            query: query,
+            repos: [repo],
+            workspaces: workspaces,
+            archived: archived,
+            transcripts: transcripts,
+            scope: scope,
+            commands: commands,
+            hasProjects: hasProjects
+        )
+    }
+
+    /// "Which workspace was it" is the question people open this with, and it is also the half
+    /// that is free: an array in memory rather than a hop onto the store.
+    @Test("workspaces lead, then commands, then transcripts")
+    func theOrderOfTheSections() {
+        let listing = build(
+            "docs",
+            workspaces: [workspace("docs chapters")],
+            transcripts: [transcriptResult("docs chapters", matches: 6)],
+            commands: [MenuBarCatalogue[.showChanges]]
+        )
+        #expect(listing.sections.map(\.title) == ["Workspaces", "Transcripts"])
+
+        let withCommand = build(
+            "changes",
+            workspaces: [workspace("changes")],
+            transcripts: [transcriptResult("changes", matches: 2)],
+            commands: [MenuBarCatalogue[.showChanges]]
+        )
+        #expect(withCommand.sections.map(\.title) == ["Workspaces", "Commands", "Transcripts"])
+    }
+
+    /// The subsequence match is what ranks and highlights; the substring match is what decides
+    /// membership, so the panel reaches exactly what Home reaches.
+    @Test("a name match reports the characters it hit and outranks a branch match")
+    func nameMatchesLeadAndHighlight() {
+        let listing = build(
+            "docs",
+            workspaces: [
+                workspace("appcast", branch: "feature/docs-fix"),
+                workspace("docs chapters"),
+            ]
+        )
+        #expect(listing.rows.map(\.id) == ["workspace:docs chapters", "workspace:appcast"])
+
+        guard case .workspace(let best)? = listing.rows.first,
+              case .workspace(let branchHit) = listing.rows[1] else {
+            Issue.record("expected two workspace rows")
+            return
+        }
+        #expect(best.highlights == [0, 1, 2, 3])
+        #expect(best.match == nil)
+        #expect(branchHit.match == "feature/docs-fix")
+        #expect(branchHit.highlights.isEmpty)
+    }
+
+    /// `docs` has to find `rewrite-documentation-site`, and then show why it did.
+    @Test("a subsequence of the name is a match and is drawn as one")
+    func subsequenceMatching() {
+        let listing = build("docs", workspaces: [workspace("rewrite-documentation-site")])
+        #expect(listing.rows.count == 1)
+    }
+
+    @Test("a row matched on its project says so")
+    func projectMatchesSayWhy() {
+        let listing = build("runbloom", workspaces: [workspace("pill caps")])
+        guard case .workspace(let hit)? = listing.rows.first else {
+            Issue.record("expected a workspace row")
+            return
+        }
+        #expect(hit.match == "runbloom")
+    }
+
+    /// Home's own counts, worked out in the same pass, so the two surfaces cannot disagree about
+    /// how much archived work there is.
+    @Test("the chips count workspaces and transcript matches, archived work in both")
+    func theChipCounts() {
+        let listing = build(
+            "docs",
+            workspaces: [workspace("docs chapters")],
+            archived: [workspace("docs import", state: .archived)],
+            transcripts: [
+                transcriptResult("docs chapters", matches: 6),
+                transcriptResult("docs import", matches: 8),
+            ]
+        )
+        #expect(listing.counts.workspaces == 2)
+        #expect(listing.counts.transcripts == 14)
+        #expect(listing.counts.transcriptWorkspaces == 2)
+        // One archived row plus the eight matches inside the archived workspace.
+        #expect(listing.counts.archived == 9)
+        #expect(listing.counts.count(of: .all, searching: true) == 16)
+    }
+
+    /// The chips split the answer by what kind of thing matched rather than filtering rows, which
+    /// is the distinction Home already draws.
+    @Test("a chip narrows the rows and leaves the counts alone")
+    func aChipDoesNotChangeItsOwnCount() {
+        let everything = build(
+            "docs",
+            workspaces: [workspace("docs chapters")],
+            transcripts: [transcriptResult("docs chapters", matches: 6)]
+        )
+        let transcriptsOnly = build(
+            "docs",
+            workspaces: [workspace("docs chapters")],
+            transcripts: [transcriptResult("docs chapters", matches: 6)],
+            scope: .transcripts
+        )
+        #expect(everything.sections.count == 2)
+        #expect(transcriptsOnly.sections.map(\.title) == ["Transcripts"])
+        #expect(transcriptsOnly.counts.workspaces == everything.counts.workspaces)
+    }
+
+    /// The Archived chip means finished work rather than finished workspaces, so it holds the
+    /// transcripts of archived workspaces as well as their rows.
+    @Test("the archived chip keeps an archived workspace's transcript and drops a live one's")
+    func theArchivedChip() {
+        let listing = build(
+            "docs",
+            workspaces: [workspace("docs chapters")],
+            archived: [workspace("docs import", state: .archived)],
+            transcripts: [
+                transcriptResult("docs chapters", matches: 6),
+                transcriptResult("docs import", matches: 8),
+            ],
+            scope: .archived
+        )
+        #expect(listing.rows.map(\.id) == ["workspace:docs import", "transcript:docs import"])
+    }
+
+    /// It has been deleted since the index was written, so there is nothing to open.
+    @Test("a transcript hit for a workspace that is gone is dropped")
+    func orphanedTranscriptsAreDropped() {
+        let listing = build(
+            "docs",
+            workspaces: [workspace("docs chapters")],
+            transcripts: [transcriptResult("deleted", matches: 3)]
+        )
+        #expect(listing.rows.map(\.id) == ["workspace:docs chapters"])
+        #expect(listing.counts.transcripts == 0)
+    }
+
+    /// Somebody who searched for a workspace that does not exist has just told you what to call
+    /// it. Two rows and no more.
+    @Test("nothing matching gives exactly the two fallback rows")
+    func theFallbackRows() {
+        let listing = build("houdini", workspaces: [workspace("docs chapters")])
+        #expect(listing.rows.map(\.id) == ["fallback:start-workspace", "fallback:search-home"])
+        guard case .fallback(let start)? = listing.rows.first else {
+            Issue.record("expected a fallback row")
+            return
+        }
+        #expect(start.title == "Start a workspace called houdini")
+        #expect(start.action == .newWorkspace)
+    }
+
+    /// With no project added there is nothing to cut a worktree from, so the row would be a
+    /// promise the app cannot keep.
+    @Test("the start row is absent when there is no project to start it in")
+    func noProjectMeansNoStartRow() {
+        let listing = build("houdini", hasProjects: false)
+        #expect(listing.rows.map(\.id) == ["fallback:search-home"])
+    }
+
+    /// Only while the backfill is running. At any other time the same sentence would be an excuse
+    /// rather than a fact.
+    @Test("the incomplete index is stated only while it is being built")
+    func theIndexNotice() {
+        #expect(SearchPanelFallback.indexNotice(isIndexing: false) == nil)
+        #expect(SearchPanelFallback.indexNotice(isIndexing: true)?.isEmpty == false)
+        #expect(SearchPanelFallback.summary(for: " houdini ") == "No workspace, transcript or command matches houdini.")
+    }
+
+    /// A menu item is neither a workspace nor a transcript, so a command row under a chip that
+    /// names one of those two would be a row the chip above it says is not there.
+    @Test("commands are shown under Everything alone, capped, and never for one letter")
+    func inlineCommandsAreAHint() {
+        let commands = MenuBarCatalogue.commands
+        let everything = build("n", workspaces: [], commands: commands)
+        #expect(!everything.sections.contains { $0.title == "Commands" })
+
+        let two = build("ne", workspaces: [], commands: commands)
+        let section = two.sections.first { $0.title == "Commands" }
+        #expect(section?.rows.count == SearchPanelCommands.inlineLimit)
+
+        let narrowed = build("ne", workspaces: [], scope: .workspaces, commands: commands)
+        #expect(!narrowed.sections.contains { $0.title == "Commands" })
+    }
+
+    @Test("an empty query has no listing of its own")
+    func anEmptyQueryIsNotASearch() {
+        #expect(build("   ").isEmpty)
+    }
+
+    /// The highlight is an index into the flattened rows, so a listing that derived them
+    /// differently from the sections would open a row the reader is not looking at.
+    @Test("the flattened rows are the drawn order with the headings taken out")
+    func flatteningMatchesTheSections() {
+        let listing = build(
+            "docs",
+            workspaces: [workspace("docs chapters")],
+            transcripts: [transcriptResult("docs chapters", matches: 6)]
+        )
+        #expect(listing.rows == listing.sections.flatMap(\.rows))
+        #expect(listing.row(at: 1)?.id == "transcript:docs chapters")
+        #expect(listing.row(at: 9) == nil)
+        #expect(listing.summary == "2 results")
+    }
+
+    /// A workspace's own menu acts on a worktree that is there. An archived row has none, and a
+    /// command has no workspace at all.
+    @Test("only a live workspace's row can be pushed into")
+    func whatCanBeDrilled() {
+        let listing = build(
+            "docs",
+            workspaces: [workspace("docs chapters")],
+            archived: [workspace("docs import", state: .archived)],
+            transcripts: [transcriptResult("docs chapters", matches: 2)]
+        )
+        let drillable = Dictionary(
+            uniqueKeysWithValues: listing.rows.map { ($0.id, $0.drillable) }
+        )
+        #expect(drillable["workspace:docs chapters"] == WorkspaceID("docs chapters"))
+        #expect(drillable["workspace:docs import"] == .some(nil))
+        #expect(drillable["transcript:docs chapters"] == WorkspaceID("docs chapters"))
+    }
+}

--- a/Tools/house-rules.sh
+++ b/Tools/house-rules.sh
@@ -325,6 +325,7 @@ id_type_allowed_lines=(
   'Sources/Bloom/Views/Center/Attachments/PromptAttachment.swift' # a draft key, which has no session yet
   'Sources/Bloom/State/TranscriptModel.swift'         # payload ids, read straight off an event
   'Sources/BloomCore/GitHub/CheckFailureHandoff.swift'       # a GitHub Actions run and job, read out of a URL gh gave us
+  'Sources/BloomCore/Presentation/SearchPanelListing.swift'  # a section heading key, not a row
 )
 # A stored property whose name ends in ID or Ids and whose type is a bare
 # String. Trailing `{` is excluded by the `$` anchor, which is what leaves

--- a/docs/MENUS.md
+++ b/docs/MENUS.md
@@ -62,6 +62,7 @@ contribute for free.
 | Find > Find… | `⌘F` | falls through to Search when nothing in front can find |
 | Find > Find Next | `⌘G` | |
 | Find > Find Previous | `⇧⌘G` | |
+| Quick Search… | `⌘K` | always, but a focused terminal keeps the key |
 | Search | `⇧⌘F` | a project exists |
 
 ### View
@@ -161,7 +162,7 @@ of an item that has a submenu. That trick is the one the View menu should borrow
 | Action | Key | Anywhere in a menu |
 | --- | --- | --- |
 | Focus pane left / right / up / down | `⌥⌘←→↑↓` | **no** |
-| Clear the shell and its scrollback | `⌘K` | **no** |
+| Clear the shell and its scrollback | `⌘K` | **no**, and it beats Edit's Quick Search |
 | Copy, Paste | `⌘C` `⌘V` | Edit menu's, but the terminal answers them itself |
 | Terminal text bigger / smaller / actual | `⌘+` `⌘-` `⌘0` | View menu's Zoom trio, resolved onto the terminal |
 
@@ -318,7 +319,7 @@ a menu item.
 | `⌥⌘←→` | none | terminal moves pane focus | terminal |
 | `⌥⌘↑↓` | Previous / Next Workspace | terminal moves pane focus | **terminal, silently** |
 | `⌘W` | Close Tab | terminal closes the pane | terminal, deliberately |
-| `⌘K` | none | terminal clears the shell | terminal |
+| `⌘K` | Quick Search… | terminal clears the shell | terminal, deliberately |
 | `⌘C` `⌘V` | Edit's own | terminal copies and pastes | terminal |
 | `⌘+` `⌘-` `⌘0` | Zoom In / Out / Actual Size | terminal text size | terminal, and both act on the same shell |
 | `⌘F` `⌘G` `⇧⌘G` | Find submenu | browser finds in the page | browser, when the page has the keyboard |


### PR DESCRIPTION
The window's `.searchable` field comes out and the same search opens as a panel on Cmd+K, with a magnifying glass beside the inspector toggle for anyone who never presses a key. Shift+Cmd+F, and Cmd+F falling through, open it on the Transcripts chip and keep meaning what they meant.

The defect this fixes is that typing one character into that field set the selection to Home. Nothing in the new path navigates: the panel opens over the window, dims it and closes leaving it exactly where it was.

Resting, it shows what is waiting on you and then what you last had open, both capped. Typing searches workspaces in memory and transcripts through the store, debounced, with the slow half filling in underneath. `>` switches to the menu bar, grouped by menu, every row printing its key or the words "no key", greyed rather than hidden when it cannot be pressed. Cmd+Return and the right arrow push into a workspace's own menu; Backspace pops back out. Tab walks Home's own scope chips.

The decisions are in BloomCore with 55 tests over them; the panel, its rows and the toolbar button are the app target's. Commands run by pressing the real menu item, so nothing is in the panel that is not also in a menu.

A focused terminal already claims Cmd+K to clear its scrollback and keeps it, which is what iTerm and Terminal do. `MenuBarCatalogueTests` and `docs/MENUS.md` record the overlap.

Not in this: query-keyed frecency, which needs a stored table of its own, and command aliases, which are a content exercise over fifty-eight items.