### PR TITLE
Tune the search panel's dim and its traffic light cut-out

### DIFF
--- a/Sources/Bloom/Design/Theme.swift
+++ b/Sources/Bloom/Design/Theme.swift
@@ -97,6 +97,17 @@ enum Palette {
             : NSColor(white: 0, alpha: 0.04)
     }
 
+    /// The scrim the search panel puts over the window behind it.
+    ///
+    /// An appearance provider rather than two call sites, so it follows a switch between light and
+    /// dark without the panel being told about it, which is the same arrangement `hoverNSColor`
+    /// above and the title bar's paint both keep. It is black in both, and the two opacities are
+    /// `SearchPanelLayout`'s, where the measurement that forced two of them is written down.
+    static let panelScrim = Color(nsColor: NSColor(name: nil) { appearance in
+        let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        return NSColor(white: 0, alpha: SearchPanelLayout.dim(isDark: isDark))
+    })
+
     /// A selected row in a list that is not the key window's focus.
     ///
     /// Named rather than `unemphasizedSelectedContentBackgroundColor`, which is a neutral grey:

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelWindowOverlay.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelWindowOverlay.swift
@@ -33,7 +33,14 @@ import BloomCore
 /// that cannot be closed, zoomed or minimised while a search card is up would be a worse bug than
 /// the one this fixes, and a dimmed close button is a control saying it is unavailable when it is
 /// not. They are cut out of the dim with an even-odd fill and out of the hit test by
-/// `SearchPanelOverlayHost`, so a click there reaches AppKit exactly as it always did.
+/// `SearchPanelOverlayHost`, so a click there reaches AppKit exactly as it always did. How much
+/// air the cut-out leaves around them is `trafficLightPadding`, and it was judged against a
+/// picture.
+///
+/// **How far the window goes down is `Palette.panelScrim`, and it is two numbers.** A black scrim
+/// has far less to take out of Bloom's dark ramp than out of its light one, so one opacity read as
+/// a grey page in light and as nothing at all in dark. `SearchPanelLayout.dimDark` carries the
+/// measurement and the argument.
 ///
 /// # What a click outside does
 ///
@@ -87,7 +94,7 @@ struct SearchPanelWindowOverlay: View {
                 )
             }
         }
-        .fill(Color.black.opacity(SearchPanelLayout.dim), style: FillStyle(eoFill: true))
+        .fill(Palette.panelScrim, style: FillStyle(eoFill: true))
         // The click outside, taken here rather than by the window under it. See the head of this
         // file for what that is protecting.
         .contentShape(Rectangle())
@@ -189,7 +196,16 @@ final class SearchPanelWindowGeometry {
 final class SearchPanelOverlayHost: NSHostingView<SearchPanelWindowOverlay> {
     /// The air left around the three buttons, so the cut-out is a rounded slot they sit in rather
     /// than three rectangles traced tightly enough to catch a click on the edge of one.
-    private static let trafficLightPadding: CGFloat = 6
+    ///
+    /// **Three, down from six, and it was judged against a picture rather than argued.** At six
+    /// the undimmed slot was 71 by 25 around three 14 point circles, and on a light window with an
+    /// empty sidebar behind it that read as a bright pill somebody had drawn on the corner: the
+    /// loudest thing in the frame, on the one control the dim is not about. At three it is 65 by
+    /// 19, which is a button's own width of air rather than half as much again, and it stops being
+    /// a shape and starts being the absence of one. Lower than three would begin to clip the
+    /// pointer's reach at the edge of a circle, which is the failure this padding exists to
+    /// prevent, so this is the bottom of the useful range rather than a step on the way down.
+    private static let trafficLightPadding: CGFloat = 3
 
     /// Nothing at all while the panel is closed.
     ///

--- a/Sources/BloomCore/Presentation/SearchPanelLayout.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelLayout.swift
@@ -53,10 +53,57 @@ public enum SearchPanelLayout {
     /// sat even though the dim now starts higher up.
     public static let topInset: CGFloat = 56
 
+    /// How far the window behind is taken down, in light.
+    ///
     /// Enough to say the window behind is not the thing being used, and not so much that a person
-    /// cannot read the workspace name they were looking at. Black in both appearances, because
-    /// what it does is take light out of the ground rather than tint it.
-    public static let dim: Double = 0.22
+    /// cannot read the workspace name they were looking at. It leaves the text behind at about ten
+    /// to one against its ground, where undimmed it is fifteen.
+    public static let dimLight: Double = 0.22
+
+    /// And in dark, where it has to be nearly twice as much to say the same thing.
+    ///
+    /// # Why this is two numbers and not one
+    ///
+    /// It was one, and the comment on it argued for one: black in both appearances, because what
+    /// the dim does is take light out of the ground rather than tint it. The ink is still right.
+    /// The amount was not, and the pictures said so: a capture in dark read as barely dimmed at
+    /// all, and the arithmetic behind that is not a matter of taste.
+    ///
+    /// At 22 per cent, the light ground loses 56 of its 255. The dark ground has no such light to
+    /// lose: `PaletteInk.surface` is `#0A1A25` in dark, whose brightest channel is 37, so **even
+    /// painting it solid black removes less than the light dim removes at 22 per cent.** No single
+    /// opacity of black can move both grounds by the same amount, because one of them is not there
+    /// to be moved. `SearchPanelLayoutTests` asserts exactly that, so the day the dark ramp
+    /// changes the suite says whether the argument still holds.
+    ///
+    /// # Why black is still the ink
+    ///
+    /// The obvious alternative in dark is a light scrim, and it is wrong here. It would raise the
+    /// ground towards the card, and the card standing above its ground is the whole of what the
+    /// dim buys in dark: the panel is `#22292F`-ish glass over a `#0A1A25` window, so lifting the
+    /// window costs the separation the scrim exists to create. Black keeps taking light out; there
+    /// is simply less of it to take, so it has to take a larger share.
+    ///
+    /// # Where the number comes from
+    ///
+    /// Not from a percentage that sounds right. It is the heaviest black that leaves the window
+    /// behind still readable, measured with `Contrast` against every ground this app draws text
+    /// on. `surfaceRaised` is the worst of the three, and there the text behind clears
+    /// `Contrast.textFloor` at 0.40 and does not at 0.45. So 0.40 it is, and the suite holds both
+    /// halves of that sentence.
+    ///
+    /// What it buys, against the 0.22 it replaces: the ground goes down 15 of its 37 rather than
+    /// 8, and the text that covers most of the window goes down 87 of its 218 rather than 48. The
+    /// two appearances do not do the same thing to the same pixels, and they are not meant to. In
+    /// light the ground goes grey and that is the signal; in dark the ground can barely move and
+    /// everything drawn on it dims by nearly half instead. Both read as "this is in front", which
+    /// is the only thing the dim has ever had to say.
+    public static let dimDark: Double = 0.40
+
+    /// The dim for one appearance.
+    public static func dim(isDark: Bool) -> Double {
+        isDark ? dimDark : dimLight
+    }
 
     /// The width to draw the card at in a window this wide.
     ///

--- a/Tests/BloomCoreTests/SearchPanelLayoutTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelLayoutTests.swift
@@ -2,8 +2,13 @@ import CoreGraphics
 import Testing
 @testable import BloomCore
 
-/// How wide the panel comes out at the widths this window is actually opened at, and what happens
-/// at both ends of the clamp.
+/// How wide the panel comes out at the widths this window is actually opened at, what happens at
+/// both ends of the clamp, and how far the window behind it is taken down in each appearance.
+///
+/// The dim half of this is a real measurement rather than a pair of numbers restated: it composites
+/// the scrim over the grounds in `PaletteInk` and reads the result with `Contrast`, which is the
+/// only way a claim about what a colour does can be contradicted. See `SearchPanelLayout.dimDark`
+/// for the argument these hold in place.
 @Suite("Search panel layout")
 struct SearchPanelLayoutTests {
     @Test("A window at the scene's own default gets a panel wider than the old constant")
@@ -46,6 +51,87 @@ struct SearchPanelLayoutTests {
             let panel = SearchPanelLayout.width(inWindow: width)
             #expect((width - panel) / 2 >= SearchPanelLayout.margin)
         }
+    }
+
+    // MARK: - The dim
+
+    /// The three grounds this app draws text on, which is `PaletteContrastTests`' own list. The
+    /// window behind the panel is made of these, so they are what "still readable" is measured
+    /// against.
+    private static let grounds: [(name: String, ink: PaletteInk.Pair)] = [
+        ("surface", PaletteInk.surface),
+        ("surfaceRaised", PaletteInk.surfaceRaised),
+        ("surfaceSunken", PaletteInk.surfaceSunken),
+    ]
+
+    /// A ground with the scrim over it.
+    private func dimmed(_ ground: UInt32, isDark: Bool) -> UInt32 {
+        Contrast.composited(0x000000, over: ground, at: SearchPanelLayout.dim(isDark: isDark))
+    }
+
+    /// The label colour as it actually lands: white at the system's own alpha over the ground,
+    /// then taken down by the same scrim, because the scrim is over the text as well as under it.
+    private func dimmedText(on ground: UInt32, isDark: Bool, at dim: Double? = nil) -> UInt32 {
+        let ink: UInt32 = isDark ? 0xFFFFFF : 0x000000
+        let label = Contrast.composited(ink, over: ground, at: 0.85)
+        return Contrast.composited(
+            0x000000, over: label, at: dim ?? SearchPanelLayout.dim(isDark: isDark)
+        )
+    }
+
+    /// The measurement that forced two numbers rather than one, asserted rather than left in a
+    /// comment: the dark ground does not hold as much light as the light dim takes away, so no
+    /// opacity of black, solid included, could ever match it.
+    @Test("no single opacity of black can take the same light out of both grounds")
+    func oneNumberCannotServeBothAppearances() {
+        let light = PaletteInk.surface.light
+        let removed = Contrast.relativeLuminance(of: light)
+            - Contrast.relativeLuminance(of: dimmed(light, isDark: false))
+        #expect(Contrast.relativeLuminance(of: PaletteInk.surface.dark) < removed)
+    }
+
+    /// Not a percentage that sounded right. It is the heaviest black that leaves the window behind
+    /// readable on every ground the app draws text on, and the step above it is not.
+    @Test("the dark dim is the heaviest one the window behind stays readable under")
+    func theDarkDimIsAsHeavyAsItCanBe() {
+        for (name, ground) in Self.grounds {
+            let ink = ground.dark
+            let ratio = Contrast.ratio(dimmedText(on: ink, isDark: true), dimmed(ink, isDark: true))
+            #expect(ratio >= Contrast.textFloor, "\(name) at the dark dim reads \(ratio)")
+        }
+
+        // And a step heavier does not, which is what makes this a measurement rather than a taste.
+        let worst = PaletteInk.surfaceRaised.dark
+        let heavier = SearchPanelLayout.dimDark + 0.05
+        let ratio = Contrast.ratio(
+            dimmedText(on: worst, isDark: true, at: heavier),
+            Contrast.composited(0x000000, over: worst, at: heavier)
+        )
+        #expect(ratio < Contrast.textFloor)
+    }
+
+    /// The light dim is untouched by all of this, and the window behind it is still comfortably
+    /// readable, which is why it needed no measuring in the first place.
+    @Test("the light dim leaves the window behind well clear of the floor")
+    func theLightDimIsUnchanged() {
+        #expect(SearchPanelLayout.dimLight == 0.22)
+        for (name, ground) in Self.grounds {
+            let ink = ground.light
+            let ratio = Contrast.ratio(
+                dimmedText(on: ink, isDark: false), dimmed(ink, isDark: false)
+            )
+            #expect(ratio >= Contrast.textFloor, "\(name) at the light dim reads \(ratio)")
+        }
+    }
+
+    /// Both are a scrim rather than a blackout, and the dark one is the heavier of the two.
+    @Test("the dark dim is heavier than the light one and neither blacks the window out")
+    func bothEndsAreSane() {
+        #expect(SearchPanelLayout.dimDark > SearchPanelLayout.dimLight)
+        #expect(SearchPanelLayout.dimLight > 0)
+        #expect(SearchPanelLayout.dimDark < 0.6)
+        #expect(SearchPanelLayout.dim(isDark: true) == SearchPanelLayout.dimDark)
+        #expect(SearchPanelLayout.dim(isDark: false) == SearchPanelLayout.dimLight)
     }
 
     @Test("The width answers the window and nothing else, so typing cannot move it")


### PR DESCRIPTION
Two tunings off the captures of #132, both about what the overlay looks like rather than where it sits.

The dim was one opacity for both appearances and the arithmetic says it could not be. At 22 per cent the light ground loses 56 of its 255 and reads as a page gone grey; the dark ground is `#0A1A25`, whose brightest channel is 37, so it loses 8 and reads as nothing. Painting that ground solid black would still take out less than the light dim takes out at 22 per cent, so no single number could say the same thing twice, and the suite asserts that against `PaletteInk` rather than leaving it in a comment.

Black stays as the ink, because a light scrim would raise the ground towards the card and the card standing above its ground is the whole of what the dim buys in dark. What changes is the share. 0.40 is the heaviest black that leaves the window behind clearing `Contrast.textFloor` on every ground the app draws text on: `surfaceRaised` is the worst of the three at 4.7, and the next step up puts it at 4.2. It takes the ground down 15 of its 37 rather than 8, and the text that covers most of the window down 87 of its 218 rather than 48.

The traffic light cut-out goes from six points of air to three. At six the undimmed slot was 71 by 25 around three 14 point circles, and on a light window with an empty sidebar behind it that was the loudest thing in the frame, on the one control the dim is not about.