### PR TITLE
Never put a reader somewhere a pane with no height says is the end

### DIFF
--- a/Sources/Bloom/Views/Center/Composer/ComposerView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerView.swift
@@ -101,7 +101,13 @@ struct ComposerView: View {
         // moves the total on every frame and leaves the chrome exactly where it was, and writing
         // an unchanged value into `@State` still re-runs this body.
         .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { total in
-            let chrome = PaneMeasure.chrome(total - editorHeight)
+            // `knowing:` rather than bare, and the transcript going blank is what it is for. A
+            // chrome of nought is a pass that measured the composer before the editor inside it
+            // moved, not a composer with no chrome, and writing it lifts `maxEditorHeight` by the
+            // whole chrome: the floor below is then measured against a number that is short by
+            // exactly the thing it is supposed to leave room for. See
+            // `PaneMeasure.chrome(_:knowing:)`.
+            let chrome = PaneMeasure.chrome(total - editorHeight, knowing: chromeHeight)
             if chrome != chromeHeight { chromeHeight = chrome }
         }
     }
@@ -173,10 +179,12 @@ struct ComposerView: View {
     /// every render and not only while dragging, so shrinking the window shrinks the composer back
     /// rather than pushing the transcript off the top.
     private var maxEditorHeight: CGFloat {
-        let available = room.height
-        guard available > 0 else { return .greatestFiniteMagnitude }
-        let left = available - chromeHeight - Self.minTranscriptHeight
-        return max(left, ComposerTextEditor.lineHeight)
+        PaneMeasure.editorCap(
+            room: room.height,
+            chrome: chromeHeight,
+            floor: Self.minTranscriptHeight,
+            atLeast: ComposerTextEditor.lineHeight
+        )
     }
 
     /// The drag begins from whatever is on screen, so switching out of automatic sizing never jumps.

--- a/Sources/Bloom/Views/Transcript/TranscriptLiveEndFollow.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptLiveEndFollow.swift
@@ -246,6 +246,14 @@ final class TranscriptLiveEndFollower {
             guard document.isFlipped else { return endLink() }
 
             let clip = scrollView.contentView
+            // The same refusal `TranscriptTable.Coordinator.put` makes, because this is the other
+            // thing that writes the clip view and it runs at display rate for the whole of a turn,
+            // which is when a divider is most likely to be under a hand. See
+            // `TranscriptAnchor.canPlace`: `endOffset` against a pane of no height is the point
+            // below the last row.
+            guard TranscriptAnchor.canPlace(viewportHeight: Double(clip.bounds.height)) else {
+                return
+            }
             let now = CACurrentMediaTime()
             let frame = lastFrame > 0 ? now - lastFrame : 0
             lastFrame = now

--- a/Sources/Bloom/Views/Transcript/TranscriptTable.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTable.swift
@@ -1268,6 +1268,17 @@ struct TranscriptTable: NSViewRepresentable {
 
         private func put(_ y: CGFloat, in scrollView: NSScrollView) {
             let clip = scrollView.contentView
+            // **Nothing at all is decided from a pane nobody has laid out**, and this is the
+            // blank transcript a composer divider left behind. The end of the content resolved
+            // against a viewport of no height is the whole content height, which is the point
+            // BELOW the last row, and the clamp below happily allows it: a reader sitting at the
+            // live end while the composer takes the pane's height for a pass is put there and
+            // cannot be brought back, because every recovery in this file needs a row on screen
+            // to start from. `measureLanding` refuses the same pane a few lines down. See
+            // `TranscriptAnchor.canPlace`, which is that rule where it can be tested.
+            guard TranscriptAnchor.canPlace(viewportHeight: Double(clip.bounds.height)) else {
+                return
+            }
             let target = TranscriptAnchor.clamped(
                 y,
                 contentHeight: Double(scrollView.documentView?.frame.height ?? 0),

--- a/Sources/BloomCore/Presentation/PaneMeasure.swift
+++ b/Sources/BloomCore/Presentation/PaneMeasure.swift
@@ -38,4 +38,50 @@ public enum PaneMeasure {
         guard height > 0 else { return 0 }
         return (height / step).rounded(.up) * step
     }
+
+    /// The same measurement, taking the last known answer when this pass cannot make one.
+    ///
+    /// **Nought is not a chrome, it is a pass that laid one of the two out and not the other**,
+    /// which is what the negative case above answers nought for. Taken as a measurement it is
+    /// worse than no answer at all: the cap it feeds is the room less the chrome less the floor
+    /// the transcript keeps, so a chrome of nought hands the editor the whole of the chrome as
+    /// well and the composer is allowed to squeeze the transcript past that floor.
+    ///
+    /// **A drag makes those passes constantly**, because the height the editor is being dragged to
+    /// is written a frame before the composer holding it is measured at it, so the difference the
+    /// chrome is taken from comes out negative on any frame the hand moves faster than the layout.
+    /// The transcript is then given a height of nothing for a pass, and what a placement resolved
+    /// against one does is `TranscriptAnchor.canPlace`: it parks the reader below the last row of
+    /// the conversation, where nothing can bring them back.
+    ///
+    /// Nought until the first real measurement, which is what the caller starts from, so a
+    /// composer that has never been laid out behaves exactly as it did before this existed.
+    public static func chrome(_ height: CGFloat, knowing known: CGFloat) -> CGFloat {
+        let measured = chrome(height)
+        return measured > 0 ? measured : known
+    }
+
+    /// **The tallest the composer's editor may be drawn without taking the floor the transcript
+    /// keeps.**
+    ///
+    /// The rule `ComposerView.maxEditorHeight` spelled inline, moved here because it is a decision
+    /// and a decision taken inside a view is a decision nothing can test. Nothing about the
+    /// arithmetic moved with it.
+    ///
+    /// **What it is worth testing is what happens when the chrome is wrong.** The floor is
+    /// subtracted from the room along with the chrome, so a chrome that is short by its own whole
+    /// value leaves the editor exactly the floor to eat into, and a real chrome is larger than the
+    /// floor in a composer carrying chips. The transcript then has no height at all for that pass,
+    /// which is the blank `TranscriptAnchor.canPlace` refuses to make permanent. See
+    /// `chrome(_:knowing:)`, which is what keeps a drag from reporting one.
+    ///
+    /// A room of nought is a pane nobody has laid out rather than a pane with no room, so it is no
+    /// cap at all: the editor takes its own height until there is a measurement to clamp it by.
+    /// Nought means "not laid out yet" everywhere else in this file for the same reason.
+    public static func editorCap(
+        room: CGFloat, chrome: CGFloat, floor: CGFloat, atLeast line: CGFloat
+    ) -> CGFloat {
+        guard room > 0 else { return .greatestFiniteMagnitude }
+        return max(room - chrome - floor, line)
+    }
 }

--- a/Sources/BloomCore/Transcript/TranscriptAnchor.swift
+++ b/Sources/BloomCore/Transcript/TranscriptAnchor.swift
@@ -37,6 +37,40 @@ public enum TranscriptAnchor {
         max(0, contentHeight - viewportHeight)
     }
 
+    /// The shortest viewport a placement may be resolved against.
+    ///
+    /// A point, for the reason `TranscriptRowHeights.narrowest` is a point across: a pane that has
+    /// not been laid out reports nought or one, and neither of those is a measurement of anything.
+    public static let laidOut: Double = 1
+
+    /// **Whether this pane has been laid out enough for a placement to mean anything.**
+    ///
+    /// **This is the blank transcript a composer divider left behind.** A pane of no height is not
+    /// a short pane, it is a pane nobody has laid out yet, and every number in this file answers
+    /// something absurd for one. `end(contentHeight:viewportHeight:)` comes out as the WHOLE
+    /// content height, which is the point BELOW the last row rather than the last screen of rows,
+    /// and `clamped` then lets a caller put the viewport exactly there. What is on screen
+    /// afterwards is the transcript's own ground and not one row of the conversation.
+    ///
+    /// **And it does not come back, which is why this is a refusal and not a clamp.** Once the
+    /// viewport is below the last row the table can see no rows at all, and every mechanism that
+    /// would put it right needs one to start from: there is no topmost entry, so the next
+    /// placement has no anchor and leaves the view where it is; the screen census counts nothing,
+    /// so nothing is repaired; and the warming pass finds no band to warm. A frame of bad layout
+    /// becomes a conversation that looks deleted.
+    ///
+    /// The pane really does have no height for a pass at a time, and `PaneMeasure.chrome` carries
+    /// why: the composer's cap is worked out from a chrome measured on the pass before the one
+    /// that moved the editor, so a divider dragged quickly can hand the editor the chrome as well
+    /// and squeeze the transcript past the floor meant to keep it.
+    ///
+    /// `TranscriptTable.Coordinator.measureLanding` already refuses a pane of no height, for the
+    /// smaller version of the same reason. This is the rule it was keeping, written where every
+    /// caller can keep it and where it can be tested.
+    public static func canPlace(viewportHeight: Double) -> Bool {
+        viewportHeight > laidOut
+    }
+
     /// A wanted offset brought inside the range the viewport can actually be at.
     ///
     /// Every scroll in the transcript goes through this, including the ones aimed at the end: a

--- a/Tests/BloomCoreTests/TranscriptBlankOnResizeTests.swift
+++ b/Tests/BloomCoreTests/TranscriptBlankOnResizeTests.swift
@@ -1,0 +1,236 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+/// **Dragging the divider that resizes the composer left the whole transcript blank.**
+///
+/// Reported against `8fb409d3` with two screenshots three seconds apart: a full transcript, then
+/// nothing at all between the pinned question strip and the composer. The pinned strip, the
+/// composer, the sidebar and the inspector all survived, which is what says the rows were still
+/// there and the table was the thing that went dark.
+///
+/// The divider moves the transcript's HEIGHT and never its width, so this suite pins the three
+/// things a height change must not do, and then the two rules that stop it doing the fourth.
+///
+/// 1. It must not empty the height cache. `TranscriptRowHeights` has no notion of height at all,
+///    and these tests are here so that nothing gives it one by handing a height to `reset` or
+///    `rewidth`.
+/// 2. It must not silence a row. A row measured at nothing is given no view by the table, and
+///    nothing ever asks again, so a nought filed by a resize would be a conversation that stays
+///    gone.
+/// 3. It must not leave a hold on. A hold is armed by a width change and is what draws the pane's
+///    own ground instead of the transcript.
+/// 4. And it must not resolve a placement against a pane that has no height, which is what it was
+///    doing. See `TranscriptAnchor.canPlace` for the whole of it: the end of the content measured
+///    against a viewport of nought is the point BELOW the last row, and a reader put there sees
+///    no rows, which leaves the table with nothing to anchor to, nothing to count and nothing to
+///    repair. `PaneMeasure` is where the pane of no height came from.
+@Suite("The transcript going blank when the composer is resized")
+struct TranscriptBlankOnResizeTests {
+    /// A key from one string, which is all these tests need to tell two entries apart. The real
+    /// one combines a dozen fields: see `TranscriptContentKey`.
+    private func key(_ text: String) -> TranscriptContentKey {
+        TranscriptContentKey { $0.combine(text) }
+    }
+
+    // MARK: - A pane of no height is not a place to put anybody
+
+    /// The arithmetic the guard exists for, written down so nobody has to rediscover it. With no
+    /// viewport there is no last screen, so the end of the content is the whole of it, and that
+    /// point is past every row rather than at the last of them.
+    @Test("the end of a pane with no height is below the last row")
+    func endOfAPaneWithNoHeightIsPastTheContent() {
+        #expect(TranscriptAnchor.end(contentHeight: 30_000, viewportHeight: 0) == 30_000)
+        #expect(
+            TranscriptAnchor.clamped(30_000, contentHeight: 30_000, viewportHeight: 0) == 30_000
+        )
+    }
+
+    @Test("nothing is placed against a pane that has not been laid out")
+    func refusesAPaneWithNoHeight() {
+        #expect(!TranscriptAnchor.canPlace(viewportHeight: 0))
+        #expect(!TranscriptAnchor.canPlace(viewportHeight: 1))
+        #expect(!TranscriptAnchor.canPlace(viewportHeight: -40))
+    }
+
+    /// A transcript squeezed to its floor is still a transcript, and a reader in one still has to
+    /// be put back where they were.
+    @Test("a pane dragged down to its floor is still placed")
+    func placesARealPane() {
+        #expect(TranscriptAnchor.canPlace(viewportHeight: 120))
+        #expect(TranscriptAnchor.canPlace(viewportHeight: 900))
+    }
+
+    // MARK: - Where a pane of no height came from
+
+    /// The composer publishes its chrome as the difference between its own height and the editor's,
+    /// and a drag moves the editor a frame before the composer is measured at it, so that
+    /// difference comes out negative on any frame the hand outruns the layout.
+    @Test("a pass that cannot measure the chrome keeps the last one")
+    func keepsAKnownChrome() {
+        #expect(PaneMeasure.chrome(-30, knowing: 72) == 72)
+        #expect(PaneMeasure.chrome(0, knowing: 72) == 72)
+        // A real measurement still wins, and still rounds up.
+        #expect(PaneMeasure.chrome(90, knowing: 72) == 96)
+    }
+
+    /// Nought until there is anything to know, which is what a composer that has never been laid
+    /// out starts from.
+    @Test("a composer with nothing known yet still reports nothing")
+    func keepsNothingWhenNothingIsKnown() {
+        #expect(PaneMeasure.chrome(-30, knowing: 0) == 0)
+    }
+
+    /// **This is the bug, as arithmetic.** The floor is subtracted from the room along with the
+    /// chrome, so a chrome reported as nought hands the editor the chrome as well, and a composer
+    /// carrying chips has more chrome than the floor is wide. The transcript is then given a
+    /// height of nothing rather than of 120.
+    @Test("a chrome of nought lets the composer take the whole transcript")
+    func aChromeOfNoughtTakesTheFloor() {
+        let room: CGFloat = 800
+        let realChrome: CGFloat = 136
+        let floor: CGFloat = 120
+        let line: CGFloat = 20
+
+        let honest = PaneMeasure.editorCap(
+            room: room, chrome: realChrome, floor: floor, atLeast: line
+        )
+        #expect(room - (honest + realChrome) == floor)
+
+        let lost = PaneMeasure.editorCap(room: room, chrome: 0, floor: floor, atLeast: line)
+        #expect(room - (lost + realChrome) < 0)
+    }
+
+    /// A pane nobody has laid out is no cap at all, which is nought's meaning everywhere else in
+    /// `PaneMeasure`. It must not come out as a floor subtracted from nothing.
+    @Test("a pane with no room caps nothing")
+    func noRoomIsNoCap() {
+        #expect(
+            PaneMeasure.editorCap(room: 0, chrome: 72, floor: 120, atLeast: 20)
+                == .greatestFiniteMagnitude
+        )
+    }
+
+    /// The editor keeps a line whatever the arithmetic says, so a very short pane leaves a box
+    /// somebody can still type in rather than a hairline.
+    @Test("the editor keeps a line in a pane with no room to spare")
+    func keepsALine() {
+        #expect(PaneMeasure.editorCap(room: 130, chrome: 72, floor: 120, atLeast: 20) == 20)
+    }
+
+    // MARK: - A height change empties no heights
+
+    /// `reset` takes a width, a text size and a line height, and a pane's height is none of those.
+    /// Said twice with the same three, it must answer that nothing moved and keep every number.
+    @Test("a resize that changes only the height keeps every measured row")
+    func heightIsNotPartOfTheCache() {
+        var heights = TranscriptRowHeights()
+        let first = heights.reset(width: 900, scale: 1, leading: 1.7)
+        #expect(first)
+        heights.note(240, for: key("row.7"), shape: .answer)
+        heights.note(22, for: key("row.8"), shape: .fold)
+
+        // The pane is half as tall as it was. Nothing above changed, so nothing here may.
+        let again = heights.reset(width: 900, scale: 1, leading: 1.7)
+        #expect(!again)
+        #expect(heights.height(for: key("row.7")) == 240)
+        #expect(heights.height(for: key("row.8")) == 22)
+        #expect(heights.count == 2)
+    }
+
+    /// `rewidth` is the resize path, and it is the WIDTH path. A pane that is the same width owes
+    /// no measurement, however tall it has become.
+    @Test("a pane that is the same width owes no remeasurement")
+    func rewidthIsAWidthQuestion() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 900, scale: 1, leading: 1.7)
+        heights.note(240, for: key("row.7"), shape: .answer)
+
+        let moved = heights.rewidth(to: 900)
+        #expect(!moved)
+        #expect(heights.staleCount == 0)
+        #expect(heights.height(for: key("row.7")) == 240)
+    }
+
+    /// And a cache that has been told a width stays ready for ever, so a table can never be
+    /// answered a hair per row after it has once been answered properly. A transcript told a
+    /// hundredth of a point per row is a transcript that is not there.
+    @Test("a cache that has a width never stops having one")
+    func staysReady() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 900, scale: 1, leading: 1.7)
+        heights.note(240, for: key("row.7"), shape: .answer)
+        heights.forget()
+        #expect(heights.isReady)
+        let refused = heights.reset(width: 0.5, scale: 1, leading: 1.7)
+        #expect(!refused)
+        #expect(heights.isReady)
+    }
+
+    // MARK: - A height change silences no row
+
+    /// A row is silenced by being measured at nothing: the table builds no view for one, so
+    /// nothing can ever report a better number. A resize must leave every measured row saying
+    /// exactly what it said.
+    @Test("a resize silences no row that draws something")
+    func silencesNothing() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 900, scale: 1, leading: 1.7)
+        heights.note(240, for: key("row.7"), shape: .answer)
+        heights.note(0, for: key("row.8"), shape: .notice)
+
+        let same = heights.reset(width: 900, scale: 1, leading: 1.7)
+        #expect(!same)
+        #expect(!heights.measuredNothing(key("row.7")))
+        // The row that really does draw nothing is still allowed to say so.
+        #expect(heights.measuredNothing(key("row.8")))
+    }
+
+    /// The promise at the head of `TranscriptRowHeights`: a row nobody has measured is told an
+    /// estimate, never nothing. Only a row that has SAID it draws nothing, or one claimed to by
+    /// `TranscriptRowInk`, is answered nought.
+    @Test("an unmeasured row is estimated rather than answered nothing")
+    func unmeasuredRowsAreNeverNought() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 900, scale: 1, leading: 1.7)
+        heights.showing(SessionID("one"))
+        for shape in TranscriptRowShape.allCases {
+            #expect(heights.assumed(for: key("unseen.\(shape)"), shape: shape) > 0)
+        }
+        #expect(heights.assumed(for: key("unseen"), shape: .answer) > 0)
+    }
+
+    /// `TranscriptRowInk` is what a row will draw, and it is answered from the row itself. Nothing
+    /// about a pane reaches it, so a resize cannot make a row claim to be empty.
+    @Test("what a row draws is a question about the row, not about the pane")
+    func inkIsAboutTheRow() {
+        let ordinary = Data(#"{"type":"assistant","subtype":"text"}"#.utf8)
+        #expect(!TranscriptRowInk.drawsNothing(kind: .assistantText, payload: ordinary))
+        let start = Data(#"{"type":"system","subtype":"init"}"#.utf8)
+        #expect(!TranscriptRowInk.drawsNothing(kind: .system, payload: start))
+        let noise = Data(#"{"type":"system","subtype":"compact_boundary"}"#.utf8)
+        #expect(TranscriptRowInk.drawsNothing(kind: .system, payload: noise))
+    }
+
+    // MARK: - A height change leaves no hold on
+
+    /// A hold draws the pane's own ground in place of the transcript, so a height change taking
+    /// one would be this bug by another route. `holds` is asked about two widths and nothing else.
+    @Test("a pane that changed only its height is not held")
+    func aHeightChangeIsNotAHold() {
+        #expect(!TranscriptPaneHold.holds(from: 900, to: 900))
+        #expect(!TranscriptPaneHold.holds(from: 900, to: 900.25))
+    }
+
+    /// And every hold that is taken lets go by itself, so no gesture whose end goes missing can
+    /// leave a pane blank for the rest of the session.
+    @Test("every hold has a deadline")
+    func everyHoldLetsGo() {
+        for held in [TranscriptPaneHold.PaneHeld.whatIsDrawn, .nothing] {
+            for hand in [true, false] {
+                #expect(TranscriptPaneHold.letsGo(of: held, underAHand: hand) > .zero)
+                #expect(TranscriptPaneHold.letsGo(of: held, underAHand: hand) < .seconds(5))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Dragging the composer divider left the whole transcript blank, from the pinned question strip down to the composer, and it stayed blank.

The divider moves the transcript's height and never its width, so the three obvious suspects are innocent and are now pinned shut by tests. `TranscriptRowHeights` has no notion of height (`reset` and `rewidth` only ever take `columnWidth`, and `measure` is never set back to nil), `TranscriptRowInk` is a pure function of a row's kind and payload, and no hold is taken because `ComposerResizeHandle` posts neither resize notification and `noteWidth` returns on its first line for a height change.

What is left is arithmetic. `TranscriptAnchor.end` of a viewport with no height is the whole content height, which is the point below the last row, and `clamped` allows it, so `Coordinator.put` parks the clip view under the end of the conversation. `measureLanding` eight lines away already refuses a pane of no height.

It cannot recover, which is why a bad frame became a report: every recovery in `TranscriptTable` needs a row on screen. `visibleRows` is empty so the census counts nothing and `repairTheScreen` never runs, `topmostEntry` is nil so the next placement has no anchor and resolves to `.stay`, and the warming pass finds no band.

The pane does have no height for a pass at a time. The composer's cap is the room less the chrome less the transcript's 120 point floor, and the chrome is the difference between the composer's measured height and the editor's, which a drag moves a frame earlier. Any frame where the hand outruns the layout makes it negative, and `PaneMeasure.chrome` answers nought for that by design; read as a chrome rather than as an unmeasured one, the cap rises by the whole chrome.

`TranscriptAnchor.canPlace` refuses a viewport nothing has laid out, and both writers of the clip view ask it first. Every placement in the table already says itself twice a turn apart, so one refused during layout lands on the second. `PaneMeasure` keeps the last known chrome when a pass cannot measure one, and now holds the cap that was spelled inside the view.

Not reproduced: the build embargo meant the app was never run here. The chain is established by reading, and both rules fail safe either way.