### PR TITLE
Never write to a process that has not started or is being closed

### DIFF
--- a/Sources/BloomCore/Agent/Codex/CodexClient.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexClient.swift
@@ -165,14 +165,26 @@ public actor CodexClient {
     /// `initialize` is a request and `initialized` is a notification, in that order. Nothing else
     /// may be sent in between: the server rejects work before the handshake, and sending
     /// `initialized` without waiting for the reply races the connection's own setup.
+    ///
+    /// **Both streams are claimed here, and that is what launches the child.** They used to be
+    /// claimed inside the two tasks below, which reads as the same thing and is not: an
+    /// unstructured task made on an actor cannot run until the actor is free, and this one holds
+    /// the actor straight through `send`, whose continuation body writes the line. So the
+    /// handshake was written into a process nobody had started, every time, on the quota reader
+    /// and on a chat alike, and `StreamingProcess.write` used to take that write to a pipe with
+    /// nothing behind it. `AgentRunner.start` and `ClaudeCodeQuotaSource.read` have always done
+    /// it in this order and say why; this is the one that did not.
     public func start() async throws {
         guard process == nil else { return }
 
         let process = makeProcess(Self.launch(configuration))
         self.process = process
         live.attach(process)
-        readTask = Task { [weak self] in await self?.readLines(from: process) }
-        stderrTask = Task { [weak self] in await self?.readErrors(from: process) }
+
+        let errors = process.errorLines
+        let lines = process.lines
+        readTask = Task { [weak self] in await self?.readLines(from: lines) }
+        stderrTask = Task { [weak self] in await self?.readErrors(from: errors) }
 
         _ = try await send(
             "initialize",
@@ -421,9 +433,9 @@ public actor CodexClient {
 
     // MARK: Reading
 
-    private func readLines(from process: any AgentProcessing) async {
+    private func readLines(from lines: AsyncThrowingStream<String, Error>) async {
         do {
-            for try await line in process.lines {
+            for try await line in lines {
                 guard let frame = CodexFrame.decode(line: line) else { continue }
                 handle(frame)
             }
@@ -433,8 +445,8 @@ public actor CodexClient {
         }
     }
 
-    private func readErrors(from process: any AgentProcessing) async {
-        for await line in process.errorLines {
+    private func readErrors(from errors: AsyncStream<String>) async {
+        for await line in errors {
             stderrTail.append(line)
             if stderrTail.count > Self.stderrTailLimit { stderrTail.removeFirst() }
         }

--- a/Sources/BloomCore/System/Shell.swift
+++ b/Sources/BloomCore/System/Shell.swift
@@ -196,7 +196,14 @@ public enum Shell {
         errReader.start()
 
         if let inPipe, let stdin {
-            inPipe.fileHandleForWriting.write(Data(stdin.utf8))
+            // The same SIGPIPE that `StreamingProcess.init` and `UnixSocketConnection` guard
+            // against, on the only other descriptor in the tree Bloom writes a child on. A child
+            // that exited between `run()` above and this line leaves nobody reading, and the
+            // default disposition of the signal that raises is to kill Bloom. `Git.run` passes a
+            // commit message and a patch through here, so the child dying early is a bad
+            // invocation rather than a hypothetical.
+            _ = fcntl(inPipe.fileHandleForWriting.fileDescriptor, F_SETNOSIGPIPE, 1)
+            try? inPipe.fileHandleForWriting.write(contentsOf: Data(stdin.utf8))
             try? inPipe.fileHandleForWriting.close()
         }
 

--- a/Sources/BloomCore/System/StreamingProcess.swift
+++ b/Sources/BloomCore/System/StreamingProcess.swift
@@ -110,6 +110,24 @@ public final class StreamingProcess: Sendable {
         linesContinuation.onTermination = { [weak self] reason in
             if case .cancelled = reason { self?.terminate() }
         }
+
+        // SIGPIPE, whose default disposition kills the process, and Bloom does not turn it off.
+        //
+        // Nothing in this tree sets the disposition process wide, which was checked rather than
+        // assumed, and `UnixSocketConnection` says the same thing in the other direction: it sets
+        // `SO_NOSIGPIPE` on every socket it owns and its comment is that without it Bloom would be
+        // taken down by an agent CLI exiting mid-call. A pipe to a child is the same hazard and
+        // was never given the same treatment, so `write(_:)` below could be killed rather than
+        // told, and the comment on it claiming a dead child turns a write into an exception was
+        // only ever true of a process that ignores the signal. It is now, for this descriptor:
+        // `F_SETNOSIGPIPE` makes a write to a pipe nobody is reading return EPIPE, which is what
+        // "the child went away" should look like.
+        //
+        // Per descriptor rather than a process wide `signal()` call, for the reason the socket
+        // took the same route: the policy belongs to the pipe this type owns, and a library that
+        // changes a signal disposition changes it for whoever linked it, including the test
+        // binary and the bridge shim.
+        _ = fcntl(stdinPipe.fileHandleForWriting.fileDescriptor, F_SETNOSIGPIPE, 1)
     }
 
     public var isRunning: Bool {
@@ -231,7 +249,11 @@ public final class StreamingProcess: Sendable {
         defer { releaseWriter() }
 
         let data = Data(text.utf8)
-        // A dead child turns a write into SIGPIPE, which `write(_:)` turns into an exception.
+        // A dead child turns a write into EPIPE rather than into SIGPIPE, because `init` set
+        // `F_SETNOSIGPIPE` on this descriptor. Without that this line is not a throw, it is the
+        // process being killed, and the guard above cannot prevent it: `status` is only set once
+        // `settle` has waited out its quiet period, so there is a fifth of a second after a child
+        // dies in which the bookkeeping still says it is alive.
         do {
             try stdinPipe.fileHandleForWriting.write(contentsOf: data)
         } catch {

--- a/Sources/BloomCore/System/StreamingProcess.swift
+++ b/Sources/BloomCore/System/StreamingProcess.swift
@@ -21,7 +21,17 @@ public final class StreamingProcess: Sendable {
         var stderrBuffer = Data()
         var exitWaiters: [CheckedContinuation<Int32, Never>] = []
         var status: Int32?
+        /// Whether stdin may still be written to. A decision, and not the same thing as the
+        /// descriptor being gone: a write that met a dead child sets this without closing a
+        /// handle another writer may be holding.
         var stdinClosed = false
+        /// Whether the write end has actually been closed. This is what makes the close single
+        /// shot, because it is the flag the `close()` call itself is guarded by.
+        var stdinHandleClosed = false
+        /// How many writes are inside `FileHandle.write` this instant. A close asked for while
+        /// one is in flight is handed to that writer instead of happening under it. See
+        /// `write(_:)`.
+        var stdinWriters = 0
         var started = false
         /// Whether each pipe has reported end of file, which is the only trustworthy signal that
         /// the child is done writing to it.
@@ -193,14 +203,37 @@ public final class StreamingProcess: Sendable {
         }
     }
 
+    /// Writes to the child's stdin, and does nothing at all when there is no child to write to.
+    ///
+    /// **This is the segmentation fault the quota reader died of.** The guard used to be one flag
+    /// read under the lock, with the write itself outside it and no question asked about whether
+    /// a child existed, so `stdinPipe.fileHandleForWriting` was reached for in whatever state it
+    /// happened to be in. Two states it can be in are not writable and neither was checked: the
+    /// process has never been launched, which is how `CodexClient` used to send its handshake,
+    /// and `closeStdin` is closing that very handle from another thread, which is what
+    /// `CodexRunner.terminateNow` does from the main actor on Stop, close, archive and quit. A
+    /// `FileHandle` reached in either state faults inside `_NSFileHandleIsClosed` on a field read
+    /// off nothing, and it takes the whole app with it for the sake of a menu bar number.
+    ///
+    /// So a write claims the handle: it is refused unless the child was started and has not
+    /// exited and stdin is still open, and while it is in flight `closeStdin` records what it
+    /// wants rather than doing it. The claim is dropped and the deferred close performed on the
+    /// way out. Nothing is held across the write itself, because a full pipe blocks there until
+    /// the child reads or dies, and a closer waiting on that would be the quit path hanging.
     public func write(_ text: String) {
-        guard !state.withLock(\.stdinClosed) else { return }
+        let claimed = state.withLock { state -> Bool in
+            guard state.started, state.status == nil, !state.stdinClosed, !state.stdinHandleClosed
+            else { return false }
+            state.stdinWriters += 1
+            return true
+        }
+        guard claimed else { return }
+        defer { releaseWriter() }
 
-        let handle = stdinPipe.fileHandleForWriting
         let data = Data(text.utf8)
         // A dead child turns a write into SIGPIPE, which `write(_:)` turns into an exception.
         do {
-            try handle.write(contentsOf: data)
+            try stdinPipe.fileHandleForWriting.write(contentsOf: data)
         } catch {
             // The process went away. Nothing useful to do beyond stopping further writes.
             state.withLock { $0.stdinClosed = true }
@@ -211,13 +244,27 @@ public final class StreamingProcess: Sendable {
         write(text + "\n")
     }
 
-    public func closeStdin() {
-        let claimed = state.withLock { state -> Bool in
-            if state.stdinClosed { return false }
-            state.stdinClosed = true
+    /// Drops one writer's claim and performs a close that was waiting for it.
+    private func releaseWriter() {
+        let close = state.withLock { state -> Bool in
+            state.stdinWriters -= 1
+            guard state.stdinClosed, state.stdinWriters == 0, !state.stdinHandleClosed
+            else { return false }
+            state.stdinHandleClosed = true
             return true
         }
-        guard claimed else { return }
+        guard close else { return }
+        try? stdinPipe.fileHandleForWriting.close()
+    }
+
+    public func closeStdin() {
+        let close = state.withLock { state -> Bool in
+            state.stdinClosed = true
+            guard state.stdinWriters == 0, !state.stdinHandleClosed else { return false }
+            state.stdinHandleClosed = true
+            return true
+        }
+        guard close else { return }
         try? stdinPipe.fileHandleForWriting.close()
     }
 

--- a/Tests/BloomCoreTests/ProcessStdinTests.swift
+++ b/Tests/BloomCoreTests/ProcessStdinTests.swift
@@ -1,0 +1,212 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// The segmentation fault the quota reader took the app down with.
+///
+/// A dev build died on `EXC_BAD_ACCESS`, a byte read at address 0x64, inside
+/// `_NSFileHandleIsClosed` reached from `StreamingProcess.write`. The stack under it was
+/// `AgentQuotaSources.readAll` into `CodexQuotaSource.read` into `CodexClient.start`, so the
+/// crashing write was the `initialize` line of the handshake, and a second thread was inside
+/// `StreamingProcess.start()` for the Claude Code source at the same moment, doing the launch the
+/// Codex source had not done. A field read off nothing, on the first write of a connection: the
+/// handle was reached for in a state nobody had checked.
+///
+/// Two states are not writable and neither was asked about. The child has never been launched,
+/// which is what `CodexClient` did every time, because it left claiming `lines` to an unstructured
+/// task that cannot run until the actor is free and the actor is held right through the write. And
+/// `closeStdin` is closing that same handle from another thread, which is what
+/// `CodexRunner.terminateNow` does from the main actor on Stop, close, archive and quit, and which
+/// the old check could not stop because it read its flag under the lock and then wrote outside it.
+///
+/// A quota reading is a background convenience. Nothing it does may take the app down, so the
+/// tests here write to processes that are not there rather than reasoning about whether anything
+/// would.
+@Suite("Writing to a process that is not there")
+struct ProcessStdinTests {
+
+    // MARK: - StreamingProcess
+
+    @Test("a line written before the child is launched is refused rather than queued", .timeLimit(.minutes(1)))
+    func aWriteBeforeTheLaunchIsRefused() async throws {
+        let process = StreamingProcess(executable: "/bin/cat", arguments: [])
+
+        // Nothing has claimed `lines`, so nothing has launched `cat` and the pipe has no process
+        // behind it. This used to be written into it anyway, and `cat` read it after exec.
+        process.writeLine("before-the-launch")
+
+        // Claiming the stream is what launches the child.
+        let lines = process.lines
+        process.writeLine("after-the-launch")
+        process.closeStdin()
+
+        var seen: [String] = []
+        for try await line in lines { seen.append(line) }
+
+        #expect(seen == ["after-the-launch"])
+        #expect(await process.exitStatus == 0)
+    }
+
+    @Test("a process that has already exited is not written to", .timeLimit(.minutes(1)))
+    func aWriteAfterTheExitIsRefused() async throws {
+        let process = StreamingProcess(executable: "/bin/echo", arguments: ["done"])
+
+        var seen: [String] = []
+        for try await line in process.lines { seen.append(line) }
+        #expect(seen == ["done"])
+        #expect(await process.exitStatus == 0)
+
+        // The child is gone and nobody called `closeStdin`, which is the only thing the old guard
+        // asked about. Reaching the end of this is the assertion.
+        for _ in 0..<200 { process.writeLine("into the void") }
+    }
+
+    @Test("stdin closing under a write does not fault", .timeLimit(.minutes(2)))
+    func aCloseDoesNotLandUnderAWrite() async throws {
+        // The crash, as directly as it can be provoked from a test: writers on the cooperative
+        // pool and a close from beside them, repeated, because the window is a handful of
+        // instructions wide. `closeStdin` used to close the handle whatever a writer was doing
+        // with it.
+        for _ in 0..<40 {
+            let process = StreamingProcess(executable: "/bin/cat", arguments: [])
+            _ = process.lines
+
+            await withTaskGroup(of: Void.self) { group in
+                for index in 0..<16 {
+                    group.addTask { process.writeLine("line-\(index)") }
+                }
+                group.addTask { process.closeStdin() }
+                group.addTask { process.terminate() }
+            }
+
+            _ = await process.exitStatus
+        }
+    }
+
+    // MARK: - CodexClient
+
+    @Test("the Codex handshake goes to a process that has been launched", .timeLimit(.minutes(1)))
+    func theHandshakeIsWrittenAfterTheLaunch() async throws {
+        let process = LaunchOrderProcess()
+        let client = CodexClient(
+            configuration: CodexClient.Configuration(cwd: "/tmp"),
+            makeProcess: { _ in process }
+        )
+
+        try await client.start()
+        await client.stop()
+
+        #expect(process.wroteBeforeTheLaunch == false)
+        #expect(process.linesWereClaimed)
+    }
+
+    // MARK: - The quota sources
+
+    @Test("a Codex source whose process says nothing answers nothing", .timeLimit(.minutes(1)))
+    func aSilentCodexProcessFailsAsASource() async {
+        let source = CodexQuotaSource(makeProcess: { _ in DeadProcess() })
+
+        // A source that cannot talk to its process contributes nothing, which is the same
+        // outcome as never having been asked, and is what `readAll` is written to expect.
+        let payload = await source.read()
+        #expect(payload == nil)
+
+        let quotas = await AgentQuotaSources.readAll([source] as [any AgentQuotaSource])
+        #expect(quotas.isEmpty)
+    }
+}
+
+// MARK: - Doubles
+
+/// Records whether anything claimed `lines`, which is what launches a real child, before the first
+/// line was written to it.
+private final class LaunchOrderProcess: AgentProcessing, @unchecked Sendable {
+    private let lock = NSLock()
+    private var launched = false
+    private var firstWriteSawTheLaunch: Bool?
+
+    private let stdout: AsyncThrowingStream<String, Error>
+    private let stdoutContinuation: AsyncThrowingStream<String, Error>.Continuation
+    private let stderr: AsyncStream<String>
+    private let stderrContinuation: AsyncStream<String>.Continuation
+
+    init() {
+        (stdout, stdoutContinuation) = AsyncThrowingStream.makeStream(
+            of: String.self, throwing: Error.self, bufferingPolicy: .unbounded
+        )
+        (stderr, stderrContinuation) = AsyncStream.makeStream(
+            of: String.self, bufferingPolicy: .unbounded
+        )
+    }
+
+    /// False when nothing was written at all, which is a failure of a different shape and is
+    /// caught by `linesWereClaimed` beside it.
+    var wroteBeforeTheLaunch: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return firstWriteSawTheLaunch == false
+    }
+
+    var linesWereClaimed: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return launched
+    }
+
+    var lines: AsyncThrowingStream<String, Error> {
+        lock.lock(); launched = true; lock.unlock()
+        return stdout
+    }
+
+    var errorLines: AsyncStream<String> { stderr }
+
+    var isRunning: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return launched
+    }
+
+    var exitStatus: Int32 { get async { 0 } }
+
+    func writeLine(_ text: String) {
+        lock.lock()
+        if firstWriteSawTheLaunch == nil { firstWriteSawTheLaunch = launched }
+        lock.unlock()
+
+        // Answer anything with an id, so the handshake completes and the test is about the order
+        // rather than about a timeout.
+        guard let json = JSONValue.parse(text), let id = json["id"] else { return }
+        stdoutContinuation.yield("{\"id\":\(id.compactJSON),\"result\":{}}")
+    }
+
+    func closeStdin() {}
+
+    func terminate() {
+        stdoutContinuation.finish()
+        stderrContinuation.finish()
+    }
+
+    func kill() { terminate() }
+}
+
+/// A process that ended before anybody asked it anything.
+private final class DeadProcess: AgentProcessing, @unchecked Sendable {
+    let lines: AsyncThrowingStream<String, Error>
+    let errorLines: AsyncStream<String>
+
+    init() {
+        let (stdout, out) = AsyncThrowingStream.makeStream(
+            of: String.self, throwing: Error.self, bufferingPolicy: .unbounded
+        )
+        let (stderr, err) = AsyncStream.makeStream(of: String.self, bufferingPolicy: .unbounded)
+        lines = stdout
+        errorLines = stderr
+        out.finish()
+        err.finish()
+    }
+
+    var isRunning: Bool { false }
+    var exitStatus: Int32 { get async { 1 } }
+
+    func writeLine(_ text: String) {}
+    func closeStdin() {}
+    func terminate() {}
+    func kill() {}
+}

--- a/Tests/BloomCoreTests/ProcessStdinTests.swift
+++ b/Tests/BloomCoreTests/ProcessStdinTests.swift
@@ -22,6 +22,18 @@ import Testing
 /// A quota reading is a background convenience. Nothing it does may take the app down, so the
 /// tests here write to processes that are not there rather than reasoning about whether anything
 /// would.
+///
+/// **The second way a dying child took Bloom down, found by this suite.** The first CI run of it
+/// killed the whole test binary with signal 13, SIGPIPE, part way through and named no failing
+/// test. Writing to a pipe nobody is reading raises that signal, its default disposition is to
+/// kill the process, and nothing in this tree turns it off: `UnixSocketConnection` sets
+/// `SO_NOSIGPIPE` on every socket it owns and says in as many words that without it an agent CLI
+/// exiting mid-call would take Bloom down, and the pipe to a child had never been given the same
+/// treatment. So the null handle and the signal were the same bug wearing two hats, and the guard
+/// in `write` cannot cover the second one: `status` is only set once `settle` has waited out its
+/// quiet period, leaving a window in which a child is dead and the bookkeeping says otherwise.
+/// `StreamingProcess.init` and `Shell.run` set `F_SETNOSIGPIPE` on the descriptors they write a
+/// child on, which turns that signal into the EPIPE the code already handled.
 @Suite("Writing to a process that is not there")
 struct ProcessStdinTests {
 
@@ -61,12 +73,33 @@ struct ProcessStdinTests {
         for _ in 0..<200 { process.writeLine("into the void") }
     }
 
+    @Test("a write to a pipe nobody is reading fails the write rather than the process", .timeLimit(.minutes(1)))
+    func aPipeWithNoReaderFailsTheWriteRatherThanTheProcess() throws {
+        // The option `StreamingProcess.init` puts on its stdin descriptor, asserted on a pipe
+        // this test owns, so the question is the descriptor's behaviour rather than whether a
+        // race with a dying child was won. Without the `fcntl` this does not throw, it ends the
+        // program, which is how the first CI run of this suite died. Pinned here rather than left
+        // implicit because the whole fix rests on the platform answering EPIPE.
+        let pipe = Pipe()
+        _ = fcntl(pipe.fileHandleForWriting.fileDescriptor, F_SETNOSIGPIPE, 1)
+        try pipe.fileHandleForReading.close()
+
+        #expect(throws: (any Error).self) {
+            try pipe.fileHandleForWriting.write(contentsOf: Data("nobody is reading".utf8))
+        }
+        try? pipe.fileHandleForWriting.close()
+    }
+
     @Test("stdin closing under a write does not fault", .timeLimit(.minutes(2)))
     func aCloseDoesNotLandUnderAWrite() async throws {
         // The crash, as directly as it can be provoked from a test: writers on the cooperative
         // pool and a close from beside them, repeated, because the window is a handful of
         // instructions wide. `closeStdin` used to close the handle whatever a writer was doing
         // with it.
+        //
+        // This is also the test that found the SIGPIPE. `terminate` kills the child while writers
+        // are still going, so some of those writes land on a pipe with no reader, and on CI that
+        // ended the test binary rather than any test in it.
         for _ in 0..<40 {
             let process = StreamingProcess(executable: "/bin/cat", arguments: [])
             _ = process.lines


### PR DESCRIPTION
A dev build segfaulted in the menu bar quota reader: `_NSFileHandleIsClosed` faulting on a field read off nothing, reached from `StreamingProcess.write` under `CodexClient.send`, `CodexClient.start` and `CodexQuotaSource.read`. The crashing write was the `initialize` line of a Codex handshake, and the sibling quota source was inside `StreamingProcess.start()` at the same moment, doing the launch the Codex source had not done.

`CodexClient.start` left claiming `lines` to an unstructured task, and claiming `lines` is what launches the child. A task made on an actor cannot run until the actor is free, and `start` holds it straight through the write, so the handshake went into a process nobody had started, every time. Both streams are claimed in `start` now, the way `AgentRunner.start` and `ClaudeCodeQuotaSource.read` already do and say why.

`StreamingProcess.write` read one flag under the lock, wrote outside it, and never asked whether a child existed. A write now claims the handle, and a `closeStdin` asked for while one is in flight is deferred to it, so a process that was never started or is being torn down cannot be written to.

The new suite then killed CI with signal 13, which turned out to be the same bug wearing a second hat. Nothing in `Sources` sets SIGPIPE's disposition, so writing to a pipe nobody is reading kills Bloom outright. `UnixSocketConnection` had already learned this for sockets and sets `SO_NOSIGPIPE` saying so; the pipe to a child never got the same treatment, which made `write`'s claim that a dead child throws an exception untrue. The guard above cannot cover it either, because `status` is set only after `settle` waits out its quiet period, leaving a window where a child is dead and the bookkeeping says otherwise, and `AgentRunner.cancelNow` walks into it on every Stop. `F_SETNOSIGPIPE` on the stdin descriptor in `StreamingProcess.init` and in `Shell.run` turns it into the EPIPE the code already handled.

Not only the quota path. `CodexRunner.connected` goes through the same `start`, and `AgentRunner.cancelNow` and `CodexRunner.terminateNow` run on the main actor on Stop, close, archive and quit, where the close could land between the old check and the old write.

Not a regression from today. `CodexClient.swift` last changed 2026-09-01, `StreamingProcess.swift` 2026-08-25, `QuotaAsk.swift` 2026-08-27; the mid-turn delivery merge touched `CodexRunner` and `TurnHandle`, not `CodexClient`, and the quota path never goes near `CodexRunner`.
