### PR TITLE
Answer the panel over live work in visible projects by default

### DIFF
--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelModel.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelModel.swift
@@ -114,6 +114,20 @@ final class SearchPanelModel {
         rebuild(app: app)
     }
 
+    /// Whether the sidebar is showing the projects it has been told to hide.
+    ///
+    /// **Read off the same key the sidebar's own switch writes, and not duplicated as a second
+    /// preference.** Hiding a project is one answer to one question, "am I looking at this project
+    /// right now", and two switches for it would be two answers. Turning it on to find something
+    /// here also puts the project back in the sidebar, which is where somebody hunting for a
+    /// hidden project is going next. See `ProjectVisibility.showsHiddenKey` and `SearchPanelReach`.
+    ///
+    /// Read at rebuild rather than observed, because a rebuild already happens on every keystroke
+    /// and on every change the panel cares about, and the switch is in a menu the panel covers.
+    private static var showsHiddenProjects: Bool {
+        UserDefaults.standard.bool(forKey: ProjectVisibility.showsHiddenKey)
+    }
+
     // MARK: - Building the list
 
     /// One pass, on the same inputs Home builds its list from, called when those inputs move
@@ -122,13 +136,17 @@ final class SearchPanelModel {
         guard isOpen else { return }
         switch field.mode {
         case .things:
+            let reach = SearchPanelReach.reading(
+                scope: scope, showsHiddenProjects: Self.showsHiddenProjects
+            )
             listing = field.isEmpty
                 ? SearchPanelResting.build(
                     workspaces: app.workspaces,
                     repos: app.repos,
                     activity: HomeActivity(
                         running: app.runningWorkspaceIDs, waiting: app.waitingWorkspaceIDs
-                    )
+                    ),
+                    reach: reach
                 )
                 : SearchPanelResults.build(
                     query: field.query,
@@ -136,7 +154,8 @@ final class SearchPanelModel {
                     workspaces: app.workspaces,
                     archived: archived,
                     transcripts: app.transcriptResults,
-                    scope: scope
+                    scope: scope,
+                    reach: reach
                 )
         case .commands:
             let sections = SearchPanelCommands.sections(SearchPanelCommands.rank(field.query))

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelNothingView.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelNothingView.swift
@@ -37,7 +37,7 @@ struct SearchPanelNothingView: View {
     private var glyph: String {
         switch nothing {
         case .nothingYet: "square.stack.3d.up.slash"
-        case .noMatch, .noLiveMatch, .noCommand: "magnifyingglass"
+        case .noMatch, .noLiveMatch, .noHiddenMatch, .noCommand: "magnifyingglass"
         }
     }
 

--- a/Sources/Bloom/Views/Chrome/Search/SearchPanelNothingView.swift
+++ b/Sources/Bloom/Views/Chrome/Search/SearchPanelNothingView.swift
@@ -37,7 +37,7 @@ struct SearchPanelNothingView: View {
     private var glyph: String {
         switch nothing {
         case .nothingYet: "square.stack.3d.up.slash"
-        case .noMatch, .noCommand: "magnifyingglass"
+        case .noMatch, .noLiveMatch, .noCommand: "magnifyingglass"
         }
     }
 

--- a/Sources/BloomCore/Bridge/ProjectHideTool.swift
+++ b/Sources/BloomCore/Bridge/ProjectHideTool.swift
@@ -34,9 +34,10 @@ public struct ProjectHideTool: BridgeToolHandling {
 
             This is a view preference and nothing more. It stops nothing, closes nothing and \
             deletes nothing: the project's agents keep running, its worktrees stay exactly where \
-            they are, and its workspaces still appear on Bloom's Home screen, in search, in the \
-            menu bar and in Shortcuts. The owner brings a hidden project back by turning on Show \
-            hidden projects in the sidebar's filter menu, or you can with project_unhide.
+            they are, and its workspaces still appear on Bloom's Home screen, in the menu bar \
+            and in Shortcuts. They are left out of the sidebar and of the Cmd+K search panel, \
+            which read the same preference. The owner brings a hidden project back by turning on \
+            Show hidden projects in the sidebar's filter menu, or you can with project_unhide.
 
             Hiding a project that is already hidden is not an error and changes nothing. A \
             project Bloom does not have is refused rather than added: project_add is what \
@@ -178,8 +179,8 @@ enum ProjectVisibilityCall {
             return "It is back in Bloom's sidebar, in the place in the list it already had. "
                 + ProjectVisibility.remainingSentence(visible: visible)
         }
-        return "Bloom's sidebar leaves it out now. Nothing stopped and nothing was deleted: its "
-            + "workspaces are running exactly as they were and are still on Home, in search and "
-            + "in the menu bar. " + ProjectVisibility.remainingSentence(visible: visible)
+        return "Bloom's sidebar and its search panel leave it out now. Nothing stopped and "
+            + "nothing was deleted: its workspaces are running exactly as they were and are still "
+            + "on Home and in the menu bar. " + ProjectVisibility.remainingSentence(visible: visible)
     }
 }

--- a/Sources/BloomCore/Model/Models.swift
+++ b/Sources/BloomCore/Model/Models.swift
@@ -15,8 +15,12 @@ public struct Repo: Identifiable, Sendable, Hashable, Codable {
     /// Whether the sidebar leaves this project out of the list unless it is asked to show the
     /// hidden ones. See `ProjectVisibility`, which is the rule, and note what it is NOT: a
     /// hidden project keeps every workspace it has, and those workspaces keep running, keep
-    /// notifying, and keep turning up on Home, in search, in the menu bar and in Shortcuts. This
-    /// column narrows one list.
+    /// notifying, and keep turning up on Home, in the menu bar and in Shortcuts.
+    ///
+    /// It narrows two lists now rather than one: the sidebar, and the search panel, both off the
+    /// one switch. The search panel was on the list above until the owner asked for it to answer
+    /// over live, visible work by default; `SearchPanelReach` is that decision and says why the
+    /// argument for the original sentence still holds.
     ///
     /// On the project rather than on the project and the machine, which is the same choice
     /// `collapsed` and `sortOrder` already made. Bloom's database is per machine already: there

--- a/Sources/BloomCore/Presentation/SearchPanelNothing.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelNothing.swift
@@ -32,13 +32,26 @@ public enum SearchPanelNothing: Equatable, Sendable {
     /// over live work alone would otherwise refuse to find the archived workspace somebody is
     /// searching for the name of, and say nothing about having refused. See `SearchPanelReach`.
     case noLiveMatch(String, archived: Int)
+    /// Nothing matched anywhere the panel is looking, and it is not looking everywhere: there are
+    /// projects the sidebar has been told to hide.
+    ///
+    /// **This is not a corner case on the machine it was written for.** Thirteen of the owner's
+    /// seventeen projects are hidden, so an answer that quietly leaves them out is leaving out most
+    /// of his machine, and without this nothing would say so.
+    ///
+    /// It says how many projects are out, and not how much is in them, because the panel does not
+    /// know: the count of hidden PROJECTS is a fact, and any count of matches inside them would be
+    /// one the reach was built to avoid computing. That is also why the archive outranks it below:
+    /// "12 archived workspaces do" names matches that exist, where this names doors that may open
+    /// on nothing.
+    case noHiddenMatch(String, hidden: Int)
     /// The menu bar, searched for something that is not in it.
     case noCommand(String)
 
     public var title: String {
         switch self {
         case .nothingYet: "Nothing to show yet"
-        case .noMatch, .noLiveMatch: "No results"
+        case .noMatch, .noLiveMatch, .noHiddenMatch: "No results"
         case .noCommand: "No such command"
         }
     }
@@ -48,7 +61,18 @@ public enum SearchPanelNothing: Equatable, Sendable {
         case .nothingYet:
             "Add a project and start a workspace, and what you are working on turns up here."
         case .noMatch(let query):
+            // "In Bloom", which is the whole app, and it stays true because this case is only
+            // reached when the panel really did look everywhere: `SearchPanelResults` sends the
+            // two cases below whenever something was held back. See the precedence there.
             "Nothing in Bloom matches \(quoted(query))."
+        case .noHiddenMatch(let query, let hidden):
+            // "Left out", not "not searched". They ARE searched: the store's index has no idea
+            // which projects the sidebar is showing, so the rows come back and the reach drops
+            // them from the answer and from every count. Saying they were not searched would be
+            // saying the untrue half of a true thing.
+            hidden == 1
+                ? "Nothing in your visible work matches \(quoted(query)). 1 hidden project is left out."
+                : "Nothing in your visible work matches \(quoted(query)). \(hidden) hidden projects are left out."
         case .noLiveMatch(let query, let archived):
             // The count and the noun, and no instruction after them. The chip that would show
             // them is on the row above this card with the same number on it, so a sentence
@@ -72,7 +96,7 @@ public enum SearchPanelNothing: Equatable, Sendable {
     public func indexNotice(isIndexing: Bool) -> String? {
         guard isIndexing else { return nil }
         switch self {
-        case .noMatch, .noLiveMatch: break
+        case .noMatch, .noLiveMatch, .noHiddenMatch: break
         case .nothingYet, .noCommand: return nil
         }
         return "The transcript index is still building, so older conversations are not searchable yet."

--- a/Sources/BloomCore/Presentation/SearchPanelNothing.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelNothing.swift
@@ -26,13 +26,19 @@ public enum SearchPanelNothing: Equatable, Sendable {
     case nothingYet
     /// A search of workspaces, transcripts and commands that matched nothing.
     case noMatch(String)
+    /// Nothing in live work matched, but the archive holds workspaces that did.
+    ///
+    /// This is what makes the default reach safe rather than merely narrow. A panel that answers
+    /// over live work alone would otherwise refuse to find the archived workspace somebody is
+    /// searching for the name of, and say nothing about having refused. See `SearchPanelReach`.
+    case noLiveMatch(String, archived: Int)
     /// The menu bar, searched for something that is not in it.
     case noCommand(String)
 
     public var title: String {
         switch self {
         case .nothingYet: "Nothing to show yet"
-        case .noMatch: "No results"
+        case .noMatch, .noLiveMatch: "No results"
         case .noCommand: "No such command"
         }
     }
@@ -43,6 +49,14 @@ public enum SearchPanelNothing: Equatable, Sendable {
             "Add a project and start a workspace, and what you are working on turns up here."
         case .noMatch(let query):
             "Nothing in Bloom matches \(quoted(query))."
+        case .noLiveMatch(let query, let archived):
+            // The count and the noun, and no instruction after them. The chip that would show
+            // them is on the row above this card with the same number on it, so a sentence
+            // telling the reader to press it would be saying what they can already see. The two
+            // rows this replaced were exactly that mistake.
+            archived == 1
+                ? "Nothing in your live work matches \(quoted(query)). 1 archived workspace does."
+                : "Nothing in your live work matches \(quoted(query)). \(archived) archived workspaces do."
         case .noCommand(let query):
             "No menu item matches \(quoted(query))."
         }
@@ -56,7 +70,11 @@ public enum SearchPanelNothing: Equatable, Sendable {
     /// keyed on the flag rather than printed always. It belongs to `noMatch` alone: an empty
     /// install has nothing to index, and the menu bar is not in the index at all.
     public func indexNotice(isIndexing: Bool) -> String? {
-        guard isIndexing, case .noMatch = self else { return nil }
+        guard isIndexing else { return nil }
+        switch self {
+        case .noMatch, .noLiveMatch: break
+        case .nothingYet, .noCommand: return nil
+        }
         return "The transcript index is still building, so older conversations are not searchable yet."
     }
 

--- a/Sources/BloomCore/Presentation/SearchPanelNothing.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelNothing.swift
@@ -71,16 +71,16 @@ public enum SearchPanelNothing: Equatable, Sendable {
             // them from the answer and from every count. Saying they were not searched would be
             // saying the untrue half of a true thing.
             hidden == 1
-                ? "Nothing in your visible work matches \(quoted(query)). 1 hidden project is left out."
-                : "Nothing in your visible work matches \(quoted(query)). \(hidden) hidden projects are left out."
+                ? "Nothing in your visible work matches \(quoted(query)). 1\u{00A0}hidden project is left out."
+                : "Nothing in your visible work matches \(quoted(query)). \(hidden)\u{00A0}hidden projects are left out."
         case .noLiveMatch(let query, let archived):
             // The count and the noun, and no instruction after them. The chip that would show
             // them is on the row above this card with the same number on it, so a sentence
             // telling the reader to press it would be saying what they can already see. The two
             // rows this replaced were exactly that mistake.
             archived == 1
-                ? "Nothing in your live work matches \(quoted(query)). 1 archived workspace does."
-                : "Nothing in your live work matches \(quoted(query)). \(archived) archived workspaces do."
+                ? "Nothing in your live work matches \(quoted(query)). 1\u{00A0}archived workspace does."
+                : "Nothing in your live work matches \(quoted(query)). \(archived)\u{00A0}archived workspaces do."
         case .noCommand(let query):
             "No menu item matches \(quoted(query))."
         }
@@ -102,6 +102,18 @@ public enum SearchPanelNothing: Equatable, Sendable {
         return "The transcript index is still building, so older conversations are not searchable yet."
     }
 
+    /// **The space after a count is `\u{00A0}` and not an ordinary one, in every sentence here.**
+    /// The card wraps, and at the width the panel is drawn at the hidden sentence broke as
+    /// "…matches “houdini”. 13" over "hidden projects are left out.", which puts a number on one
+    /// line and the thing it counts on the next. That reads as carelessness rather than as
+    /// wrapping, and it is the exact class of thing this panel has been reported for all day. The
+    /// archive sentence can break the same way at some other width, so it is tied too.
+    ///
+    /// Written as the escape rather than as the character, because an invisible byte in a string
+    /// literal is a thing the next reader cannot see and will delete by accident.
+    /// `SearchPanelNothingTests` proves the property over every sentence rather than matching
+    /// these two, so a fourth sentence with a count in it fails until it is tied as well.
+    ///
     /// Typographic quotes, because the query is quoted prose rather than code.
     private func quoted(_ query: String) -> String {
         "\u{201C}\(query.trimmingCharacters(in: .whitespacesAndNewlines))\u{201D}"

--- a/Sources/BloomCore/Presentation/SearchPanelReach.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelReach.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// How far the search panel is allowed to look: live work by default, and finished or tidied-away
+/// work only when something asks for it.
+///
+/// # Why the default narrowed
+///
+/// The panel used to answer over everything the database held. On the owner's machine that made
+/// "Everything" 3752 against "Archived" 2317, so more than half of every answer was work he had
+/// finished with, and a name he half remembered came back as four archived worktrees and the one
+/// live workspace he wanted, in whatever order the ranking chose. His words were to make the panel
+/// "only take active non-archived, non-hidden workspace and project into account by default", and
+/// to add a way to widen it.
+///
+/// # The two halves are not the same fact and do not get the same control
+///
+/// **Archived work is finished.** The way back to it is the Archived chip, which was already on
+/// the row and already meant exactly this: `HomeScope.archived` is "readable, restorable, with
+/// nothing left on disk", and it holds the transcripts of archived workspaces as well as their
+/// rows. So no control is added for it. What changes is that the other three chips stop carrying
+/// it, which is also what makes their counts honest: Everything now counts what Everything shows.
+///
+/// **Hidden is somebody saying "not now, and not in my way".** It already has a control, a
+/// persistent one, and it is the sidebar's own "Show hidden projects": see
+/// `ProjectVisibility.showsHiddenKey`. The panel reads that same preference rather than growing a
+/// second switch, so there is one answer in the window to "am I looking at hidden projects", and
+/// turning it on to find something puts it back in the sidebar too, which is where somebody
+/// looking for a hidden project is going next.
+///
+/// **This makes an old sentence false and it has been corrected rather than left.**
+/// `ProjectVisibility` and `Repo.hidden` both said that a hidden project's workspaces keep turning
+/// up in search, and that was a deliberate decision at the time: hiding is a view preference and
+/// must never be a way to lose work. That argument still holds and this does not break it, because
+/// a hidden project's workspaces still run, still notify, still appear on Home and in the menu bar,
+/// and are one switch away here. What changed is that "narrows one list" is now "narrows the two
+/// lists that are about browsing", and both are governed by the same switch.
+///
+/// # Nothing is lost silently
+///
+/// A search of live work alone would otherwise refuse to find the archived workspace somebody is
+/// searching for the name of, which `HomeScope.settle` warns about in as many words. So when the
+/// live answer is empty and the archive is not, the card says so and says how much: see
+/// `SearchPanelNothing.noLiveMatch`. The narrowing is only safe because that sentence exists.
+public struct SearchPanelReach: Equatable, Sendable {
+    /// Whether finished work is in the answer.
+    public var archived: Bool
+
+    /// Whether the projects the sidebar is leaving out are in the answer.
+    public var hidden: Bool
+
+    /// The default: live work, in the projects the sidebar is showing.
+    public static let live = SearchPanelReach()
+
+    public init(archived: Bool = false, hidden: Bool = false) {
+        self.archived = archived
+        self.hidden = hidden
+    }
+
+    /// What the panel reaches for under one chip, with the sidebar's own preference.
+    ///
+    /// The Archived chip is the widening rather than a narrowing of something already there,
+    /// which is the whole of the design: under it the archive is fetched and drawn, and under
+    /// every other chip it is counted and not drawn. Counted, because a chip whose number went to
+    /// nought whenever it was not lit is a chip nobody would ever press.
+    public static func reading(scope: HomeScope, showsHiddenProjects: Bool) -> SearchPanelReach {
+        SearchPanelReach(archived: scope == .archived, hidden: showsHiddenProjects)
+    }
+
+    /// The projects a search is allowed to answer over.
+    public func projects(_ repos: [Repo]) -> [Repo] {
+        hidden ? repos : repos.filter { !$0.hidden }
+    }
+}

--- a/Sources/BloomCore/Presentation/SearchPanelResting.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelResting.swift
@@ -34,14 +34,22 @@ public enum SearchPanelResting {
     ///   - activity: which agents are running and which have stopped to ask. Handed in for the
     ///     reason `HomeActivity` gives: it lives in the app's memory and moves without the row
     ///     moving.
+    ///   - reach: how far the panel is allowed to look. The resting list never holds archived
+    ///     work, so only the project half of it applies here, and it applies for the reason the
+    ///     search half does: the two lists have to agree about what exists, or the resting list
+    ///     would offer a workspace that typing its name then refuses to find.
     public static func build(
         workspaces: [Workspace],
         repos: [Repo],
-        activity: HomeActivity
+        activity: HomeActivity,
+        reach: SearchPanelReach = .live
     ) -> SearchPanelListing {
         var byID: [RepoID: Repo] = [:]
         byID.reserveCapacity(repos.count)
         for repo in repos { byID[repo.id] = repo }
+
+        let reachable = Set(reach.projects(repos).map(\.id))
+        let workspaces = workspaces.filter { reachable.contains($0.repoID) }
 
         // Most recent first in both sections, which is the order every other list of workspaces in
         // the app is in. Sorted once and split, rather than sorted twice.

--- a/Sources/BloomCore/Presentation/SearchPanelResults.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelResults.swift
@@ -31,7 +31,8 @@ public enum SearchPanelResults {
         archived: [Workspace],
         transcripts: [TranscriptWorkspaceMatches],
         scope: HomeScope,
-        commands: [MenuBarItem] = MenuBarCatalogue.commands
+        commands: [MenuBarItem] = MenuBarCatalogue.commands,
+        reach: SearchPanelReach = .live
     ) -> SearchPanelListing {
         let needle = WorkspaceSearch.needle(query)
         guard !needle.isEmpty else { return .empty }
@@ -40,12 +41,25 @@ public enum SearchPanelResults {
         byID.reserveCapacity(repos.count)
         for repo in repos { byID[repo.id] = repo }
 
+        // The projects the answer is allowed to be about. A workspace whose project is not among
+        // them is not considered at all: not drawn, not counted, and not offered as a reason to
+        // widen, because "12 archived workspaces match" pointing at a project the sidebar is not
+        // showing would be a hint the reader cannot act on. See `SearchPanelReach`.
+        let reachable = Set(reach.projects(repos).map(\.id))
+
         var counts = HomeScopeCounts()
-        var matched: [SearchPanelWorkspaceHit] = []
-        matched.reserveCapacity(workspaces.count)
+        /// Live matches, which are what every chip but Archived draws.
+        var live: [SearchPanelWorkspaceHit] = []
+        live.reserveCapacity(workspaces.count)
+        /// Archived matches, drawn only under the Archived chip and counted always, so that chip
+        /// carries a number worth pressing.
+        var finished: [SearchPanelWorkspaceHit] = []
 
         func consider(_ workspace: Workspace, isArchived: Bool) {
             let repo = byID[workspace.repoID]
+            // A project the sidebar is not showing is not an answer this panel gives, unless the
+            // sidebar's own switch says otherwise. See `SearchPanelReach`.
+            guard reachable.contains(workspace.repoID) else { return }
             // **Two rules, and a row is in the list if either answers.** The subsequence over the
             // name is what makes `docs` find `rewrite-documentation-site` and is what says which
             // characters to draw bold. `WorkspaceSearch` is the substring rule Home uses, and it
@@ -54,39 +68,61 @@ public enum SearchPanelResults {
             let hit = FuzzyMatch.hit(workspace.name, query: needle)
             let field = WorkspaceSearch.match(workspace: workspace, repo: repo, needle: needle)
             guard hit != nil || field != nil else { return }
-            matched.append(
-                SearchPanelWorkspaceHit(
-                    workspace: workspace,
-                    repo: repo,
-                    highlights: hit?.positions ?? [],
-                    // Only when the name was not what put it there, since the row already draws
-                    // the name and the characters that hit in it.
-                    match: hit == nil && field != workspace.name ? field : nil,
-                    isArchived: isArchived,
-                    // A name match outranks a branch or project match, always: a workspace called
-                    // what you typed is the answer, and one whose project happens to contain the
-                    // letters is a near miss.
-                    score: hit?.score ?? 0
-                )
+            let found = SearchPanelWorkspaceHit(
+                workspace: workspace,
+                repo: repo,
+                highlights: hit?.positions ?? [],
+                // Only when the name was not what put it there, since the row already draws the
+                // name and the characters that hit in it.
+                match: hit == nil && field != workspace.name ? field : nil,
+                isArchived: isArchived,
+                // A name match outranks a branch or project match, always: a workspace called what
+                // you typed is the answer, and one whose project happens to contain the letters is
+                // a near miss.
+                score: hit?.score ?? 0
             )
-            if isArchived { counts.archived += 1 } else { counts.live += 1 }
+            if isArchived {
+                finished.append(found)
+                counts.archived += 1
+            } else {
+                live.append(found)
+                counts.live += 1
+            }
         }
 
         for workspace in workspaces { consider(workspace, isArchived: false) }
         for workspace in archived { consider(workspace, isArchived: true) }
-        counts.workspaces = matched.count
+        // The three live chips count live work and nothing else, which is the whole reason their
+        // numbers can be trusted against their own rows now. Archived keeps its own tally above.
+        counts.workspaces = live.count
 
         let archivedIDs = Set(archived.map(\.id))
         let known = Set(workspaces.map(\.id)).union(archivedIDs)
         // A result whose workspace has been deleted since the index was written has nothing to
-        // open, so it is dropped rather than drawn as a row that does nothing.
-        let hits = transcripts.filter { known.contains($0.workspaceID) }
+        // open, so it is dropped rather than drawn as a row that does nothing. A result from a
+        // project the reach does not cover is dropped for the reason `reachable` gives.
+        let repoOf: (WorkspaceID) -> RepoID? = { id in
+            (workspaces.first { $0.id == id } ?? archived.first { $0.id == id })?.repoID
+        }
+        let hits = transcripts.filter { result in
+            guard known.contains(result.workspaceID) else { return false }
+            guard let repoID = repoOf(result.workspaceID) else { return false }
+            return reachable.contains(repoID)
+        }
+        /// Every archived workspace this query reached, however it matched, which is what the card
+        /// offers when the live answer is empty.
+        var archivedWorkspaces = Set(finished.map(\.id))
         for hit in hits {
-            counts.transcripts += hit.total
-            counts.transcriptWorkspaces += 1
-            if archivedIDs.contains(hit.workspaceID) { counts.archived += hit.total }
+            if archivedIDs.contains(hit.workspaceID) {
+                counts.archived += hit.total
+                archivedWorkspaces.insert(hit.workspaceID)
+            } else {
+                counts.transcripts += hit.total
+                counts.transcriptWorkspaces += 1
+            }
         }
 
+        let matched = reach.archived ? live + finished : live
         let shownWorkspaces = matched
             .filter { hit in
                 scope.showsWorkspaces && scope.includes(
@@ -99,7 +135,14 @@ public enum SearchPanelResults {
             }
 
         let shownTranscripts = hits
-            .filter { scope.includesTranscript(isArchived: archivedIDs.contains($0.workspaceID)) }
+            .filter { result in
+                let isArchived = archivedIDs.contains(result.workspaceID)
+                // The reach first, then the chip. Under Everything the chip would take an archived
+                // transcript, and it must not: the three live chips draw live work, which is what
+                // makes their counts describe their own rows.
+                guard reach.archived || !isArchived else { return false }
+                return scope.includesTranscript(isArchived: isArchived)
+            }
             .map { result in
                 let workspace = workspaces.first { $0.id == result.workspaceID }
                     ?? archived.first { $0.id == result.workspaceID }
@@ -150,8 +193,22 @@ public enum SearchPanelResults {
             // while the chips counted matches, and nothing on the card said they were answering
             // different questions. See `SearchPanelSummary`.
             summary: SearchPanelSummary.searching(scope: scope, counts: counts),
-            nothing: sections.isEmpty ? .noMatch(query) : nil
+            nothing: sections.isEmpty ? nothing(query, archived: archivedWorkspaces.count, reach: reach) : nil
         )
+    }
+
+    /// What the card says when the answer is empty, which is not one sentence any more.
+    ///
+    /// A search of live work alone would otherwise refuse to find the archived workspace somebody
+    /// is searching for the name of, and `HomeScope.settle` warns about exactly that. So an empty
+    /// live answer over a non-empty archive says how much is in the archive, and the narrowing is
+    /// only safe because it does. Under the Archived chip the reach already covers the archive, so
+    /// there is nothing left to point at and the plain sentence is the true one.
+    private static func nothing(
+        _ query: String, archived: Int, reach: SearchPanelReach
+    ) -> SearchPanelNothing {
+        guard !reach.archived, archived > 0 else { return .noMatch(query) }
+        return .noLiveMatch(query, archived: archived)
     }
 
     /// The few commands a search of things is allowed to show.

--- a/Sources/BloomCore/Presentation/SearchPanelResults.swift
+++ b/Sources/BloomCore/Presentation/SearchPanelResults.swift
@@ -193,22 +193,41 @@ public enum SearchPanelResults {
             // while the chips counted matches, and nothing on the card said they were answering
             // different questions. See `SearchPanelSummary`.
             summary: SearchPanelSummary.searching(scope: scope, counts: counts),
-            nothing: sections.isEmpty ? nothing(query, archived: archivedWorkspaces.count, reach: reach) : nil
+            nothing: sections.isEmpty
+                ? nothing(
+                    query,
+                    archived: archivedWorkspaces.count,
+                    // The projects, not what is in them: `ProjectVisibility` already counts these
+                    // for the sidebar's own toggle title, so the panel and that switch cannot
+                    // disagree about how many there are.
+                    hidden: ProjectVisibility.hiddenCount(repos),
+                    reach: reach
+                )
+                : nil
         )
     }
 
-    /// What the card says when the answer is empty, which is not one sentence any more.
+    /// What the card says when the answer is empty, which is three sentences now and one of them
+    /// at a time.
     ///
-    /// A search of live work alone would otherwise refuse to find the archived workspace somebody
-    /// is searching for the name of, and `HomeScope.settle` warns about exactly that. So an empty
-    /// live answer over a non-empty archive says how much is in the archive, and the narrowing is
-    /// only safe because it does. Under the Archived chip the reach already covers the archive, so
-    /// there is nothing left to point at and the plain sentence is the true one.
+    /// **Whatever the reach held back, the card names it.** A search of live work alone would
+    /// otherwise refuse to find the archived workspace somebody is searching for the name of, and
+    /// `HomeScope.settle` warns about exactly that; an answer that leaves out thirteen of
+    /// seventeen projects has the same fault one axis along. So the narrowing is only safe because
+    /// this function exists, and `.noMatch`'s "Nothing in Bloom matches" stays true because it is
+    /// only reached when nothing was held back at all.
+    ///
+    /// **The archive outranks the hidden projects when both apply, and it is not a coin toss.**
+    /// The archive's number counts matches that are known to exist, so pressing Archived is known
+    /// to help. The hidden number counts projects, not matches, because the panel deliberately
+    /// does not look inside them, so it names doors that may open on nothing. Given one sentence,
+    /// the one that names a certainty is worth more than the one that names a possibility.
     private static func nothing(
-        _ query: String, archived: Int, reach: SearchPanelReach
+        _ query: String, archived: Int, hidden: Int, reach: SearchPanelReach
     ) -> SearchPanelNothing {
-        guard !reach.archived, archived > 0 else { return .noMatch(query) }
-        return .noLiveMatch(query, archived: archived)
+        if !reach.archived, archived > 0 { return .noLiveMatch(query, archived: archived) }
+        if !reach.hidden, hidden > 0 { return .noHiddenMatch(query, hidden: hidden) }
+        return .noMatch(query)
     }
 
     /// The few commands a search of things is allowed to show.

--- a/Sources/BloomCore/Workspace/ProjectVisibility.swift
+++ b/Sources/BloomCore/Workspace/ProjectVisibility.swift
@@ -4,15 +4,22 @@ import Foundation
 ///
 /// ## What hiding is
 ///
-/// A decluttering of one list. A project with nothing running in it this month is still a project
-/// the owner wants, and the sidebar is a column 260 points wide that has to be scannable at a
-/// glance. Hiding takes a project's header and its workspace rows out of that column and does
-/// nothing else at all.
+/// A decluttering of the lists that are about browsing. A project with nothing running in it this
+/// month is still a project the owner wants, and the sidebar is a column 260 points wide that has
+/// to be scannable at a glance. Hiding takes a project's header and its workspace rows out of that
+/// column, and out of what the search panel answers over, and does nothing else at all.
 ///
 /// **It is emphatically not archiving, and not closing.** The workspaces of a hidden project are
 /// untouched: their agents keep running, their turns keep landing, their notifications keep
-/// arriving, and they keep appearing on Home, in Search, in the menu bar summary, in the Shortcuts
-/// entities and in the `bloom://` links. Anything that would make a running agent disappear
+/// arriving, and they keep appearing on Home, in the menu bar summary, in the Shortcuts entities
+/// and in the `bloom://` links.
+///
+/// Search used to be in that list and is not any more, and the change is worth reading rather than
+/// noticing. The owner asked for the panel to answer over live, visible work by default, so it
+/// reads the same preference this file names, and a hidden project's workspaces are one switch
+/// away there exactly as they are in the sidebar. Nothing about the paragraph above is weakened by
+/// it: the point was that hiding must never be a way to LOSE work, and a list you can widen from a
+/// switch you already own is not that. See `SearchPanelReach`. Anything that would make a running agent disappear
 /// because a list was tidied would be a way to lose work, and this is a view preference. Two
 /// consequences follow and are deliberate: hiding the project of the workspace on screen does not
 /// change the selection or close anything, and the sidebar can be showing a project the pane is

--- a/Tests/BloomCoreTests/SearchPanelNothingTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelNothingTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// What the card says when it has no rows, and one property that holds over all of it.
+@Suite("Search panel nothing")
+struct SearchPanelNothingTests {
+    /// Every sentence the card can draw, so a case added without a thought fails the property
+    /// below rather than passing by not being listed.
+    private static let all: [SearchPanelNothing] = [
+        .nothingYet,
+        .noMatch("houdini"),
+        .noLiveMatch("houdini", archived: 1),
+        .noLiveMatch("houdini", archived: 12),
+        .noHiddenMatch("houdini", hidden: 1),
+        .noHiddenMatch("houdini", hidden: 13),
+        .noCommand("houdini"),
+    ]
+
+    /// Whether a line break could part a number from the word it counts.
+    ///
+    /// **This asks the question rather than matching the answer.** Asserting that a message
+    /// contains "13\u{00A0}hidden" would prove only that the string is the one that was typed; a
+    /// fourth sentence with a count in it would pass by not being mentioned. So this walks the
+    /// characters and refuses any digit followed by a breaking space, whatever the sentence is.
+    private func partsACount(_ message: String) -> Bool {
+        let characters = Array(message)
+        for (index, character) in characters.enumerated() where character.isNumber {
+            guard index + 1 < characters.count else { continue }
+            let next = characters[index + 1]
+            guard next.isWhitespace else { continue }
+            if next != "\u{00A0}" { return true }
+        }
+        return false
+    }
+
+    /// The card wraps, and at the width the panel is drawn at the hidden sentence broke after the
+    /// number: "…matches “houdini”. 13" with "hidden projects are left out." on the next line.
+    @Test("no count on the card can be parted from its noun by a line break")
+    func countsAreTiedToTheirNouns() {
+        for nothing in Self.all {
+            #expect(!partsACount(nothing.message), "\(nothing.message)")
+        }
+    }
+
+    /// The property is worth nothing if it cannot fail, so this is the same walk over a sentence
+    /// written the wrong way.
+    @Test("an ordinary space after a count is what this catches")
+    func theCheckCanFail() {
+        #expect(partsACount("13 hidden projects are left out."))
+        #expect(!partsACount("13\u{00A0}hidden projects are left out."))
+    }
+
+    /// Three different facts, three different sentences, and a reader should not be able to tell
+    /// which case they are looking at from the tone.
+    @Test("every case says something, and no two say the same thing")
+    func eachCaseSaysItsOwnThing() {
+        let messages = Self.all.map(\.message)
+        #expect(messages.allSatisfy { !$0.isEmpty })
+        #expect(Set(messages).count == messages.count)
+        #expect(Self.all.allSatisfy { !$0.title.isEmpty })
+    }
+
+    /// The query is the useful part, so it survives into every sentence that is about one.
+    @Test("a sentence about a query quotes it")
+    func theQueryIsQuoted() {
+        let aboutAQuery: [SearchPanelNothing] = [
+            .noMatch("houdini"),
+            .noLiveMatch("houdini", archived: 12),
+            .noHiddenMatch("houdini", hidden: 13),
+            .noCommand("houdini"),
+        ]
+        for nothing in aboutAQuery {
+            #expect(nothing.message.contains("\u{201C}houdini\u{201D}"), "\(nothing.message)")
+        }
+    }
+}

--- a/Tests/BloomCoreTests/SearchPanelReachTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelReachTests.swift
@@ -142,7 +142,10 @@ struct SearchPanelReachTests {
         #expect(listing.nothing == .noLiveMatch("houdini", archived: 2))
         let message = listing.nothing?.message ?? ""
         #expect(message.contains("houdini"))
-        #expect(message.contains("2 archived workspaces"))
+        // The count and the noun separately, so this does not depend on which space is
+        // between them: `SearchPanelNothingTests` is what holds that.
+        #expect(message.contains("2"))
+        #expect(message.contains("archived workspaces do"))
     }
 
     /// Thirteen of the owner's seventeen projects are hidden, so an answer that quietly leaves
@@ -161,7 +164,8 @@ struct SearchPanelReachTests {
         #expect(listing.nothing == .noHiddenMatch("houdini", hidden: 1))
         let message = listing.nothing?.message ?? ""
         #expect(message.contains("houdini"))
-        #expect(message.contains("1 hidden project is left out"))
+        #expect(message.contains("1"))
+        #expect(message.contains("hidden project is left out"))
         // Not "were not searched". The store's index has no idea which projects the sidebar is
         // showing, so they are searched and then dropped from the answer and from every count.
         #expect(!message.contains("searched"))

--- a/Tests/BloomCoreTests/SearchPanelReachTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelReachTests.swift
@@ -1,0 +1,204 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// How far the panel looks: live work in visible projects by default, wider when something asks.
+@Suite("Search panel reach")
+struct SearchPanelReachTests {
+    private let visible = Repo(id: RepoID("visible"), name: "runbloom", path: "/tmp/visible")
+    private let tidied = Repo(
+        id: RepoID("tidied"), name: "there-there", path: "/tmp/tidied", hidden: true
+    )
+
+    private func workspace(
+        _ name: String,
+        repoID: RepoID = RepoID("visible"),
+        state: WorkspaceState = .active
+    ) -> Workspace {
+        Workspace(
+            id: WorkspaceID(name),
+            repoID: repoID,
+            name: name,
+            branch: "feature/\(name)",
+            path: "/tmp/\(name)",
+            baseBranch: "main",
+            state: state,
+            lastActivityAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+
+    private func transcriptResult(_ workspace: String, matches: Int) -> TranscriptWorkspaceMatches {
+        TranscriptWorkspaceMatches(
+            workspaceID: WorkspaceID(workspace),
+            matches: [
+                TranscriptMatch(
+                    messageID: 1,
+                    workspaceID: WorkspaceID(workspace),
+                    sessionID: SessionID("s"),
+                    sessionTitle: "Session",
+                    seq: 7,
+                    kind: .assistantText,
+                    createdAt: Date(timeIntervalSince1970: 0),
+                    snippet: TranscriptSnippet(segments: []),
+                    score: -1
+                ),
+            ],
+            total: matches
+        )
+    }
+
+    private func build(
+        scope: HomeScope = .all, reach: SearchPanelReach = .live
+    ) -> SearchPanelListing {
+        SearchPanelResults.build(
+            query: "docs",
+            repos: [visible, tidied],
+            workspaces: [
+                workspace("docs here"),
+                workspace("docs tidied", repoID: RepoID("tidied")),
+            ],
+            archived: [workspace("docs finished", state: .archived)],
+            transcripts: [
+                transcriptResult("docs here", matches: 2),
+                transcriptResult("docs tidied", matches: 4),
+                transcriptResult("docs finished", matches: 8),
+            ],
+            scope: scope,
+            commands: [],
+            reach: reach
+        )
+    }
+
+    // MARK: - The default
+
+    /// What the owner asked for: active, non-archived, non-hidden, and nothing else.
+    @Test("by default the panel answers over live work in the projects the sidebar is showing")
+    func theDefaultIsLiveAndVisible() {
+        let listing = build()
+        #expect(listing.rows.map(\.id) == ["workspace:docs here", "transcript:docs here"])
+        // The hidden project's workspace is not counted either, so no chip offers a number that
+        // pressing it could not produce.
+        #expect(listing.counts.workspaces == 1)
+        #expect(listing.counts.transcripts == 2)
+    }
+
+    /// A hidden project is left out of the archive's tally too, so the widening the card offers is
+    /// one the reader can actually act on.
+    @Test("a hidden project is out of every count, the archive's included")
+    func hiddenIsOutOfTheCountsToo() {
+        let listing = build()
+        // One archived row plus its eight matches, and nothing from the hidden project.
+        #expect(listing.counts.archived == 9)
+    }
+
+    // MARK: - Widening
+
+    /// The Archived chip is the way to the archive, and it needs no control of its own because it
+    /// was already on the row.
+    @Test("the Archived chip reaches the archive and draws it")
+    func theArchivedChipWidens() {
+        let listing = build(scope: .archived, reach: .reading(scope: .archived, showsHiddenProjects: false))
+        #expect(listing.rows.map(\.id) == ["workspace:docs finished", "transcript:docs finished"])
+    }
+
+    /// One switch, the sidebar's own, and turning it on widens both lists at once.
+    @Test("the sidebar's own switch is what reaches a hidden project")
+    func theHiddenSwitchWidens() {
+        let listing = build(reach: .reading(scope: .all, showsHiddenProjects: true))
+        #expect(listing.rows.map(\.id).contains("workspace:docs tidied"))
+        #expect(listing.counts.workspaces == 2)
+        #expect(listing.counts.transcripts == 6)
+    }
+
+    @Test("the reach a chip asks for is the chip and the preference, and nothing else")
+    func whatTheChipAsksFor() {
+        #expect(SearchPanelReach.reading(scope: .all, showsHiddenProjects: false) == .live)
+        #expect(SearchPanelReach.reading(scope: .archived, showsHiddenProjects: false)
+            == SearchPanelReach(archived: true))
+        #expect(SearchPanelReach.reading(scope: .transcripts, showsHiddenProjects: true)
+            == SearchPanelReach(hidden: true))
+    }
+
+    // MARK: - Nothing is lost silently
+
+    /// The narrowing is only safe because this sentence exists. `HomeScope.settle` warns in as
+    /// many words that a search of live work alone would refuse to find the archived workspace
+    /// somebody is searching for the name of.
+    @Test("an empty live answer says how much the archive holds")
+    func theCardOffersTheArchive() {
+        let listing = SearchPanelResults.build(
+            query: "houdini",
+            repos: [visible],
+            workspaces: [workspace("docs here")],
+            archived: [
+                workspace("houdini one", state: .archived),
+                workspace("houdini two", state: .archived),
+            ],
+            transcripts: [],
+            scope: .all,
+            commands: []
+        )
+        #expect(listing.rows.isEmpty)
+        #expect(listing.nothing == .noLiveMatch("houdini", archived: 2))
+        let message = listing.nothing?.message ?? ""
+        #expect(message.contains("houdini"))
+        #expect(message.contains("2 archived workspaces"))
+    }
+
+    /// Nothing anywhere is a different sentence from nothing live, and the archive is not offered
+    /// when the reader is already looking at it.
+    @Test("nothing anywhere, and nothing left to offer, say the plain thing")
+    func thePlainNothing() {
+        let nowhere = SearchPanelResults.build(
+            query: "houdini",
+            repos: [visible],
+            workspaces: [workspace("docs here")],
+            archived: [],
+            transcripts: [],
+            scope: .all,
+            commands: []
+        )
+        #expect(nowhere.nothing == .noMatch("houdini"))
+
+        let alreadyThere = SearchPanelResults.build(
+            query: "houdini",
+            repos: [visible],
+            workspaces: [workspace("docs here")],
+            archived: [workspace("nothing like it", state: .archived)],
+            transcripts: [],
+            scope: .archived,
+            commands: [],
+            reach: SearchPanelReach(archived: true)
+        )
+        #expect(alreadyThere.nothing == .noMatch("houdini"))
+    }
+
+    // MARK: - The resting list obeys it too
+
+    /// The two lists have to agree about what exists, or the resting list would offer a workspace
+    /// that typing its name then refuses to find.
+    @Test("the resting list leaves out the projects the search would leave out")
+    func theRestingListObeys() {
+        let listing = SearchPanelResting.build(
+            workspaces: [
+                workspace("docs here"),
+                workspace("docs tidied", repoID: RepoID("tidied")),
+            ],
+            repos: [visible, tidied],
+            activity: HomeActivity()
+        )
+        #expect(listing.rows.map(\.id) == ["workspace:docs here"])
+        #expect(listing.summary == "1 workspace")
+
+        let widened = SearchPanelResting.build(
+            workspaces: [
+                workspace("docs here"),
+                workspace("docs tidied", repoID: RepoID("tidied")),
+            ],
+            repos: [visible, tidied],
+            activity: HomeActivity(),
+            reach: SearchPanelReach(hidden: true)
+        )
+        #expect(widened.rows.count == 2)
+    }
+}

--- a/Tests/BloomCoreTests/SearchPanelReachTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelReachTests.swift
@@ -145,6 +145,61 @@ struct SearchPanelReachTests {
         #expect(message.contains("2 archived workspaces"))
     }
 
+    /// Thirteen of the owner's seventeen projects are hidden, so an answer that quietly leaves
+    /// them out is leaving out most of his machine. Without this nothing would say so.
+    @Test("an empty answer says how many projects it left out")
+    func theCardNamesTheHiddenProjects() {
+        let listing = SearchPanelResults.build(
+            query: "houdini",
+            repos: [visible, tidied],
+            workspaces: [workspace("docs here")],
+            archived: [],
+            transcripts: [],
+            scope: .all,
+            commands: []
+        )
+        #expect(listing.nothing == .noHiddenMatch("houdini", hidden: 1))
+        let message = listing.nothing?.message ?? ""
+        #expect(message.contains("houdini"))
+        #expect(message.contains("1 hidden project is left out"))
+        // Not "were not searched". The store's index has no idea which projects the sidebar is
+        // showing, so they are searched and then dropped from the answer and from every count.
+        #expect(!message.contains("searched"))
+    }
+
+    /// The archive names matches that are known to exist; the hidden count names projects that may
+    /// hold nothing. Given one sentence, the certainty is worth more than the possibility.
+    @Test("the archive outranks the hidden projects when both would speak")
+    func theArchiveOutranksTheHiddenProjects() {
+        let listing = SearchPanelResults.build(
+            query: "houdini",
+            repos: [visible, tidied],
+            workspaces: [workspace("docs here")],
+            archived: [workspace("houdini one", state: .archived)],
+            transcripts: [],
+            scope: .all,
+            commands: []
+        )
+        #expect(listing.nothing == .noLiveMatch("houdini", archived: 1))
+    }
+
+    /// Turning the sidebar's switch on leaves nothing held back on that axis, so the sentence goes
+    /// with it rather than reporting projects that are in the answer.
+    @Test("a widened reach has no hidden projects to name")
+    func nothingLeftOutIsNotNamed() {
+        let listing = SearchPanelResults.build(
+            query: "houdini",
+            repos: [visible, tidied],
+            workspaces: [workspace("docs here")],
+            archived: [],
+            transcripts: [],
+            scope: .all,
+            commands: [],
+            reach: SearchPanelReach(hidden: true)
+        )
+        #expect(listing.nothing == .noMatch("houdini"))
+    }
+
     /// Nothing anywhere is a different sentence from nothing live, and the archive is not offered
     /// when the reader is already looking at it.
     @Test("nothing anywhere, and nothing left to offer, say the plain thing")
@@ -158,6 +213,8 @@ struct SearchPanelReachTests {
             scope: .all,
             commands: []
         )
+        // `[visible]` alone, so nothing is held back on either axis and "Nothing in Bloom
+        // matches" is the true sentence rather than an overclaim.
         #expect(nowhere.nothing == .noMatch("houdini"))
 
         let alreadyThere = SearchPanelResults.build(

--- a/Tests/BloomCoreTests/SearchPanelResultsTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelResultsTests.swift
@@ -59,7 +59,7 @@ struct SearchPanelResultsTests {
         scope: HomeScope = .all,
         commands: [MenuBarItem] = [],
         repos: [Repo]? = nil,
-        reach: SearchPanelReach = .live
+        reach: SearchPanelReach? = nil
     ) -> SearchPanelListing {
         SearchPanelResults.build(
             query: query,
@@ -69,7 +69,11 @@ struct SearchPanelResultsTests {
             transcripts: transcripts,
             scope: scope,
             commands: commands,
-            reach: reach
+            // Derived from the chip unless a test says otherwise, which is what the panel itself
+            // does: `SearchPanelReach.reading` is the one place that rule lives, and a helper that
+            // defaulted to `.live` under the Archived chip would be modelling a pair the app never
+            // produces and would have every future test walk into it.
+            reach: reach ?? .reading(scope: scope, showsHiddenProjects: false)
         )
     }
 

--- a/Tests/BloomCoreTests/SearchPanelResultsTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelResultsTests.swift
@@ -57,16 +57,19 @@ struct SearchPanelResultsTests {
         archived: [Workspace] = [],
         transcripts: [TranscriptWorkspaceMatches] = [],
         scope: HomeScope = .all,
-        commands: [MenuBarItem] = []
+        commands: [MenuBarItem] = [],
+        repos: [Repo]? = nil,
+        reach: SearchPanelReach = .live
     ) -> SearchPanelListing {
         SearchPanelResults.build(
             query: query,
-            repos: [repo],
+            repos: repos ?? [repo],
             workspaces: workspaces,
             archived: archived,
             transcripts: transcripts,
             scope: scope,
-            commands: commands
+            commands: commands,
+            reach: reach
         )
     }
 
@@ -132,9 +135,11 @@ struct SearchPanelResultsTests {
         #expect(hit.match == "runbloom")
     }
 
-    /// Home's own counts, worked out in the same pass, so the two surfaces cannot disagree about
-    /// how much archived work there is.
-    @Test("the chips count workspaces and transcript matches, archived work in both")
+    /// **Each chip counts what pressing it would show, and no chip counts another chip's work.**
+    /// The three live chips used to carry archived work as well, so Everything read 3752 against
+    /// Archived 2317 on the owner's machine and more than half of Everything was work he had
+    /// finished with. See `SearchPanelReach`.
+    @Test("the live chips count live work and Archived counts the archive")
     func theChipCounts() {
         let listing = build(
             "docs",
@@ -145,12 +150,16 @@ struct SearchPanelResultsTests {
                 transcriptResult("docs import", matches: 8),
             ]
         )
-        #expect(listing.counts.workspaces == 2)
-        #expect(listing.counts.transcripts == 14)
-        #expect(listing.counts.transcriptWorkspaces == 2)
-        // One archived row plus the eight matches inside the archived workspace.
+        #expect(listing.counts.workspaces == 1)
+        #expect(listing.counts.transcripts == 6)
+        #expect(listing.counts.transcriptWorkspaces == 1)
+        // One archived row plus the eight matches inside the archived workspace. Counted even
+        // though none of it is drawn: a chip whose number went to nought whenever it was not lit
+        // is a chip nobody would ever press.
         #expect(listing.counts.archived == 9)
-        #expect(listing.counts.count(of: .all, searching: true) == 16)
+        #expect(listing.counts.count(of: .all, searching: true) == 7)
+        // And the rows are the live ones alone.
+        #expect(listing.rows.map(\.id) == ["workspace:docs chapters", "transcript:docs chapters"])
     }
 
     /// The chips split the answer by what kind of thing matched rather than filtering rows, which
@@ -297,11 +306,13 @@ struct SearchPanelResultsTests {
     /// shorter menu Home already draws for one. A command has no workspace at all.
     @Test("a row that names a workspace can be pushed into, whether or not it is archived")
     func whatCanBeDrilled() {
+        // Under the Archived chip, because that is the only place an archived row is drawn now.
         let listing = build(
             "docs",
             workspaces: [workspace("docs chapters")],
             archived: [workspace("docs import", state: .archived)],
-            transcripts: [transcriptResult("docs chapters", matches: 2)]
+            transcripts: [transcriptResult("docs chapters", matches: 2)],
+            reach: SearchPanelReach(archived: true)
         )
         let drillable = Dictionary(
             uniqueKeysWithValues: listing.rows.map { ($0.id, $0.drillable) }


### PR DESCRIPTION
The panel answered over everything the database held. On the owner's machine that made Everything 3752 against Archived 2317, so more than half of every answer was work he had finished with, and a name he half remembered came back as four archived worktrees and the one live workspace he wanted.

The two halves of the request are not the same fact and do not get the same control.

**Archived work is finished, and the way back to it was already on the row.** `HomeScope.archived` means "readable, restorable, with nothing left on disk" and holds the transcripts of archived workspaces as well as their rows, so no control is added. What changes is that the other three chips stop carrying archived work, which is what makes their counts honest: Everything now counts what Everything shows. The archive is still counted while it is not drawn, because a chip whose number went to nought whenever it was not lit is a chip nobody would press.

**Hidden already has a persistent control**, the sidebar's own Show hidden projects. The panel reads that same key rather than growing a second switch, so there is one answer in the window to "am I looking at hidden projects", and turning it on to find something puts the project back in the sidebar too, which is where somebody hunting for a hidden project is going next.

That makes an old sentence false and it is corrected rather than left: `ProjectVisibility`, `Repo.hidden` and `project_hide`'s own description all said a hidden project's workspaces keep turning up in search. The argument behind it still holds, which was that hiding must never be a way to lose work, and a list you can widen from a switch you already own is not that.

Nothing is lost silently. `HomeScope.settle` warns that a search of live work alone would refuse to find the archived workspace somebody is searching for the name of, so an empty live answer over a non-empty archive says how much the archive holds. The narrowing is only safe because that sentence exists.

`HomeScope` and `HomeScopeCounts` are untouched, and Home is untouched with them.