### PR TITLE
Make the panel's counts agree, and stop the chips reading as web pills

### DIFF
--- a/Sources/Bloom/Design/Theme.swift
+++ b/Sources/Bloom/Design/Theme.swift
@@ -1184,7 +1184,10 @@ struct CountLabel: View {
     private static let reserved = "000"
 
     var body: some View {
-        ZStack(alignment: .trailing) {
+        // Leading, so the digits sit against the label they belong to and the reserved slack falls
+        // at the end, inside the capsule where the padding already is. Trailing put a lone "3" two
+        // characters away from "Workspaces", reading as a number somebody had left there.
+        ZStack(alignment: .leading) {
             Text(verbatim: Self.reserved)
                 .monospacedDigit()
                 .hidden()

--- a/Sources/Bloom/Design/Theme.swift
+++ b/Sources/Bloom/Design/Theme.swift
@@ -1098,7 +1098,7 @@ struct Callout: View {
 /// first and wrote it down: a bare count goes through `formatted` rather than `String(value)`, so
 /// the digits are the reader's own on a machine that does not use Western ones, and it drops the
 /// grouping separator, because a separator on a number nobody is going to add up is noise.
-/// `CountBadge` arrived later and used a plain `.number`, which is the same decision taken the
+/// `CountLabel` arrived later and used a plain `.number`, which is the same decision taken the
 /// other way by not taking it, and the search panel's chips came out reading "Everything 3.752"
 /// on a machine whose separator is a full stop. Four digits that read as a decimal.
 ///
@@ -1144,46 +1144,47 @@ struct Chip: View {
     }
 }
 
-/// A number on a control, drawn in a round.
+/// A number set beside a control's label, for reading rather than for adding up.
 ///
-/// **Bloom had no way of doing this before, which is why it is here rather than in the one view
-/// that wanted it.** Home's scope strip prints its counts as part of a segmented control's own
-/// titles, which is a string and not a badge; the sidebar prints none at all; `PullRequestBadge`
-/// is a control with an arrow on it that opens GitHub. The search panel's chips are the first
-/// place in the app where a number sits ON a control and is read rather than pressed, and the
-/// owner asked for it in a round, so the round lives beside `Chip` where the next surface that
-/// needs one will find it.
+/// # It was a filled round, and macOS does not draw one here
 ///
-/// **Its width is reserved for three digits and does not move.** The counts change on nearly every
-/// keystroke, and a badge sized to its own content takes the chip, the row of chips and the eye
-/// with it: the owner's report was that the whole control jumped while he typed. Three digits of
-/// monospaced figures are laid out behind the number and hidden, so one, ten and a hundred are the
-/// same width and only a thousand grows.
+/// The owner asked for the count "in a round" and got one: a filled capsule inside the chip's own
+/// capsule. He then looked at it twice and said the chips do not feel native, that the number
+/// touches the border of the thing holding it, and to make it breathe. All three are the same
+/// fault. Two nested capsules is a web pill, not a Mac control, and the inner one had nowhere to
+/// sit because the outer one is only as tall as its text.
 ///
-/// **A nought is drawn rather than left out.** `HomeScopeCounts.badge` argues the other way for
-/// Home's resting strip and is right about it there: a strip that says "Needs you 0, Running 0"
-/// most of the time teaches the eye to skip the numbers. This is the other case. The badge only
-/// appears while a search is running, where "Transcripts 0" is a real answer and the reason not to
-/// press that chip, and a badge that disappeared at nought would be a fourth thing moving while
-/// somebody types.
-struct CountBadge: View {
+/// **A filled round on macOS means unread, not "how many".** Mail draws one in the sidebar for
+/// messages you have not read, and a notification badge is the same idiom: it is a thing wanting
+/// your attention. A count on a filter is a different sentence, "this is how much pressing me
+/// would show", and macOS sets that as a plain trailing number in a quieter ink, which is what a
+/// `List` row's own `badge` is and what a segmented control does when it puts a number in its
+/// title. So this is that: no fill, no shape, one step quieter than the label beside it.
+///
+/// # Its width is still reserved, because that complaint was separate and still stands
+///
+/// The counts change on nearly every keystroke, and a number sized to its own content takes the
+/// chip, the row of chips and the eye with it. Three digits of monospaced figures are laid out
+/// behind the number and hidden, so one, ten and a hundred are the same width and only a thousand
+/// grows. A nought is drawn rather than left out, for the reason `HomeScopeCounts.badge` argues
+/// the other way for Home's resting strip and which does not hold here: this only appears while a
+/// search is running, where "Transcripts 0" is a real answer and the reason not to press that
+/// chip, and a number that disappeared at nought would be a fourth thing moving while somebody
+/// types.
+struct CountLabel: View {
     var count: Int
-    /// Whether the control under it is drawn in the accent, which the ink and the fill both answer
-    /// to. Passed rather than read from `isOnEmphasizedSelection`, because a chip paints its own
-    /// selection rather than sitting inside a selected row.
+    /// Whether the control under it is drawn in the accent, which the ink answers to. Passed
+    /// rather than read from `isOnEmphasizedSelection`, because a chip paints its own selection
+    /// rather than sitting inside a selected row.
     var isOnSelection = false
 
-    /// What the badge is always at least as wide as. Three digits, in figures that are all one
-    /// width, so nothing under a thousand moves it.
-    ///
-    /// A thousand and over grows it by one digit and no more, because the number is set without a
-    /// thousands separator: see `Figures.count` for why, which is a defect this reserve was
-    /// quietly making worse. With a separator the first four digit count cost two glyphs rather
-    /// than one, so the row moved further than this comment claimed it could.
+    /// What the number is always at least as wide as. Three digits, in figures that are all one
+    /// width, so nothing under a thousand moves it. A thousand and over grows it by one digit and
+    /// no more, because it is set without a thousands separator: see `Figures.count`.
     private static let reserved = "000"
 
     var body: some View {
-        ZStack {
+        ZStack(alignment: .trailing) {
             Text(verbatim: Self.reserved)
                 .monospacedDigit()
                 .hidden()
@@ -1191,13 +1192,11 @@ struct CountBadge: View {
                 .monospacedDigit()
                 .lineLimit(1)
         }
-        .font(Typo.micro)
-        .foregroundStyle(isOnSelection ? Palette.selectedEmphasizedText : Palette.textTertiary)
-        .padding(.horizontal, Metrics.chipInsetH)
-        .padding(.vertical, Metrics.spacingHair)
-        .background(
-            isOnSelection ? Palette.selectedEmphasizedText.opacity(0.2) : Palette.hover,
-            in: Capsule()
+        .font(Typo.caption)
+        // One step quieter than the label it follows, in both states, because it is the label's
+        // subordinate rather than a second thing to read.
+        .foregroundStyle(
+            isOnSelection ? Palette.selectedEmphasizedText.opacity(0.76) : Palette.textTertiary
         )
         .accessibilityHidden(true)
     }
@@ -1240,7 +1239,7 @@ struct DiffStatLabel: View {
     /// while nothing the reader can see has moved.
     ///
     /// The plain case is `Figures.count`, which is where the argument for it now lives: this
-    /// label made that decision first and `CountBadge` needed the same one, so it is one style
+    /// label made that decision first and `CountLabel` needed the same one, so it is one style
     /// read twice rather than two that can drift.
     private static let thousandsStyle = FloatingPointFormatStyle<Double>.number
         .precision(.fractionLength(1))

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelFooter.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelFooter.swift
@@ -35,6 +35,12 @@ struct SearchPanelFooter: View {
                 Text(summary)
                     .font(Typo.caption)
                     .foregroundStyle(Palette.textTertiary)
+                    // One line, always. The keys on the left are four fixed pairs and cannot
+                    // compress, so at the narrow end of `SearchPanelLayout` a long count would
+                    // wrap this strip to two lines rather than shorten itself. Nothing said here
+                    // is long enough today: measured at 560, the keys take about 330 points of the
+                    // 540 available and the longest count is under 90.
+                    .lineLimit(1)
             }
         }
         .padding(.horizontal, Metrics.inset)

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelScopes.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelScopes.swift
@@ -2,35 +2,41 @@ import SwiftUI
 import BloomCore
 
 /// The chips at the head of the panel's list: Everything, Workspaces, Transcripts, Archived, each
-/// with its count in a round.
+/// with its count.
 ///
-/// # It was Home's segmented picker, and it is not any more
+/// # It was Home's segmented picker, then a row of pills, and it is a row of controls now
 ///
-/// The panel borrowed `HomeBar`'s control outright: one `Picker` in `.segmented` over the same
-/// `HomeScope.offered(searching:)`, with the count interpolated into each segment's title. That
-/// was deliberate in the specification and it was the wrong call for this surface. The owner's
-/// report was that the chips "do not feel native", and the two things underneath that judgement
-/// are both real.
+/// The panel borrowed `HomeBar`'s control outright, which was deliberate in the specification and
+/// wrong for this surface: a segmented control is right at the head of a pane, attached to the
+/// title bar, and wrong inside a floating card. That much still holds and Home still has its
+/// picker, which is untouched here and should stay: its strip IS attached to the title bar.
 ///
-/// A segmented control is a form control. It is right at the head of a pane, attached to the
-/// title bar, which is where Finder puts a scope bar and where Home's strip is; it is wrong inside
-/// a floating card over glass, where macOS 26's own Spotlight draws a row of capsules and not a
-/// segmented switch. And a segment's label is a `Text`, so a count in it can only ever be more
-/// words in the same string: there is nowhere to put a round.
+/// What replaced it was a row of capsules, each holding a filled round with its count in, and the
+/// owner said twice that they do not feel native. He is right, and the fault was the round rather
+/// than the capsules. **Two nested capsules is a web pill.** The inner one had nowhere to sit,
+/// because the outer one was only as tall as its own text, so the number touched the border of the
+/// thing holding it in every state. And a filled round means something specific on this platform:
+/// Mail draws one in the sidebar for unread mail, and a notification badge is the same idiom, a
+/// thing wanting your attention. "How much would pressing me show" is a different sentence and
+/// macOS sets it as a quiet trailing number. See `CountLabel`.
 ///
-/// **So the two surfaces differ now, and Home is deliberately untouched.** Its picker is in a
-/// toolbar strip, which is exactly where a segmented control belongs, and this is a floating
-/// panel. The chips still come off `HomeScope.offered(searching:)` and the numbers still come off
-/// `HomeScopeCounts`, so the two cannot offer different scopes or different answers for one
-/// machine; what differs is the chrome, and it differs because the two places are different.
+/// So: one capsule, not two. The count is a number a step quieter than the label beside it. The
+/// chip is `Metrics.controlHeight` tall, which is the height every other small control in this app
+/// is drawn at, with `Metrics.gutter` of air either side of its content, so it reads as a control
+/// with room in it rather than as a label somebody drew a border around.
+///
+/// **Only the lit chip carries a fill, and that is the native shape rather than a saving.** Three
+/// plain labels and one filled capsule is what a floating panel does with a set of filters; four
+/// filled capsules is a web tab bar. The unlit ones take `Palette.hover` under the pointer, which
+/// is how every other quiet control in this window says it can be pressed.
 ///
 /// # Nothing here moves while somebody types
 ///
-/// Every chip is a label and a badge, the labels are constants, and `CountBadge` reserves three
-/// digits whatever it holds. So the row is the same shape at "Everything 13, Workspaces 12,
-/// Transcripts 1, Archived 10" as it is at "Everything 1, Workspaces 1, Transcripts 0,
-/// Archived 1", which was the exact jump the owner reported. A scope with nothing in it draws a
-/// nought rather than dropping its badge, and `CountBadge` says why.
+/// The labels are constants and `CountLabel` reserves three digits whatever it holds, so the row
+/// is the same shape at "Everything 131, Workspaces 6, Transcripts 125, Archived 10" as at
+/// "Everything 1, Workspaces 1, Transcripts 0, Archived 1", which was the exact jump reported. A
+/// scope with nothing in it draws a nought rather than dropping its number, and the counts carry
+/// no thousands separator, which is `Figures.count`: both of those were their own reports.
 ///
 /// Tab and Shift+Tab step them, which is why nothing here is ever given the keyboard: the field
 /// keeps it, and `SearchPanelKeys` decides what Tab means. See `MenuSearchField`.
@@ -72,20 +78,20 @@ private struct ScopeChip: View {
 
     var body: some View {
         Button(action: pick) {
-            HStack(spacing: Metrics.spacingSmall) {
+            HStack(spacing: Metrics.spacing) {
                 Text(label)
                     .font(Typo.caption)
                     .lineLimit(1)
                     .fixedSize()
 
-                CountBadge(count: count, isOnSelection: isEmphasized)
+                CountLabel(count: count, isOnSelection: isEmphasized)
             }
             .foregroundStyle(isEmphasized ? Palette.selectedEmphasizedText : Palette.textSecondary)
             // Inside the label, which is the whole of the bug `WindowPaneToggle` records: a
             // `.plain` Button takes its clicks inside its label, so padding put outside the
             // finished Button is padding nothing can be pressed on.
-            .padding(.horizontal, Metrics.spacingWide)
-            .padding(.vertical, Metrics.chipInsetV)
+            .padding(.horizontal, Metrics.gutter)
+            .frame(height: Metrics.controlHeight)
             .background(fill, in: Capsule())
             .contentShape(Capsule())
         }

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelWindowOverlay.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelWindowOverlay.swift
@@ -29,13 +29,23 @@ import BloomCore
 /// one, the window's name and three small controls: leaving that lit while everything under it
 /// goes down is exactly what the screenshot showed and it read as half a window.
 ///
-/// **The traffic lights are the one exception, in the paint and in the hit test alike.** A window
-/// that cannot be closed, zoomed or minimised while a search card is up would be a worse bug than
-/// the one this fixes, and a dimmed close button is a control saying it is unavailable when it is
-/// not. They are cut out of the dim with an even-odd fill and out of the hit test by
-/// `SearchPanelOverlayHost`, so a click there reaches AppKit exactly as it always did. How much
-/// air the cut-out leaves around them is `trafficLightPadding`, and it was judged against a
-/// picture.
+/// **The traffic lights are cut out of the HIT TEST and of nothing else, and the two halves of
+/// that are a decision each.** The window has to stay closable, zoomable and minimisable while a
+/// card is up, so `SearchPanelOverlayHost` answers nothing over them and the click reaches AppKit
+/// exactly as it always did. But they are painted over like everything else, because they are part
+/// of the window the panel is in front of. They were cut out of the paint as well for two
+/// versions, on the argument that a dimmed close button is a control claiming to be unavailable
+/// when it is not; the owner looked at that twice and did not want it, and he is right that the
+/// exception was louder than the thing it was protecting. The hole was the brightest object in an
+/// otherwise dimmed window, on the one corner nobody was looking at.
+///
+/// What that costs, said plainly because it is a real cost. AppKit draws the symbols in those
+/// buttons on hover, and the scrim is over the top, so the cross and the two dashes come up dimmed
+/// with everything else. Nothing is disturbed, because the buttons never learn about the scrim:
+/// their tracking area still gets the mouse, since the hit test passes through, and they still
+/// draw and still fire. A coloured button under a 22 to 40 per cent scrim also reads a little like
+/// an inactive window's grey, which is the one honest objection to this and is the owner's to
+/// weigh rather than mine.
 ///
 /// **How far the window goes down is `Palette.panelScrim`, and it is two numbers.** A black scrim
 /// has far less to take out of Bloom's dark ramp than out of its light one, so one opacity read as
@@ -66,7 +76,7 @@ struct SearchPanelWindowOverlay: View {
         GeometryReader { proxy in
             ZStack(alignment: .top) {
                 if panel.isOpen {
-                    dim(in: proxy.size)
+                    dim
                     card(inWindow: proxy.size.width)
                 }
             }
@@ -78,29 +88,20 @@ struct SearchPanelWindowOverlay: View {
         .environment(app)
     }
 
-    /// The dim, with a hole where the traffic lights are.
+    /// The dim, over the whole window and with nothing cut out of it.
     ///
-    /// One `Path` filled even-odd rather than a rectangle with a mask on it: the hole and the
-    /// ground are one shape, so there is no second view whose blend mode has to agree with the
-    /// first, and the rounded end of the cut-out is a `cornerSize` rather than a `Capsule` that
-    /// has to be positioned.
-    private func dim(in size: CGSize) -> some View {
-        Path { path in
-            path.addRect(CGRect(origin: .zero, size: size))
-            if let hole = geometry.trafficLightHole {
-                path.addRoundedRect(
-                    in: hole,
-                    cornerSize: CGSize(width: hole.height / 2, height: hole.height / 2)
-                )
-            }
-        }
-        .fill(Palette.panelScrim, style: FillStyle(eoFill: true))
-        // The click outside, taken here rather than by the window under it. See the head of this
-        // file for what that is protecting.
-        .contentShape(Rectangle())
-        .onTapGesture { panel.close(app: app) }
-        .accessibilityHidden(true)
-        .transition(.opacity)
+    /// It carried a hole where the traffic lights are for two versions. The hole is gone from the
+    /// paint and kept in the hit test, and the head of this file says why the two are not the same
+    /// question.
+    private var dim: some View {
+        Rectangle()
+            .fill(Palette.panelScrim)
+            // The click outside, taken here rather than by the window under it. See the head of
+            // this file for what that is protecting.
+            .contentShape(Rectangle())
+            .onTapGesture { panel.close(app: app) }
+            .accessibilityHidden(true)
+            .transition(.opacity)
     }
 
     /// The card itself, centred on the window because that is what this view is the size of.
@@ -161,20 +162,6 @@ final class SearchPanelWindowGeometry {
     /// the strip itself is built at.
     private(set) var titleBarHeight: CGFloat = 0
 
-    /// The window's frame height, held so the flip below needs nothing from the view drawing it.
-    private(set) var windowHeight: CGFloat = 0
-
-    /// The same rectangle in SwiftUI's space: down from the top of the window.
-    var trafficLightHole: CGRect? {
-        guard let trafficLights else { return nil }
-        return CGRect(
-            x: trafficLights.minX,
-            y: windowHeight - trafficLights.maxY,
-            width: trafficLights.width,
-            height: trafficLights.height
-        )
-    }
-
     /// Called by `WindowChrome` with the height it measured for the title bar strip.
     func setTitleBarHeight(_ height: CGFloat) {
         guard titleBarHeight != height else { return }
@@ -182,9 +169,9 @@ final class SearchPanelWindowGeometry {
     }
 
     /// Called by the overlay whenever the window moves under it.
-    func setChrome(windowHeight: CGFloat, trafficLights: CGRect?) {
-        if self.windowHeight != windowHeight { self.windowHeight = windowHeight }
-        if self.trafficLights != trafficLights { self.trafficLights = trafficLights }
+    func setChrome(trafficLights: CGRect?) {
+        guard self.trafficLights != trafficLights else { return }
+        self.trafficLights = trafficLights
     }
 }
 
@@ -194,26 +181,22 @@ final class SearchPanelWindowGeometry {
 /// belongs to this overlay at all, and whether a press on it moves the window. Both are wrong by
 /// default for a view that covers the whole window all the time.
 final class SearchPanelOverlayHost: NSHostingView<SearchPanelWindowOverlay> {
-    /// The air left around the three buttons, so the cut-out is a rounded slot they sit in rather
-    /// than three rectangles traced tightly enough to catch a click on the edge of one.
+    /// The air left around the three buttons in the HIT TEST hole, so a click at the edge of a
+    /// circle still reaches it rather than landing on the overlay and closing the panel.
     ///
-    /// **Three, down from six, and it was judged against a picture rather than argued.** At six
-    /// the undimmed slot was 71 by 25 around three 14 point circles, and on a light window with an
-    /// empty sidebar behind it that read as a bright pill somebody had drawn on the corner: the
-    /// loudest thing in the frame, on the one control the dim is not about. At three it is 65 by
-    /// 19, which is a button's own width of air rather than half as much again, and it stops being
-    /// a shape and starts being the absence of one. Lower than three would begin to clip the
-    /// pointer's reach at the edge of a circle, which is the failure this padding exists to
-    /// prevent, so this is the bottom of the useful range rather than a step on the way down.
+    /// It used to size a hole in the paint as well and was tuned against a capture for that: six
+    /// points read as a bright pill drawn on the corner, three as a halo. The paint has no hole
+    /// any more, so the number is only ever asked what the pointer can reach, and three points of
+    /// slop around a 14 point circle is generous for that and invisible either way.
     ///
-    /// **How to measure it off a capture, since both of those numbers were.** The obvious detector
-    /// is wrong and cost an hour: asking which pixels differ from the dim selects every antialiased
-    /// glyph in a title bar that is dithered rather than flat. The slot is a hole rather than a
-    /// mark, so the honest question is which pixels are the ground with NO scrim over them. Count
-    /// the ones within about 6 of `#F1F5F6` in light or 3 of `#0E202D` in dark, inside the top left
-    /// 240 by 120 points, and take the bounding box. Nothing else in that corner sits on the
-    /// undimmed ground, and antialiasing never lands on it in bulk, so it needs no tuning: it read
-    /// 72 by 26 at six points of padding and 66 by 20 at three, on every capture, first time.
+    /// **How to measure a hole in a capture, kept because it was hard won and the next person to
+    /// draw one will want it.** The obvious detector is wrong: asking which pixels differ from the
+    /// dim selects every antialiased glyph in a title bar that is dithered rather than flat. A hole
+    /// is an absence, so the question is which pixels are the ground with NO scrim over them.
+    /// Count the ones within about 6 of `#F1F5F6` in light or 3 of `#0E202D` in dark, inside the
+    /// top left 240 by 120 points, and take the bounding box. Nothing else in that corner sits on
+    /// the undimmed ground and antialiasing never lands on it in bulk, so it needs no tuning: it
+    /// read 72 by 26 at six points of padding and 66 by 20 at three, on every capture, first time.
     private static let trafficLightPadding: CGFloat = 3
 
     /// Nothing at all while the panel is closed.
@@ -260,7 +243,7 @@ final class SearchPanelOverlayHost: NSHostingView<SearchPanelWindowOverlay> {
         // must NOT respect: it is the region it exists to cover.
         safeAreaRegions = []
         guard let window else {
-            SearchPanelWindowGeometry.shared.setChrome(windowHeight: 0, trafficLights: nil)
+            SearchPanelWindowGeometry.shared.setChrome(trafficLights: nil)
             return
         }
         if !isWatchingWindow {
@@ -313,16 +296,14 @@ final class SearchPanelOverlayHost: NSHostingView<SearchPanelWindowOverlay> {
         self.frame = frame.bounds
     }
 
-    /// The two numbers the overlay measures for itself, off the frame view. The third, the title
-    /// bar's height, is `WindowChrome`'s and is written down on the property.
+    /// Where the window buttons are, measured off the frame view. The title bar's height is the
+    /// other number the overlay needs and it is `WindowChrome`'s, for the reason on the property.
     private func publishGeometry() {
         let geometry = SearchPanelWindowGeometry.shared
         guard let window, let frame = superview else {
-            geometry.setChrome(windowHeight: 0, trafficLights: nil)
+            geometry.setChrome(trafficLights: nil)
             return
         }
-        let height = frame.bounds.height
-
         let buttons = [NSWindow.ButtonType.closeButton, .miniaturizeButton, .zoomButton]
             .compactMap { window.standardWindowButton($0) }
             .filter { !$0.isHidden }
@@ -333,6 +314,6 @@ final class SearchPanelOverlayHost: NSHostingView<SearchPanelWindowOverlay> {
             }
             lights = union.insetBy(dx: -Self.trafficLightPadding, dy: -Self.trafficLightPadding)
         }
-        geometry.setChrome(windowHeight: height, trafficLights: lights)
+        geometry.setChrome(trafficLights: lights)
     }
 }

--- a/Sources/BloomCore/Presentation/SearchPanelListing.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelListing.swift
@@ -34,6 +34,16 @@ public struct SearchPanelListing: Equatable, Sendable {
     public var counts: HomeScopeCounts
     /// Whether there is a query behind this listing, which is what decides the chips on offer.
     public var isSearching: Bool
+    /// The line at the right of the footer: how much there is.
+    ///
+    /// Stored rather than derived from `rows.count`, for the reason `nothing` below is: the row
+    /// count is not the answer in either of the two lists that fold or cap. Only the builder knows
+    /// which chip is lit, how many matches those rows stand for, and how many workspaces were left
+    /// off the resting list. See `SearchPanelSummary`, which holds the words and the argument.
+    ///
+    /// The default is the plain row count, which is right for the menu bar and for a workspace's
+    /// own actions: neither folds anything and neither caps.
+    public var summary: String?
     /// What the card says instead of rows, and nil whenever there are any.
     ///
     /// It is here rather than derived in the view from `rows.isEmpty`, because an empty list is
@@ -45,12 +55,14 @@ public struct SearchPanelListing: Equatable, Sendable {
         sections: [SearchPanelSection],
         counts: HomeScopeCounts = HomeScopeCounts(),
         isSearching: Bool = false,
+        summary: String? = nil,
         nothing: SearchPanelNothing? = nil
     ) {
         self.sections = sections
         self.rows = sections.flatMap(\.rows)
         self.counts = counts
         self.isSearching = isSearching
+        self.summary = summary ?? SearchPanelSummary.rows(self.rows.count)
         self.nothing = nothing
     }
 
@@ -64,13 +76,4 @@ public struct SearchPanelListing: Equatable, Sendable {
         return rows[index]
     }
 
-    /// The count in the footer, on the right, where it does not compete with the keys.
-    ///
-    /// Nil when there is nothing to count. It used to read "2 results" under a sentence saying
-    /// nothing matched, because the two fallback rows were rows: the panel contradicted itself in
-    /// one glance, and that is half of why those rows are gone.
-    public var summary: String? {
-        guard !rows.isEmpty else { return nil }
-        return rows.count == 1 ? "1 result" : "\(rows.count) results"
-    }
 }

--- a/Sources/BloomCore/Presentation/SearchPanelResting.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelResting.swift
@@ -83,7 +83,14 @@ public enum SearchPanelResting {
         // state nobody who builds this ever sees. The card says so rather than drawing an empty
         // rounded rectangle with a footer under it.
         return SearchPanelListing(
-            sections: sections, nothing: sections.isEmpty ? .nothingYet : nil
+            sections: sections,
+            // The one place in this panel where a total really is withheld: the two caps above
+            // mean a machine with forty-three live workspaces draws ten rows, and nothing used to
+            // say the other thirty-three were there. See `SearchPanelSummary.resting`.
+            summary: SearchPanelSummary.resting(
+                shown: waiting.count + opened.count, of: workspaces.count
+            ),
+            nothing: sections.isEmpty ? .nothingYet : nil
         )
     }
 

--- a/Sources/BloomCore/Presentation/SearchPanelResults.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelResults.swift
@@ -146,6 +146,10 @@ public enum SearchPanelResults {
             sections: sections,
             counts: counts,
             isSearching: true,
+            // The lit chip's own number, in the lit chip's own unit. The footer used to count rows
+            // while the chips counted matches, and nothing on the card said they were answering
+            // different questions. See `SearchPanelSummary`.
+            summary: SearchPanelSummary.searching(scope: scope, counts: counts),
             nothing: sections.isEmpty ? .noMatch(query) : nil
         )
     }

--- a/Sources/BloomCore/Presentation/SearchPanelSummary.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelSummary.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// The one line at the right of the panel's footer: how much there is.
+///
+/// # The two numbers were not the same kind of thing
+///
+/// The card showed "Transcripts 3749" on a chip and "30 results" in the footer, and the owner read
+/// that as a contradiction. It was worth finding out which of them was wrong before changing
+/// either, and the answer is neither: **they were counting different things and neither said so.**
+///
+/// A transcript row is one workspace, folded by `TranscriptSearch.group`, and it carries every
+/// match in that workspace in `total`. So the chip was summing MATCHES, 3749 of them, and the
+/// footer was counting ROWS, 30 of them, and the 3719 in between were not withheld from anybody:
+/// they were on screen, folded into twenty-seven rows that each say "26 matches" on their own
+/// second line. "30 of 3749" would have been a tidier looking sentence and a new untruth.
+///
+/// So the footer answers the lit chip in the chip's own unit. Nothing on the card can disagree
+/// with anything else on it, because the two are now the same number said twice, and the word
+/// beside it says what it counts.
+///
+/// # Where "N of M" is honest, and it is not here
+///
+/// There is one place in this panel where a total really is being withheld, and it had no number
+/// at all: the resting list. `SearchPanelResting` caps at five waiting and five recent, so a
+/// machine with forty-three live workspaces drew ten rows and said "10 results", with nothing
+/// saying the other thirty-three existed. That is the shape the footer was reached for, applied
+/// where it is true.
+public enum SearchPanelSummary {
+    /// What a search says, under the chip it is being read through.
+    ///
+    /// `all` and `archived` keep the vague word on purpose. `HomeScopeCounts` builds both of them
+    /// by adding workspace rows to transcript matches, which is Home's definition and shared with
+    /// it, so "results" is the only honest noun for a number made of two kinds of thing. The two
+    /// chips that count one kind get that kind named.
+    public static func searching(scope: HomeScope, counts: HomeScopeCounts) -> String? {
+        let count = counts.count(of: scope, searching: true)
+        guard count > 0 else { return nil }
+        switch scope {
+        case .workspaces:
+            return count == 1 ? "1 workspace" : "\(count) workspaces"
+        case .transcripts:
+            return count == 1 ? "1 match" : "\(count) matches"
+        default:
+            return rows(count)
+        }
+    }
+
+    /// What the resting list says: how many workspaces it is showing, and how many there are.
+    ///
+    /// The total is named only when it is bigger. "10 of 10 workspaces" is a worse sentence than
+    /// "10 workspaces" and says nothing the first half did not.
+    public static func resting(shown: Int, of total: Int) -> String? {
+        guard shown > 0 else { return nil }
+        guard total > shown else {
+            return shown == 1 ? "1 workspace" : "\(shown) workspaces"
+        }
+        return "\(shown) of \(total) workspaces"
+    }
+
+    /// A plain list of rows, which is the menu bar and a workspace's own actions. Nothing is folded
+    /// and nothing is capped in either, so a row is a result and the count is the count.
+    public static func rows(_ count: Int) -> String? {
+        guard count > 0 else { return nil }
+        return count == 1 ? "1 result" : "\(count) results"
+    }
+}

--- a/Tests/BloomCoreTests/SearchPanelResultsTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelResultsTests.swift
@@ -284,7 +284,12 @@ struct SearchPanelResultsTests {
         #expect(listing.rows == listing.sections.flatMap(\.rows))
         #expect(listing.row(at: 1)?.id == "transcript:docs chapters")
         #expect(listing.row(at: 9) == nil)
-        #expect(listing.summary == "2 results")
+        // Two rows, and the footer says seven, which is the whole point of `SearchPanelSummary`:
+        // the second row is one workspace standing for six matches, so counting rows and counting
+        // what the chips count are two different questions. This used to say "2 results" under a
+        // chip saying seven.
+        #expect(listing.rows.count == 2)
+        #expect(listing.summary == "7 results")
     }
 
     /// Every row that names a workspace can be pushed into, archived ones included: what an
@@ -304,5 +309,69 @@ struct SearchPanelResultsTests {
         #expect(drillable["workspace:docs chapters"] == WorkspaceID("docs chapters"))
         #expect(drillable["workspace:docs import"] == WorkspaceID("docs import"))
         #expect(drillable["transcript:docs chapters"] == WorkspaceID("docs chapters"))
+    }
+}
+
+/// What the one line at the right of the footer says, and why it is not the row count.
+@Suite("Search panel summary")
+struct SearchPanelSummaryTests {
+    private func counts(workspaces: Int = 0, transcripts: Int = 0, archived: Int = 0) -> HomeScopeCounts {
+        var built = HomeScopeCounts()
+        built.workspaces = workspaces
+        built.transcripts = transcripts
+        built.archived = archived
+        return built
+    }
+
+    /// The bug this exists for: the chip said 3749 and the footer said 30, and neither was wrong.
+    /// A transcript row is one workspace folded out of many matches, so the two were counting
+    /// different things and nothing on the card said so.
+    @Test("a search answers the lit chip in the lit chip's own unit")
+    func theFooterAnswersTheChip() {
+        let found = counts(workspaces: 3, transcripts: 3_749)
+        #expect(SearchPanelSummary.searching(scope: .transcripts, counts: found) == "3749 matches")
+        #expect(SearchPanelSummary.searching(scope: .workspaces, counts: found) == "3 workspaces")
+        // `all` is workspaces plus matches, which is Home's definition and is two kinds of thing
+        // added together, so the vague noun is the only honest one for it.
+        #expect(SearchPanelSummary.searching(scope: .all, counts: found) == "3752 results")
+    }
+
+    @Test("one of anything is said in the singular")
+    func theSingular() {
+        #expect(SearchPanelSummary.searching(
+            scope: .workspaces, counts: counts(workspaces: 1)
+        ) == "1 workspace")
+        #expect(SearchPanelSummary.searching(
+            scope: .transcripts, counts: counts(transcripts: 1)
+        ) == "1 match")
+        #expect(SearchPanelSummary.rows(1) == "1 result")
+    }
+
+    /// Nothing to count is said by the card rather than by the footer. See `SearchPanelNothing`.
+    @Test("nothing found says nothing here")
+    func nothingIsSaidElsewhere() {
+        #expect(SearchPanelSummary.searching(scope: .all, counts: HomeScopeCounts()) == nil)
+        #expect(SearchPanelSummary.rows(0) == nil)
+        #expect(SearchPanelSummary.resting(shown: 0, of: 0) == nil)
+    }
+
+    /// The one place in the panel where a total really is withheld, and it had no number at all.
+    @Test("the resting list names the workspaces it is not showing")
+    func theRestingCap() {
+        #expect(SearchPanelSummary.resting(shown: 10, of: 43) == "10 of 43 workspaces")
+        // "10 of 10" is a worse sentence than "10 workspaces" and says nothing the first half did
+        // not, so the total is named only when it is bigger.
+        #expect(SearchPanelSummary.resting(shown: 10, of: 10) == "10 workspaces")
+        #expect(SearchPanelSummary.resting(shown: 1, of: 1) == "1 workspace")
+    }
+
+    /// A listing that says nothing about itself falls back to the plain row count, which is right
+    /// for the two lists that neither fold nor cap.
+    @Test("a plain list of rows counts its rows")
+    func thePlainCase() {
+        let listing = SearchPanelListing(sections: [
+            SearchPanelSection(id: "commands", title: nil, rows: []),
+        ])
+        #expect(listing.summary == nil)
     }
 }


### PR DESCRIPTION
Three from the same card.

**The footer and the chips were counting different things and neither said so.** "Transcripts 3749" over "30 results" read as a contradiction and is not one: a transcript row is one workspace, folded by `TranscriptSearch.group` out of every match in it, so the chip was summing matches and the footer was counting rows. The 3719 in between were not withheld from anybody, they were on screen in twenty-seven rows that each say "26 matches" on their own second line, so "30 of 3749" would have been a tidier sentence and a new untruth. The footer answers the lit chip in the lit chip's own unit now, and the two cannot disagree because they are one number said twice.

There is one place in this panel where a total really is withheld, and it had no number at all: the resting list caps at five waiting and five recent, so a machine with forty-three live workspaces drew ten rows and said "10 results". It says "10 of 43 workspaces" now.

**The count came out of its round.** A filled capsule inside the chip's own capsule is two nested capsules, and the inner one had nowhere to sit because the outer one was only as tall as its text, which is the "touches the border" report. A filled round also means unread on this platform, which is Mail's sidebar and a notification badge; "how much would pressing me show" is set as a quiet trailing number. So one capsule rather than two, `Metrics.controlHeight` tall, a gutter of air either side, and the number one step quieter than its label. The width is still reserved for three digits, a nought is still drawn, and there are still no thousands separators.

Home's segmented picker is untouched.

**The window buttons are dimmed with everything else.** The cut-out is gone from the paint and kept in the hit test, which are two different questions: the window stays closable, zoomable and minimisable while a card is up.