### PR TITLE
Deliver a queued message into a turn that will take it

### DIFF
--- a/Sources/Bloom/Design/PendingDeleteSnapshotGallery.swift
+++ b/Sources/Bloom/Design/PendingDeleteSnapshotGallery.swift
@@ -41,7 +41,7 @@ struct PendingDeleteSnapshotGallery: View {
             group("At rest") {
                 PendingTurnRowView(
                     delivery: Self.delivery(Self.typed),
-                    hold: .question,
+                    holdSentence: DeliveryHold.question.sentence(on: .claudeCode),
                     onEdit: {},
                     onDelete: {}
                 )
@@ -50,7 +50,7 @@ struct PendingDeleteSnapshotGallery: View {
             group("Under the pointer") {
                 PendingTurnRowView(
                     delivery: Self.delivery(Self.typed),
-                    hold: .question,
+                    holdSentence: DeliveryHold.question.sentence(on: .claudeCode),
                     onEdit: {},
                     onDelete: {},
                     pointerInside: true
@@ -64,20 +64,20 @@ struct PendingDeleteSnapshotGallery: View {
                 VStack(spacing: 0) {
                     PendingTurnRowView(
                         delivery: Self.delivery("Also check the migration."),
-                        hold: nil,
+                        holdSentence: nil,
                         onEdit: {},
                         onDelete: {}
                     )
                     PendingTurnRowView(
                         delivery: Self.delivery(Self.typed),
-                        hold: nil,
+                        holdSentence: nil,
                         onEdit: {},
                         onDelete: {},
                         pointerInside: true
                     )
                     PendingTurnRowView(
                         delivery: Self.delivery("And run the tests when you are done."),
-                        hold: .turn,
+                        holdSentence: DeliveryHold.setup.sentence(on: .claudeCode),
                         onEdit: {},
                         onDelete: {}
                     )
@@ -91,7 +91,7 @@ struct PendingDeleteSnapshotGallery: View {
                     delivery: Self.delivery(
                         "Look at this \(AttachmentDraft.token(for: ".bloom/attachments/2UCGb6/shot.png"))"
                     ),
-                    hold: .turn,
+                    holdSentence: DeliveryHold.setup.sentence(on: .claudeCode),
                     onEdit: {},
                     onDelete: {},
                     pointerInside: true

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -536,10 +536,10 @@ final class TranscriptModel {
         // bubble that goes on screen are one object with one id. Drawn twice under two ids is the
         // duplicate that would appear the moment the queue was read back.
         let delivery = Delivery(targetSessionID: session.id, body: body)
-        if Delivery.goesImmediately(behind: pendingDeliveries, hold: deliveryHold) {
-            sending = delivery
-        } else {
+        if queuesNextMessage {
             pendingDeliveries.append(delivery)
+        } else {
+            sending = delivery
         }
 
         // And the list is taken to it, on the same frame, for the same reason the bubble is drawn
@@ -604,10 +604,37 @@ final class TranscriptModel {
         )
     }
 
-    /// Hands the front of the queue to the agent, if anything is allowed to go.
+    /// Whether pressing Return right now puts the message in the queue rather than handing it over.
     ///
-    /// One at a time. The next one goes when this turn ends, which is what "never mid-turn" means
-    /// on both backends and what keeps the queue an ordered thing rather than a burst.
+    /// Read by `submit` to decide which bubble to draw and by the footer to decide what the Send
+    /// button's tooltip promises, so the caption over the button and the bubble under it cannot
+    /// say different things. It was `isRunning` in the footer, which stopped being the same
+    /// question the moment a running turn stopped holding the queue on two of the four backends:
+    /// the tooltip went on offering to queue a message that was about to go straight out.
+    var queuesNextMessage: Bool {
+        !Delivery.goesImmediately(
+            behind: pendingDeliveries, hold: deliveryHold, on: session.agentKind
+        )
+    }
+
+    /// What the last pending bubble says under itself, or nothing when nothing is holding it.
+    ///
+    /// Here rather than in the row because it needs the chat's backend, which the row has no
+    /// business knowing, and because a caption that disagrees with the drain is the one thing this
+    /// queue may not do: both read `DeliveryHold`. See `DeliveryHold.sentence(on:)`.
+    var holdSentence: String? { deliveryHold.sentence(on: session.agentKind) }
+
+    /// Hands the queue to the agent, from the front, for as long as it is allowed to go.
+    ///
+    /// **How many leave in one pass is the backend's answer and `Delivery.deliverable` is where it
+    /// is taken.** On a CLI that will not read a line written into a running turn this hands over
+    /// one, because the turn that one starts holds the rest, which is what it always did. On one
+    /// that will, a running turn holds nothing, so the queue empties in the order it was asked
+    /// for rather than one message per turn under a caption promising a wait that is not
+    /// happening.
+    ///
+    /// The hold is read again on every pass rather than once at the top. A permission question can
+    /// arrive between two sends, and nothing may be written into a turn that is blocked on one.
     ///
     /// Called from the three moments a queue is meant to move and from nowhere else: the setup
     /// script finishing, a turn ending of its own accord, and the owner submitting. Not on launch,
@@ -617,26 +644,42 @@ final class TranscriptModel {
     func drain() async {
         guard let store else { return }
         await refreshQueue()
-        guard let next = Delivery.next(from: pendingDeliveries, hold: deliveryHold) else { return }
 
-        // Drawn as said from here, whichever moment the queue is moving in: the owner submitting
-        // (where `submit` has already done it, to the same id), a setup script finishing, or the
-        // turn in front of it ending. Before the retire below, so there is no frame on which the
-        // sentence has left the queue and has not yet become a bubble. See `sending`.
-        sending = next
+        // The list is taken once and walked, rather than the queue being re-asked for a front
+        // each pass. A start that fails puts its delivery back at the front (see `abandon`), so a
+        // loop that asked again would hand the same message over for ever.
+        for next in Delivery.deliverable(
+            from: pendingDeliveries, hold: deliveryHold, on: session.agentKind
+        ) {
+            guard deliveryHold.allowsDelivery(on: session.agentKind) else { return }
+            // Deleted, or steered out, since the list was taken.
+            guard pendingDeliveries.contains(where: { $0.id == next.id }) else { continue }
 
-        // Retired before it is handed over, rather than after. The pending bubble and the real one
-        // are two drawings of the same sentence, and a delivery that is still pending while its
-        // turn is starting is drawn twice. `restoreDelivery` below is the one path back.
-        try? await store.markDelivered(id: next.id)
-        await refreshQueue()
+            // Drawn as said from here, whichever moment the queue is moving in: the owner
+            // submitting (where `submit` has already done it, to the same id), a setup script
+            // finishing, or the turn in front of it ending. Before the retire below, so there is
+            // no frame on which the sentence has left the queue and has not yet become a bubble.
+            // See `sending`.
+            sending = next
 
-        await deliver(next)
+            // Retired before it is handed over, rather than after. The pending bubble and the real
+            // one are two drawings of the same sentence, and a delivery that is still pending
+            // while its turn is starting is drawn twice. `restoreDelivery` is the one path back.
+            try? await store.markDelivered(id: next.id)
+            await refreshQueue()
+
+            // A turn that would not start stops the pass. Its delivery is back at the front of
+            // the queue with an error row under it, and pushing the next one into an agent that
+            // just refused would bury that.
+            guard await deliver(next) else { return }
+        }
     }
 
     /// Whether this delivery is at the front of an idle queue and can be attempted now.
     func canRetry(_ delivery: Delivery) -> Bool {
-        Delivery.next(from: pendingDeliveries, hold: deliveryHold)?.id == delivery.id
+        Delivery.next(
+            from: pendingDeliveries, hold: deliveryHold, on: session.agentKind
+        )?.id == delivery.id
     }
 
     /// Attempts the front of the queue again without changing its order or duplicating its text.
@@ -755,7 +798,7 @@ final class TranscriptModel {
 
     /// Whether this queued message may be sent in place of the turn that is running.
     func canSteer(_ delivery: Delivery) -> Bool {
-        DeliverySteer.canSteer(delivery, hold: deliveryHold)
+        DeliverySteer.canSteer(delivery, hold: deliveryHold, on: session.agentKind)
     }
 
     /// Stops the turn that is running and sends this queued message into the space it makes.
@@ -816,8 +859,13 @@ final class TranscriptModel {
         dropDiscardIfDelivered()
     }
 
-    /// The one place a turn starts, reached only from `drain`.
-    private func deliver(_ delivery: Delivery) async {
+    /// The one place a turn starts, reached only from `drain`, and now also the place a sentence
+    /// goes into a turn that has already started.
+    ///
+    /// Answers whether the sentence actually went out, because the drain hands over more than one
+    /// on a backend that takes a message mid turn and must stop at the first that did not.
+    @discardableResult
+    private func deliver(_ delivery: Delivery) async -> Bool {
         // A bare `return` used to stand here, and the sentence went nowhere: `drain` has already
         // retired this delivery from the queue and drawn it as sent, so a quiet return leaves a
         // bubble claiming to have been said to an agent that was never built. It takes a database
@@ -825,21 +873,34 @@ final class TranscriptModel {
         // disappearing without a word is not a thing to leave resting on that.
         guard let runner = ensureRunner() else {
             await abandon(delivery, saying: "Bloom could not open an agent for this chat.")
-            return
+            return false
         }
-        turnStartedAt = Date()
+        // The queue is moving, whether or not that begins a turn.
         wasStoppedByHand = false
-        hasReportedTurnEnded = false
-        // **The clearing rule.** The last turn's FINISHED subagents go here, at the one place a
-        // turn starts, and nowhere else. Clearing them when they finish is the option that reads
-        // well in a screenshot and badly in use: three rows leaving one by one take everything
-        // below them up the pane while you are still reading the third. Clearing them here means a
-        // finished subagent keeps its place, with its tick or its cross and what it answered, for
-        // as long as the turn it belongs to is the last thing that happened. One still running is
-        // not cleared at all, because it is still running. See `SubagentRoster.turnStarted`.
-        subagents.turnStarted()
-        setRunning(true)
-        statusLabel = "Starting"
+
+        // **Everything below is about a turn beginning, so it is asked whether one is.** On a
+        // backend that takes a message mid turn this is reached with a turn already running, and
+        // each of these lines is wrong there: the clock the footer counts from would restart in
+        // the middle of the turn it is timing, the label would put "Starting" over an agent that
+        // has been working for two minutes, and the roster clear would take the finished
+        // subagents of the turn being read out from under the reader. See
+        // `Delivery.deliverable(from:hold:on:)` for why a send arrives here at all.
+        let startsATurn = !isRunning
+        if startsATurn {
+            turnStartedAt = Date()
+            hasReportedTurnEnded = false
+            // **The clearing rule.** The last turn's FINISHED subagents go here, at the one place
+            // a turn starts, and nowhere else. Clearing them when they finish is the option that
+            // reads well in a screenshot and badly in use: three rows leaving one by one take
+            // everything below them up the pane while you are still reading the third. Clearing
+            // them here means a finished subagent keeps its place, with its tick or its cross and
+            // what it answered, for as long as the turn it belongs to is the last thing that
+            // happened. One still running is not cleared at all, because it is still running. See
+            // `SubagentRoster.turnStarted`.
+            subagents.turnStarted()
+            setRunning(true)
+            statusLabel = "Starting"
+        }
 
         do {
             // `sent` rather than `body`, and the payload beside it. They are the same string for
@@ -853,10 +914,16 @@ final class TranscriptModel {
             // echo, and `absorb` is what clears `sending` when the row lands, so the two drawings
             // of the sentence swap inside one synchronous pass and nothing on screen moves.
             await appendLatestMessages()
+            return true
         } catch {
-            setRunning(false)
-            statusLabel = nil
+            // Only what this call turned on. A send that failed into a turn somebody else started
+            // must not report that turn as over: it is still running and still writing rows.
+            if startsATurn {
+                setRunning(false)
+                statusLabel = nil
+            }
             await abandon(delivery, saying: error.readableMessage)
+            return false
         }
     }
 
@@ -1536,8 +1603,10 @@ final class TranscriptModel {
     ///
     /// It enqueues and only then drains, rather than sending. The orchestrator is very often mid
     /// turn at this moment, because a turn of its own is usually what started this agent, and
-    /// `DeliveryHold` is what decides: a held report goes when that turn ends, through the same
-    /// `drain` every other queued message goes through.
+    /// `DeliveryHold` is what decides. On a backend that takes a message mid turn the report goes
+    /// into that turn, which is what the orchestrator wanted anyway; on one that does not it goes
+    /// when the turn ends. Either way it is the same `drain` every other queued message goes
+    /// through, and it keeps its place in the same order.
     ///
     /// A chat nobody started returns on the first line, which is nearly every chat in the app.
     ///

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -681,20 +681,21 @@ final class WorkspaceModel {
         )
 
         // Enqueued first and drained after, never sent: the chat being spoken to is very often mid
-        // turn, and `DeliveryHold` is what decides whether this goes now or when that turn ends.
+        // turn, and `DeliveryHold` is what decides whether this goes into that turn, waits for it
+        // to end, or waits for something else.
         let transcript = transcript(for: target)
         await transcript.refreshQueue()
         await transcript.drain()
 
+        // `Crew`'s words rather than this file's, because what happens to a message mid turn is
+        // the backend's answer and a sentence stating it here would be a second copy to drift.
+        let when = Crew.deliverySentence(to: target.agentKind)
         if name == nil {
-            return .delivered(
-                "Passed that to the agent that started you. If it is mid turn it will read it when "
-                    + "that turn ends."
-            )
+            return .delivered("Passed that to the agent that started you. \(when)")
         }
         return .delivered(
-            "Passed that to subagent \"\(target.title)\". If it is mid turn it will read it when "
-                + "that turn ends, and Bloom will tell you here when it stops."
+            "Passed that to subagent \"\(target.title)\". \(when) Bloom will tell you here when "
+                + "it stops."
         )
     }
 

--- a/Sources/Bloom/Views/Center/Composer/ComposerFooterView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerFooterView.swift
@@ -14,7 +14,11 @@ struct ComposerFooterView: View {
     /// anything about the window. Absent rather than zero: a gauge reading 0% would be a claim.
     /// Always nil in the create window, where there is not yet anything to report.
     var context: ContextWindowUsage?
+    /// Whether a turn is running, which is what decides whether Stop is drawn.
     var isRunning: Bool = false
+    /// Whether Send would queue the message rather than hand it over. Not the same question as
+    /// `isRunning` any more: see `ComposerSendButton.queues`.
+    var queues: Bool = false
     var canSend: Bool
     /// What the button at the end of the row does. See `ComposerIntent`.
     var intent: ComposerIntent = .send
@@ -303,7 +307,7 @@ struct ComposerFooterView: View {
 
             ComposerSendButton(
                 intent: intent,
-                isRunning: isRunning,
+                queues: queues,
                 canSend: canSend,
                 onSend: onSend
             )

--- a/Sources/Bloom/Views/Center/Composer/ComposerSendButton.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerSendButton.swift
@@ -18,11 +18,16 @@ import SwiftUI
 /// `ComposerIntent`.
 struct ComposerSendButton: View {
     var intent: ComposerIntent = .send
-    /// Whether a turn is running, which changes nothing about whether this may be pressed and
-    /// everything about what pressing it means. A message sent now goes into the queue in front of
-    /// the agent rather than to the agent, and the tooltip is where that is said, because the
-    /// bubble that appears afterwards is the honest version of the answer. See `DeliveryHold`.
-    var isRunning: Bool = false
+    /// Whether pressing this queues the message rather than handing it over, which changes nothing
+    /// about whether it may be pressed and everything about what pressing it means. The tooltip is
+    /// where that is said, because the bubble that appears afterwards is the honest version of the
+    /// answer.
+    ///
+    /// **Not "is a turn running", which is what it used to be.** A running turn holds the queue on
+    /// a backend that will not read a line written into one and holds nothing on the two that
+    /// will, so the tooltip was offering to queue messages that were about to go straight out.
+    /// `TranscriptModel.queuesNextMessage` is the same function `submit` asks. See `DeliveryHold`.
+    var queues: Bool = false
     var canSend: Bool
     var onSend: @MainActor () -> Void
 
@@ -71,6 +76,9 @@ struct ComposerSendButton: View {
         // The system control accent keeps this primary action consistent with every native control.
         .tint(Palette.controlAccent)
         .disabled(!canSend)
-        .help(isRunning ? "Queue this message. It goes when the turn ends (Return)" : intent.help)
+        // "When the queue moves" rather than "when the turn ends", because a turn is no longer the
+        // only thing it can be waiting for and was never the only thing it could be waiting for:
+        // the bubble that appears underneath names the specific one. See `DeliveryHold.sentence`.
+        .help(queues ? "Queue this message. It goes when the queue moves (Return)" : intent.help)
     }
 }

--- a/Sources/Bloom/Views/Center/Composer/ComposerView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerView.swift
@@ -132,6 +132,7 @@ struct ComposerView: View {
                 onChange: apply(controls:),
                 context: transcript.contextUsage,
                 isRunning: transcript.isRunning,
+                queues: transcript.queuesNextMessage,
                 canSend: canSend,
                 project: transcript.cwd,
                 onAttach: actions.attach,

--- a/Sources/Bloom/Views/Transcript/PendingTurnRowView.swift
+++ b/Sources/Bloom/Views/Transcript/PendingTurnRowView.swift
@@ -32,7 +32,11 @@ struct PendingTurnRowView: View {
     /// which is where it was: between two bubbles it read as a caption on the one below it, or as
     /// a divider somebody had left in. At the foot of the run it reads as what it is, which is a
     /// note about everything above it.
-    var hold: DeliveryHold?
+    ///
+    /// The sentence rather than the hold, because which of them a hold produces depends on the
+    /// chat's backend and a row is the wrong place to be asking that. `TranscriptModel.holdSentence`
+    /// is where it is worked out, off the same `DeliveryHold` the drain reads.
+    var holdSentence: String?
     /// Whether the message is at the front of an idle queue after a failed start.
     var canRetry = false
     /// Attempts this queued message again without adding a duplicate to the queue.
@@ -261,7 +265,7 @@ struct PendingTurnRowView: View {
     @ViewBuilder
     private var caption: some View {
         HStack(spacing: Metrics.gutter) {
-            if let sentence = hold?.sentence {
+            if let sentence = holdSentence {
                 Text(sentence)
                     .foregroundStyle(Palette.textTertiary)
             }

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -764,7 +764,7 @@ struct TranscriptListView: View {
         for delivery in transcript.waitingDeliveries {
             let isLast = delivery.id == transcript.waitingDeliveries.last?.id
             // One sentence for the queue, at the foot of it. See `PendingTurnRowView.caption`.
-            let hold = isLast ? transcript.deliveryHold : nil
+            let holdSentence = isLast ? transcript.holdSentence : nil
             // In the key as well as in the row, because a cell whose key has not moved is left
             // exactly as it is: a Steer button offered against a turn that has since ended would
             // sit there until something else rebuilt the cell. It changes when the turn starts and
@@ -777,6 +777,10 @@ struct TranscriptListView: View {
                     $0.combine(delivery.id)
                     $0.combine(isLast)
                     $0.combine(canSteer)
+                    // The sentence changes without `canSteer` moving on a backend that takes a
+                    // message mid turn, where Steer is never offered: a setup script finishing
+                    // swaps one caption for none. A key that missed it left the old one drawn.
+                    $0.combine(holdSentence)
                 },
                 content: {
                     // A message an agent wrote, waiting its turn in the same queue. It is drawn as
@@ -793,7 +797,7 @@ struct TranscriptListView: View {
                         PendingTurnRowView(
                             delivery: delivery,
                             home: transcript.home,
-                            hold: hold,
+                            holdSentence: holdSentence,
                             canRetry: transcript.canRetry(delivery),
                             onRetry: { Task { await transcript.retryPending() } },
                             canSteer: canSteer,

--- a/Sources/BloomCore/Agent/Codex/CodexRunner.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexRunner.swift
@@ -128,6 +128,12 @@ public actor CodexRunner: SessionRunner {
     /// Model, effort, approval policy and sandbox all travel **with the turn** rather than with
     /// the process, which is what makes changing a composer chip mid chat take effect on the next
     /// turn without restarting anything. Claude Code cannot do that: its equivalents are argv.
+    ///
+    /// **A turn that is already open takes the words instead of a second turn beside it.** This
+    /// backend has a call for exactly that, `turn/steer`, and what `turn/start` does to a thread
+    /// with an open turn is not measured, so it is not the thing to find out with somebody's
+    /// sentence. See `AgentKind.acceptsMidTurnMessage` for why a message reaches here mid turn at
+    /// all, and `steer(_:threadID:turnID:on:)` for the fall back when the turn has just ended.
     public func send(_ text: String, recording: Data? = nil) async throws {
         await applyContextWindowChange()
         let client = try await connected()
@@ -140,6 +146,18 @@ public actor CodexRunner: SessionRunner {
             await persist(kind: .crew, payload: recording)
         } else {
             await persist(kind: .user, payload: Self.userPayload(text))
+        }
+
+        // Absorbed into the running turn, so there is no new turn id to hold and no state to
+        // move: `turnStarted` is `unchanged` from `running` anyway. See `SessionLifecycle`.
+        //
+        // `steerableTurnID` rather than `turnID`, and the difference is a turn somebody stopped.
+        // Asked rather than left to the steer failing, because a state has to be guarded by asking:
+        // a turn the server has been told to abandon is not a turn a message belongs in, whatever
+        // the server answers about it.
+        if let turnID = handle.steerableTurnID,
+           await steer(text, threadID: threadID, turnID: turnID, on: client) {
+            return
         }
 
         let turn = try await client.startTurn(
@@ -547,6 +565,31 @@ public actor CodexRunner: SessionRunner {
         await save(session)
     }
 
+    /// Put the words into the turn that is already running, and say whether they landed.
+    ///
+    /// **A miss is not a failure, it is a turn that ended under the read.** `expectedTurnId` is a
+    /// precondition on this wire, so the server refuses a steer for a turn that is no longer the
+    /// active one, and the message wants an ordinary `turn/start` after all. `send` then carries
+    /// on down the path it always took.
+    ///
+    /// **This is a race guard and not a state guard, and the difference cost a regression.** It
+    /// only fires for a turn that finished between `handle.steerableTurnID` being read and this
+    /// request landing, because `end()` runs on the actor and this call suspends. A turn somebody
+    /// STOPPED is a state rather than a race: the id is still there, the server may well take the
+    /// steer, and nothing here would have said no. That is what `steerableTurnID` asks, before
+    /// this is reached.
+    private func steer(
+        _ text: String, threadID: String, turnID: String, on client: CodexClient
+    ) async -> Bool {
+        do {
+            _ = try await client.steerTurn(threadID: threadID, turnID: turnID, input: [.text(text)])
+            return true
+        } catch {
+            Self.log.info("a message missed the turn it was steered into, so it starts one")
+            return false
+        }
+    }
+
     /// Say why, in the only place this protocol has room for it.
     ///
     /// An approval is answered with a word: `accept`, `decline`, `cancel`. There is no field for
@@ -707,6 +750,24 @@ private final class TurnHandle: Sendable {
     private let state = Mutex(State())
 
     var turnID: String? { state.withLock(\.current) }
+
+    /// The turn a message may be **steered into**, which is one that is open and has not been
+    /// stopped.
+    ///
+    /// **A stopped turn keeps its id for a moment and is over all the same.** `end()` runs on the
+    /// `turn/completed` the interrupt produces, so between `cancelNow` and that notification
+    /// arriving `current` still names a turn nobody is running. Steering into it is the wrong call
+    /// whatever the server answers, and it cost the one thing Stop is for: the next message went
+    /// into the dead turn instead of starting a new one on the same connection, which is what
+    /// keeps the grants the person has already given. `CodexRunnerTests`
+    /// `stopInterruptsTheTurnAndLeavesTheServerRunning` is that bug written down, at one handshake
+    /// and two turns.
+    ///
+    /// Both fields under one lock, which is the whole reason this is a `Mutex<State>`: reading
+    /// them separately is two answers that can disagree about the same instant.
+    var steerableTurnID: String? {
+        state.withLock { $0.cancelled ? nil : $0.current }
+    }
 
     var wasCancelled: Bool { state.withLock(\.cancelled) }
 

--- a/Sources/BloomCore/Agent/Crew.swift
+++ b/Sources/BloomCore/Agent/Crew.swift
@@ -123,6 +123,27 @@ public enum Crew {
         }
     }
 
+    /// What `agent_say` and `workspace_send` tell the caller about when the words will be read.
+    ///
+    /// **The old sentence promised a wait that no longer happens.** It said "If it is mid turn it
+    /// will read it when that turn ends", which was true while a running turn held every queue.
+    /// Two of the four backends take a message into the turn they are running, so the caller was
+    /// being told to expect a delay it will not see, and a model told to wait is a model that
+    /// polls or gives up. Here rather than in `WorkspaceModel` so the suite can hold it, for the
+    /// reason `DeliveryHold.sentence(on:)` is in the core.
+    ///
+    /// The clause about something being queued in front of it is the honest hedge, and it is
+    /// deliberately not spelled out into the three things that could be: a setup script, an
+    /// unanswered permission question, or simply an older message. `workspace_list` names each of
+    /// those in `hold_note`, and this is a confirmation that the words were taken rather than a
+    /// status report on the chat.
+    public static func deliverySentence(to agent: AgentKind) -> String {
+        agent.acceptsMidTurnMessage
+            ? "It reads this inside the turn it is running, or straight away if it is idle, "
+                + "unless something is queued in front of it."
+            : "If it is mid turn it will read this when that turn ends."
+    }
+
     /// The line Bloom puts in the orchestrator's chat when one of its subagents stops.
     ///
     /// **This is the whole point of the design, so it is worth saying why it exists.** Without it

--- a/Sources/BloomCore/Agent/Delivery.swift
+++ b/Sources/BloomCore/Agent/Delivery.swift
@@ -141,6 +141,37 @@ public struct Delivery: Identifiable, Sendable, Hashable {
 
     public var isPending: Bool { deliveredAt == nil }
 
+    /// Everything that may be handed over right now, in the order it was asked for.
+    ///
+    /// **The order never changes. What the backend changes is how many may leave in one pass.**
+    ///
+    /// On a CLI that will not read a line written into a running turn, handing over the front
+    /// starts a turn, and that turn holds everything behind it, so exactly one may go. That was
+    /// the only rule there used to be, and the drain's comment gave the reason in as many words:
+    /// the next one goes when this turn ends, which is what never mid-turn means on both backends.
+    ///
+    /// On a CLI that does read one, that reason is gone, and keeping the rule would break the
+    /// promise the pending bubble makes. The second message would sit under "Goes when this turn
+    /// ends", and the owner's very next sentence would falsify it: `submit` drains, the drain
+    /// takes the front, and the front would go mid turn. A caption and a drain that disagree is
+    /// the whole class of bug this file exists to close, so on that backend a running turn holds
+    /// nothing and the queue empties in order. See `DeliveryHold.sentence(on:)`.
+    ///
+    /// **Nothing here lets a newer message overtake an older one.** The answer is `pending`
+    /// itself, in `Store.pendingDeliveries` order, which is the order it was asked for; a message
+    /// typed during a turn joins the back of it like every other. See `goesImmediately`.
+    ///
+    /// The caller walks this rather than trusting it blind: a permission question can arrive
+    /// between two sends, and a hold read once at the top of a drain is a hold that was true when
+    /// it was read.
+    public static func deliverable(
+        from pending: [Delivery], hold: DeliveryHold, on agent: AgentKind
+    ) -> [Delivery] {
+        guard hold.allowsDelivery(on: agent) else { return [] }
+        guard agent.acceptsMidTurnMessage else { return Array(pending.prefix(1)) }
+        return pending
+    }
+
     /// Which of the waiting messages goes next, if any may go at all.
     ///
     /// The front of the queue, always, and never the one that was just typed. That is the whole of
@@ -150,9 +181,10 @@ public struct Delivery: Identifiable, Sendable, Hashable {
     ///
     /// `pending` must be in the order `Store.pendingDeliveries` returns, which is the order it was
     /// asked for.
-    public static func next(from pending: [Delivery], hold: DeliveryHold) -> Delivery? {
-        guard hold.allowsDelivery else { return nil }
-        return pending.first
+    public static func next(
+        from pending: [Delivery], hold: DeliveryHold, on agent: AgentKind
+    ) -> Delivery? {
+        deliverable(from: pending, hold: hold, on: agent).first
     }
 
     /// Whether something enqueued this instant would go straight out, with nothing in front of it.
@@ -166,10 +198,14 @@ public struct Delivery: Identifiable, Sendable, Hashable {
     /// Asked of the same function the drain asks, rather than by restating the rule, because the
     /// two answers disagreeing is the whole class of bug this file exists to close. `pending` is
     /// the queue as it stands **before** the new message joins it.
-    public static func goesImmediately(behind pending: [Delivery], hold: DeliveryHold) -> Bool {
+    public static func goesImmediately(
+        behind pending: [Delivery], hold: DeliveryHold, on agent: AgentKind
+    ) -> Bool {
         // Nothing may go at all, so nor may this one.
-        guard hold.allowsDelivery else { return false }
+        guard hold.allowsDelivery(on: agent) else { return false }
         // Anything already waiting is in front of it, and the front of the queue always wins.
-        return next(from: pending, hold: hold) == nil
+        // This is the guard that keeps immediate delivery from being a reordering: a backend that
+        // takes a message mid turn still takes the oldest one first.
+        return next(from: pending, hold: hold, on: agent) == nil
     }
 }

--- a/Sources/BloomCore/Agent/DeliveryHold.swift
+++ b/Sources/BloomCore/Agent/DeliveryHold.swift
@@ -21,6 +21,13 @@ import Foundation
 /// is still said in four other places, none of which this changes: the red setup row with its
 /// log, the alert, the notification, and `WorkspaceStatus.setupFailed` in the sidebar.
 ///
+/// **A hold and a refusal are two different things, and this type now holds both.** `of` says what
+/// the session is doing; `allowsDelivery(on:)` says whether that stops a delivery, and it needs the
+/// backend to answer, because a running turn stops one on a CLI that will not read a line written
+/// into it and stops nothing on the two that will. Keeping the case and the refusal apart is what
+/// lets `WorkspaceMergeTool` go on refusing to merge a worktree an agent is writing into while the
+/// composer goes on talking to it.
+///
 /// Here rather than in the view for the usual reason: the precedence between these is a decision,
 /// the drain reads the same answer the bubble does, and the test target cannot see a view. The
 /// sentences are here too, so the promise the transcript makes is pinned by the suite rather than
@@ -33,6 +40,10 @@ public enum DeliveryHold: Equatable, Sendable, CaseIterable {
     /// blocked on an answer is the mid-turn injection every backend is unhappy about.
     case question
     /// The agent is mid turn.
+    ///
+    /// **Whether that holds anything is the backend's answer, not this case's.** See
+    /// `allowsDelivery(on:)`: Claude Code and Codex both take a message into a turn that is
+    /// already running, so on those two this names a fact about the session and holds nothing.
     case turn
     /// Nothing in the session is holding it.
     ///
@@ -49,6 +60,14 @@ public enum DeliveryHold: Equatable, Sendable, CaseIterable {
     /// still marked running: `TranscriptModel` only clears that flag on a result. Answering
     /// `.turn` there would be true and useless, since what the reader has to do is answer the
     /// question above the composer.
+    ///
+    /// **It still answers `.turn` for a backend that would take the message anyway, and that is
+    /// deliberate.** A hold describes the session; whether it stops a delivery is
+    /// `allowsDelivery(on:)`, and the two are kept apart because they have different readers.
+    /// `WorkspaceMergeTool` asks for the case, and a running turn is a refusal there whatever the
+    /// backend does with a sentence: merging a worktree an agent is writing into is unsafe for
+    /// reasons that have nothing to do with whether it can hear you. Collapsing `.turn` into
+    /// `.none` for Claude Code would have told that tool a busy workspace was quiet.
     public static func of(
         isRunningSetup: Bool,
         isTurnRunning: Bool,
@@ -61,7 +80,23 @@ public enum DeliveryHold: Equatable, Sendable, CaseIterable {
     }
 
     /// Whether a drain triggered right now may hand the next delivery to the runner.
-    public var allowsDelivery: Bool { self == .none }
+    ///
+    /// **The backend is asked because only the backend knows.** `.turn` refused on every one of
+    /// them, so a message typed during a turn waited for a turn that would have accepted it. It
+    /// now refuses only where writing into a live turn is not a thing the CLI does: see
+    /// `AgentKind.acceptsMidTurnMessage`, which carries the measurement for each of the four.
+    ///
+    /// `.setup` and `.question` refuse everywhere and are not asked. A worktree that is still
+    /// being built has nothing installed to work with, and a turn blocked on a permission answer
+    /// is not reading anything else, which `SessionLifecycle` says a second time by refusing
+    /// `turnStarted` from `waiting`. Neither is a fact about a protocol.
+    public func allowsDelivery(on agent: AgentKind) -> Bool {
+        switch self {
+        case .none: true
+        case .turn: agent.acceptsMidTurnMessage
+        case .setup, .question: false
+        }
+    }
 
     /// What the pending bubble says under itself, or nothing when nothing is holding it.
     ///
@@ -74,12 +109,19 @@ public enum DeliveryHold: Equatable, Sendable, CaseIterable {
     /// the three sentences above are worth reading because each names a specific thing to wait on,
     /// and a fourth explaining that there is nothing to wait on made the other three look like
     /// decoration.
-    public var sentence: String? {
+    ///
+    /// **A running turn says nothing on a backend that would take the message anyway.** "Goes
+    /// when this turn ends" is a promise the drain no longer keeps there: on Claude Code and
+    /// Codex the queue empties into the turn rather than behind it, so the caption would be
+    /// describing a wait that is not happening. Nothing is holding it, so it says what nothing
+    /// holding it has always said, which is nothing. See `Delivery.deliverable(from:hold:on:)`.
+    public func sentence(on agent: AgentKind) -> String? {
+        guard !allowsDelivery(on: agent) else { return nil }
         switch self {
-        case .setup: "Goes as soon as setup finishes."
-        case .question: "Goes once you have answered the question above."
-        case .turn: "Goes when this turn ends."
-        case .none: nil
+        case .setup: return "Goes as soon as setup finishes."
+        case .question: return "Goes once you have answered the question above."
+        case .turn: return "Goes when this turn ends."
+        case .none: return nil
         }
     }
 }

--- a/Sources/BloomCore/Agent/DeliverySteer.swift
+++ b/Sources/BloomCore/Agent/DeliverySteer.swift
@@ -27,8 +27,17 @@ public enum DeliverySteer {
     /// person's decision rather than another agent's. A body carrying chips or attachments is fine
     /// here, unlike Edit, because nothing is being turned back into text: the message goes to the
     /// agent exactly as it would have gone when its turn came.
-    public static func canSteer(_ delivery: Delivery, hold: DeliveryHold) -> Bool {
-        guard hold == .turn else { return false }
+    ///
+    /// **And not offered at all on a backend that takes a message mid turn**, which is a decision
+    /// rather than a consequence. Talking over an agent and stopping one are two different acts,
+    /// and only the second is what this button does: it cancels the turn and spends whatever that
+    /// turn had done. Where the message can simply go, spending the turn to make room for it buys
+    /// nothing and costs the work. There is also nothing left to draw it on, because a message
+    /// that goes at once is never a pending bubble (`Delivery.goesImmediately`) and the queue does
+    /// not sit behind a running turn there (`Delivery.deliverable(from:hold:on:)`). Interrupting
+    /// is still one press away, under the name it deserves, which is Stop.
+    public static func canSteer(_ delivery: Delivery, hold: DeliveryHold, on agent: AgentKind) -> Bool {
+        guard hold == .turn, !agent.acceptsMidTurnMessage else { return false }
         return delivery.isPending && delivery.kind == .owner && delivery.crewPayload == nil
     }
 

--- a/Sources/BloomCore/Bridge/WorkspaceListTool.swift
+++ b/Sources/BloomCore/Bridge/WorkspaceListTool.swift
@@ -331,8 +331,10 @@ public struct WorkspaceListTool: BridgeToolHandling {
 
         // Absent when nothing is holding the queue, which is the same answer the transcript gives
         // by drawing no sentence: a note saying a message goes with the next message tells a
-        // caller nothing `state` has not already said.
-        if let note = hold.sentence {
+        // caller nothing `state` has not already said. Asked of the chat's own backend, because a
+        // running turn holds nothing on one that reads a line written into it, and a note saying
+        // otherwise would be this tool telling a caller to wait for nothing.
+        if let note = hold.sentence(on: session.agentKind) {
             answer["hold_note"] = .string(note)
         }
 

--- a/Sources/BloomCore/Model/Models.swift
+++ b/Sources/BloomCore/Model/Models.swift
@@ -740,6 +740,46 @@ public enum AgentKind: String, Sendable, Codable, CaseIterable, Identifiable {
         }
     }
 
+    /// Whether a user message may be written into a turn that is already running.
+    ///
+    /// **Measured per backend, because the answer is a fact about the CLI rather than a taste.**
+    /// `DeliveryHold.turn` used to refuse every delivery on every backend, so a message typed
+    /// during a turn waited for a turn that would have taken it.
+    ///
+    /// **Claude Code: yes.** stdin stays open for the whole session (see `docs/PROTOCOL.md`), and
+    /// a user line written four seconds into a running turn was measured on 2.1.260 to be
+    /// accepted rather than refused, with the message neither lost nor turned into an error. The
+    /// CLI's own copy says what it does with one: a message whose origin is the person is framed
+    /// as "The user sent a new message while you were working", and the paragraph under it says
+    /// that is how Claude Code surfaces a mid-turn message, within the running turn and often
+    /// alongside the next tool result rather than as a separate turn. A turn with no tool call
+    /// left in it has no such boundary, and the probe measured that case: the CLI ran the message
+    /// as the next turn instead, announcing it with a second `init`. Both landings are ones Bloom
+    /// already handles, because `AgentRunner.ingest` applies `turnStarted` on an `init` for
+    /// exactly the CLI's habit of starting turns of its own. See `StrayResult`.
+    ///
+    /// **Codex: yes.** `turn/steer` is the protocol's own call for this, it takes the running
+    /// turn's id, and `docs/CODEX.md` records it measured against the real server: a steered
+    /// sentence behind a refusal made the agent do the different thing that was asked for.
+    /// `CodexRunner` has shipped it since, as the reason that travels behind a denial.
+    ///
+    /// **Cursor and OpenCode: no**, and not as a judgement about the CLIs. Neither has a runner,
+    /// so there is no turn to write into and no wire to write on. This answers `false` for the
+    /// same reason `canRunWorkspaces` does, and a backend that grows a runner has to measure this
+    /// rather than inherit it.
+    ///
+    /// **What this is NOT.** It does not widen `DeliveryHold.question` or `DeliveryHold.setup`,
+    /// neither of which is about the backend: a turn blocked on a permission answer is not
+    /// reading anything else, which `SessionLifecycle` states independently by refusing
+    /// `turnStarted` from `waiting`, and a worktree whose setup script is still running has no
+    /// dependencies installed to work with.
+    public var acceptsMidTurnMessage: Bool {
+        switch self {
+        case .claudeCode, .codex: true
+        case .cursor, .openCode: false
+        }
+    }
+
     /// The ones a workspace can actually be started on, in the order they are offered.
     ///
     /// Derived rather than listed, so an agent that grows a runner joins this by answering

--- a/Sources/BloomCore/Transcript/PendingMessageReturn.swift
+++ b/Sources/BloomCore/Transcript/PendingMessageReturn.swift
@@ -8,7 +8,11 @@ import Foundation
 /// answer. The message typed four minutes ago went on sitting under the transcript, and the
 /// sentence beneath it had been saying "Goes when this turn ends." The turn ended. It did not go,
 /// and nothing on screen ever said so again, because a queue nothing is holding says nothing at
-/// all (`DeliveryHold.none.sentence`).
+/// all (`DeliveryHold.sentence(on:)` answers nil for a hold that is holding nothing).
+///
+/// **A backend that takes a message mid turn does not reopen this.** A running turn holds nothing
+/// there, so the queue empties into it rather than sitting under a promise; what is left after a
+/// Stop is the queue this type is about, under no sentence at all, exactly as before.
 ///
 /// So Stop hands the words back to the composer, where they are his to change, send again or
 /// throw away, and where no bubble is making a promise on their behalf. It is the move

--- a/Tests/BloomCoreTests/CrewDeliveryTests.swift
+++ b/Tests/BloomCoreTests/CrewDeliveryTests.swift
@@ -263,3 +263,38 @@ struct CrewStopTests {
         #expect(started == .success("reader"))
     }
 }
+
+/// **What `agent_say` promises the caller about when the words will be read.** It used to say the
+/// message would be read when the current turn ended, which stopped being true the moment two of
+/// the four backends began taking a message into the turn they were running. A model told to wait
+/// for a wait that is not happening either polls or gives up, so the sentence is pinned here.
+@Suite("What a crew message's caller is told about when it lands")
+struct CrewDeliverySentenceTests {
+    @Test("a backend that takes a message mid turn is not described as making the caller wait")
+    func midTurnBackendsPromiseNoWait() {
+        for agent in AgentKind.allCases where agent.acceptsMidTurnMessage {
+            let sentence = Crew.deliverySentence(to: agent)
+            #expect(sentence.contains("inside the turn it is running"))
+            #expect(!sentence.contains("when that turn ends"))
+        }
+    }
+
+    @Test("a backend that cannot still says so, because there the wait is real")
+    func otherBackendsStillNameTheTurn() {
+        for agent in AgentKind.allCases where !agent.acceptsMidTurnMessage {
+            #expect(
+                Crew.deliverySentence(to: agent)
+                    == "If it is mid turn it will read this when that turn ends."
+            )
+        }
+    }
+
+    @Test("every backend gets a sentence, and it is one sentence")
+    func everyBackendSpeaks() {
+        for agent in AgentKind.allCases {
+            let sentence = Crew.deliverySentence(to: agent)
+            #expect(!sentence.isEmpty)
+            #expect(sentence.hasSuffix("."))
+        }
+    }
+}

--- a/Tests/BloomCoreTests/DeliveryTests.swift
+++ b/Tests/BloomCoreTests/DeliveryTests.swift
@@ -4,13 +4,15 @@ import Foundation
 
 @Suite("What holds a queued message")
 struct DeliveryHoldTests {
-    @Test("a running setup script holds everything behind it")
+    @Test("a running setup script holds everything behind it, on every backend")
     func setupWins() {
         let hold = DeliveryHold.of(
             isRunningSetup: true, isTurnRunning: true, isAwaitingQuestion: true
         )
         #expect(hold == .setup)
-        #expect(!hold.allowsDelivery)
+        for agent in AgentKind.allCases {
+            #expect(!hold.allowsDelivery(on: agent))
+        }
     }
 
     @Test("a question is named before the turn it is holding open")
@@ -23,13 +25,53 @@ struct DeliveryHoldTests {
         #expect(hold == .question)
     }
 
-    @Test("a running turn holds the queue")
-    func turnHolds() {
+    /// **The half that did not change, and the half that did.** A running turn is still a running
+    /// turn, because `WorkspaceMergeTool` asks for the case and a busy worktree is no safer to
+    /// merge into on a backend that can hear a sentence. What it holds is now the backend's
+    /// answer.
+    @Test("a running turn is still named as one, whatever the backend does about it")
+    func turnIsStillNamed() {
         let hold = DeliveryHold.of(
             isRunningSetup: false, isTurnRunning: true, isAwaitingQuestion: false
         )
         #expect(hold == .turn)
-        #expect(!hold.allowsDelivery)
+    }
+
+    /// **This assertion used to read `!hold.allowsDelivery` for every backend at once**, and it
+    /// was the whole of what this change is about: a message typed during a turn waited for a turn
+    /// that would have taken it. See `AgentKind.acceptsMidTurnMessage` for the measurement behind
+    /// each answer below.
+    @Test("a running turn holds the queue only where a line cannot be written into one")
+    func turnHoldsPerBackend() {
+        let hold = DeliveryHold.turn
+        #expect(hold.allowsDelivery(on: .claudeCode))
+        #expect(hold.allowsDelivery(on: .codex))
+        #expect(!hold.allowsDelivery(on: .cursor))
+        #expect(!hold.allowsDelivery(on: .openCode))
+        for agent in AgentKind.allCases {
+            #expect(hold.allowsDelivery(on: agent) == agent.acceptsMidTurnMessage)
+        }
+    }
+
+    /// The two that are not about a protocol, so no backend gets to answer them differently. A
+    /// worktree with nothing installed has nothing to work with, and a turn blocked on a
+    /// permission answer is not reading anything else, which `SessionLifecycle` says again by
+    /// refusing `turnStarted` from `waiting`.
+    @Test("a question and a setup script hold on every backend, including the two that take a message mid turn")
+    func questionAndSetupHoldEverywhere() {
+        for agent in AgentKind.allCases {
+            #expect(!DeliveryHold.question.allowsDelivery(on: agent))
+            #expect(!DeliveryHold.setup.allowsDelivery(on: agent))
+        }
+    }
+
+    @Test("only a runnable backend claims to take a message mid turn")
+    func onlyRunnableBackendsAccept() {
+        // Not a judgement about Cursor or OpenCode: neither has a runner, so there is no turn to
+        // write into. A backend that grows one has to measure this rather than inherit it.
+        for agent in AgentKind.allCases where agent.acceptsMidTurnMessage {
+            #expect(agent.canRunWorkspaces)
+        }
     }
 
     @Test("a setup script that failed holds nothing, so the queue still moves")
@@ -41,26 +83,120 @@ struct DeliveryHoldTests {
             isRunningSetup: false, isTurnRunning: false, isAwaitingQuestion: false
         )
         #expect(hold == .none)
-        #expect(hold.allowsDelivery)
+        #expect(hold.allowsDelivery(on: .claudeCode))
     }
 
-    @Test("an idle session lets the queue move")
+    @Test("an idle session lets the queue move, on every backend")
     func idleDelivers() {
         let hold = DeliveryHold.of(
             isRunningSetup: false, isTurnRunning: false, isAwaitingQuestion: false
         )
         #expect(hold == .none)
-        #expect(hold.allowsDelivery)
+        for agent in AgentKind.allCases {
+            #expect(hold.allowsDelivery(on: agent))
+        }
     }
 
-    @Test("every hold that is holding something says what, and only one lets a message go")
+    /// **A caption may not promise a wait that is not happening.** The sentences are pinned here
+    /// rather than in a view precisely so one cannot quietly start lying, and the one that could
+    /// have is "Goes when this turn ends" on a backend where the drain no longer waits for it.
+    @Test("everything that is holding something says what, and nothing else says anything")
     func everyHoldSpeaks() {
-        for hold in DeliveryHold.allCases where hold != .none {
-            #expect(hold.sentence?.isEmpty == false)
+        for agent in AgentKind.allCases {
+            for hold in DeliveryHold.allCases {
+                if hold.allowsDelivery(on: agent) {
+                    #expect(hold.sentence(on: agent) == nil)
+                } else {
+                    #expect(hold.sentence(on: agent)?.isEmpty == false)
+                }
+            }
         }
-        // Nothing to wait on, so nothing to say. See `DeliveryHold.sentence`.
-        #expect(DeliveryHold.none.sentence == nil)
-        #expect(DeliveryHold.allCases.filter(\.allowsDelivery) == [.none])
+    }
+
+    @Test("a running turn says nothing where the message goes into it")
+    func aTurnThatHoldsNothingSaysNothing() {
+        #expect(DeliveryHold.turn.sentence(on: .claudeCode) == nil)
+        #expect(DeliveryHold.turn.sentence(on: .codex) == nil)
+        #expect(DeliveryHold.turn.sentence(on: .cursor) == "Goes when this turn ends.")
+    }
+
+    @Test("the two that hold everywhere say the same thing everywhere")
+    func heldSentencesDoNotVaryByBackend() {
+        for agent in AgentKind.allCases {
+            #expect(DeliveryHold.setup.sentence(on: agent) == "Goes as soon as setup finishes.")
+            #expect(
+                DeliveryHold.question.sentence(on: agent)
+                    == "Goes once you have answered the question above."
+            )
+        }
+        // Nothing to wait on, so nothing to say. See `DeliveryHold.sentence(on:)`.
+        for agent in AgentKind.allCases {
+            #expect(DeliveryHold.none.sentence(on: agent) == nil)
+        }
+    }
+}
+
+/// **What immediate delivery does to the order things were asked for, which is the promise the
+/// table exists to keep.** The rule chosen: the front of the queue always goes first, and the
+/// backend decides only how many may leave in one pass. Nothing typed during a turn can overtake
+/// something queued before it on any backend.
+@Suite("How much of the queue may go at once")
+struct DeliveryDeliverableTests {
+    private func waiting(_ bodies: String...) -> [Delivery] {
+        bodies.map { Delivery(targetSessionID: SessionID("s"), body: $0) }
+    }
+
+    @Test("a hold that holds lets nothing go, whatever the backend")
+    func heldLetsNothingGo() {
+        let queue = waiting("first", "second")
+        for agent in AgentKind.allCases {
+            for hold in DeliveryHold.allCases where !hold.allowsDelivery(on: agent) {
+                #expect(Delivery.deliverable(from: queue, hold: hold, on: agent).isEmpty)
+                #expect(Delivery.next(from: queue, hold: hold, on: agent) == nil)
+            }
+        }
+    }
+
+    /// The old rule, kept where its reason still holds: handing over the front starts a turn, and
+    /// on a backend that will not read a line written into one, that turn holds the rest.
+    @Test("a backend that cannot take a message mid turn hands over one")
+    func oneAtATimeWhereATurnHolds() {
+        let queue = waiting("first", "second", "third")
+        let going = Delivery.deliverable(from: queue, hold: .none, on: .cursor)
+        #expect(going.map(\.body) == ["first"])
+        #expect(Delivery.deliverable(from: queue, hold: .turn, on: .cursor).isEmpty)
+    }
+
+    /// **And why it does not survive on a backend that takes one.** Holding the second message
+    /// back would put it under "Goes when this turn ends", and the owner's next sentence would
+    /// falsify it: `submit` drains, the drain takes the front, and the front would go mid turn.
+    @Test("a backend that takes a message mid turn empties the queue, in the order it was asked for")
+    func theQueueEmptiesInOrder() {
+        let queue = waiting("first", "second", "third")
+        for agent in AgentKind.allCases where agent.acceptsMidTurnMessage {
+            #expect(
+                Delivery.deliverable(from: queue, hold: .none, on: agent).map(\.body)
+                    == ["first", "second", "third"]
+            )
+            #expect(
+                Delivery.deliverable(from: queue, hold: .turn, on: agent).map(\.body)
+                    == ["first", "second", "third"]
+            )
+        }
+    }
+
+    /// The invariant behind the whole table, stated over every backend and every hold: whatever
+    /// may go goes in the order it was asked for, and `next` is the head of it.
+    @Test("what may go is always a prefix of the queue, in its own order")
+    func alwaysAPrefixInOrder() {
+        let queue = waiting("first", "second", "third")
+        for agent in AgentKind.allCases {
+            for hold in DeliveryHold.allCases {
+                let going = Delivery.deliverable(from: queue, hold: hold, on: agent)
+                #expect(going.map(\.id) == queue.prefix(going.count).map(\.id))
+                #expect(Delivery.next(from: queue, hold: hold, on: agent)?.id == going.first?.id)
+            }
+        }
     }
 }
 
@@ -141,17 +277,26 @@ struct DeliveryStoreTests {
 
         // Nothing goes anywhere while the worktree is still being built, whoever asked.
         let duringSetup = try await store.pendingDeliveries(sessionID: session.id)
-        #expect(Delivery.next(from: duringSetup, hold: .setup) == nil)
+        for agent in AgentKind.allCases {
+            #expect(Delivery.next(from: duringSetup, hold: .setup, on: agent) == nil)
+        }
 
         // The script finishes, and the first thing asked for is the first thing sent.
-        let first = try #require(Delivery.next(from: duringSetup, hold: .none))
+        let first = try #require(Delivery.next(from: duringSetup, hold: .none, on: .claudeCode))
         #expect(first.body == "list the technologies used")
         try await store.markDelivered(id: first.id)
 
-        // Then the turn it started holds the rest, and the rest is what was typed second.
+        // And the rest is what was typed second, whenever it goes.
+        //
+        // **This used to assert that a running turn held it back on every backend**, which was the
+        // coarse answer this change removed: on Claude Code and Codex the turn the first one
+        // started takes the second as well. What the bug was ever about is the line below it,
+        // which is unchanged and is the whole promise: the second thing typed is the second thing
+        // handed over.
         let duringTurn = try await store.pendingDeliveries(sessionID: session.id)
-        #expect(Delivery.next(from: duringTurn, hold: .turn) == nil)
-        #expect(Delivery.next(from: duringTurn, hold: .none)?.body == "test")
+        #expect(Delivery.next(from: duringTurn, hold: .turn, on: .cursor) == nil)
+        #expect(Delivery.next(from: duringTurn, hold: .turn, on: .claudeCode)?.body == "test")
+        #expect(Delivery.next(from: duringTurn, hold: .none, on: .claudeCode)?.body == "test")
     }
 
     @Test("a delivered message leaves the queue and stays out of it")
@@ -294,14 +439,28 @@ struct DeliveryEchoTests {
 
     @Test("a message typed into an idle chat has gone, so it is drawn as one that has")
     func idleGoesAtOnce() {
-        #expect(Delivery.goesImmediately(behind: [], hold: .none))
+        for agent in AgentKind.allCases {
+            #expect(Delivery.goesImmediately(behind: [], hold: .none, on: agent))
+        }
     }
 
     @Test("a message typed while anything is holding the queue is drawn as waiting")
     func heldIsDrawnAsWaiting() {
-        for hold in DeliveryHold.allCases where !hold.allowsDelivery {
-            #expect(!Delivery.goesImmediately(behind: [], hold: hold))
+        for agent in AgentKind.allCases {
+            for hold in DeliveryHold.allCases where !hold.allowsDelivery(on: agent) {
+                #expect(!Delivery.goesImmediately(behind: [], hold: hold, on: agent))
+            }
         }
+    }
+
+    /// **The bubble the owner asked about.** He typed while a turn was running and read "Goes when
+    /// this turn ends" under it. On a backend that takes a message mid turn it does not wait, so
+    /// it is drawn as said, and no bubble promises anything on its behalf.
+    @Test("a message typed during a turn has gone, where the turn can take it")
+    func typedDuringATurnGoesAtOnce() {
+        #expect(Delivery.goesImmediately(behind: [], hold: .turn, on: .claudeCode))
+        #expect(Delivery.goesImmediately(behind: [], hold: .turn, on: .codex))
+        #expect(!Delivery.goesImmediately(behind: [], hold: .turn, on: .cursor))
     }
 
     @Test("a message typed behind one that is still waiting waits too")
@@ -309,20 +468,39 @@ struct DeliveryEchoTests {
         // Nothing is holding this session, and the message still does not go: the one in front of
         // it does. Drawing it as sent would be the transcript claiming an order the drain will
         // not honour.
-        #expect(!Delivery.goesImmediately(behind: waiting("first"), hold: .none))
+        #expect(!Delivery.goesImmediately(behind: waiting("first"), hold: .none, on: .claudeCode))
+    }
+
+    /// **The ordering promise, on the backend that changed.** Immediate delivery is not a
+    /// reordering: a message typed during a turn still joins the back of a queue that already has
+    /// something in it, and the drain still takes the front.
+    @Test("nothing typed during a turn overtakes what was queued before it")
+    func nothingOvertakes() {
+        let queued = waiting("asked for first")
+        for agent in AgentKind.allCases where agent.acceptsMidTurnMessage {
+            #expect(!Delivery.goesImmediately(behind: queued, hold: .turn, on: agent))
+            #expect(Delivery.next(from: queued, hold: .turn, on: agent)?.body == "asked for first")
+        }
     }
 
     @Test("the bubble and the drain never disagree about what goes next")
     func echoAgreesWithTheDrain() {
-        // The invariant, stated over every shape the queue can be in: what the transcript draws as
-        // sent is exactly what the drain would hand to the runner. Asked of `next`, which is the
-        // ordering rule itself, so a change to that rule cannot leave this behind.
+        // The invariant, stated over every shape the queue can be in and every backend: what the
+        // transcript draws as sent is exactly what the drain would hand to the runner. Asked of
+        // `next`, which is the ordering rule itself, so a change to that rule cannot leave this
+        // behind.
         let queues = [waiting(), waiting("first"), waiting("first", "second")]
-        for hold in DeliveryHold.allCases {
-            for queue in queues {
-                let typed = Delivery(targetSessionID: SessionID("s"), body: "just typed")
-                let goesNext = Delivery.next(from: queue + [typed], hold: hold)?.id == typed.id
-                #expect(Delivery.goesImmediately(behind: queue, hold: hold) == goesNext)
+        for agent in AgentKind.allCases {
+            for hold in DeliveryHold.allCases {
+                for queue in queues {
+                    let typed = Delivery(targetSessionID: SessionID("s"), body: "just typed")
+                    let goesNext = Delivery.next(
+                        from: queue + [typed], hold: hold, on: agent
+                    )?.id == typed.id
+                    #expect(
+                        Delivery.goesImmediately(behind: queue, hold: hold, on: agent) == goesNext
+                    )
+                }
             }
         }
     }
@@ -453,17 +631,34 @@ struct DeliverySteerTests {
         )
     }
 
-    @Test("offered only while there is a turn to interrupt")
+    /// **This used to be offered on every backend while a turn ran.** It still is on one that
+    /// cannot take a message mid turn, where stopping the turn is the only way to be heard. Where
+    /// the message can simply go, spending the turn to make room for it buys nothing and costs
+    /// whatever that turn had done, so the button is not offered and Stop keeps the job under its
+    /// own name. See `DeliverySteer.canSteer`.
+    @Test("offered only while there is a turn to interrupt, and only where interrupting is the way in")
     func onlyDuringATurn() {
         let one = typed("one")
         for hold in DeliveryHold.allCases {
-            #expect(DeliverySteer.canSteer(one, hold: hold) == (hold == .turn))
+            #expect(!DeliverySteer.canSteer(one, hold: hold, on: .claudeCode))
+            #expect(!DeliverySteer.canSteer(one, hold: hold, on: .codex))
+            #expect(DeliverySteer.canSteer(one, hold: hold, on: .cursor) == (hold == .turn))
+        }
+    }
+
+    /// Stated as the rule rather than as a list, so a backend that grows the capability loses the
+    /// button by answering one question.
+    @Test("a backend that takes a message mid turn never offers it")
+    func midTurnBackendsNeverSteer() {
+        let one = typed("one")
+        for agent in AgentKind.allCases where agent.acceptsMidTurnMessage {
+            #expect(!DeliverySteer.canSteer(one, hold: .turn, on: agent))
         }
     }
 
     @Test("a message that has already gone cannot be steered")
     func deliveredCannotSteer() {
-        #expect(!DeliverySteer.canSteer(typed("gone", delivered: true), hold: .turn))
+        #expect(!DeliverySteer.canSteer(typed("gone", delivered: true), hold: .turn, on: .cursor))
     }
 
     /// Interrupting an agent is a person's decision. A crew message is drawn in its own row and
@@ -477,7 +672,7 @@ struct DeliverySteerTests {
             kind: .message,
             crew: CrewMessage.said(from: "indexer", text: "done", sender: .subagent)
         )
-        #expect(!DeliverySteer.canSteer(fromAnAgent, hold: .turn))
+        #expect(!DeliverySteer.canSteer(fromAnAgent, hold: .turn, on: .cursor))
     }
 
     /// Where Steer parts company with Edit. Nothing is being turned back into text, so a body the
@@ -486,7 +681,7 @@ struct DeliverySteerTests {
     func attachmentsCanStillSteer() {
         let attached = typed(AttachmentTrailer.compose(text: "look at this", paths: ["a.png"]))
         #expect(!PendingMessageEdit.canEdit(attached))
-        #expect(DeliverySteer.canSteer(attached, hold: .turn))
+        #expect(DeliverySteer.canSteer(attached, hold: .turn, on: .cursor))
     }
 
     /// The ordering rule, stated over every position in the queue: one message leaves, and what is
@@ -506,7 +701,7 @@ struct DeliverySteerTests {
     @Test("steering the front leaves what the drain would have left")
     func steeringTheFrontMatchesTheDrain() throws {
         let queue = [typed("first"), typed("second"), typed("third")]
-        let front = try #require(Delivery.next(from: queue, hold: .none))
+        let front = try #require(Delivery.next(from: queue, hold: .none, on: .cursor))
         #expect(DeliverySteer.queue(after: front, from: queue).map(\.body) == ["second", "third"])
     }
 }

--- a/Tests/BloomCoreTests/WorkspaceContinuationTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceContinuationTests.swift
@@ -304,7 +304,9 @@ struct WorkspaceContinuationTests {
         try worktree.write("scratch.md", "half an idea for the next thing\n")
         try worktree.write("README.md", "hello\nedited after the merge\n")
 
-        let continuation = try await manager.continueOnNewBranch(
+        // Discarded on purpose: what this test is about is what the worktree still holds after
+        // the move, not what the move answered. The sibling tests above read the continuation.
+        _ = try await manager.continueOnNewBranch(
             workspace: workspace, branch: "dark-mode-next"
         )
 

--- a/Tests/BloomCoreTests/WorkspaceListToolTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceListToolTests.swift
@@ -162,7 +162,12 @@ struct WorkspaceListToolTests {
             Repo(name: "flare", path: "/tmp/flare", defaultBranch: "main")
         )
         let workspace = try await store.upsert(Workspace(
-            repoID: repo.id, name: "busy", branch: "b", path: "/tmp/w", baseBranch: "main"
+            repoID: repo.id,
+            name: "busy",
+            branch: "b",
+            path: "/tmp/w",
+            baseBranch: "main",
+            setupState: .running
         ))
         var session = Session(workspaceID: workspace.id, title: "First chat")
         session.apply(.turnStarted)
@@ -177,10 +182,37 @@ struct WorkspaceListToolTests {
 
         #expect(row["queued_messages"]?.intValue == 1)
         #expect(chat["queued_messages"]?.intValue == 1)
-        #expect(chat["hold_note"]?.stringValue == DeliveryHold.turn.sentence)
+        #expect(chat["hold_note"]?.stringValue == DeliveryHold.setup.sentence(on: .claudeCode))
         #expect(chat["state"]?.stringValue == "running")
         #expect(chat["title"]?.stringValue == "First chat")
         #expect(chat["agent"]?.stringValue == AgentKind.claudeCode.rawValue)
+    }
+
+    /// **This test used to assert the opposite**, with a running turn producing "Goes when this
+    /// turn ends". It does not any more, and the note going quiet is the honest half: a message a
+    /// caller sends into a running Claude Code chat goes into that turn rather than waiting behind
+    /// it, so a note telling the caller to wait would be this tool asking for a delay it does not
+    /// need. `queued_messages` still says what is in front of it.
+    @Test("a running turn holds nothing to say on a backend that takes a message mid turn")
+    func aRunningTurnSaysNothing() async throws {
+        let store = try makeTestStore("list-hold-mid-turn")
+        let repo = try await store.upsert(
+            Repo(name: "flare", path: "/tmp/flare", defaultBranch: "main")
+        )
+        let workspace = try await store.upsert(Workspace(
+            repoID: repo.id, name: "busy", branch: "b", path: "/tmp/w", baseBranch: "main"
+        ))
+        var session = Session(workspaceID: workspace.id, title: "First chat")
+        session.apply(.turnStarted)
+        _ = try await store.upsert(session)
+
+        let result = await WorkspaceListTool().call(request(), as: .owner, store: store)
+        let row = try named("busy", in: result)
+        let chat = try #require(row["sessions"]?[0])
+
+        #expect(chat["state"]?.stringValue == "running")
+        #expect(chat["hold_note"] == nil)
+        #expect(AgentKind.claudeCode.acceptsMidTurnMessage)
     }
 
     /// A workspace stopped on a question is the one state that gets worse the longer it is left,

--- a/docs/CODEX.md
+++ b/docs/CODEX.md
@@ -75,6 +75,13 @@ sentence saying the file should be named differently, it wrote the different nam
 the reason as a steer right behind the refusal, and a Codex denial says as much as a Claude Code
 one.
 
+That same call is why a queued message no longer waits for a turn to end on this backend.
+`CodexRunner.send` steers when `handle.turnID` names a live turn and starts a turn otherwise, and
+it starts one after a steer that missed, because the turn id can be a tenth of a second stale. It
+is deliberately not `turn/start` twice: what the server does with a second `turn/start` on a thread
+whose turn is open has never been measured here, and a person's sentence is not the thing to find
+that out with. See `AgentKind.acceptsMidTurnMessage`.
+
 **What is in `FileUpdateChange.diff`?** Not always a diff, which is the trap in the name:
 
 | Kind | What the field holds | Recorded |

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -45,6 +45,28 @@ One JSON object, one line:
 {"type":"user","message":{"role":"user","content":[{"type":"text","text":"do the thing"}]}}
 ```
 
+### Sending into a turn that is already running
+
+Measured on `claude 2.1.260` on 4 September 2026, driving the invocation above with a cheap model.
+A second user line was written to stdin four seconds into a running turn. It was **accepted**: no
+error, nothing lost, and the CLI did not close the pipe.
+
+What it did with it depends on what the turn had left to do. The probe's turn was prose with no
+tool call after the injection, and the CLI finished it, emitted its `result`, then emitted a
+**second `init`** and ran the injected line as a turn of its own. The other landing is in the CLI's
+own copy: a message whose origin is the person is framed as "The user sent a new message while you
+were working", with a paragraph under it saying that is how Claude Code surfaces a mid-turn
+message, within the running turn and often alongside the next tool result rather than as a separate
+turn. So a turn with a tool boundary left in it takes the message inside the turn, and a turn
+without one runs it next.
+
+Both are landings Bloom already handles. `AgentRunner.ingest` applies `turnStarted` on an `init`,
+which is the fix written for the CLI's habit of starting turns of its own (see `StrayResult`), so a
+second `init` puts the chat back to running rather than leaving it drawn as idle through a turn.
+
+`AgentKind.acceptsMidTurnMessage` is where this is written down as a fact the app reads, and
+`DeliveryHold.allowsDelivery(on:)` is what it decides.
+
 ## Output events
 
 Every line has `type`. Every line except a few carries `uuid` and `session_id`.


### PR DESCRIPTION
A message typed while an agent was working waited for a turn that would have taken it: `DeliveryHold.turn` refused every delivery on every backend. Whether a running turn holds anything is now the backend's own answer, `AgentKind.acceptsMidTurnMessage`, measured per CLI rather than assumed. Claude Code and Codex both take a message into a live turn, and `CodexRunner.send` steers into an open turn rather than starting a second one beside it, since `turn/steer` is the call this protocol has for exactly that. Cursor and OpenCode have no runner, so there is no turn to write into and they keep queueing. `.question` and `.setup` still hold everywhere.

The order is unchanged, and that is the point. `Delivery.deliverable` hands over from the front, never the newest, so nothing typed during a turn overtakes what was queued before it.

Three captions would have started lying, two of them the same bug: a caption gated on `isRunning` was answering a question that stopped being the same question. The third is the one nobody would have seen, `agent_say` telling a calling model to wait for a turn that will not hold it. Steer is not offered where the message can simply go: stopping a turn and talking over one are different acts.
