### PR TITLE
Draw a subagent's output as the conversation it is

### DIFF
--- a/Sources/Bloom/Design/Gallery.swift
+++ b/Sources/Bloom/Design/Gallery.swift
@@ -72,6 +72,7 @@ extension Snapshot {
         .statusColumn,
         .retries,
         .subagentRows,
+        .subagentOutput,
         .paneTabs,
         .sidebarSelection,
         .quickPrompts,

--- a/Sources/Bloom/Design/SubagentOutputGallery.swift
+++ b/Sources/Bloom/Design/SubagentOutputGallery.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+import BloomCore
+
+/// A subagent's conversation, drawn from the lines that produced the report this page answers.
+///
+/// **The complaint was that this pane drew raw material where the transcript draws a conversation**
+/// and there was no way to look at it without opening the app on a live subagent. The fixture below
+/// is the shape of the file that was screenshotted: a brief handed to the subagent as a `user`
+/// line carrying a text block, an answer written in markdown, a Bash call whose input is a long
+/// command, and the result that came back. Three things are on trial here and all three are in the
+/// picture:
+///
+/// - the markdown is rendered rather than showing its own asterisks and backticks;
+/// - the Bash call is one line with the command in it, not a screen of pretty printed JSON;
+/// - the brief is NOT in the conversation. It arrives on the live stream as a text block on a
+///   `user` line, and reading it as something the subagent had said is what drew it under
+///   "Answered" as well as under "Asked". See `SubagentTranscript`.
+///
+/// The rows go through the real parse and the transcript's own fold, so this photographs the code
+/// the pane runs rather than a hand-built arrangement of views.
+///
+///     Bloom --snapshot-gallery <dir> --gallery subagent-output
+struct SubagentOutputGallery: View {
+    var app: AppModel
+
+    private static let home = TranscriptHome(
+        workspaceID: WorkspaceID("w1"), worktree: "/Users/you/dev/code/assign"
+    )
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Tasks 7-8: HTTP layer")
+                    .font(Typo.title)
+                Text("general-purpose . 11m")
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textSecondary)
+                    .padding(.bottom, TranscriptLayout.block)
+
+                SubagentConversationView(rows: Self.rows, home: Self.home, droppedRows: 3)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, Metrics.pane)
+        }
+        .background(Palette.windowBackground)
+        .environment(app)
+    }
+
+    // MARK: - Fixture
+
+    private static var rows: [TranscriptRow] {
+        TranscriptModel.rows(
+            from: SubagentTranscript.parse(lines.joined(separator: "\n"), sessionID: SessionID("gallery"))
+                .messages
+        )
+    }
+
+    /// Stream-json as the CLI writes it, one content block per line, which is what every capture
+    /// measured turned out to hold.
+    private static let lines = [
+        #"{"type":"user","uuid":"u1","parent_tool_use_id":"toolu_1","message":{"role":"user","content":[{"type":"text","text":"You are implementing Tasks 7 and 8 of a plan for \"Assign\", an internal Asana-style task manager. These add the HTTP layer for projects, initiatives and tasks.\n\n**Working directory: /Users/you/dev/code/assign**"}]}}"#,
+        #"{"type":"assistant","uuid":"u2","parent_tool_use_id":"toolu_1","message":{"role":"assistant","content":[{"type":"thinking","thinking":"The plan lists the rule files first, so read those before touching a controller."}]}}"#,
+        #"{"type":"assistant","uuid":"u3","parent_tool_use_id":"toolu_1","message":{"role":"assistant","content":[{"type":"text","text":"**Read first, in this order:**\n\n1. `.ai/rules/index.md`, then every rule file whose globs cover `app/Http/**`.\n2. The requirements for Tasks 7 and 8.\n\nThe reference implementation is `WorkspaceStoreController`, which is *invokable* and returns a redirect."}]}}"#,
+        #"{"type":"assistant","uuid":"u4","parent_tool_use_id":"toolu_1","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_a","name":"Bash","input":{"command":"cd /Users/you/dev/code/assign && grep -rin 'FormRequest' app/Http --include='*.php' | head -40","description":"Find the form requests"}}]}}"#,
+        #"{"type":"user","uuid":"u5","parent_tool_use_id":"toolu_1","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_a","content":"app/Http/Requests/Workspaces/StoreWorkspaceRequest.php:9:class StoreWorkspaceRequest extends FormRequest"}]}}"#,
+        #"{"type":"assistant","uuid":"u6","parent_tool_use_id":"toolu_1","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_b","name":"Read","input":{"file_path":"/Users/you/dev/code/assign/routes/web.php"}}]}}"#,
+        #"{"type":"user","uuid":"u7","parent_tool_use_id":"toolu_1","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_b","content":"     1\t<?php\n     2\t\n     3\tRoute::get('/', HomeController::class);"}]}}"#,
+        #"{"type":"assistant","uuid":"u8","parent_tool_use_id":"toolu_1","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_c","name":"Bash","input":{"command":"cd /Users/you/dev/code/assign && ./vendor/bin/pest --filter=Project","description":"Run the Task 7 suite"}}]}}"#,
+        #"{"type":"user","uuid":"u9","parent_tool_use_id":"toolu_1","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_c","content":"Tests:  23 passed (61 assertions)"}]}}"#,
+        #"{"type":"assistant","uuid":"u10","parent_tool_use_id":"toolu_1","message":{"role":"assistant","content":[{"type":"text","text":"Both tasks are in, one commit each.\n\n- **Task 7** adds the project and initiative controllers, their form requests and their policies.\n- **Task 8** adds the task controllers and the `my-tasks` grouping.\n\n197 tests green (174 baseline + 23 new), PHPStan clean, Pint clean."}]}}"#,
+    ]
+}
+
+extension Gallery {
+    /// The registry entry for this page. See `Gallery`.
+    static let subagentOutput = Gallery(
+        name: "subagent-output",
+        title: "Subagent output",
+        size: CGSize(width: 900, height: 780),
+        needsFocus: false,
+        view: { app in AnyView(SubagentOutputGallery(app: app)) }
+    )
+}

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -7,7 +7,7 @@ import BloomCore
 /// It deliberately carries the raw JSON rather than a decoded structure. The store keeps every
 /// event verbatim, so a renderer added later can show detail that was not decoded when the row
 /// was written, and a row costs nothing to hold until it scrolls into view.
-struct TranscriptRow: Identifiable, Hashable {
+struct TranscriptRow: Identifiable, Hashable, Sendable {
     var id: Int64
     var seq: Int
     var kind: MessageKind
@@ -414,6 +414,25 @@ final class TranscriptModel {
         if message.kind == .toolUse, let refID = message.refID {
             indexByRefID[refID] = rows.count - 1
         }
+    }
+
+    /// The same fold, over messages that were never stored.
+    ///
+    /// **The subagent pane draws a conversation and had grown a renderer of its own to do it.** A
+    /// subagent's lines come back from `SubagentTranscript` in the shape the store hands a message
+    /// back in, so they are folded with this rule rather than with a second one: which result
+    /// belongs to which call, what a refusal is and how long a call took are decided here for
+    /// every conversation in the window, and a second copy of that is a second copy to keep right.
+    ///
+    /// No decisions, because a subagent is never asked a permission question: the CLI puts those
+    /// on the parent's stream, where the transcript already answers them.
+    nonisolated static func rows(from messages: [Message]) -> [TranscriptRow] {
+        var built: [TranscriptRow] = []
+        var indexByRefID: [String: Int] = [:]
+        for message in messages {
+            Self.absorb(message, decisions: [:], into: &built, indexByRefID: &indexByRefID)
+        }
+        return built
     }
 
     /// The same fold, straight onto the model, for the rows that arrive while the session is open.

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -841,7 +841,7 @@ final class WorkspaceModel {
     /// The nested rows the transcript already draws behind a hairline: a line from inside a
     /// subagent carries that subagent's `tool_use_id` as its `parent_tool_use_id`. It is what the
     /// output pane reads while the subagent is running, because the CLI names its file only on
-    /// the line that ends it. See `SubagentTranscript.live(streamLines:)`.
+    /// the line that ends it. See `SubagentTranscript.live(streamLines:sessionID:)`.
     ///
     /// The payloads and not a parse of them: parsing is the core's, and it is done off the main
     /// actor by the caller.

--- a/Sources/Bloom/Views/Center/Panes/SubagentConversationView.swift
+++ b/Sources/Bloom/Views/Center/Panes/SubagentConversationView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import BloomCore
+
+/// A subagent's own conversation, drawn with the rows the transcript beside it draws.
+///
+/// **This view exists so that there is one renderer for a conversation and not two.** The pane it
+/// sits in used to draw a subagent's transcript itself: a caption and a `Text` per entry, which
+/// meant markdown arrived as literal asterisks where the transcript renders prose, and a Bash call
+/// arrived as a screen of pretty printed JSON where the transcript draws one line with the command
+/// in it. Every one of those was a decision the transcript had already taken. `TranscriptRowView`
+/// dispatches on the row's kind, `ProseRowView` renders the markdown, `ToolRowView` and
+/// `ToolPresentation` draw the call, and this hands them rows.
+///
+/// **It deliberately does not fold.** `TranscriptFold` turns a run of grey activity rows into one
+/// line, and main went in today with a change that folds a subagent's nested rows in the
+/// transcript. That is the right answer there and the wrong one here, for two reasons. This is the
+/// pane somebody opens BECAUSE the transcript folded the work away, so folding it again would
+/// leave the detail nowhere to be seen. And the fold is a performance fix wearing a disclosure
+/// triangle: it exists because the transcript's table keys, measures and builds every entry it is
+/// handed, over a session that runs to thousands of rows. This is a `LazyVStack` over a bounded
+/// `SubagentTranscript.rowLimit`, where a row off screen is never built at all, so the cost the
+/// fold was written to remove is not being paid.
+struct SubagentConversationView: View {
+    var rows: [TranscriptRow]
+    /// Which worktree the rows' paths are relative to, and where a file chip opens. The parent's,
+    /// because a subagent runs in the worktree its parent runs in.
+    var home: TranscriptHome
+    /// How many rows were dropped off the front to keep the pane bounded, drawn as a line saying
+    /// so. A conversation that silently starts in the middle is a lie about what the subagent did.
+    var droppedRows: Int
+
+    /// Which rows the reader has opened, by row id.
+    ///
+    /// Held here rather than in the pane above, so that the pane re-reading the file once a second
+    /// does not touch it. The ids are derived from the payload rather than from the position (see
+    /// `SubagentTranscript.rowID`), which is what keeps an opened row open across a re-read and
+    /// across the handover from the live stream to the file.
+    @State private var expanded: Set<Int64> = []
+
+    var body: some View {
+        LazyVStack(alignment: .leading, spacing: 0) {
+            if droppedRows > 0 {
+                DetailCaption(text: "\(Counted.of(droppedRows, "earlier step")) not shown")
+                    .padding(.horizontal, TranscriptLayout.inset)
+                    .padding(.bottom, TranscriptLayout.block)
+            }
+
+            ForEach(rows) { row in
+                TranscriptRowView(
+                    row: row,
+                    home: home,
+                    isExpanded: expanded.contains(row.id),
+                    // Nil, because a subagent is never asked a permission question: the CLI puts
+                    // those on the parent's stream, where the transcript answers them.
+                    projectName: nil,
+                    onToggle: { toggle(row.id) }
+                )
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func toggle(_ id: Int64) {
+        if expanded.contains(id) {
+            expanded.remove(id)
+        } else {
+            expanded.insert(id)
+        }
+    }
+}

--- a/Sources/Bloom/Views/Center/Panes/SubagentOutputView.swift
+++ b/Sources/Bloom/Views/Center/Panes/SubagentOutputView.swift
@@ -21,7 +21,8 @@ import BloomCore
 /// path is named on the line that ENDS the task, so until then there is nothing on disk to open.
 /// The lines the subagent produced came past on the parent's own stream carrying its
 /// `parent_tool_use_id` and Bloom stored every one of them, so the pane falls back to those. See
-/// `SubagentTranscript.live(streamLines:)` and `WorkspaceModel.subagentStreamLines(forToolUseID:)`.
+/// `SubagentTranscript.live(streamLines:sessionID:)` and
+/// `WorkspaceModel.subagentStreamLines(forToolUseID:)`.
 ///
 /// **It stays live while the subagent works**, which is the case it is most often opened in. The
 /// brief is known the moment the task starts, so it is on screen immediately; the output file
@@ -29,14 +30,31 @@ import BloomCore
 /// before this keyed its one read on the subagent's state, so a pane opened mid run showed
 /// whatever prefix existed at the instant it was opened and then nothing more until the end.
 ///
+/// **What it does NOT do any more is draw the conversation itself.** It used to put a caption and
+/// a `Text` over every entry, which is a second renderer for the thing the pane beside it already
+/// renders, and it lost every argument that one had won: an answer written in markdown arrived as
+/// literal asterisks, and a Bash call arrived as a screen of pretty printed JSON where the
+/// transcript draws one line with the command in it. `SubagentConversationView` hands the rows to
+/// `TranscriptRowView`, which is the only thing in the window that decides how a row is drawn.
+///
 /// Everything decided is decided in `SubagentPane`, `SubagentKind` and `SubagentTranscript`.
 struct SubagentOutputView: View {
     var model: WorkspaceModel
     var subagentID: SubagentID
 
-    @State private var transcript: SubagentTranscript?
+    /// The conversation, already folded into rows. Rows rather than the messages they came from,
+    /// because folding a result onto its call parses the largest payload in the file and this
+    /// runs once a second: see `load`, which does it off the main actor.
+    @State private var reading = SubagentReading()
     @State private var failure: SubagentOutput.Failure?
     @State private var isBriefExpanded = false
+
+    /// The conversation's text size, face and line height, read here for the reason `ChatPaneView`
+    /// reads them: this pane is a conversation, and a reader who has set the transcript larger has
+    /// not asked for a subagent's half of it to stay small.
+    @AppStorage(ChatTextSize.defaultsKey) private var textSize = ChatTextSize.standard
+    @AppStorage(ChatFont.defaultsKey) private var chatFontID = ChatFont.standardID
+    @AppStorage(ChatLineHeight.defaultsKey) private var lineHeight = ChatLineHeight.standard
 
     private var subagent: Subagent? {
         model.activeTranscript?.subagents[subagentID]
@@ -44,9 +62,17 @@ struct SubagentOutputView: View {
 
     private var kind: SubagentKind { subagent?.kind ?? .agent }
 
+    /// Where this subagent's paths point. The parent's worktree, because a subagent runs in it.
+    private var home: TranscriptHome {
+        model.activeTranscript?.home ?? TranscriptHome(model.workspace)
+    }
+
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: Metrics.pane) {
+            // Plain, with the lazy stack one level down in `SubagentConversationView`. Two nested
+            // lazy stacks is the outer one measuring the inner one whole, which is the laziness
+            // this pane actually needs given away to get it on the three views above.
+            VStack(alignment: .leading, spacing: 0) {
                 if let subagent {
                     header(subagent)
                     brief(subagent)
@@ -56,14 +82,21 @@ struct SubagentOutputView: View {
                     Text("That subagent belonged to a turn that has since been replaced.")
                         .font(Typo.body)
                         .foregroundStyle(Palette.textSecondary)
+                        .padding(.horizontal, TranscriptLayout.inset)
                 }
 
                 output
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(Metrics.pane)
+            .padding(.vertical, Metrics.pane)
         }
         .background(Palette.windowBackground)
+        .environment(\.fontScale, textSize.scale)
+        .environment(\.chatFont, ChatFont(rawValue: chatFontID))
+        .environment(\.chatLineHeight, lineHeight)
+        // What a link in a subagent's answer does when it is pressed, which is what it does in the
+        // transcript: one rule for every address the window draws. See `TranscriptLink.actions`.
+        .markdownLinkActions(TranscriptLink.actions(for: model))
         // Re-read when the selection moves to a different subagent, and when this one ends. The
         // running case keeps re-reading inside the task rather than re-keying it: an id that
         // carried the elapsed seconds would tear the whole pane down and rebuild it once a second,
@@ -88,32 +121,35 @@ struct SubagentOutputView: View {
 
     private func load() async {
         // Off the main actor. A subagent's transcript is small in the capture and is not promised
-        // to be, and this now runs once a second rather than once.
+        // to be, and this now runs once a second rather than once. Folding the messages into rows
+        // goes with it: pairing a result onto its call decodes the result payload, which is the
+        // largest one in the file.
         let path = subagent?.outputFile
         let kind = kind
+        let session = model.activeTranscript?.session.id ?? SessionID("")
         // Read on the main actor, parsed off it. These are rows the transcript owns.
         let lines = kind == .agent ? model.subagentStreamLines(forToolUseID: toolUseID) : []
-        let result = await Task.detached {
-            switch SubagentOutput.read(path: path, kind: kind) {
+        let result = await Task.detached { () -> Result<SubagentReading, SubagentOutput.Failure> in
+            switch SubagentOutput.read(path: path, kind: kind, sessionID: session) {
             case .success(let parsed):
-                return Result<SubagentTranscript, SubagentOutput.Failure>.success(parsed)
+                return .success(SubagentReading(parsed))
             case .failure(let reason):
                 // **What Bloom saw, when the CLI has not written anything to read.** This is the
                 // whole of a running subagent's pane: the file is named on the line that ends it,
                 // so for the length of the run the read above can only fail. Falling back rather
                 // than replacing, because once the file is there it is the CLI's own record of
                 // the task and this is a copy of what went past. See
-                // `SubagentTranscript.live(streamLines:)`.
-                let live = SubagentTranscript.live(streamLines: lines)
-                return live.isEmpty ? .failure(reason) : .success(live)
+                // `SubagentTranscript.live(streamLines:sessionID:)`.
+                let live = SubagentTranscript.live(streamLines: lines, sessionID: session)
+                return live.isEmpty ? .failure(reason) : .success(SubagentReading(live))
             }
         }.value
         switch result {
         case .success(let parsed):
-            transcript = parsed
+            reading = parsed
             failure = nil
         case .failure(let reason):
-            transcript = nil
+            reading = SubagentReading()
             failure = reason
         }
     }
@@ -143,6 +179,8 @@ struct SubagentOutputView: View {
                     .textSelection(.enabled)
             }
         }
+        .padding(.horizontal, TranscriptLayout.inset)
+        .padding(.bottom, TranscriptLayout.block)
     }
 
     /// What it was given to do: a prompt for an agent, a command line for a background command.
@@ -151,29 +189,50 @@ struct SubagentOutputView: View {
     /// is the half of this that is useful before the task has finished. A command line arrives
     /// nowhere on the task's own lines, so it is lifted back out of the parent's Bash call: see
     /// `SubagentPane.commandLine`.
+    ///
+    /// **A long one opens shut**, showing the line that opens it and nothing else. See
+    /// `SubagentPane.briefCollapseLimit` for why: the head it used to show filled the pane with
+    /// the reader's own words and pushed what the subagent DID below the fold.
+    ///
+    /// A prompt is markdown that somebody wrote, so it is rendered as the markdown it is, by the
+    /// same view that renders an answer. Set as literal text it arrived full of `**` and backticks,
+    /// which is the complaint that started all of this.
     @ViewBuilder
     private func brief(_ subagent: Subagent) -> some View {
         let text = briefText(subagent)
         if !text.isEmpty {
+            let collapses = SubagentPane.briefCollapses(text)
             VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
                 caption(SubagentPane.briefLabel(subagent.kind))
-                Text(isBriefExpanded ? text : SubagentPane.briefHead(text))
-                    .font(SubagentPane.briefIsCode(subagent.kind) ? Typo.codeSmall : Typo.body)
-                    .textSelection(.enabled)
-                if SubagentPane.briefCollapses(text) {
-                    Button(TextFold.title(isExpanded: isBriefExpanded)) {
+                    .padding(.horizontal, TranscriptLayout.inset)
+
+                if collapses {
+                    Button(SubagentPane.briefToggle(isExpanded: isBriefExpanded, kind: subagent.kind)) {
                         isBriefExpanded.toggle()
                     }
                     .buttonStyle(.link)
                     .font(Typo.caption)
+                    .padding(.horizontal, TranscriptLayout.inset)
+                }
+
+                if !collapses || isBriefExpanded {
+                    if SubagentPane.briefIsCode(subagent.kind) {
+                        DetailCodeBlock(text: text, copyTitle: "Copy the command")
+                            .padding(.horizontal, TranscriptLayout.inset)
+                    } else {
+                        ProseRowView(text: text)
+                    }
                 }
             }
+            .padding(.bottom, TranscriptLayout.block)
         }
     }
 
     private func briefText(_ subagent: Subagent) -> String {
         switch subagent.kind {
-        case .agent: subagent.prompt
+        // `task_started` is the honest copy and it is gone with the turn that carried it, so the
+        // one read back out of the transcript stands in for a pane opened after that.
+        case .agent: subagent.prompt.isEmpty ? reading.prompt : subagent.prompt
         case .command: model.commandLine(forToolUseID: subagent.toolUseID) ?? ""
         }
     }
@@ -186,55 +245,19 @@ struct SubagentOutputView: View {
             ))
                 .font(Typo.body)
                 .foregroundStyle(Palette.textSecondary)
-        } else if let transcript {
-            if transcript.droppedEntries > 0 {
-                caption("\(transcript.droppedEntries) earlier steps not shown")
+                .padding(.horizontal, TranscriptLayout.inset)
+        } else if !reading.printed.isEmpty {
+            // A background command has no conversation in it. What it has to say is the bytes it
+            // wrote to a terminal, which are code and are set as code.
+            VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
+                caption(SubagentPane.outputLabel(.command))
+                DetailCodeBlock(text: reading.printed, copyTitle: "Copy the output")
             }
-            // `.prompt` is dropped: it is the same text the brief above already shows in full,
-            // and showing it twice would push the answer another screen down.
-            ForEach(transcript.entries.filter { $0.kind != .prompt }) { entry in
-                self.entry(entry)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func entry(_ entry: SubagentTranscript.Entry) -> some View {
-        VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
-            caption(label(for: entry))
-            Text(entry.body)
-                .font(Self.isProse(entry.kind) ? Typo.body : Typo.codeSmall)
-                .foregroundStyle(colour(for: entry.kind))
-                .textSelection(.enabled)
-        }
-    }
-
-    /// Which entries are somebody's words and which are a machine's. The standing rule: monospace
-    /// is for what a machine said or will run, and what a model wrote in English is not that.
-    static func isProse(_ kind: SubagentTranscript.Entry.Kind) -> Bool {
-        switch kind {
-        case .text, .failure, .thinking, .prompt: true
-        case .tool, .toolResult, .printed: false
-        }
-    }
-
-    private func label(for entry: SubagentTranscript.Entry) -> String {
-        switch entry.kind {
-        case .prompt: "Asked"
-        case .text: "Answered"
-        case .thinking: "Thought"
-        case .tool: entry.title.isEmpty ? "Called a tool" : entry.title
-        case .toolResult: "Result"
-        case .failure: "Stopped"
-        case .printed: SubagentPane.outputLabel(.command)
-        }
-    }
-
-    private func colour(for kind: SubagentTranscript.Entry.Kind) -> Color {
-        switch kind {
-        case .failure: Palette.negative
-        case .thinking, .toolResult: Palette.textSecondary
-        default: Palette.textPrimary
+            .padding(.horizontal, TranscriptLayout.inset)
+        } else {
+            SubagentConversationView(
+                rows: reading.rows, home: home, droppedRows: reading.droppedRows
+            )
         }
     }
 
@@ -243,5 +266,33 @@ struct SubagentOutputView: View {
             .font(Typo.micro)
             .tracking(Typo.microTracking)
             .foregroundStyle(Palette.textTertiary)
+    }
+}
+
+/// One read's worth of pane, folded into rows and assigned in one go.
+///
+/// A value rather than four pieces of `@State`, so a re-read can never leave the rows of one
+/// moment beside the dropped count of another. Outside the view rather than nested in it because
+/// it is built off the main actor and a type nested in a `View` inherits that view's isolation.
+///
+/// `TranscriptModel.rows(from:)` is the transcript's own fold, used rather than copied for the
+/// reason its doc comment gives: which result belongs to which call is decided once for every
+/// conversation in the window.
+private struct SubagentReading: Equatable, Sendable {
+    var rows: [TranscriptRow] = []
+    var droppedRows = 0
+    /// What a background command printed. Empty for an agent.
+    var printed = ""
+    /// The brief as the source carried it, used only when the roster has lost the task that
+    /// carried it.
+    var prompt = ""
+
+    init() {}
+
+    init(_ transcript: SubagentTranscript) {
+        rows = TranscriptModel.rows(from: transcript.messages)
+        droppedRows = transcript.droppedRows
+        printed = transcript.printed
+        prompt = transcript.prompt
     }
 }

--- a/Sources/BloomCore/Transcript/SubagentPane.swift
+++ b/Sources/BloomCore/Transcript/SubagentPane.swift
@@ -111,26 +111,36 @@ public enum SubagentPane: Sendable {
         kind == .command
     }
 
-    /// How many characters of a brief are shown before it is offered collapsed.
+    /// How long a brief may be before the pane opens with it shut.
     ///
     /// Shown in full when it is under this, because a two line prompt behind a disclosure arrow is
-    /// a click to read two lines. Past it the pane opens with the head and an arrow, because a
-    /// handed-off brief runs to a page and a half and the answer is what you came for. The number
-    /// is roughly what fits above the fold of the pane at its default height.
+    /// a click to read two lines.
+    ///
+    /// **Past it the pane now shows none of it, where it used to show the first 500 characters.**
+    /// That head was six or seven lines of a handed-off brief, on top of a title, a subtitle and
+    /// the CLI's own summary, and between them they filled the pane: what the subagent DID began
+    /// below the fold of the one view somebody opens to find out. The title and the summary
+    /// already say what it was asked for in a sentence, and the brief is the reader's own words,
+    /// which is the one thing in this pane they have read before. So it is a line to press, and
+    /// the conversation starts at the top.
     public static let briefCollapseLimit = 500
 
     public static func briefCollapses(_ brief: String) -> Bool {
         brief.count > briefCollapseLimit
     }
 
-    /// The head of a long brief, cut on a line boundary so a collapsed prompt does not stop
-    /// mid-sentence and a collapsed command does not stop mid-flag.
-    public static func briefHead(_ brief: String) -> String {
-        guard briefCollapses(brief) else { return brief }
-        let head = String(brief.prefix(briefCollapseLimit))
-        guard let line = head.lastIndex(of: "\n"), head.distance(from: line, to: head.endIndex) < 200
-        else { return head }
-        return String(head[head.startIndex..<line])
+    /// What the line that opens a long brief says.
+    ///
+    /// Named rather than `TextFold`'s "Show all", because there is nothing above it to be all of:
+    /// a shut brief draws no text at all, so a button offering to show the rest of nothing says
+    /// nothing about what is behind it.
+    public static func briefToggle(isExpanded: Bool, kind: SubagentKind) -> String {
+        switch (isExpanded, kind) {
+        case (false, .agent): "Show the prompt"
+        case (true, .agent): "Hide the prompt"
+        case (false, .command): "Show the command"
+        case (true, .command): "Hide the command"
+        }
     }
 
     /// The command line a background command was given.

--- a/Sources/BloomCore/Transcript/SubagentRow.swift
+++ b/Sources/BloomCore/Transcript/SubagentRow.swift
@@ -109,7 +109,7 @@ public struct SubagentRow: Sendable, Hashable, Identifiable {
         // `SubagentPane.refreshSeconds` unreachable: nothing could open the pane a live re-read
         // was written for. There is something to show from the first frame either way, because
         // `task_started` carries the whole prompt, and the pane falls back to the nested rows
-        // Bloom itself stored when there is no file. See `SubagentTranscript.live(streamLines:)`.
+        // Bloom itself stored when there is no file. See `SubagentTranscript.live(streamLines:sessionID:)`.
         //
         // A background command keeps the old gate. Its brief is lifted out of the parent's Bash
         // call and its output is plain stdout that only `output_file` holds, so with no file

--- a/Sources/BloomCore/Transcript/SubagentTranscript.swift
+++ b/Sources/BloomCore/Transcript/SubagentTranscript.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// A subagent's own transcript, read off the file the CLI wrote for it.
+/// A subagent's own transcript, read as the rows the window already knows how to draw.
 ///
 /// **What `output_file` turned out to be**, because this was the one thing worth checking rather
 /// than assuming. `system/task_notification.output_file` is an absolute path to
@@ -13,88 +13,116 @@ import Foundation
 /// prompt, two attachment records and an assistant message carrying the API error. So there is no
 /// need for the fallback to Bloom's own nested rows, and this is the honest source.
 ///
+/// **Why it hands back `Message` values rather than a shape of its own, which is the whole of
+/// this file's design.** The version before this invented an `Entry` with a body of plain text,
+/// and the pane drew each one as a `Text`. That is a second renderer for a conversation, and it
+/// lost every argument the first one had already won: markdown arrived as literal asterisks, a
+/// Bash call arrived as pretty printed JSON with a space before the colon, and a page of tool
+/// input sat where the transcript would have drawn one line. A subagent's line and a stored
+/// transcript row are the same object, so this reads one into the other and the drawing is the
+/// drawing the transcript already does. Nothing here is stored: these messages belong to no
+/// `messages` row, and `id` says so by being negative.
+///
+/// **The prompt is a user turn on both sources and it arrives in two different shapes**, which is
+/// the bug that put it on screen twice. In the file it is a `user` line whose `content` is a bare
+/// string. On the parent's live stream it is a `user` line whose `content` is an ARRAY holding one
+/// `text` block, and the reader here used to look at the block's type without looking at whose
+/// message it was, so the brief was read back as something the subagent had said and drawn under
+/// "Answered" as well as under "Asked". A `text` block on a `user` line is the brief, on either
+/// source, and it is taken out of the rows and handed back as `prompt`.
+///
 /// Bloom does not own the file, which is why nothing here throws on a shape it does not know: a
 /// line that will not parse is skipped, a file that will not open is a sentence in the pane, and
-/// a format that changes under us degrades to fewer entries rather than to an empty pane.
-public struct SubagentTranscript: Sendable, Hashable {
-    public struct Entry: Sendable, Hashable, Identifiable {
-        public enum Kind: Sendable, Hashable {
-            /// The prompt the parent gave it. Always the first line of the file.
-            case prompt
-            case text
-            case thinking
-            case tool
-            case toolResult
-            /// An assistant message the CLI marked as an API error.
-            case failure
-            /// Bytes a background command printed. Not NDJSON and not parsed: a `local_bash`
-            /// task writes plain stdout to `tasks/<task_id>.output`, and the whole of what it
-            /// has to say is that text.
-            case printed
-        }
+/// a format that changes under us degrades to fewer rows rather than to an empty pane.
+public struct SubagentTranscript: Sendable, Equatable {
+    /// The conversation, oldest first, as the messages a transcript is built from.
+    ///
+    /// Deliberately not paired up here: a `tool_result` is its own message with the call's id in
+    /// `refID`, exactly as the store hands one back, so the window folds it onto its call with the
+    /// same rule it uses for every other transcript and the two cannot drift apart.
+    public let messages: [Message]
 
-        public let id: Int
-        public let kind: Kind
-        /// The tool's name, for a tool entry. Empty otherwise.
-        public let title: String
-        public let body: String
-
-        public init(id: Int, kind: Kind, title: String = "", body: String) {
-            self.id = id
-            self.kind = kind
-            self.title = title
-            // Cut here rather than in the pane, so no reader of this type can be handed a
-            // megabyte. The HEAD is kept, unlike the transcript's own cut above: a tool result
-            // says what it found in its first lines and a file dumped into one is the tail.
-            self.body = body.count > SubagentTranscript.bodyLimit
-                ? String(body.prefix(SubagentTranscript.bodyLimit)) + "..."
-                : body
-        }
-    }
-
-    public let entries: [Entry]
-    /// How many entries were dropped off the front to keep the pane bounded. Drawn as a line
+    /// How many messages were dropped off the front to keep the pane bounded. Drawn as a line
     /// saying so, because a transcript that silently starts in the middle is a lie about what
     /// the subagent did.
-    public let droppedEntries: Int
+    public let droppedRows: Int
 
-    public init(entries: [Entry] = [], droppedEntries: Int = 0) {
-        self.entries = entries
-        self.droppedEntries = droppedEntries
-    }
-
-    public var isEmpty: Bool { entries.isEmpty }
-
-    /// How many entries the pane will render.
+    /// The brief the subagent was handed, when the source carried one.
     ///
-    /// A fan-out agent that read forty files leaves eighty entries and a long one leaves many
-    /// more, and every one of them is a `Text` in a `ScrollView` that is laid out whether or not
-    /// it is on screen. The LAST of them are kept rather than the first: the answer is at the end,
-    /// and the prompt, which is the one early entry worth having, is drawn from
-    /// `task_started.prompt` above rather than from this file.
-    public static let entryLimit = 120
+    /// Read back even though `task_started` already carries it, because the two sources fail at
+    /// different moments: a pane opened on a turn that has since been replaced has no
+    /// `task_started` left to read, and the file has the brief in it either way.
+    public let prompt: String
 
-    /// How much of one entry is rendered. A tool result can be a whole file.
-    public static let bodyLimit = 4_000
+    /// What a background command printed. Empty for an agent.
+    ///
+    /// Not NDJSON and not parsed: a `local_bash` task writes plain stdout to
+    /// `tasks/<task_id>.output`, and the whole of what it has to say is that text.
+    public let printed: String
 
-    /// The last thing the subagent said, which is its answer. Nil when it never said anything.
-    public var answer: Entry? {
-        entries.last { $0.kind == .text || $0.kind == .failure }
+    public init(
+        messages: [Message] = [],
+        droppedRows: Int = 0,
+        prompt: String = "",
+        printed: String = ""
+    ) {
+        self.messages = messages
+        self.droppedRows = droppedRows
+        self.prompt = prompt
+        self.printed = printed
     }
 
-    /// Read one file of NDJSON.
+    public var isEmpty: Bool { messages.isEmpty && printed.isEmpty }
+
+    /// How many rows the pane will draw.
+    ///
+    /// The LAST of them are kept rather than the first: the answer is at the end, and the brief,
+    /// which is the one early row worth having, is drawn above the conversation rather than in it.
+    /// Higher than the 120 entries this replaced, because a row is now built only when it is
+    /// scrolled to and a tool call's payload is only decoded when it is opened, so the number no
+    /// longer stands for a screenful of laid out `Text` views.
+    public static let rowLimit = 500
+
+    /// Read one file, or one run of stored stream lines, of NDJSON.
     ///
     /// `attachment` records are skipped whole. In the capture two of every four lines were one,
     /// each carrying the subagent's entire deferred tool list, thousands of characters of it, and
     /// none of it is an account of what the subagent did.
-    public static func parse(_ text: String) -> SubagentTranscript {
-        var entries: [Entry] = []
-        for line in text.split(whereSeparator: \.isNewline) {
-            guard let json = JSONValue.parse(String(line)) else { continue }
-            entries.append(contentsOf: read(json, from: entries.count))
+    ///
+    /// - Parameter sessionID: the session these lines came off, which is the parent's. It is
+    ///   carried because a `Message` has one and for no other reason: nothing drawn from these
+    ///   rows reads it.
+    public static func parse(_ text: String, sessionID: SessionID) -> SubagentTranscript {
+        var messages: [Message] = []
+        var prompt = ""
+        var used = Set<Int64>()
+
+        for source in text.split(whereSeparator: \.isNewline) {
+            let raw = Data(source.utf8)
+            guard let json = JSONValue.parse(raw) else { continue }
+            for reading in read(json, raw: raw) {
+                switch reading {
+                case .brief(let brief):
+                    // The last one wins. A file holds exactly one; a run of stored stream lines
+                    // holds one per subagent and this is only ever handed one subagent's.
+                    prompt = brief
+                case .row(let kind, let payload, let refID):
+                    messages.append(Message(
+                        id: identifier(for: payload, avoiding: &used),
+                        sessionID: sessionID,
+                        seq: messages.count,
+                        kind: kind,
+                        payload: payload,
+                        refID: refID
+                    ))
+                }
+            }
         }
-        let dropped = max(0, entries.count - entryLimit)
-        return SubagentTranscript(entries: Array(entries.suffix(entryLimit)), droppedEntries: dropped)
+
+        let dropped = max(0, messages.count - rowLimit)
+        return SubagentTranscript(
+            messages: Array(messages.suffix(rowLimit)), droppedRows: dropped, prompt: prompt
+        )
     }
 
     /// The same reading, taken off Bloom's own stored rows rather than off the CLI's file.
@@ -116,87 +144,145 @@ public struct SubagentTranscript: Sendable, Hashable {
     /// task, and this is what Bloom happened to see while it was being written.
     ///
     /// - Parameter streamLines: the stored payloads of the nested rows, in the order they arrived.
-    public static func live(streamLines: [Data]) -> SubagentTranscript {
-        parse(streamLines.map { String(decoding: $0, as: UTF8.self) }.joined(separator: "\n"))
+    public static func live(streamLines: [Data], sessionID: SessionID) -> SubagentTranscript {
+        parse(streamLines.map { String(decoding: $0, as: UTF8.self) }.joined(separator: "\n"), sessionID: sessionID)
     }
 
-    /// What a background command printed, as the one entry it is.
+    /// What a background command printed, as the one block of text it is.
     ///
     /// No parsing, because there is nothing to parse: it is the bytes a program wrote to a
     /// terminal. Trimmed only, so an empty capture is an empty transcript and the pane can say
     /// "nothing yet" rather than draw a blank block.
-    public static func printed(_ text: String) -> SubagentTranscript {
-        let body = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !body.isEmpty else { return SubagentTranscript() }
-        return SubagentTranscript(entries: [Entry(id: 0, kind: .printed, body: body)])
+    public static func command(_ text: String) -> SubagentTranscript {
+        SubagentTranscript(printed: text.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 
-    private static func read(_ json: JSONValue, from index: Int) -> [Entry] {
+    // MARK: - Identity
+
+    /// The id a row that was never stored is drawn under.
+    ///
+    /// **Negative, and that is not decoration.** The window caches how a tool call is drawn under
+    /// the row's id alone (`TranscriptPresentationCache`, whose whole argument is that a stored
+    /// payload is written once so a presentation taken from it cannot go stale). A `messages`
+    /// rowid is a positive `AUTOINCREMENT`, so a synthetic row numbered from zero would read the
+    /// label of whichever real row shared its number, in whichever workspace was open.
+    ///
+    /// Derived from the payload rather than from the position, because this pane re-reads once a
+    /// second and hands over from the live stream to the file the moment the subagent ends. Rows
+    /// numbered by position would be renumbered by either of those, which moves a cached
+    /// presentation onto the wrong call and closes whatever row the reader had opened.
+    ///
+    /// FNV-1a rather than `Hasher`, because `Hasher` is seeded per process and this wants the same
+    /// answer for the same bytes every time, including across the two sources.
+    public static func rowID(for payload: Data) -> Int64 {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        for byte in payload {
+            hash = (hash ^ UInt64(byte)) &* 0x0000_0100_0000_01b3
+        }
+        return -Int64(hash & 0x7fff_ffff_ffff_ffff) - 1
+    }
+
+    /// The same id, stepped down until it is one nothing else in this transcript is using.
+    ///
+    /// Two identical payloads would otherwise be two rows with one identity, which a list draws
+    /// in whatever order it pleases. Every real line carries a `uuid`, so this only ever fires on
+    /// a source that has repeated itself.
+    private static func identifier(for payload: Data, avoiding used: inout Set<Int64>) -> Int64 {
+        var id = rowID(for: payload)
+        while used.contains(id) { id -= 1 }
+        used.insert(id)
+        return id
+    }
+
+    // MARK: - Reading one line
+
+    /// What one content block turned out to be.
+    private enum Reading {
+        /// The brief, which is drawn above the conversation rather than inside it.
+        case brief(String)
+        case row(kind: MessageKind, payload: Data, refID: String?)
+    }
+
+    private static func read(_ json: JSONValue, raw: Data) -> [Reading] {
         guard let type = json["type"]?.stringValue else { return [] }
         guard type == "user" || type == "assistant" else { return [] }
         guard let message = json["message"] else { return [] }
-        let isError = json["isApiErrorMessage"]?.boolValue ?? false
+        let isUser = type == "user"
 
-        // The first user line of a subagent's file is the prompt it was handed, and it arrives as
-        // a bare string rather than as blocks.
+        // The first user line of a file is the brief, and it arrives as a bare string rather than
+        // as blocks. An assistant message shaped the same way is the thing it said.
         if let content = message["content"]?.stringValue {
             let body = content.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !body.isEmpty else { return [] }
-            return [Entry(id: index, kind: type == "user" ? .prompt : .text, body: body)]
+            guard !isUser else { return [.brief(body)] }
+            guard let payload = oneBlockLine(json, holding: .object([
+                "type": .string("text"), "text": .string(body),
+            ])) else { return [] }
+            return [.row(kind: .assistantText, payload: payload, refID: nil)]
         }
 
-        var entries: [Entry] = []
-        for block in message["content"]?.arrayValue ?? [] {
-            guard let entry = read(block: block, id: index + entries.count, isError: isError) else {
-                continue
-            }
-            entries.append(entry)
+        let blocks = message["content"]?.arrayValue ?? []
+        return blocks.compactMap { block in
+            read(block: block, in: json, raw: raw, isOnlyBlock: blocks.count == 1, isUser: isUser)
         }
-        return entries
     }
 
-    private static func read(block: JSONValue, id: Int, isError: Bool) -> Entry? {
+    private static func read(
+        block: JSONValue, in json: JSONValue, raw: Data, isOnlyBlock: Bool, isUser: Bool
+    ) -> Reading? {
+        // The bytes of the line itself wherever the line holds one block, which is every line in
+        // every capture measured. It is the payload every renderer downstream wants: the uuid,
+        // the model, the usage and `tool_result_meta` are all outside `content` and all of them
+        // are lost by rebuilding the line rather than keeping it.
+        func payload() -> Data? {
+            isOnlyBlock ? raw : oneBlockLine(json, holding: block)
+        }
+
         switch block["type"]?.stringValue {
         case "text":
             let body = (block["text"]?.stringValue ?? "")
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             guard !body.isEmpty else { return nil }
-            return Entry(id: id, kind: isError ? .failure : .text, body: body)
+            // A text block on a USER line is the brief, not an answer. See the type's header:
+            // reading it as an answer is what drew the prompt under both headings.
+            guard !isUser else { return .brief(body) }
+            guard let payload = payload() else { return nil }
+            return .row(kind: .assistantText, payload: payload, refID: nil)
 
         case "thinking":
-            let body = (block["thinking"]?.stringValue ?? "")
+            let thought = (block["thinking"]?.stringValue ?? "")
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !body.isEmpty else { return nil }
-            return Entry(id: id, kind: .thinking, body: body)
+            guard !isUser, !thought.isEmpty, let payload = payload() else { return nil }
+            return .row(kind: .thinking, payload: payload, refID: nil)
 
         case "tool_use":
-            // The input verbatim. A subagent's transcript is read to find out what it actually
-            // did, and a summarised tool call is the half that gets summarised away.
-            return Entry(
-                id: id,
-                kind: .tool,
-                title: block["name"]?.stringValue ?? "",
-                body: (block["input"] ?? .null).prettyPrinted
-            )
+            guard !isUser, let payload = payload() else { return nil }
+            return .row(kind: .toolUse, payload: payload, refID: block["id"]?.stringValue)
 
         case "tool_result":
-            let body = text(ofResult: block["content"])
-            guard !body.isEmpty else { return nil }
-            return Entry(id: id, kind: .toolResult, body: body)
+            guard let payload = payload() else { return nil }
+            return .row(kind: .toolResult, payload: payload, refID: block["tool_use_id"]?.stringValue)
 
         default:
             return nil
         }
     }
 
-    /// A tool result is a string on some lines and an array of text blocks on others, and both
-    /// shapes appear in one file.
-    private static func text(ofResult content: JSONValue?) -> String {
-        guard let content else { return "" }
-        if let string = content.stringValue { return string }
-        return (content.arrayValue ?? [])
-            .compactMap { $0["text"]?.stringValue }
-            .joined(separator: "\n")
+    /// The same line with one block where its content was, for the message that carried several.
+    ///
+    /// One line means one row throughout Bloom, and `AgentEvent` reads the first block of a
+    /// message and no others, so a message with two blocks in it has to become two lines before
+    /// either can be drawn. Every key outside `content` is kept, which is what makes this safe to
+    /// do to a line Bloom does not own.
+    private static func oneBlockLine(_ json: JSONValue, holding block: JSONValue) -> Data? {
+        guard case .object(var top) = json, case .object(var message)? = json["message"] else {
+            return nil
+        }
+        message["content"] = .array([block])
+        top["message"] = .object(message)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.withoutEscapingSlashes]
+        return try? encoder.encode(JSONValue.object(top))
     }
 }
 
@@ -221,7 +307,7 @@ public enum SubagentOutput: Sendable {
     /// The pane re-reads once a second while the subagent works (`SubagentPane.refreshSeconds`),
     /// and that is only affordable against a bound. It is the END that is read, because that is
     /// where the answer is and because the pane only renders the last
-    /// `SubagentTranscript.entryLimit` entries anyway. A quarter of a megabyte holds far more
+    /// `SubagentTranscript.rowLimit` rows anyway. A quarter of a megabyte holds far more
     /// than that many lines of anything the capture contained, so in practice this reads whole
     /// files and exists for the one that is not.
     public static let tailBytes = 256 * 1024
@@ -232,7 +318,7 @@ public enum SubagentOutput: Sendable {
     /// Claude Code's transcript shape; for a background command it is plain stdout, which is why
     /// the kind is asked for rather than sniffed. Parsing one as the other is what made a
     /// background command's pane empty.
-    public static func read(path: String?, kind: SubagentKind = .agent)
+    public static func read(path: String?, kind: SubagentKind = .agent, sessionID: SessionID)
         -> Result<SubagentTranscript, Failure> {
         guard let path, !path.isEmpty else { return .failure(.noFile) }
         let url = URL(fileURLWithPath: path)
@@ -240,8 +326,8 @@ public enum SubagentOutput: Sendable {
         do {
             let text = try tail(of: url)
             return .success(kind.writesTranscript
-                ? SubagentTranscript.parse(text)
-                : SubagentTranscript.printed(text))
+                ? SubagentTranscript.parse(text, sessionID: sessionID)
+                : SubagentTranscript.command(text))
         } catch {
             return .failure(.unreadable(error.localizedDescription))
         }

--- a/Tests/BloomCoreTests/SubagentPaneTests.swift
+++ b/Tests/BloomCoreTests/SubagentPaneTests.swift
@@ -150,22 +150,23 @@ import Foundation
     @Test func aShortBriefIsNotHiddenBehindAClick() {
         let short = "Read a.txt and report its line count."
         #expect(!SubagentPane.briefCollapses(short))
-        #expect(SubagentPane.briefHead(short) == short)
     }
 
-    @Test func aLongBriefIsOfferedCollapsed() {
+    /// A handed-off brief runs to a page and a half. It used to open with the first 500 characters
+    /// of it, which together with the title, the subtitle and the summary filled the pane, so what
+    /// the subagent DID began below the fold of the one view somebody opens to find that out.
+    @Test func aLongBriefOpensShutRatherThanShowingItsHead() {
         let long = String(repeating: "word ", count: 400)
         #expect(SubagentPane.briefCollapses(long))
-        #expect(SubagentPane.briefHead(long).count <= SubagentPane.briefCollapseLimit)
     }
 
-    /// Cut on a line so a collapsed prompt does not stop mid-sentence and a collapsed command does
-    /// not stop mid-flag.
-    @Test func aCollapsedBriefStopsOnALine() {
-        let brief = String(repeating: "a paragraph of the brief\n", count: 40)
-        let head = SubagentPane.briefHead(brief)
-        #expect(head.hasSuffix("the brief"))
-        #expect(!head.hasSuffix("\n"))
+    /// The line that opens it says what is behind it. A shut brief draws no text at all, so "Show
+    /// all" would be offering to show the rest of nothing.
+    @Test func theLineThatOpensABriefNamesWhatItHides() {
+        #expect(SubagentPane.briefToggle(isExpanded: false, kind: .agent) == "Show the prompt")
+        #expect(SubagentPane.briefToggle(isExpanded: true, kind: .agent) == "Hide the prompt")
+        #expect(SubagentPane.briefToggle(isExpanded: false, kind: .command) == "Show the command")
+        #expect(SubagentPane.briefToggle(isExpanded: true, kind: .command) == "Hide the command")
     }
 
     // MARK: Finding what a command ran
@@ -195,6 +196,10 @@ import Foundation
 // MARK: - Reading two different files
 
 @Suite(.scratchDirectory) struct SubagentOutputReadingTests {
+    /// The parent's session, which is the one these lines came off. Carried because a `Message`
+    /// has one and for no other reason: nothing drawn from these rows reads it.
+    private static let session = SessionID("s1")
+
     /// In the running test's own directory, which is removed when it ends. It used to be a fresh
     /// directory under `NSTemporaryDirectory()` that nothing removed, and there were 1,007 of them
     /// on the machine this was found on. See `TestScratch`.
@@ -210,13 +215,12 @@ import Foundation
     /// nothing at all, which is exactly what the pane was showing.
     @Test func aCommandsStdoutIsNotParsedAsATranscript() throws {
         let path = try write("> build\nassets written in 1.2s\n")
-        let asTranscript = SubagentOutput.read(path: path, kind: .agent)
+        let asTranscript = SubagentOutput.read(path: path, kind: .agent, sessionID: Self.session)
         #expect(try asTranscript.get().isEmpty)
 
-        let printed = try SubagentOutput.read(path: path, kind: .command).get()
-        #expect(printed.entries.count == 1)
-        #expect(printed.entries[0].kind == .printed)
-        #expect(printed.entries[0].body == "> build\nassets written in 1.2s")
+        let printed = try SubagentOutput.read(path: path, kind: .command, sessionID: Self.session).get()
+        #expect(printed.messages.isEmpty)
+        #expect(printed.printed == "> build\nassets written in 1.2s")
     }
 
     @Test func anAgentsFileIsStillParsedAsNDJSON() throws {
@@ -224,13 +228,16 @@ import Foundation
         {"type":"user","message":{"role":"user","content":"Count the lines"}}
         {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"3"}]}}
         """)
-        let transcript = try SubagentOutput.read(path: path, kind: .agent).get()
-        #expect(transcript.entries.map(\.kind) == [.prompt, .text])
+        let transcript = try SubagentOutput.read(path: path, kind: .agent, sessionID: Self.session).get()
+        // The brief is not one of the rows. It is drawn above the conversation, and reading it back
+        // as something the subagent said is what drew it under "Answered" as well as under "Asked".
+        #expect(transcript.prompt == "Count the lines")
+        #expect(transcript.messages.map(\.kind) == [.assistantText])
     }
 
     @Test func aCommandThatPrintedNothingIsEmptyRatherThanABlankBlock() throws {
         let path = try write("   \n\n")
-        #expect(try SubagentOutput.read(path: path, kind: .command).get().isEmpty)
+        #expect(try SubagentOutput.read(path: path, kind: .command, sessionID: Self.session).get().isEmpty)
     }
 
     /// The failure sentences are worded per kind. "This subagent's output" said of a `git push`
@@ -257,17 +264,35 @@ import Foundation
     @Test func aRunningSubagentIsReadFromTheStreamBloomAlreadyStored() {
         let lines = [
             #"{"type":"assistant","parent_tool_use_id":"toolu_1","message":{"role":"assistant","content":[{"type":"text","text":"Reading the diff"}]}}"#,
-            #"{"type":"assistant","parent_tool_use_id":"toolu_1","message":{"role":"assistant","content":[{"type":"tool_use","name":"Read","input":{"file_path":"/a/b.php"}}]}}"#,
-            #"{"type":"user","parent_tool_use_id":"toolu_1","message":{"role":"user","content":[{"type":"tool_result","content":"<?php"}]}}"#,
+            #"{"type":"assistant","parent_tool_use_id":"toolu_1","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_2","name":"Read","input":{"file_path":"/a/b.php"}}]}}"#,
+            #"{"type":"user","parent_tool_use_id":"toolu_1","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_2","content":"<?php"}]}}"#,
         ].map { Data($0.utf8) }
 
-        let live = SubagentTranscript.live(streamLines: lines)
-        #expect(live.entries.map(\.kind) == [.text, .tool, .toolResult])
-        #expect(live.entries[0].body == "Reading the diff")
-        #expect(live.entries[1].title == "Read")
-        #expect(live.entries[2].body == "<?php")
+        let live = SubagentTranscript.live(streamLines: lines, sessionID: Self.session)
+        #expect(live.messages.map(\.kind) == [.assistantText, .toolUse, .toolResult])
+        // The bytes of the line itself, so every renderer downstream reads what it always read.
+        #expect(live.messages[0].payload == lines[0])
+        #expect(live.messages[2].refID == "toolu_2")
 
-        #expect(SubagentTranscript.live(streamLines: []).isEmpty)
+        #expect(SubagentTranscript.live(streamLines: [], sessionID: Self.session).isEmpty)
+    }
+
+    /// **The brief was on screen twice, under two headings, and this is why.**
+    ///
+    /// In the CLI's file it is a `user` line whose content is a bare string. On the parent's live
+    /// stream, which is what a RUNNING subagent's pane reads, it is a `user` line whose content is
+    /// an array holding one `text` block. The reader used to look at the block's type without
+    /// looking at whose message it was, so the brief came back as something the subagent had said.
+    @Test func theBriefOnTheLiveStreamIsNotReadBackAsAnAnswer() {
+        let lines = [
+            #"{"type":"user","parent_tool_use_id":"toolu_1","message":{"role":"user","content":[{"type":"text","text":"You are implementing Tasks 7 and 8 of a plan for Assign."}]}}"#,
+            #"{"type":"assistant","parent_tool_use_id":"toolu_1","message":{"role":"assistant","content":[{"type":"text","text":"Both tasks are in."}]}}"#,
+        ].map { Data($0.utf8) }
+
+        let live = SubagentTranscript.live(streamLines: lines, sessionID: Self.session)
+        #expect(live.prompt == "You are implementing Tasks 7 and 8 of a plan for Assign.")
+        #expect(live.messages.count == 1)
+        #expect(live.messages[0].kind == .assistantText)
     }
 
     /// A subagent that has not spoken yet has not failed to write anything, and the reasons in
@@ -282,9 +307,12 @@ import Foundation
     }
 
     @Test func aFileThatIsNotThereIsASentenceRatherThanAThrow() {
-        #expect(SubagentOutput.read(path: "/no/such/file", kind: .command) == .failure(.missing))
-        #expect(SubagentOutput.read(path: "", kind: .command) == .failure(.noFile))
-        #expect(SubagentOutput.read(path: nil, kind: .agent) == .failure(.noFile))
+        #expect(SubagentOutput.read(path: "/no/such/file", kind: .command, sessionID: Self.session)
+            == .failure(.missing))
+        #expect(SubagentOutput.read(path: "", kind: .command, sessionID: Self.session)
+            == .failure(.noFile))
+        #expect(SubagentOutput.read(path: nil, kind: .agent, sessionID: Self.session)
+            == .failure(.noFile))
     }
 
     // MARK: Bounds
@@ -316,24 +344,16 @@ import Foundation
     }
 
     @Test func aTranscriptIsCappedAtWhatThePaneWillDraw() {
-        let line = """
-        {"type":"assistant","message":{"content":[{"type":"text","text":"step"}]}}
-        """
-        let many = Array(repeating: line, count: SubagentTranscript.entryLimit + 30)
-            .joined(separator: "\n")
-        let transcript = SubagentTranscript.parse(many)
-        #expect(transcript.entries.count == SubagentTranscript.entryLimit)
-        #expect(transcript.droppedEntries == 30)
-    }
-
-    @Test func aSingleEnormousEntryIsCutRatherThanHeldWhole() {
-        let huge = String(repeating: "z", count: SubagentTranscript.bodyLimit * 2)
-        let entry = SubagentTranscript.Entry(id: 0, kind: .toolResult, body: huge)
-        #expect(entry.body.count == SubagentTranscript.bodyLimit + 3)
-        #expect(entry.body.hasSuffix("..."))
+        // Numbered, so the rows are not all one payload and therefore not all one identity.
+        let many = (0..<(SubagentTranscript.rowLimit + 30)).map {
+            #"{"type":"assistant","uuid":"u\#($0)","message":{"content":[{"type":"text","text":"step"}]}}"#
+        }.joined(separator: "\n")
+        let transcript = SubagentTranscript.parse(many, sessionID: Self.session)
+        #expect(transcript.messages.count == SubagentTranscript.rowLimit)
+        #expect(transcript.droppedRows == 30)
     }
 
     @Test func anOrdinaryTranscriptReportsNothingDropped() {
-        #expect(SubagentTranscript.parse("").droppedEntries == 0)
+        #expect(SubagentTranscript.parse("", sessionID: Self.session).droppedRows == 0)
     }
 }

--- a/Tests/BloomCoreTests/SubagentTests.swift
+++ b/Tests/BloomCoreTests/SubagentTests.swift
@@ -455,48 +455,123 @@ import Foundation
 // MARK: - Reading a subagent's own transcript
 
 @Suite struct SubagentTranscriptTests {
+    /// The parent's session, which is the one these lines came off.
+    private static let session = SessionID("s1")
+
     @Test func aFailedSubagentStillLeftAReadableFile() throws {
         let text = try bloomFixtureLines("subagent-output-529.jsonl").joined(separator: "\n")
-        let transcript = SubagentTranscript.parse(text)
+        let transcript = SubagentTranscript.parse(text, sessionID: Self.session)
         // Four lines in, two of them `attachment` records carrying the whole deferred tool list.
-        #expect(transcript.entries.count == 2)
-        #expect(transcript.entries.first?.kind == .prompt)
-        #expect(transcript.entries.first?.body.hasPrefix("Read the file a.txt") == true)
-        let answer = try #require(transcript.answer)
-        #expect(answer.kind == .failure)
-        #expect(answer.body.contains("529 Overloaded"))
+        // The brief is the first, and it is not one of the rows: it is drawn above them.
+        #expect(transcript.prompt.hasPrefix("Read the file a.txt"))
+        #expect(transcript.messages.map(\.kind) == [.assistantText])
+        let answer = try #require(transcript.messages.last)
+        #expect(String(decoding: answer.payload, as: UTF8.self).contains("529 Overloaded"))
     }
 
     @Test func toolCallsAndResultsAreKept() {
         // Synthetic, because every subagent in the capture died before it could call a tool.
         let text = """
-        {"type":"assistant","message":{"role":"assistant","content":[\
-        {"type":"thinking","thinking":"weighing it"},\
-        {"type":"tool_use","name":"Read","input":{"file_path":"/a.txt"}}]}}
-        {"type":"user","message":{"role":"user","content":[\
-        {"type":"tool_result","content":[{"type":"text","text":"three lines"}]}]}}
-        {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"3"}]}}
+        {"type":"assistant","uuid":"u1","message":{"role":"assistant","content":[\
+        {"type":"thinking","thinking":"weighing it"}]}}
+        {"type":"assistant","uuid":"u2","message":{"role":"assistant","content":[\
+        {"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"/a.txt"}}]}}
+        {"type":"user","uuid":"u3","message":{"role":"user","content":[\
+        {"type":"tool_result","tool_use_id":"toolu_1","content":[{"type":"text","text":"three lines"}]}]}}
+        {"type":"assistant","uuid":"u4","message":{"role":"assistant","content":[{"type":"text","text":"3"}]}}
         """
-        let transcript = SubagentTranscript.parse(text)
-        #expect(transcript.entries.map(\.kind) == [.thinking, .tool, .toolResult, .text])
-        #expect(transcript.entries[1].title == "Read")
-        #expect(transcript.entries[1].body.contains("/a.txt"))
-        #expect(transcript.entries[2].body == "three lines")
-        #expect(transcript.answer?.body == "3")
+        let transcript = SubagentTranscript.parse(text, sessionID: Self.session)
+        #expect(transcript.messages.map(\.kind) == [.thinking, .toolUse, .toolResult, .assistantText])
+        // The call and its result are filed under the same id, which is how the window folds the
+        // one onto the other. See `TranscriptModel.rows(from:)`.
+        #expect(transcript.messages[1].refID == "toolu_1")
+        #expect(transcript.messages[2].refID == "toolu_1")
+    }
+
+    /// Every row has to decode to the event its bucket promises, because that is what the window
+    /// dispatches on. A row filed as a tool call whose line decodes to something else draws
+    /// nothing at all.
+    @Test func everyRowDecodesToTheEventItsBucketPromises() throws {
+        let text = """
+        {"type":"assistant","uuid":"u1","message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}
+        {"type":"assistant","uuid":"u2","message":{"role":"assistant","content":[\
+        {"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"ls"}}]}}
+        {"type":"user","uuid":"u3","message":{"role":"user","content":[\
+        {"type":"tool_result","tool_use_id":"toolu_1","content":"a.txt"}]}}
+        """
+        for message in SubagentTranscript.parse(text, sessionID: Self.session).messages {
+            let event = try #require(
+                AgentEvent.decode(line: String(decoding: message.payload, as: UTF8.self))
+            )
+            #expect(event.kind == message.kind)
+        }
+    }
+
+    /// One line means one row throughout Bloom, and `AgentEvent` reads the first block of a
+    /// message and no others, so a message carrying two has to become two lines first.
+    @Test func aMessageCarryingSeveralBlocksBecomesSeveralRows() throws {
+        let text = """
+        {"type":"assistant","uuid":"u1","session_id":"s","message":{"role":"assistant","content":[\
+        {"type":"text","text":"Reading it"},\
+        {"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"/a.txt"}}]}}
+        """
+        let transcript = SubagentTranscript.parse(text, sessionID: Self.session)
+        #expect(transcript.messages.map(\.kind) == [.assistantText, .toolUse])
+        for message in transcript.messages {
+            let json = try #require(JSONValue.parse(message.payload))
+            // Every key outside `content` survives the split, because the renderers read them.
+            #expect(json["uuid"]?.stringValue == "u1")
+            #expect(json["session_id"]?.stringValue == "s")
+            #expect(json["message"]?["content"]?.arrayValue?.count == 1)
+        }
     }
 
     @Test func aLineThatWillNotParseIsSkippedRatherThanEndingTheRead() {
-        // Bloom does not own this file, so a shape it does not know degrades to fewer entries.
+        // Bloom does not own this file, so a shape it does not know degrades to fewer rows.
         let transcript = SubagentTranscript.parse("""
         not json at all
         {"type":"summary","summary":"something new"}
+        {"type":"attachment","attachment":{"type":"skill_listing","content":"a page of skills"}}
         {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}
-        """)
-        #expect(transcript.entries.map(\.body) == ["ok"])
+        """, sessionID: Self.session)
+        #expect(transcript.messages.count == 1)
+        #expect(transcript.messages[0].kind == .assistantText)
     }
 
     @Test func anEmptyFileIsEmptyRatherThanAFailure() {
-        #expect(SubagentTranscript.parse("").isEmpty)
+        #expect(SubagentTranscript.parse("", sessionID: Self.session).isEmpty)
+    }
+
+    // MARK: Identity
+
+    /// **A row that was never stored is numbered below every row that was.** The window caches how
+    /// a tool call is drawn under the row's id alone, and a `messages` rowid is a positive
+    /// `AUTOINCREMENT`, so a synthetic row numbered from zero would read the label of whichever
+    /// real row shared its number.
+    @Test func aRowThatWasNeverStoredIsNumberedBelowEveryRowThatWas() {
+        let line = #"{"type":"assistant","uuid":"u1","message":{"content":[{"type":"text","text":"ok"}]}}"#
+        let transcript = SubagentTranscript.parse(line, sessionID: Self.session)
+        #expect(transcript.messages.allSatisfy { $0.id < 0 })
+    }
+
+    /// The same bytes get the same number every time, so a row stays itself across the re-read
+    /// that happens once a second and across the handover from the live stream to the file. Row
+    /// numbers taken from the position moved under both.
+    @Test func aRowKeepsItsNumberAcrossAReRead() {
+        let payload = Data(#"{"type":"assistant","uuid":"u1"}"#.utf8)
+        #expect(SubagentTranscript.rowID(for: payload) == SubagentTranscript.rowID(for: payload))
+        #expect(SubagentTranscript.rowID(for: payload) != SubagentTranscript.rowID(for: Data("x".utf8)))
+    }
+
+    /// Two identical lines are still two rows, and a list handed rows whose identifiers repeat
+    /// lays them out in whatever order it pleases.
+    @Test func twoIdenticalLinesStillGetTwoIdentities() {
+        let line = #"{"type":"assistant","message":{"content":[{"type":"text","text":"same"}]}}"#
+        let transcript = SubagentTranscript.parse(
+            [line, line].joined(separator: "\n"), sessionID: Self.session
+        )
+        #expect(transcript.messages.count == 2)
+        #expect(transcript.messages[0].id != transcript.messages[1].id)
     }
 }
 


### PR DESCRIPTION
The subagent pane drew its own transcript: a caption and a `Text` per entry. Markdown arrived as literal asterisks, a Bash call arrived as a screen of pretty printed JSON, and the brief was on screen twice.

`SubagentTranscript` now reads the CLI's file, and the stream lines Bloom stored while the subagent was running, into `Message` values. The pane folds those with `TranscriptModel.rows(from:)` and hands them to `TranscriptRowView`, so prose, tool rows and `ToolPresentation` are the ones the transcript already uses.

The brief being drawn twice was a real bug and not two headings that looked alike. In the CLI's file the brief is a `user` line whose content is a bare string; on the parent's live stream, which is what a running subagent's pane reads, it is a `user` line whose content is an array holding one `text` block. The reader looked at the block's type without looking at whose message it was, so the brief came back as something the subagent had said.

Two judgement calls, both argued in the code:

- A long brief opens shut rather than showing its first 500 characters. That head, on top of the title, the subtitle and the summary, filled the pane, so what the subagent did began below the fold.
- The pane does not fold its rows. It is the view somebody opens because the transcript folded the work away, and the fold exists to stop the transcript's table keying and measuring thousands of entries, which a `LazyVStack` over a bounded row count is not doing.

Rows that were never stored are numbered negative and derived from their payload, so they cannot take a stored row's entry in `TranscriptPresentationCache` and do not move under the once-a-second re-read.

`Bloom --snapshot-gallery <dir> --gallery subagent-output` photographs the result.
