### PR TITLE
Fix what the transcript believes about how tall its rows are

### DIFF
--- a/Sources/Bloom/BloomApp.swift
+++ b/Sources/Bloom/BloomApp.swift
@@ -66,6 +66,12 @@ struct BloomApp: App {
         // and reports how far short of it the view came to rest. See `JumpProbe`.
         if JumpProbe.isRequested { JumpProbe.schedule() }
 
+        // And the one that catches a bug rather than timing a gesture: `Bloom --composer-probe
+        // <out.json>` drags the composer's divider and reports, row by row, what the height cache
+        // and the table each believe before it, after it, after a scroll and after a window
+        // resize. It is how somebody finally watches the transcript go blank. See `ComposerProbe`.
+        if ComposerProbe.isRequested { ComposerProbe.schedule() }
+
         // And the one that answers "the battery menu says Bloom is using significant energy":
         // `Bloom --idle-probe <out.json> --idle-worktrees <list>` runs the diff stat pass the six
         // second loop runs and reports what it cost in process time and in subprocesses. It is the

--- a/Sources/Bloom/Design/ComposerProbe.swift
+++ b/Sources/Bloom/Design/ComposerProbe.swift
@@ -1,0 +1,525 @@
+import AppKit
+import SwiftUI
+import QuartzCore
+import BloomCore
+
+/// **Watches the transcript go blank when the composer divider is dragged.**
+///
+/// The eighth of the family, and the first written to catch a bug rather than to time a gesture.
+/// What it produces is a row by row table of what the height cache and the table each believe,
+/// taken before the drag, after it, after a scroll and after a window resize, plus a light sample
+/// per step of the drag. The question is not what the drag cost. It is which rows stopped being
+/// drawn and which frame stopped them.
+///
+/// **Why it exists.** Dragging the composer taller empties the transcript. It has been diagnosed
+/// twice by reading and shipped once, as a placement resolved against a pane of no height
+/// (`TranscriptAnchor.canPlace`, PR 136), and the owner reproduced it again on 1.1.0 with that fix
+/// in. What he then described rules the placement theory out on its own: he scrolled up and saw
+/// some content but not all, scrolled back down and saw only the final line with the middle
+/// missing, and after scrolling about a while got all of it back. A viewport parked below the last
+/// row shows nothing at all and then shows everything. Rows appearing one at a time is rows drawn
+/// at no height, individually.
+///
+/// **So what this is looking for is a silence.** `TranscriptRowHeights.note` records a measured
+/// nought as an answer. `measuredNothing` then refuses the row a view for ever, `needsMeasuring`
+/// refuses to measure it again, and `isGuessed` does not even count it, because the cache and the
+/// table agree perfectly about nothing. One bad measurement while the pane is mid drag is a row
+/// the reader has lost until something marks the key stale, and the only thing that marks every
+/// key stale is a width change. That is exactly the shape of "dragging the window edge brings it
+/// back", which the owner confirmed.
+///
+/// **And a second theory the owner's own recording argues for instead, which is why the report
+/// carries both.** In the video the transcript comes back by SCROLLING, with no window resize:
+/// blank, then a screen of rows, then the last line with the middle missing, then all of it.
+/// `repairTheScreen` measures a screenful on every settle, and `measureExactly` skips any key the
+/// cache already knows, so a row recorded at nought could not be repaired that way. A row the
+/// cache holds NOTHING for could. So the shape that fits the video is the measured heights being
+/// LOST rather than one row being silenced: `forget` and `reset` empty the lot, every row is then
+/// answered from the mean, the document is the wrong length, and the reader is left looking at
+/// part of it until each screen is measured again.
+///
+/// `cached` and `cacheWidth` are the two columns that tell those apart, per step of the drag. A
+/// step where `cached` falls to nothing emptied the cache; `cacheWidth` beside it says whether a
+/// width did it, which matters because `Coordinator.columnWidth` answers the TABLE's width and
+/// falls back to the clip view's, and with legacy scrollers those two differ by fifteen points.
+///
+/// The four phases are what the two theories predict, so a run can falsify either:
+///
+/// - `afterTaller`: rows with `known` nought and `drawsNothing` false, `hasCell` false, and
+///   `silencedRows` above nought, if rows are being silenced. `cached` at nothing, and rows with
+///   `known` nil, if the cache is being emptied instead.
+/// - `afterScrolling`: a silenced row is still silenced and a merely unmeasured one is not, so
+///   this phase is what separates them.
+/// - `afterWindowResize`: everything measured again either way, because `rewidth` marks every key
+///   stale. A run where even this does not repair it says both theories are wrong.
+///
+/// **The driver is the stored height rather than a synthetic hand**, for `ResizeProbe`'s reason: a
+/// mouse driver needs this app in front and takes the owner's keyboard. `ComposerView` reads
+/// `composer.editorHeight` out of the defaults domain through `@AppStorage`, so stepping it once
+/// per vsync moves the editor exactly as the end of a real drag does, one step at a time, and
+/// reproduces the thing the last diagnosis turned on: the editor's height moves a pass before the
+/// composer holding it is laid out, so `ComposerView.chromeHeight` is measured from a total a
+/// frame behind and `PaneMeasure.editorCap` is computed from a chrome that is short. What it does
+/// not reproduce is `liveHeight`, which is the same arithmetic through a different property.
+///
+/// It writes to the DEV defaults domain, which is what `make dev` gives this build, and it puts
+/// the key back where it found it. A run that inherits the last run's composer height is the
+/// mistake `ResizeProbe.arrange` learned about splits.
+///
+///     Bloom --composer-probe /tmp/composer.json --composer-workspace <id>
+///           [--composer-arrangement chat|chat+browser] [--composer-url file:///…]
+///           [--composer-travel 320] [--composer-step 24] [--composer-settle 1200]
+///           [--composer-band 400] [--window-size 1440x900] [--window-hidden]
+///
+/// The per-step sample reads six numbers and one `rows(in:)` and walks nothing: see the head of
+/// `ProbeHarness` for the run that was read as a regression in the app because its census grew
+/// with what it was watching. The row tables do walk, and they are taken four times, each while
+/// the pane is standing still.
+@MainActor
+enum ComposerProbe {
+    private static let harness = ProbeHarness(subject: "composer")
+
+    static var isRequested: Bool { harness.isRequested }
+
+    /// The key `ComposerView.manualHeight` is stored under. Spelled here rather than reached for,
+    /// because a probe driving a key the view had stopped reading would report a clean run.
+    private static let heightKey = "composer.editorHeight"
+
+    // MARK: - Arguments
+
+    private static var workspaceID: WorkspaceID? {
+        ProbeHarness.value(for: "--composer-workspace").map(WorkspaceID.init)
+    }
+
+    /// How much taller the editor is dragged, in points, and how much of that lands per vsync.
+    /// The default step is a line and a half, which is a firm drag rather than a flick: the
+    /// suspicion is that the hand outruns the layout, so a step that cannot is no test.
+    private static var travel: CGFloat { ProbeHarness.points("--composer-travel", or: 320) }
+    private static var step: CGFloat { ProbeHarness.points("--composer-step", or: 24) }
+
+    /// How long the pane is left alone before a row table is taken. Everything in
+    /// `TranscriptTable` that would repair a row runs on a settle or a turn later, so a dump taken
+    /// too early reports a state the app was about to leave.
+    private static var settleMs: Int { ProbeHarness.count("--composer-settle", or: 1200) }
+
+    /// How many rows either side of the visible ones the row table covers. Wider than the screen
+    /// on purpose: a row silenced while the pane was short is one the reader scrolls back to
+    /// rather than one they are looking at.
+    private static var band: Int { ProbeHarness.count("--composer-band", or: 400) }
+
+    /// The owner reproduced this with a browser beside the conversation and again with it closed,
+    /// so the split is not the cause. `chat` is the default because it is the simpler window and
+    /// `chat+browser` is what his screenshots show.
+    private static var arrangement: String {
+        ProbeHarness.text("--composer-arrangement", or: "chat")
+    }
+
+    private static var pageURL: String { ProbeHarness.text("--composer-url", or: "") }
+
+    // MARK: - Entry
+
+    static func schedule() {
+        Task { @MainActor in await run() }
+    }
+
+    private static func run() async {
+        // Never brought to the front. See the head of `ProbeHarness.window`.
+        let (window, contentView) = await harness.window()
+
+        guard let app = ProbeHarness.appModel else { harness.fail("no app model") }
+        guard let workspaceID else { harness.fail("--composer-workspace named no workspace") }
+        app.selection = .workspace(workspaceID)
+        app.isInspectorVisible = true
+
+        // The workspace's own arrival, which this probe is not measuring.
+        try? await Task.sleep(for: .seconds(8))
+
+        guard let workspace = app.existingModel(for: workspaceID) else {
+            harness.fail("workspace \(workspaceID.rawValue) is not open")
+        }
+        await arrange(workspace)
+        try? await Task.sleep(for: .seconds(8))
+
+        guard let scroll = ProbeHarness.transcriptScrollView(in: contentView) else {
+            harness.fail("no transcript NSScrollView found")
+        }
+        guard let hold = holdView(in: contentView) else {
+            harness.fail("no TranscriptHoldView found, so this is not the transcript's pane")
+        }
+        let pane = Pane(
+            scroll: scroll,
+            hold: hold,
+            table: scroll.documentView as? NSTableView,
+            coordinator: hold.delegate as? TranscriptTable.Coordinator
+        )
+        guard pane.coordinator != nil else {
+            harness.fail("the hold view has no coordinator, so no row facts can be read")
+        }
+
+        // A known starting composer, so two runs are the same run. Restored at the end.
+        let storedHeight = UserDefaults.standard.double(forKey: heightKey)
+        UserDefaults.standard.set(0.0, forKey: heightKey)
+        try? await Task.sleep(for: .seconds(1))
+
+        // At the live end, which is where a reader dragging the composer normally is and the only
+        // state in which anything places the view at all. `ResizeProbe` starts the same way.
+        scroll.contentView.setBoundsOrigin(
+            NSPoint(x: scroll.contentView.bounds.origin.x, y: scroll.endOffset)
+        )
+        scroll.reflectScrolledClipView(scroll.contentView)
+        try? await Task.sleep(for: .milliseconds(400))
+
+        TranscriptHoldCensus.reset()
+        harness.markStarted()
+        let before = dump(pane)
+
+        // Taller, a step per vsync, which is the direction the bug is reported in.
+        var samples = await drive(from: 0, to: travel, by: step, pane: pane)
+        try? await Task.sleep(for: .milliseconds(settleMs))
+        let afterTaller = dump(pane)
+
+        // **Scrolling, because he says it brings some of it back.** A row that was merely
+        // unmeasured is put right by `repairTheScreen` on the settle. A row recorded at nought is
+        // not, and the difference between these two tables is the whole hypothesis.
+        await scrollAbout(pane)
+        try? await Task.sleep(for: .milliseconds(settleMs))
+        let afterScrolling = dump(pane)
+
+        // **And the window edge, because he says that fixes it.** A width change is the one thing
+        // that marks every key stale, so if the rows come back here they were silenced rather than
+        // misplaced.
+        await nudgeWindowWidth(window)
+        try? await Task.sleep(for: .milliseconds(settleMs))
+        let afterWindowResize = dump(pane)
+
+        // And back down, so the run leaves the composer where it found it as well as the key.
+        samples += await drive(from: travel, to: 0, by: -step, pane: pane)
+        UserDefaults.standard.set(storedHeight, forKey: heightKey)
+
+        harness.write(report(
+            window: window,
+            workspace: workspace,
+            before: before,
+            afterTaller: afterTaller,
+            afterScrolling: afterScrolling,
+            afterWindowResize: afterWindowResize,
+            samples: samples
+        ), echo: false)
+        exit(0)
+    }
+
+    /// The four things a phase is read off, gathered once so no phase can pick up a different one.
+    private struct Pane {
+        var scroll: NSScrollView
+        var hold: TranscriptHoldView
+        var table: NSTableView?
+        var coordinator: TranscriptTable.Coordinator?
+    }
+
+    // MARK: - The arrangement
+
+    /// A browser beside the conversation, in the same tab, when the run asks for one.
+    ///
+    /// `ResizeProbe.arrange`'s, including the collapse to one pane first: a split is persisted in
+    /// the defaults domain, so a second run against the same domain inherits the first run's split
+    /// and adds another. Four panes on the second run and six on the third, compared as though
+    /// they were the same window.
+    private static func arrange(_ workspace: WorkspaceModel) async {
+        let tabs = WorkspaceTabsStore.shared
+        guard let chat = tabs.entries(in: workspace).first(where: { $0.isChat }) else {
+            harness.fail("the workspace has no conversation to drag a composer in")
+        }
+        tabs.select(chat, in: workspace)
+
+        for _ in 0..<16 {
+            let layout = tabs.layout(of: chat)
+            guard layout.paneCount > 1, let pane = layout.panes.last else { break }
+            guard tabs.close(pane: pane, in: chat, of: workspace.workspace.id) else { break }
+        }
+        try? await Task.sleep(for: .seconds(2))
+
+        guard arrangement != "chat" else { return }
+        NewPane.open(.browser, in: workspace, url: pageURL) { content in
+            tabs.split(tab: chat, axis: .horizontal, showing: content)
+        }
+    }
+
+    // MARK: - Driving
+
+    /// Steps the stored editor height from one value to another, sampling the pane on each step.
+    ///
+    /// A sleep between steps rather than a display link, for `ResizeProbe`'s reason: the point is
+    /// that each step is laid out before the next arrives, which is what a hand produces, and a
+    /// step whose layout AppKit is free to coalesce measures a drag that never happened.
+    private static func drive(
+        from start: CGFloat,
+        to finish: CGFloat,
+        by step: CGFloat,
+        pane: Pane
+    ) async -> [JSONValue] {
+        guard step != 0 else { return [] }
+        var samples: [JSONValue] = []
+        var height = start
+        while step > 0 ? height < finish : height > finish {
+            height += step
+            let clamped = step > 0 ? min(height, finish) : max(height, finish)
+            UserDefaults.standard.set(Double(clamped), forKey: heightKey)
+            // A layout pass, and only then the sample: what is being watched for is the pane at
+            // the size this step left it, not the size the step before left it.
+            pane.scroll.window?.layoutIfNeeded()
+            try? await Task.sleep(for: .microseconds(8_333))
+            samples.append(sample(at: clamped, pane: pane))
+        }
+        return samples
+    }
+
+    /// A reader looking for what went missing: up a few screens, and back down.
+    ///
+    /// Through `scrollWheel` rather than by writing the clip view's bounds, because a bounds write
+    /// is not a scroll and none of the settle, the census or the repair is on that path. See
+    /// `ProbeHarness.wheel`.
+    private static func scrollAbout(_ pane: Pane) async {
+        let screen = pane.scroll.contentView.bounds.height
+        guard screen > 1 else { return }
+        for _ in 0..<6 {
+            ProbeHarness.wheel(pane.scroll, by: screen / 2, steps: 2)
+            try? await Task.sleep(for: .milliseconds(250))
+        }
+        for _ in 0..<6 {
+            ProbeHarness.wheel(pane.scroll, by: -screen / 2, steps: 2)
+            try? await Task.sleep(for: .milliseconds(250))
+        }
+    }
+
+    /// Four points wider and back, which is the smallest thing that is still a width change.
+    ///
+    /// Small on purpose: the claim being tested is that a width change repairs the rows, not that
+    /// a big resize does. `TranscriptRowHeights.isSameWidth` is what decides whether four points
+    /// counts, and if it does not the report will show nothing changed here, which is itself the
+    /// answer.
+    private static func nudgeWindowWidth(_ window: NSWindow) async {
+        let start = window.frame
+        var wider = start
+        wider.size.width = start.width + 4
+        window.setFrame(wider, display: true)
+        try? await Task.sleep(for: .milliseconds(600))
+        window.setFrame(start, display: true)
+        try? await Task.sleep(for: .milliseconds(600))
+    }
+
+    // MARK: - What a step looked like
+
+    /// Six numbers and one `rows(in:)`, per step. Nothing here walks rows, cells or views.
+    ///
+    /// `silenced` is the column to read down: the step it first moves on is the frame that lost a
+    /// row, and `viewportHeight` on that line is the pane it was measured against.
+    private static func sample(at height: CGFloat, pane: Pane) -> JSONValue {
+        let clip = pane.scroll.contentView
+        let visible = pane.table.map { $0.rows(in: clip.documentVisibleRect).length } ?? -1
+        return .object([
+            "editorHeight": .number(Double(height)),
+            "viewportHeight": .number(Double(clip.bounds.height)),
+            "viewportWidth": .number(Double(clip.bounds.width)),
+            "contentHeight": .number(Double(pane.scroll.documentView?.frame.height ?? 0)),
+            "offset": .number(Double(clip.bounds.origin.y)),
+            "overshoot": .number(Double(clip.bounds.origin.y - pane.scroll.endOffset)),
+            "visibleRows": .integer(visible),
+            "silenced": .integer(TranscriptHoldCensus.silencedRows),
+            // The number that tells an emptied cache from a missed row. See
+            // `Coordinator.heightCacheCount`.
+            "cached": .integer(pane.coordinator?.heightCacheCount ?? -1),
+            "cacheWidth": .number(pane.coordinator?.heightCacheWidth ?? 0),
+            "scrollAlpha": .number(Double(pane.scroll.alphaValue)),
+            "held": .string(name(of: pane.hold.held)),
+        ])
+    }
+
+    // MARK: - What the pane looked like
+
+    /// Everything worth knowing about a transcript that is standing still, in one object.
+    ///
+    /// Taken four times, while nothing is moving. `lostRows` is the verdict: rows the cache has
+    /// recorded at nothing that `TranscriptRowInk` expected to draw something. Those are the rows
+    /// the reader cannot see and cannot get back.
+    private static func dump(_ pane: Pane) -> [String: JSONValue] {
+        let clip = pane.scroll.contentView
+        let offset = Double(clip.bounds.origin.y)
+        let end = Double(pane.scroll.endOffset)
+        let range = pane.table.map { $0.rows(in: clip.documentVisibleRect) }
+        let count = pane.table?.numberOfRows ?? -1
+        let visible = range?.length ?? -1
+        let facts = rowFacts(pane)
+        let lost = facts.filter { $0.known == 0 && !$0.drawsNothing }
+
+        var out: [String: JSONValue] = [
+            "offset": .number(offset),
+            "endOffset": .number(end),
+            "overshoot": .number(offset - end),
+            "contentHeight": .number(Double(pane.scroll.documentView?.frame.height ?? 0)),
+            "viewportHeight": .number(Double(clip.bounds.height)),
+            "viewportWidth": .number(Double(clip.bounds.width)),
+            "scrollAlpha": .number(Double(pane.scroll.alphaValue)),
+            "scrollFrame": rect(pane.scroll.frame),
+            "holdBounds": rect(pane.hold.bounds),
+            "held": .string(name(of: pane.hold.held)),
+            // `frozen` is private to `TranscriptHoldView`, and this is the same question: a scroll
+            // view sitting at anything other than its host's bounds is a frozen one.
+            "scrollIsFrozen": .bool(pane.scroll.frame != pane.hold.bounds),
+            "cached": .integer(pane.coordinator?.heightCacheCount ?? -1),
+            "cacheWidth": .number(pane.coordinator?.heightCacheWidth ?? 0),
+            "cacheIsReady": .bool(pane.coordinator?.heightCacheIsReady ?? false),
+            "numberOfRows": .integer(count),
+            "visibleRows": .integer(visible),
+            "firstVisibleRow": .integer(range.map { $0.length > 0 ? $0.location : -1 } ?? -1),
+            "rowViews": .integer(pane.table?.subviews.count ?? -1),
+            "hostedRows": .integer(hostingViewCount(in: pane.table)),
+            // The two verdicts, said by the probe rather than left to whoever reads the file.
+            // Rows in the table and none in the viewport is the placement theory; rows recorded at
+            // nothing that were expected to draw is the silence.
+            "isBlank": .bool(count > 0 && visible == 0),
+            "lostRows": .integer(lost.count),
+            "bandRows": .integer(facts.count),
+            "guessedRows": .integer(facts.filter { $0.known == nil && !$0.drawsNothing }.count),
+            "cellsHeld": .integer(facts.filter(\.hasCell).count),
+            "rows": .array(facts.map { json(of: $0) }),
+        ]
+        out["lost"] = .array(lost.prefix(40).map { json(of: $0) })
+        return out
+    }
+
+    /// The rows either side of the ones on screen, which is where a row lost mid drag is.
+    private static func rowFacts(_ pane: Pane) -> [TranscriptTable.Coordinator.RowFact] {
+        guard let coordinator = pane.coordinator else { return [] }
+        let visible = coordinator.visibleRowRange
+        let count = pane.table?.numberOfRows ?? 0
+        // A visible range of nothing is the blank itself, so the band is taken from whatever row
+        // is under the offset instead of from a range that has collapsed. `row(at:)` answers -1
+        // for a point past the last row, which is the parking case, and the band then starts at
+        // the end of the table.
+        let middle: Int
+        if visible.isEmpty {
+            let under = pane.table?.row(
+                at: NSPoint(x: 0, y: pane.scroll.contentView.bounds.origin.y)
+            ) ?? -1
+            middle = under >= 0 ? under : max(0, count - band)
+        } else {
+            middle = visible.lowerBound
+        }
+        let lower = max(0, middle - band)
+        let upper = min(count, max(visible.upperBound, middle) + band)
+        guard lower < upper else { return [] }
+        return coordinator.rowFacts(for: lower..<upper)
+    }
+
+    private static func json(of fact: TranscriptTable.Coordinator.RowFact) -> JSONValue {
+        .object([
+            "row": .integer(fact.row),
+            "entry": .string(fact.name),
+            "shape": .string(fact.shape),
+            "drawsNothing": .bool(fact.drawsNothing),
+            "known": fact.known.map { JSONValue.number($0) } ?? .null,
+            "assumed": .number(fact.assumed),
+            "measuredNothing": .bool(fact.measuredNothing),
+            "needsMeasuring": .bool(fact.needsMeasuring),
+            "told": .number(fact.told),
+            "top": .number(fact.top),
+            "hasCell": .bool(fact.hasCell),
+        ])
+    }
+
+    private static func name(of held: TranscriptHoldView.Held?) -> String {
+        guard let held else { return "none" }
+        switch held {
+        case .nothing: return "nothing"
+        case .whatIsDrawn: return "whatIsDrawn"
+        }
+    }
+
+    private static func rect(_ rect: CGRect) -> JSONValue {
+        .object([
+            "x": .number(Double(rect.origin.x)), "y": .number(Double(rect.origin.y)),
+            "w": .number(Double(rect.width)), "h": .number(Double(rect.height)),
+        ])
+    }
+
+    /// How many views under the table are hosting a SwiftUI graph, which is the number the three
+    /// minute hang is quadratic in. By class name, because `NSHostingView` is generic and a probe
+    /// has no business naming the row's view type.
+    private static func hostingViewCount(in table: NSTableView?) -> Int {
+        guard let table else { return -1 }
+        var found = 0
+        func walk(_ view: NSView) {
+            if String(describing: type(of: view)).hasPrefix("NSHostingView") { found += 1 }
+            for subview in view.subviews { walk(subview) }
+        }
+        walk(table)
+        return found
+    }
+
+    private static func holdView(in root: NSView) -> TranscriptHoldView? {
+        if let found = root as? TranscriptHoldView { return found }
+        for subview in root.subviews {
+            if let found = holdView(in: subview) { return found }
+        }
+        return nil
+    }
+
+    // MARK: - Reporting
+
+    private static func report(
+        window: NSWindow,
+        workspace: WorkspaceModel,
+        before: [String: JSONValue],
+        afterTaller: [String: JSONValue],
+        afterScrolling: [String: JSONValue],
+        afterWindowResize: [String: JSONValue],
+        samples: [JSONValue]
+    ) -> JSONValue {
+        let tabs = WorkspaceTabsStore.shared
+        let panes = tabs.selectedTab(in: workspace).map { tabs.layout(of: $0).paneCount } ?? 0
+        func lost(_ phase: [String: JSONValue]) -> Int {
+            guard case .integer(let count)? = phase["lostRows"] else { return -1 }
+            return count
+        }
+
+        let own: [String: JSONValue] = [
+            "driver": .string("storedHeight"),
+            "arrangement": .string(arrangement),
+            "workspace": .string(workspace.workspace.id.rawValue),
+            "workspaceName": .string(workspace.workspace.name),
+            "sessionRows": .integer(workspace.activeTranscript?.rows.count ?? 0),
+            "drawnRows": .integer(TranscriptDrawn.rows),
+            "panes": .integer(panes),
+            "travel": .number(Double(travel)),
+            "step": .number(Double(step)),
+            "band": .integer(band),
+            "settleMs": .integer(settleMs),
+            "before": .object(before),
+            "afterTaller": .object(afterTaller),
+            "afterScrolling": .object(afterScrolling),
+            "afterWindowResize": .object(afterWindowResize),
+            "steps": .array(samples),
+            "silences": .array(TranscriptHoldCensus.silences.map { json(of: $0) }),
+            "transcriptHold": .map(TranscriptHoldCensus.summary()),
+            // The answer, in four keys, so a run can be read without opening the tables. The
+            // hypothesis is that the drag loses rows, a scroll does not get them back, and a width
+            // change does.
+            "lostAfterDrag": .integer(lost(afterTaller)),
+            "lostAfterScrolling": .integer(lost(afterScrolling)),
+            "lostAfterWindowResize": .integer(lost(afterWindowResize)),
+            "reproduced": .bool(lost(afterTaller) > lost(before)),
+        ]
+        return .object(own.merging(harness.conditions(window: window)) { mine, _ in mine })
+    }
+
+    private static func json(of silence: TranscriptHoldCensus.Silence) -> JSONValue {
+        .object([
+            "row": .integer(silence.row),
+            "source": .string(silence.source),
+            "shape": .string(silence.shape),
+            "columnWidth": .number(silence.columnWidth),
+            "viewportWidth": .number(silence.viewportWidth),
+            "viewportHeight": .number(silence.viewportHeight),
+        ])
+    }
+}

--- a/Sources/Bloom/Design/ComposerProbe.swift
+++ b/Sources/Bloom/Design/ComposerProbe.swift
@@ -465,6 +465,7 @@ enum ComposerProbe {
             "overshoot": .number(Double(clip.bounds.origin.y - pane.scroll.endOffset)),
             "visibleRows": .integer(visible),
             "silenced": .integer(TranscriptHoldCensus.silencedRows),
+            "widthMismatches": .integer(TranscriptHoldCensus.widthMismatches),
             // The number that tells an emptied cache from a missed row. See
             // `Coordinator.heightCacheCount`.
             "cached": .integer(pane.coordinator?.heightCacheCount ?? -1),
@@ -744,6 +745,12 @@ enum ComposerProbe {
             "afterWindowResize": .object(afterWindowResize),
             "steps": .array(drag),
             "stepsBack": .array(dragBack),
+            // **The count that says whether the cause is ordinary or a once-in-four accident.**
+            // A height reported from a pass that laid the row out at another width is the fault
+            // that emptied the owner's transcript, and it is refused now rather than believed.
+            // Nought here on every run would mean the account of it is wrong.
+            "widthMismatches": .integer(TranscriptHoldCensus.widthMismatches),
+            "mismatches": .array(TranscriptHoldCensus.mismatches.map { json(of: $0) }),
             "silences": .array(TranscriptHoldCensus.silences.map { json(of: $0) }),
             "transcriptHold": .map(TranscriptHoldCensus.summary()),
             "lostBefore": .integer(Int(number(before, "lostRows"))),
@@ -752,6 +759,18 @@ enum ComposerProbe {
             "lostAfterWindowResize": .integer(Int(number(afterWindowResize, "lostRows"))),
         ]
         return .object(own.merging(harness.conditions(window: window)) { mine, _ in mine })
+    }
+
+    private static func json(of mismatch: TranscriptHoldCensus.Mismatch) -> JSONValue {
+        .object([
+            "row": .integer(mismatch.row),
+            "shape": .string(mismatch.shape),
+            "reportedWidth": .number(mismatch.reportedWidth),
+            "cacheWidth": .number(mismatch.cacheWidth),
+            "columnWidth": .number(mismatch.columnWidth),
+            "reportedHeight": .number(mismatch.reportedHeight),
+            "knownHeight": .number(mismatch.knownHeight),
+        ])
     }
 
     private static func json(of silence: TranscriptHoldCensus.Silence) -> JSONValue {

--- a/Sources/Bloom/Design/ComposerProbe.swift
+++ b/Sources/Bloom/Design/ComposerProbe.swift
@@ -507,6 +507,13 @@ enum ComposerProbe {
             "viewportWidth": .number(Double(clip.bounds.width)),
             "scrollAlpha": .number(Double(pane.scroll.alphaValue)),
             "scrollFrame": rect(pane.scroll.frame),
+            // The running counts at this phase, so two phases bracket when something happened
+            // without anybody cross-referencing the step arrays to find it.
+            "widthMismatches": .integer(TranscriptHoldCensus.widthMismatches),
+            "silenced": .integer(TranscriptHoldCensus.silencedRows),
+            "cellsBuilt": .integer(TranscriptHoldCensus.cellsBuilt),
+            "screenEstimated": .integer(TranscriptHoldCensus.screenEstimated),
+            "screensSeen": .integer(TranscriptHoldCensus.screensSeen),
             "holdBounds": rect(pane.hold.bounds),
             "held": .string(name(of: pane.hold.held)),
             // `frozen` is private to `TranscriptHoldView`, and this is the same question: a scroll
@@ -750,6 +757,15 @@ enum ComposerProbe {
             // that emptied the owner's transcript, and it is refused now rather than believed.
             // Nought here on every run would mean the account of it is wrong.
             "widthMismatches": .integer(TranscriptHoldCensus.widthMismatches),
+            // Meaningless without this beside it: two refused reports out of forty nine cells
+            // built is a rate, and two out of two thousand would be a different finding.
+            "cellsBuilt": .integer(TranscriptHoldCensus.cellsBuilt),
+            // **The signature of a starved cache**, which is what refusing reports would cost if
+            // the guard were wrong: rows on screen, after the view has stopped moving, drawn at a
+            // height nobody has measured. `repairTheScreen` is what stands behind it.
+            "screenEstimated": .integer(TranscriptHoldCensus.screenEstimated),
+            "screenEstimatedSettled": .integer(TranscriptHoldCensus.screenEstimatedSettled),
+            "screensSeen": .integer(TranscriptHoldCensus.screensSeen),
             "mismatches": .array(TranscriptHoldCensus.mismatches.map { json(of: $0) }),
             "silences": .array(TranscriptHoldCensus.silences.map { json(of: $0) }),
             "transcriptHold": .map(TranscriptHoldCensus.summary()),
@@ -768,6 +784,7 @@ enum ComposerProbe {
             "reportedWidth": .number(mismatch.reportedWidth),
             "cacheWidth": .number(mismatch.cacheWidth),
             "columnWidth": .number(mismatch.columnWidth),
+            "cellWidth": .number(mismatch.cellWidth),
             "reportedHeight": .number(mismatch.reportedHeight),
             "knownHeight": .number(mismatch.knownHeight),
         ])

--- a/Sources/Bloom/Design/ComposerProbe.swift
+++ b/Sources/Bloom/Design/ComposerProbe.swift
@@ -153,7 +153,12 @@ enum ComposerProbe {
     /// every absolute figure in this report incomparable. `pin` puts it where the run asks and
     /// ENDS THE RUN if it cannot, because a probe that quietly measures the wrong width is worse
     /// than no probe.
-    private static var paneWidth: CGFloat { ProbeHarness.points("--composer-pane-width", or: 640) }
+    /// **420 by default, because that is the only width the fault has ever been seen at.**
+    /// It is `DetailSplitViewController.detailMinimum` exactly, which is what a 1440 window gives
+    /// the centre column when the inspector is at its 760 maximum, and it is near what the owner's
+    /// own layout produces with a browser pane taking half his window. At 640 the estimator this
+    /// replaces behaves perfectly well: a run there proves nothing about a fix for a run here.
+    private static var paneWidth: CGFloat { ProbeHarness.points("--composer-pane-width", or: 420) }
 
     /// The owner reproduced this with a browser beside the conversation and again with it closed,
     /// so the split is not the cause. `chat` is the default because it is the simpler window and
@@ -206,7 +211,7 @@ enum ComposerProbe {
 
         // **Before anything is measured**, because the width is what every row height is measured
         // against and this is the variable two batches of this probe did not control.
-        await pin(window, pane: pane)
+        await pin(window, pane: pane, in: contentView)
 
         // A known starting composer, so two runs are the same run. Restored at the end.
         let storedHeight = UserDefaults.standard.double(forKey: heightKey)
@@ -304,32 +309,79 @@ enum ComposerProbe {
 
     /// **Puts the transcript pane at the width the run asked for, or ends the run.**
     ///
-    /// The window is what moves, not the divider. `detailItem.holdingPriority` is `defaultLow`, so
-    /// the centre column is the one that absorbs a window resize while the inspector keeps the
-    /// width it was left at: growing the window by the shortfall is therefore working with the
-    /// split's own rule rather than against it, and it needs nothing private. The inspector's own
-    /// minimum and maximum, and the sidebar's width, are what can make a target unreachable.
+    /// **The divider is the lever, not the window, and the first spelling of this had it wrong.**
+    /// Growing the window looked right, because the centre column holds at `defaultLow` and is the
+    /// item that absorbs a resize. It cannot reach the widths that matter: the pane cannot go below
+    /// `DetailSplitViewController.detailMinimum` however small the window gets, the window has a
+    /// minimum of its own that it hits first, and a run asking for 640 refused at a pane of 810 in
+    /// a window of 1,122. What makes the pane narrow is a WIDE INSPECTOR, which is why batch 24
+    /// landed on exactly 420: the inspector was at its 760 maximum and 1440 less 760 less a 260
+    /// sidebar is the centre column's floor.
     ///
-    /// A loop rather than one step, because the split does not always hand the centre the whole
-    /// delta on the first pass, and a hard failure at the end of it, because the whole reason this
-    /// exists is that two batches of runs measured widths nobody had stated.
-    private static func pin(_ window: NSWindow, pane: Pane) async {
-        for _ in 0..<8 {
+    /// So the window is set first, because `--window-size` is applied before `arrange` and the
+    /// arrangement moves it afterwards, and because the dev app's saved window state lives in its
+    /// own preferences domain and survives a reinstall, so two runs asking for 1440x900 reached
+    /// 1,333 and 1,122. Then the divider is driven until the pane is where the run asked.
+    ///
+    /// A hard failure at the end, naming every width involved, because the whole reason this
+    /// exists is that two batches of runs measured panes nobody had stated.
+    private static func pin(_ window: NSWindow, pane: Pane, in root: NSView) async {
+        if let raw = ProbeHarness.value(for: "--window-size"),
+           let size = ProbeStats.windowSize(raw) {
+            window.setContentSize(size)
+            window.layoutIfNeeded()
+            try? await Task.sleep(for: .milliseconds(500))
+        }
+        guard let split = detailSplitView(in: root) else {
+            harness.fail("no split view holds the transcript, so its width cannot be pinned")
+        }
+        // **Both levers, in that order.** The divider is the one that matters, because a wide
+        // inspector is what makes the pane narrow. It runs out: the inspector has a maximum of 760
+        // and the sidebar takes what it takes, so at some window widths the centre column cannot
+        // be squeezed to the target however the divider is set. A pass that moves the divider and
+        // finds the pane exactly where it was is that limit, and the window is what is left to
+        // move.
+        for _ in 0..<12 {
             let current = pane.hold.bounds.width
-            let delta = paneWidth - current
-            guard abs(delta) > 1 else { return }
+            guard abs(current - paneWidth) > 1 else { return }
+            let column = split.arrangedSubviews[0].frame.width
+            split.setPosition(column + (paneWidth - current), ofDividerAt: 0)
+            window.layoutIfNeeded()
+            try? await Task.sleep(for: .milliseconds(250))
+            guard abs(pane.hold.bounds.width - current) < 1 else { continue }
             var frame = window.frame
-            frame.size.width += delta
+            frame.size.width += paneWidth - pane.hold.bounds.width
             window.setFrame(frame, display: true)
-            try? await Task.sleep(for: .milliseconds(400))
+            window.layoutIfNeeded()
+            try? await Task.sleep(for: .milliseconds(250))
         }
-        guard abs(pane.hold.bounds.width - paneWidth) <= 1 else {
-            harness.fail(
-                "the transcript pane is \(pane.hold.bounds.width) points wide and the run asked "
-                    + "for \(paneWidth). The window reached \(window.frame.width). Nothing "
-                    + "measured at another width is comparable, so this run is refused."
-            )
+        let widths = split.arrangedSubviews.map { Int($0.frame.width) }
+        harness.fail(
+            "the transcript pane is \(Int(pane.hold.bounds.width)) points wide and the run asked "
+                + "for \(Int(paneWidth)). The window is \(Int(window.frame.width)) and the split "
+                + "is \(widths). Nothing measured at another width is comparable, so this run is "
+                + "refused."
+        )
+    }
+
+    /// The split view whose FIRST arranged half holds the transcript, which is
+    /// `DetailSplitViewController`'s and not the window's own.
+    ///
+    /// The deepest match, because the transcript is inside both: the window's split has the
+    /// sidebar beside the whole detail half, and this one has the centre column beside the
+    /// inspector. Two arranged subviews, because that is what the detail split has and the sidebar
+    /// one may not.
+    private static func detailSplitView(in root: NSView) -> NSSplitView? {
+        var best: (view: NSSplitView, depth: Int)?
+        func walk(_ view: NSView, _ depth: Int) {
+            if let split = view as? NSSplitView, split.arrangedSubviews.count == 2,
+               let first = split.arrangedSubviews.first, holdView(in: first) != nil {
+                if best == nil || depth > (best?.depth ?? 0) { best = (split, depth) }
+            }
+            for subview in view.subviews { walk(subview, depth + 1) }
         }
+        walk(root, 0)
+        return best?.view
     }
 
     // MARK: - Driving
@@ -637,8 +689,14 @@ enum ComposerProbe {
             "band": .integer(band),
             "settleMs": .integer(settleMs),
 
-            // **The one figure that says what this is about, and the one that does not depend on
-            // the width.** The tallest thing a row nobody has looked at was told it is.
+            // **The tallest thing a row nobody has looked at was told it is.**
+            //
+            // **It depends on the width, and it was promoted here on the belief that it does
+            // not.** The same estimator answered 6,025 at a 420 point pane and 170.67 at a 640
+            // point one, on the same conversation, which makes sense the moment it is said out
+            // loud: a narrow pane wraps prose into tall rows, and a tall row in a small sample is
+            // exactly what a mean cannot survive. So this is a figure to read BESIDE the pane
+            // width at the top of the report, never across runs at different ones.
             "largestGuess": .number(max(
                 number(before, "largestGuess"),
                 max(number(afterTaller, "largestGuess"), number(afterScrolling, "largestGuess"))
@@ -662,6 +720,16 @@ enum ComposerProbe {
             // Two, because a document that doubles under a hand is a document the reader is
             // somewhere else in, and because the old estimator's own drag swung by 3.86 while the
             // median's swung by 1.74 on the same gesture.
+            // **The guess against what a measured row of this conversation actually is**, which
+            // is the closest thing here to a figure that survives a change of width: both halves
+            // of it move with the pane. Measured on the same conversation: 70 with the mean at a
+            // 420 point pane, 6.1 with the mean at 640, 5.6 with the median at 747. The pathology
+            // is the first of those and nothing else here separates it as cleanly.
+            "guessRatio": .number(
+                number(before, "measuredPointsPerRow") > 0
+                    ? number(before, "largestGuess") / number(before, "measuredPointsPerRow")
+                    : 0
+            ),
             "documentSwingDuringDrag": .number(swing),
             "documentAtDragStart": .number(lengths.first ?? 0),
             "documentAtDragEnd": .number(lengths.last ?? 0),

--- a/Sources/Bloom/Design/ComposerProbe.swift
+++ b/Sources/Bloom/Design/ComposerProbe.swift
@@ -43,7 +43,7 @@ import BloomCore
 /// width did it, which matters because `Coordinator.columnWidth` answers the TABLE's width and
 /// falls back to the clip view's, and with legacy scrollers those two differ by fifteen points.
 ///
-/// The four phases are what the two theories predict, so a run can falsify either:
+/// The four phases are what those theories predict, so a run can falsify either:
 ///
 /// - `afterTaller`: rows with `known` nought and `drawsNothing` false, `hasCell` false, and
 ///   `silencedRows` above nought, if rows are being silenced. `cached` at nothing, and rows with
@@ -52,6 +52,32 @@ import BloomCore
 ///   this phase is what separates them.
 /// - `afterWindowResize`: everything measured again either way, because `rewidth` marks every key
 ///   stale. A run where even this does not repair it says both theories are wrong.
+///
+/// # What the first run said, which was neither of them
+///
+/// **Both theories died and the bug was in the report anyway.** Against the owner's own
+/// conversation, 20,357 messages and 14,322 drawn rows: two lost rows before the drag and two
+/// after, so nothing was silenced; `cached` rose monotonically and `cacheWidth` never moved, so
+/// nothing was emptied. `reproduced` said false because it was asking about silences.
+///
+/// What the steps showed instead is the document's own length. 229,351 points at step 0, 885,212
+/// by step 13, 171,535 at step 14. The same 2,650 rows throughout, and nine new measurements
+/// across the thirteen steps that quadrupled it. The rows above the band, 2,242 of them and not
+/// one measured, were given 75 points each before the drag, 367 during it and 65 after the window
+/// resize: the region above the reader grew by 656,000 points and then collapsed by 678,000,
+/// while nothing about those rows changed.
+///
+/// That is `TranscriptRowHeights.estimate(for:)`, and the row tables say why. Of 408 rows in the
+/// band, 26 had ever been measured at more than nothing; their mean was 651 points and their
+/// largest was 10,806. `settleShapeAfter` is three, so three samples settle a shape's number for
+/// every unmeasured row of it, and one huge answer in a sample of five is what handed 54
+/// unmeasured `answer` rows 347 points each, three `message` rows 418, and, before it re-settled,
+/// four rows 6,025 points each. A viewport of 446 points inside rows drawn six thousand points
+/// tall is a blank pane, and a reader scrolling through them measures them one screen at a time,
+/// which is the recovery the owner filmed.
+///
+/// So `reproduced` asks about the length now. The silence keys stay because they are cheap and
+/// because the run that shows both is worth more than the run that shows either.
 ///
 /// **The driver is the stored height rather than a synthetic hand**, for `ResizeProbe`'s reason: a
 /// mouse driver needs this app in front and takes the owner's keyboard. `ComposerView` reads
@@ -377,6 +403,14 @@ enum ComposerProbe {
             // Rows in the table and none in the viewport is the placement theory; rows recorded at
             // nothing that were expected to draw is the silence.
             "isBlank": .bool(count > 0 && visible == 0),
+            // **What the document is actually made of.** The rows above the band are the ones
+            // nobody has measured, so the points they are given divided by their number is the
+            // estimate the transcript's whole length rests on. It is the number that moved.
+            "rowsAboveBand": .integer(facts.first?.row ?? 0),
+            "pointsAboveBand": .number(facts.first?.top ?? 0),
+            "pointsPerRowAboveBand": .number(
+                (facts.first?.row ?? 0) > 0 ? (facts.first?.top ?? 0) / Double(facts.first?.row ?? 1) : 0
+            ),
             "lostRows": .integer(lost.count),
             "bandRows": .integer(facts.count),
             "guessedRows": .integer(facts.filter { $0.known == nil && !$0.drawsNothing }.count),
@@ -481,6 +515,12 @@ enum ComposerProbe {
             guard case .integer(let count)? = phase["lostRows"] else { return -1 }
             return count
         }
+        // Every document length the drag went through, which is what the verdict is taken from.
+        let lengths: [Double] = samples.compactMap { sample in
+            guard case .object(let fields) = sample,
+                  case .number(let height)? = fields["contentHeight"] else { return nil }
+            return height
+        }
 
         let own: [String: JSONValue] = [
             "driver": .string("storedHeight"),
@@ -501,13 +541,28 @@ enum ComposerProbe {
             "steps": .array(samples),
             "silences": .array(TranscriptHoldCensus.silences.map { json(of: $0) }),
             "transcriptHold": .map(TranscriptHoldCensus.summary()),
-            // The answer, in four keys, so a run can be read without opening the tables. The
-            // hypothesis is that the drag loses rows, a scroll does not get them back, and a width
-            // change does.
+            // The answer, in a handful of keys, so a run can be read without opening the tables.
+            //
+            // **`reproduced` asks whether the document disagreed with itself, and it used to ask
+            // whether a row was silenced.** The first run of this probe reported false on a
+            // conversation where the document went from 229,351 points to 885,212 and back to
+            // 171,535 in twenty-eight steps, because the predicate was about the theory that had
+            // been written down rather than about the thing the owner can see. A transcript whose
+            // length moves by a factor of five while nothing about its rows changes is the bug,
+            // whatever else is or is not true.
+            "documentMin": .number(lengths.min() ?? 0),
+            "documentMax": .number(lengths.max() ?? 0),
+            "documentSwing": .number(
+                (lengths.min() ?? 0) > 0 ? (lengths.max() ?? 0) / (lengths.min() ?? 1) : 0
+            ),
+            "reproduced": .bool((lengths.min() ?? 0) > 0
+                && (lengths.max() ?? 0) / (lengths.min() ?? 1) >= 2),
+            // And the row level theory, kept because it is cheap and because a run that shows
+            // both is worth more than one that shows either.
             "lostAfterDrag": .integer(lost(afterTaller)),
             "lostAfterScrolling": .integer(lost(afterScrolling)),
             "lostAfterWindowResize": .integer(lost(afterWindowResize)),
-            "reproduced": .bool(lost(afterTaller) > lost(before)),
+            "lostBefore": .integer(lost(before)),
         ]
         return .object(own.merging(harness.conditions(window: window)) { mine, _ in mine })
     }

--- a/Sources/Bloom/Design/ComposerProbe.swift
+++ b/Sources/Bloom/Design/ComposerProbe.swift
@@ -93,9 +93,16 @@ import BloomCore
 /// mistake `ResizeProbe.arrange` learned about splits.
 ///
 ///     Bloom --composer-probe /tmp/composer.json --composer-workspace <id>
-///           [--composer-arrangement chat|chat+browser] [--composer-url file:///…]
-///           [--composer-travel 320] [--composer-step 24] [--composer-settle 1200]
-///           [--composer-band 400] [--window-size 1440x900] [--window-hidden]
+///           [--composer-pane-width 640] [--composer-arrangement chat|chat+browser]
+///           [--composer-url file:///…] [--composer-travel 320] [--composer-step 24]
+///           [--composer-settle 1200] [--composer-band 400]
+///           [--window-size 1440x900] [--window-hidden]
+///
+/// **A run states its pane width before anything else and refuses to run at another one.** Two
+/// batches of this probe were compared against each other before anybody noticed they had measured
+/// panes 420 and 747 points wide, on the same window size and the same arrangement, because the
+/// divider position is autosaved into the defaults domain. Width decides every row height there
+/// is, so those runs were never comparable. See `paneWidth` and `pin`.
 ///
 /// The per-step sample reads six numbers and one `rows(in:)` and walks nothing: see the head of
 /// `ProbeHarness` for the run that was read as a regression in the app because its census grew
@@ -132,6 +139,21 @@ enum ComposerProbe {
     /// on purpose: a row silenced while the pane was short is one the reader scrolls back to
     /// rather than one they are looking at.
     private static var band: Int { ProbeHarness.count("--composer-band", or: 400) }
+
+    /// **The width the transcript pane is put at before anything is measured.**
+    ///
+    /// A run that does not state this is a run that cannot be compared with another, and two
+    /// batches were spent finding that out. The pane came out 420 points wide in one batch and 747
+    /// in the next, on the same window size and the same arrangement, because
+    /// `DetailSplitViewController` autosaves its divider into the defaults domain and the pane is
+    /// whatever the last run or the last launch left. 420 is exactly `detailMinimum`, which is the
+    /// coincidence that gave it away.
+    ///
+    /// Width decides every row height in `TranscriptRowHeights`, so an uncontrolled width makes
+    /// every absolute figure in this report incomparable. `pin` puts it where the run asks and
+    /// ENDS THE RUN if it cannot, because a probe that quietly measures the wrong width is worse
+    /// than no probe.
+    private static var paneWidth: CGFloat { ProbeHarness.points("--composer-pane-width", or: 640) }
 
     /// The owner reproduced this with a browser beside the conversation and again with it closed,
     /// so the split is not the cause. `chat` is the default because it is the simpler window and
@@ -182,6 +204,10 @@ enum ComposerProbe {
             harness.fail("the hold view has no coordinator, so no row facts can be read")
         }
 
+        // **Before anything is measured**, because the width is what every row height is measured
+        // against and this is the variable two batches of this probe did not control.
+        await pin(window, pane: pane)
+
         // A known starting composer, so two runs are the same run. Restored at the end.
         let storedHeight = UserDefaults.standard.double(forKey: heightKey)
         UserDefaults.standard.set(0.0, forKey: heightKey)
@@ -199,8 +225,10 @@ enum ComposerProbe {
         harness.markStarted()
         let before = dump(pane)
 
-        // Taller, a step per vsync, which is the direction the bug is reported in.
-        var samples = await drive(from: 0, to: travel, by: step, pane: pane)
+        // Taller, a step per vsync, which is the direction the bug is reported in. Kept apart
+        // from the drag back down, because everything between them exists to remeasure and a
+        // verdict taken over both would be a verdict about the probe's own phases. See `report`.
+        let drag = await drive(from: 0, to: travel, by: step, pane: pane)
         try? await Task.sleep(for: .milliseconds(settleMs))
         let afterTaller = dump(pane)
 
@@ -219,17 +247,19 @@ enum ComposerProbe {
         let afterWindowResize = dump(pane)
 
         // And back down, so the run leaves the composer where it found it as well as the key.
-        samples += await drive(from: travel, to: 0, by: -step, pane: pane)
+        let dragBack = await drive(from: travel, to: 0, by: -step, pane: pane)
         UserDefaults.standard.set(storedHeight, forKey: heightKey)
 
         harness.write(report(
             window: window,
+            pane: pane,
             workspace: workspace,
             before: before,
             afterTaller: afterTaller,
             afterScrolling: afterScrolling,
             afterWindowResize: afterWindowResize,
-            samples: samples
+            drag: drag,
+            dragBack: dragBack
         ), echo: false)
         exit(0)
     }
@@ -267,6 +297,38 @@ enum ComposerProbe {
         guard arrangement != "chat" else { return }
         NewPane.open(.browser, in: workspace, url: pageURL) { content in
             tabs.split(tab: chat, axis: .horizontal, showing: content)
+        }
+    }
+
+    // MARK: - Pinning the width
+
+    /// **Puts the transcript pane at the width the run asked for, or ends the run.**
+    ///
+    /// The window is what moves, not the divider. `detailItem.holdingPriority` is `defaultLow`, so
+    /// the centre column is the one that absorbs a window resize while the inspector keeps the
+    /// width it was left at: growing the window by the shortfall is therefore working with the
+    /// split's own rule rather than against it, and it needs nothing private. The inspector's own
+    /// minimum and maximum, and the sidebar's width, are what can make a target unreachable.
+    ///
+    /// A loop rather than one step, because the split does not always hand the centre the whole
+    /// delta on the first pass, and a hard failure at the end of it, because the whole reason this
+    /// exists is that two batches of runs measured widths nobody had stated.
+    private static func pin(_ window: NSWindow, pane: Pane) async {
+        for _ in 0..<8 {
+            let current = pane.hold.bounds.width
+            let delta = paneWidth - current
+            guard abs(delta) > 1 else { return }
+            var frame = window.frame
+            frame.size.width += delta
+            window.setFrame(frame, display: true)
+            try? await Task.sleep(for: .milliseconds(400))
+        }
+        guard abs(pane.hold.bounds.width - paneWidth) <= 1 else {
+            harness.fail(
+                "the transcript pane is \(pane.hold.bounds.width) points wide and the run asked "
+                    + "for \(paneWidth). The window reached \(window.frame.width). Nothing "
+                    + "measured at another width is comparable, so this run is refused."
+            )
         }
     }
 
@@ -375,7 +437,13 @@ enum ComposerProbe {
         let count = pane.table?.numberOfRows ?? -1
         let visible = range?.length ?? -1
         let facts = rowFacts(pane)
-        let lost = facts.filter { $0.known == 0 && !$0.drawsNothing }
+        // **Not the three that redraw themselves.** The streaming tail and the bubble on its way
+        // out draw nothing between turns and are measured on every pass, so counting them made
+        // `lostRows` two before anything had gone wrong. `viewFor` exempts them from the silence
+        // guard for the same reason, so nought is never held against one.
+        let lost = facts.filter { $0.known == 0 && !$0.drawsNothing && !$0.redrawsItself }
+        let guesses = facts.filter { $0.known == nil }.map(\.assumed)
+        let measured = facts.compactMap(\.known)
 
         var out: [String: JSONValue] = [
             "offset": .number(offset),
@@ -411,6 +479,19 @@ enum ComposerProbe {
             "pointsPerRowAboveBand": .number(
                 (facts.first?.row ?? 0) > 0 ? (facts.first?.top ?? 0) / Double(facts.first?.row ?? 1) : 0
             ),
+            // **The largest height ever handed to a row nobody has looked at**, which is the one
+            // figure that says what this is all about and the one that does not depend on the
+            // width. It was 6,025 on the old estimator, fourteen screens for content nobody had
+            // seen, and 154 on the median.
+            "largestGuess": .number(guesses.max() ?? 0),
+            // What the rows that HAVE been measured come to, per row, counting the ones that
+            // measured nothing. The only truth this probe holds, and it is the truth about the
+            // band rather than about the document: see `report`, which is why the verdict does
+            // not lean on it.
+            "measuredPointsPerRow": .number(
+                measured.isEmpty ? 0 : measured.reduce(0, +) / Double(measured.count)
+            ),
+            "measuredRows": .integer(measured.count),
             "lostRows": .integer(lost.count),
             "bandRows": .integer(facts.count),
             "guessedRows": .integer(facts.filter { $0.known == nil && !$0.drawsNothing }.count),
@@ -457,6 +538,7 @@ enum ComposerProbe {
             "needsMeasuring": .bool(fact.needsMeasuring),
             "told": .number(fact.told),
             "top": .number(fact.top),
+            "redrawsItself": .bool(fact.redrawsItself),
             "hasCell": .bool(fact.hasCell),
         ])
     }
@@ -502,67 +584,104 @@ enum ComposerProbe {
 
     private static func report(
         window: NSWindow,
+        pane: Pane,
         workspace: WorkspaceModel,
         before: [String: JSONValue],
         afterTaller: [String: JSONValue],
         afterScrolling: [String: JSONValue],
         afterWindowResize: [String: JSONValue],
-        samples: [JSONValue]
+        drag: [JSONValue],
+        dragBack: [JSONValue]
     ) -> JSONValue {
         let tabs = WorkspaceTabsStore.shared
         let panes = tabs.selectedTab(in: workspace).map { tabs.layout(of: $0).paneCount } ?? 0
-        func lost(_ phase: [String: JSONValue]) -> Int {
-            guard case .integer(let count)? = phase["lostRows"] else { return -1 }
-            return count
+        func number(_ phase: [String: JSONValue], _ field: String) -> Double {
+            switch phase[field] {
+            case .number(let value)?: return value
+            case .integer(let value)?: return Double(value)
+            default: return 0
+            }
         }
-        // Every document length the drag went through, which is what the verdict is taken from.
-        let lengths: [Double] = samples.compactMap { sample in
+        // **The drag alone.** Everything between the two drags exists to remeasure: the scroll
+        // phase draws rows and the window resize marks every key stale, and both are supposed to
+        // move the document. A swing taken over them says nothing about the gesture.
+        let lengths = drag.compactMap { sample -> Double? in
             guard case .object(let fields) = sample,
                   case .number(let height)? = fields["contentHeight"] else { return nil }
             return height
         }
+        let low = lengths.min() ?? 0
+        let high = lengths.max() ?? 0
+        let swing = low > 0 ? high / low : 0
+        let grew = (lengths.last ?? 0) > (lengths.first ?? 0)
 
         let own: [String: JSONValue] = [
-            "driver": .string("storedHeight"),
+            // **What a run has to state before anything else**, because two batches of this probe
+            // produced numbers that could not be compared and nobody could tell until afterwards.
+            "paneWidth": .number(Double(pane.hold.bounds.width)),
+            "windowWidth": .number(Double(window.frame.width)),
+            "tableRows": .integer(pane.table?.numberOfRows ?? -1),
+            "sessionRows": .integer(workspace.activeTranscript?.rows.count ?? 0),
             "arrangement": .string(arrangement),
+            "panes": .integer(panes),
+            "version": .string(
+                Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+            ),
+            "build": .string(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"),
             "workspace": .string(workspace.workspace.id.rawValue),
             "workspaceName": .string(workspace.workspace.name),
-            "sessionRows": .integer(workspace.activeTranscript?.rows.count ?? 0),
+            "driver": .string("storedHeight"),
             "drawnRows": .integer(TranscriptDrawn.rows),
-            "panes": .integer(panes),
             "travel": .number(Double(travel)),
             "step": .number(Double(step)),
             "band": .integer(band),
             "settleMs": .integer(settleMs),
+
+            // **The one figure that says what this is about, and the one that does not depend on
+            // the width.** The tallest thing a row nobody has looked at was told it is.
+            "largestGuess": .number(max(
+                number(before, "largestGuess"),
+                max(number(afterTaller, "largestGuess"), number(afterScrolling, "largestGuess"))
+            )),
+
+            // **The verdict: did the document run away during the DRAG.**
+            //
+            // Two of the earlier verdicts here were wrong and both are worth remembering. The
+            // first asked whether a row had been silenced, which was the theory that had been
+            // written down rather than the thing the owner can see. The second asked about the
+            // whole run, so it counted the scroll and the resize phases, whose job is to move the
+            // document, and it counted an estimate improving as evidence arrives as a fault.
+            //
+            // **The direction is reported rather than judged.** A document converging on the truth
+            // is the system working and one running away from it is the bug, but this probe cannot
+            // tell those apart on its own: it knows the true height of the rows that have been
+            // MEASURED and not of the document, and on a conversation where most rows have never
+            // been measured those are different questions. `measuredPointsPerRow` and
+            // `largestGuess` are what a reader judges the direction with.
+            //
+            // Two, because a document that doubles under a hand is a document the reader is
+            // somewhere else in, and because the old estimator's own drag swung by 3.86 while the
+            // median's swung by 1.74 on the same gesture.
+            "documentSwingDuringDrag": .number(swing),
+            "documentAtDragStart": .number(lengths.first ?? 0),
+            "documentAtDragEnd": .number(lengths.last ?? 0),
+            "documentMinDuringDrag": .number(low),
+            "documentMaxDuringDrag": .number(high),
+            "documentGrewDuringDrag": .bool(grew),
+            "reproduced": .bool(swing >= 2),
+
             "before": .object(before),
             "afterTaller": .object(afterTaller),
             "afterScrolling": .object(afterScrolling),
             "afterWindowResize": .object(afterWindowResize),
-            "steps": .array(samples),
+            "steps": .array(drag),
+            "stepsBack": .array(dragBack),
             "silences": .array(TranscriptHoldCensus.silences.map { json(of: $0) }),
             "transcriptHold": .map(TranscriptHoldCensus.summary()),
-            // The answer, in a handful of keys, so a run can be read without opening the tables.
-            //
-            // **`reproduced` asks whether the document disagreed with itself, and it used to ask
-            // whether a row was silenced.** The first run of this probe reported false on a
-            // conversation where the document went from 229,351 points to 885,212 and back to
-            // 171,535 in twenty-eight steps, because the predicate was about the theory that had
-            // been written down rather than about the thing the owner can see. A transcript whose
-            // length moves by a factor of five while nothing about its rows changes is the bug,
-            // whatever else is or is not true.
-            "documentMin": .number(lengths.min() ?? 0),
-            "documentMax": .number(lengths.max() ?? 0),
-            "documentSwing": .number(
-                (lengths.min() ?? 0) > 0 ? (lengths.max() ?? 0) / (lengths.min() ?? 1) : 0
-            ),
-            "reproduced": .bool((lengths.min() ?? 0) > 0
-                && (lengths.max() ?? 0) / (lengths.min() ?? 1) >= 2),
-            // And the row level theory, kept because it is cheap and because a run that shows
-            // both is worth more than one that shows either.
-            "lostAfterDrag": .integer(lost(afterTaller)),
-            "lostAfterScrolling": .integer(lost(afterScrolling)),
-            "lostAfterWindowResize": .integer(lost(afterWindowResize)),
-            "lostBefore": .integer(lost(before)),
+            "lostBefore": .integer(Int(number(before, "lostRows"))),
+            "lostAfterDrag": .integer(Int(number(afterTaller, "lostRows"))),
+            "lostAfterScrolling": .integer(Int(number(afterScrolling, "lostRows"))),
+            "lostAfterWindowResize": .integer(Int(number(afterWindowResize, "lostRows"))),
         ]
         return .object(own.merging(harness.conditions(window: window)) { mine, _ in mine })
     }

--- a/Sources/Bloom/Design/Snapshot.swift
+++ b/Sources/Bloom/Design/Snapshot.swift
@@ -394,7 +394,7 @@ enum Snapshot {
     static var isDrivingTheWindow: Bool {
         isRequested || isWindowCaptureRequested || isGalleryCaptureRequested
             || FrameProbe.isRequested || SwitchProbe.isRequested || ScrollProbe.isRequested
-            || ResizeProbe.isRequested || TabProbe.isRequested
+            || ResizeProbe.isRequested || TabProbe.isRequested || ComposerProbe.isRequested
             || CommandLine.arguments.contains("--menu-probe")
     }
 

--- a/Sources/Bloom/Design/TranscriptHoldCensus.swift
+++ b/Sources/Bloom/Design/TranscriptHoldCensus.swift
@@ -272,16 +272,37 @@ enum TranscriptHoldCensus {
     /// ordinary rather than a once-in-four accident, and the widths recorded beside it are where
     /// somebody picks the thread up.
     ///
-    /// **What the first run with this in it caught, which was not what was predicted.** Two
-    /// reports out of forty nine cells built, both at 747 against a table of 420, and 747 is the
-    /// width that pane had before the run pinned it. So the reports came from a layout at a width
-    /// the run had left behind, which is what a reuse pool holds after a width change: a cell is
-    /// taken from it, handed a new row, and reports before the table has resized it. Neither did
-    /// any harm, because a stale WIDER frame under-states a height, 32 points against a true 54.
-    /// A stale narrower one over-states it enormously, which is the same mechanism with the sign
-    /// turned round and is what a blank transcript is made of. `cellWidth` is recorded to tell
-    /// those two apart: a stale SwiftUI pass inside a correctly framed cell, or a cell AppKit has
-    /// not resized yet.
+    /// # What it is, which the runs answered in two goes
+    ///
+    /// **The harmless half is a reuse pool holding cells from before a width change.** Two reports
+    /// out of forty nine cells built, both at 747 against a table of 420, where 747 is the width
+    /// that pane had before the run pinned it. A cell comes out of the pool, is handed a new row,
+    /// and reports before the table has resized it.
+    ///
+    /// **The half that does the damage is a cell that has no frame yet**, and it was caught with
+    /// this watching: row 2593, an `answer`, reporting **2,568 points against a known 75** from a
+    /// layout **24 points wide**, with no view held for the row at all. That is the same shape as
+    /// the 1,972 and the 10,806 that emptied the owner's transcript.
+    ///
+    /// It is ours and it is in `viewFor`. A cell that misses the reuse pool is built by
+    /// `TranscriptTableCell(identifier:)`, which is `super.init(frame: .zero)`; `onMeasured` is
+    /// wired to it, and `apply` then installs the root view. All of that happens BEFORE `viewFor`
+    /// returns the cell, so the table has not framed it and is holding no view for the row, which
+    /// is the minus one. A SwiftUI graph laid out against a proposal of nought does not come out
+    /// nought wide: the content bottoms out at its own minimum, which is the 24, and a paragraph
+    /// wrapped into 24 points is 34 times taller than the same paragraph at 420.
+    ///
+    /// **So the sign is the whole difference in consequence.** A stale WIDER frame under-states a
+    /// height, 32 points against a true 54, and draws a row short. A frame with no width at all
+    /// over-states it by an order of magnitude, and that is what a blank transcript is made of.
+    ///
+    /// **The rate, measured rather than assumed: four in fifty one cells built, about eight per
+    /// cent, of which two were harmless for the reason above.** It is not rare and it is not the
+    /// probe's doing: the pane was 420 points wide at every step of every run in which it happened.
+    ///
+    /// **What this file does about it is refuse to believe the report, which is not the same as
+    /// fixing it.** The upstream fix is to give a cell the width it is about to be drawn at before
+    /// handing it content to measure, in `viewFor`, and it is not made here.
     static func reportedAtAnotherWidth(_ mismatch: Mismatch) {
         widthMismatches += 1
         guard mismatches.count < mostMismatches else { return }
@@ -298,12 +319,13 @@ enum TranscriptHoldCensus {
         var cacheWidth: Double
         /// The table's own width now, which is what the cache is told on the next pass.
         var columnWidth: Double
-        /// **The cell's own frame width at the moment of the report**, which is what tells a
-        /// stale SwiftUI layout from a cell AppKit has not resized yet. If this agrees with
-        /// `columnWidth` while `reportedWidth` does not, the cell was the right size and SwiftUI
-        /// answered from an older pass. If it agrees with `reportedWidth`, the cell itself was
-        /// still the size it had in a previous life, which is what a reuse pool holds after a
-        /// width change. Nought when the table is holding no cell for the row.
+        /// **The cell's own frame width at the moment of the report, or minus one when the table
+        /// is holding no view for the row at all.**
+        ///
+        /// Those are different facts and the first spelling of this conflated them, which is how
+        /// the answer was nearly missed: a report arriving with no cell behind it reads as a cell
+        /// of no width, and it is neither. See `reportedAtAnotherWidth` for what minus one turned
+        /// out to mean.
         var cellWidth: Double
         var reportedHeight: Double
         /// What was already known for this content, or -1 for nothing.

--- a/Sources/Bloom/Design/TranscriptHoldCensus.swift
+++ b/Sources/Bloom/Design/TranscriptHoldCensus.swift
@@ -40,6 +40,11 @@ enum TranscriptHoldCensus {
     private(set) static var measurements = 0
     /// Rows a reflow left holding an estimate rather than measuring. What the hold buys.
     private(set) static var estimatedRows = 0
+    /// **Rows expected to draw something that measured nothing.** See `silenced(_:)`, which
+    /// carries why one of these is a row the reader never sees again. `silences` is the log, up to
+    /// `mostSilences` of them, and `silencedRows` is the count of all of them.
+    private(set) static var silencedRows = 0
+    private(set) static var silences: [Silence] = []
     /// **The check that a row is the height it draws at.** Rows that reported the height they
     /// drew at, and how many of those the table was still drawing at another height a turn after
     /// it was told. See `TranscriptTable.Coordinator.checkCorrected`, which carries the bug.
@@ -201,6 +206,39 @@ enum TranscriptHoldCensus {
         entriesBuilt += count
     }
 
+    /// **A row that was expected to draw something turned out to measure nothing.**
+    ///
+    /// The blank transcript a composer drag leaves, watched rather than reasoned about. A height
+    /// of nought is remembered as an answer: `TranscriptRowHeights.measuredNothing` then refuses
+    /// the row a view for ever, `needsMeasuring` refuses to ask again, and `isGuessed` does not
+    /// even count it, because the cache and the table agree perfectly about nothing. A row
+    /// silenced by one bad measurement is gone until the pane changes width, which is the one
+    /// thing that marks every key stale.
+    ///
+    /// So this records each one WITH the geometry of the pass that took it, because the question
+    /// a report has to answer is not how many but which frame. `TranscriptRowInk` is what says
+    /// the row was expected to draw: a row that claims to draw nothing measuring nothing is the
+    /// design working and is not recorded here.
+    static func silenced(_ silence: Silence) {
+        silencedRows += 1
+        guard silences.count < mostSilences else { return }
+        silences.append(silence)
+    }
+
+    /// One row, and the pane it was measured against.
+    struct Silence: Sendable {
+        var row: Int
+        var source: String
+        var shape: String
+        var columnWidth: Double
+        var viewportWidth: Double
+        var viewportHeight: Double
+    }
+
+    /// A run that silences a thousand rows should not write a thousand of these into a report
+    /// nobody can read. `silencedRows` still counts them all.
+    private static let mostSilences = 200
+
     /// One batch of corrections, and the ones that did not take.
     static func corrected(rows: Int, uncorrected: Int) {
         correctedRows += rows
@@ -235,6 +273,8 @@ enum TranscriptHoldCensus {
         noteWorstMs = 0
         entryPasses = 0
         entriesBuilt = 0
+        silencedRows = 0
+        silences = []
     }
 
     static func summary() -> [String: Double] {
@@ -266,6 +306,7 @@ enum TranscriptHoldCensus {
             "noteWorstMs": noteWorstMs,
             "entryPasses": Double(entryPasses),
             "entriesBuilt": Double(entriesBuilt),
+            "silencedRows": Double(silencedRows),
         ]
     }
 }

--- a/Sources/Bloom/Design/TranscriptHoldCensus.swift
+++ b/Sources/Bloom/Design/TranscriptHoldCensus.swift
@@ -219,6 +219,20 @@ enum TranscriptHoldCensus {
     /// a report has to answer is not how many but which frame. `TranscriptRowInk` is what says
     /// the row was expected to draw: a row that claims to draw nothing measuring nothing is the
     /// design working and is not recorded here.
+    ///
+    /// **Every entry the first three probe runs produced has been explained, and none of them was
+    /// a fault.** Two were the entries that redraw themselves, which draw nothing between turns
+    /// and are measured on every pass; they are excluded now. The other five were `thinking` rows
+    /// whose thinking text is empty, a signature and nothing else, looked up by sequence number in
+    /// the database the run was driven against. `TranscriptRowInk` only answers for `system` rows,
+    /// so an empty thinking block is not CLAIMED to draw nothing, is estimated like any other row,
+    /// and then measures nothing when it is drawn. Recording nought for it and refusing it a view
+    /// is the design working.
+    ///
+    /// It stays because it is one comparison on a path that has just laid out a hosting view, and
+    /// because a real silence is invisible to everything else here: `isGuessed` does not count a
+    /// row the cache and the table agree about, even when what they agree on is nothing. Anything
+    /// it reports should be looked up before it is believed.
     static func silenced(_ silence: Silence) {
         silencedRows += 1
         guard silences.count < mostSilences else { return }

--- a/Sources/Bloom/Design/TranscriptHoldCensus.swift
+++ b/Sources/Bloom/Design/TranscriptHoldCensus.swift
@@ -45,6 +45,10 @@ enum TranscriptHoldCensus {
     /// `mostSilences` of them, and `silencedRows` is the count of all of them.
     private(set) static var silencedRows = 0
     private(set) static var silences: [Silence] = []
+    /// **Heights reported from a pass that laid the row out at another width.** See
+    /// `reportedAtAnotherWidth`, which carries the two that emptied the owner's transcript.
+    private(set) static var widthMismatches = 0
+    private(set) static var mismatches: [Mismatch] = []
     /// **The check that a row is the height it draws at.** Rows that reported the height they
     /// drew at, and how many of those the table was still drawing at another height a turn after
     /// it was told. See `TranscriptTable.Coordinator.checkCorrected`, which carries the bug.
@@ -253,6 +257,43 @@ enum TranscriptHoldCensus {
     /// nobody can read. `silencedRows` still counts them all.
     private static let mostSilences = 200
 
+    /// **A drawn row reported its height from a pass that laid it out at another width.**
+    ///
+    /// The one instrument here that was written for a fault already found rather than for a
+    /// suspicion. Two rows in one probe run reported 1,972 points for a three line paragraph whose
+    /// height is 54, and 10,806 for a row whose height is 444, both only during a composer drag
+    /// and both correct again afterwards. Both ratios are a row wrapped into a column about
+    /// fifteen points wide, and the second settled an estimate at 6,025 points which was then
+    /// handed to every unmeasured row of its kind.
+    ///
+    /// `TranscriptRowHeights.isEvidence` refuses those reports now, and this counts them, because
+    /// **the refusal is not the explanation.** Nobody knows why a cell is laid out at a fraction
+    /// of its width for a pass. A count that is non-zero on every run is what says the fault is
+    /// ordinary rather than a once-in-four accident, and the widths recorded beside it are where
+    /// somebody picks the thread up.
+    static func reportedAtAnotherWidth(_ mismatch: Mismatch) {
+        widthMismatches += 1
+        guard mismatches.count < mostMismatches else { return }
+        mismatches.append(mismatch)
+    }
+
+    /// One report, and the two widths that disagreed about it.
+    struct Mismatch: Sendable {
+        var row: Int
+        var shape: String
+        /// What the cell was laid out at when it reported.
+        var reportedWidth: Double
+        /// What the cache believes every height in it was taken at.
+        var cacheWidth: Double
+        /// The table's own width now, which is what the cache is told on the next pass.
+        var columnWidth: Double
+        var reportedHeight: Double
+        /// What was already known for this content, or -1 for nothing.
+        var knownHeight: Double
+    }
+
+    private static let mostMismatches = 200
+
     /// One batch of corrections, and the ones that did not take.
     static func corrected(rows: Int, uncorrected: Int) {
         correctedRows += rows
@@ -289,6 +330,8 @@ enum TranscriptHoldCensus {
         entriesBuilt = 0
         silencedRows = 0
         silences = []
+        widthMismatches = 0
+        mismatches = []
     }
 
     static func summary() -> [String: Double] {
@@ -321,6 +364,7 @@ enum TranscriptHoldCensus {
             "entryPasses": Double(entryPasses),
             "entriesBuilt": Double(entriesBuilt),
             "silencedRows": Double(silencedRows),
+            "widthMismatches": Double(widthMismatches),
         ]
     }
 }

--- a/Sources/Bloom/Design/TranscriptHoldCensus.swift
+++ b/Sources/Bloom/Design/TranscriptHoldCensus.swift
@@ -271,6 +271,17 @@ enum TranscriptHoldCensus {
     /// of its width for a pass. A count that is non-zero on every run is what says the fault is
     /// ordinary rather than a once-in-four accident, and the widths recorded beside it are where
     /// somebody picks the thread up.
+    ///
+    /// **What the first run with this in it caught, which was not what was predicted.** Two
+    /// reports out of forty nine cells built, both at 747 against a table of 420, and 747 is the
+    /// width that pane had before the run pinned it. So the reports came from a layout at a width
+    /// the run had left behind, which is what a reuse pool holds after a width change: a cell is
+    /// taken from it, handed a new row, and reports before the table has resized it. Neither did
+    /// any harm, because a stale WIDER frame under-states a height, 32 points against a true 54.
+    /// A stale narrower one over-states it enormously, which is the same mechanism with the sign
+    /// turned round and is what a blank transcript is made of. `cellWidth` is recorded to tell
+    /// those two apart: a stale SwiftUI pass inside a correctly framed cell, or a cell AppKit has
+    /// not resized yet.
     static func reportedAtAnotherWidth(_ mismatch: Mismatch) {
         widthMismatches += 1
         guard mismatches.count < mostMismatches else { return }
@@ -287,6 +298,13 @@ enum TranscriptHoldCensus {
         var cacheWidth: Double
         /// The table's own width now, which is what the cache is told on the next pass.
         var columnWidth: Double
+        /// **The cell's own frame width at the moment of the report**, which is what tells a
+        /// stale SwiftUI layout from a cell AppKit has not resized yet. If this agrees with
+        /// `columnWidth` while `reportedWidth` does not, the cell was the right size and SwiftUI
+        /// answered from an older pass. If it agrees with `reportedWidth`, the cell itself was
+        /// still the size it had in a previous life, which is what a reuse pool holds after a
+        /// width change. Nought when the table is holding no cell for the row.
+        var cellWidth: Double
         var reportedHeight: Double
         /// What was already known for this content, or -1 for nothing.
         var knownHeight: Double

--- a/Sources/Bloom/Views/Transcript/TranscriptTable.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTable.swift
@@ -797,6 +797,10 @@ struct TranscriptTable: NSViewRepresentable {
                     reportedWidth: Double(size.width),
                     cacheWidth: heights.measure?.width ?? 0,
                     columnWidth: Double(columnWidth),
+                    cellWidth: Double(
+                        tableView?.view(atColumn: 0, row: row, makeIfNecessary: false)?
+                            .frame.width ?? 0
+                    ),
                     reportedHeight: Double(height),
                     knownHeight: heights.height(for: contentKey) ?? -1
                 ))

--- a/Sources/Bloom/Views/Transcript/TranscriptTable.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTable.swift
@@ -529,21 +529,31 @@ struct TranscriptTable: NSViewRepresentable {
 
             // **Rows in and out rather than `reloadData()`, and this is the whole of the scroll
             // stall.** See `TranscriptEntryChange`, which carries the measurement.
-            switch change {
-            case .same:
+            //
+            // **One edit, never two**, and `TranscriptTableUpdate` carries the three minute beach
+            // ball that came of making both. A moved environment used to stage the rows out AND
+            // then reload on top of them, so the reload had every staged row view to tear off the
+            // window as well as the ones on screen, at O(n²) in the observers each one removes.
+            let plan = TranscriptTableUpdate.plan(change: change, environmentMoved: environmentMoved)
+            switch plan {
+            case .nothing:
                 break
-            case .grew(let head, let tail):
-                rowsArrived(head: head, tail: tail, fading: fadesFoldRows, in: tableView)
-            case .shrank(let head, let tail):
-                rowsLeft(head: head, tail: tail, fading: fadesFoldRows, in: tableView)
-            case .rebuilt:
-                rebuiltEverything(in: tableView)
+            case .rows(let rowChange):
+                switch rowChange {
+                case .grew(let head, let tail):
+                    rowsArrived(head: head, tail: tail, fading: fadesFoldRows, in: tableView)
+                case .shrank(let head, let tail):
+                    rowsLeft(head: head, tail: tail, fading: fadesFoldRows, in: tableView)
+                case .same, .rebuilt:
+                    // Neither reaches here: `plan` answers `.nothing` and `.reload` for them.
+                    break
+                }
+            case .reload:
+                // Every cell thrown away and the visible ones built again. A session being
+                // replaced, and the environment the cells were built in having moved, and nothing
+                // else should ever reach here.
+                tableView.reloadData()
             }
-
-            // Every cell holds values from the environment it was built in, so one that has moved
-            // is every cell, whether or not a single height moved with it. Not after a `.rebuilt`,
-            // which has just reloaded the table on its own account.
-            if environmentMoved, change != .rebuilt { tableView.reloadData() }
 
             if remeasured {
                 // **The screen first, exactly.** A reset empties the cache under cells that are
@@ -555,7 +565,15 @@ struct TranscriptTable: NSViewRepresentable {
             } else if !changed.isEmpty {
                 // The cells first, so that a row whose height is about to travel already holds
                 // what it is travelling to show. See `noteHeights(_:over:)`.
-                tableView.reloadData(forRowIndexes: changed, columnIndexes: IndexSet(integer: 0))
+                //
+                // Not after a reload, which has just rebuilt every one of these cells. Rebuilding
+                // them a second time in the same pass is the second half of the same mistake the
+                // plan above exists to stop; the measuring below still has to happen either way.
+                if plan != .reload {
+                    tableView.reloadData(
+                        forRowIndexes: changed, columnIndexes: IndexSet(integer: 0)
+                    )
+                }
                 // **A key that has just moved is a key nothing has measured, and this pass is the
                 // cheapest moment to take it.** It used to go straight to `noteHeights`, which
                 // tells the table what the cache holds, and for a new key the cache holds nothing:
@@ -762,6 +780,12 @@ struct TranscriptTable: NSViewRepresentable {
             guard !isHeld else { return }
             guard let row = index[entryID], entries.indices.contains(row),
                   entries[row].contentKey == contentKey else { return }
+            // The other half of the same question `measureExactly` asks: a row the reader was
+            // being shown, reporting that it drew nothing after all. See
+            // `TranscriptHoldCensus.silenced`.
+            if height == 0, !entries[row].drawsNothing {
+                noteSilence(row: row, entry: entries[row], source: "drawn")
+            }
             guard heights.note(height, for: contentKey, shape: entries[row].shape) else { return }
             // **News to the cache is not always news to the table.** A row the table is already
             // drawing at this height needs no `noteHeightOfRows`, and the whole of a correction's
@@ -1298,10 +1322,11 @@ struct TranscriptTable: NSViewRepresentable {
             isPutting = false
         }
 
-        /// The three ways the table is told rows moved, each with a name of its own **so that the
-        /// next `sample` can tell them apart**. An earlier profile put `apply` at 47.7 per cent of
-        /// the main thread with `NSHostingView` under it and `measure` at half a per cent, which
-        /// only means a reload rebuilding cells if the shape really was `.rebuilt`.
+        /// The two ways the table is told rows moved, each with a name of its own **so that the
+        /// next `sample` can tell them apart** and from the third way, which is `reloadData` at
+        /// the call site above. An earlier profile put `apply` at 47.7 per cent of the main thread
+        /// with `NSHostingView` under it and `measure` at half a per cent, which only means a
+        /// reload rebuilding cells if the plan really was `.reload`.
         private func rowsArrived(
             head: Range<Int>, tail: Range<Int>, fading: Bool, in tableView: NSTableView
         ) {
@@ -1332,12 +1357,6 @@ struct TranscriptTable: NSViewRepresentable {
             if !head.isEmpty { tableView.removeRows(at: IndexSet(integersIn: head), withAnimation: animation) }
             tableView.endUpdates()
             NSAnimationContext.endGrouping()
-        }
-
-        /// Every cell thrown away and the visible ones built again. A session being replaced, and
-        /// nothing else should ever reach here.
-        private func rebuiltEverything(in tableView: NSTableView) {
-            tableView.reloadData()
         }
 
         /// The row at the top of the pane and how far above it the viewport starts, so a growth
@@ -1799,11 +1818,17 @@ struct TranscriptTable: NSViewRepresentable {
                 guard heights.needsMeasuring(
                     entry.contentKey, redrawsItself: entry.id.redrawsItself
                 ) else { continue }
-                let taken = heights.note(
-                    measure(entry, at: CGFloat(sizing.width)),
-                    for: entry.contentKey,
-                    shape: entry.shape
-                )
+                let height = measure(entry, at: CGFloat(sizing.width))
+                // **A row that was expected to draw something and came out at nothing.** Recorded
+                // rather than refused, because refusing it is a change to what the cache believes
+                // and this is here to find out what is happening first. One of these is a row the
+                // reader never sees again: nought is remembered as an answer, so `viewFor` will
+                // not build it and `needsMeasuring` will not ask again. See
+                // `TranscriptHoldCensus.silenced`, and `ComposerProbe`, which is reading it.
+                if height == 0, !entry.drawsNothing {
+                    noteSilence(row: row, entry: entry, source: "measureExactly")
+                }
+                let taken = heights.note(height, for: entry.contentKey, shape: entry.shape)
                 if taken { moved.insert(row) }
             }
             return moved
@@ -1845,6 +1870,99 @@ struct TranscriptTable: NSViewRepresentable {
 
         private func reportGeometry() {
             onGeometry?(currentGeometry)
+        }
+
+        // MARK: - What a probe is allowed to ask
+
+        /// One row silenced, with the pane it was measured against.
+        ///
+        /// The geometry rather than the count, because "how many" is a number that says a bug
+        /// happened and "at what viewport" is the one that says which frame did it. Two reads of
+        /// the clip view, on a path that has just laid out a hosting view, so the cost is not a
+        /// thing to weigh.
+        private func noteSilence(row: Int, entry: TranscriptTableEntry, source: String) {
+            let clip = scrollView?.contentView
+            TranscriptHoldCensus.silenced(TranscriptHoldCensus.Silence(
+                row: row,
+                source: source,
+                shape: String(describing: entry.shape),
+                columnWidth: Double(columnWidth),
+                viewportWidth: Double(clip?.bounds.width ?? 0),
+                viewportHeight: Double(clip?.bounds.height ?? 0)
+            ))
+        }
+
+        /// **What the cache and the table each believe about these rows.**
+        ///
+        /// For `ComposerProbe` and for nothing else. The transcript going blank is rows silenced
+        /// one at a time rather than a pane that went dark, so the report that can answer it is a
+        /// row by row table and no counter is a substitute for one. A row with `known` nought and
+        /// `drawsNothing` false is a row the reader has lost.
+        ///
+        /// Nothing here is a measurement: every field is a lookup or a rect the table already
+        /// holds. It is called twice per run, while the pane is standing still.
+        func rowFacts(for rows: some Sequence<Int>) -> [RowFact] {
+            rows.compactMap { row in
+                guard entries.indices.contains(row) else { return nil }
+                let entry = entries[row]
+                return RowFact(
+                    row: row,
+                    name: String(describing: entry.id),
+                    shape: String(describing: entry.shape),
+                    drawsNothing: entry.drawsNothing,
+                    known: heights.height(for: entry.contentKey),
+                    assumed: heights.assumed(
+                        for: entry.contentKey, shape: entry.shape, drawsNothing: entry.drawsNothing
+                    ),
+                    measuredNothing: heights.measuredNothing(entry.contentKey),
+                    needsMeasuring: heights.needsMeasuring(
+                        entry.contentKey, redrawsItself: entry.id.redrawsItself
+                    ),
+                    told: Double(tableView?.rect(ofRow: row).height ?? 0),
+                    top: Double(tableView?.rect(ofRow: row).minY ?? 0),
+                    hasCell: tableView?.view(atColumn: 0, row: row, makeIfNecessary: false) != nil
+                )
+            }
+        }
+
+        /// **How many heights the cache is holding, and what it is holding them for.**
+        ///
+        /// The number that tells an emptying from a miss. `forget` and `reset` take every measured
+        /// height away in one go, and afterwards every row is answered from the mean, which is a
+        /// document of the wrong length rather than a cache with a hole in it. A step of a drag
+        /// where this falls to nothing is a step that emptied it, and the width beside it says
+        /// which of the two did.
+        var heightCacheCount: Int { heights.count }
+        var heightCacheWidth: Double { heights.measure?.width ?? 0 }
+        var heightCacheIsReady: Bool { heights.isReady }
+
+        /// The rows the pane can see, for a probe that has no business knowing how that is worked
+        /// out. See `visibleRows`.
+        var visibleRowRange: Range<Int> { visibleRows }
+
+        /// One row, as a probe reads it.
+        struct RowFact: Sendable {
+            var row: Int
+            /// The entry id as text, for a person reading the report. Not an id: nothing looks a
+            /// row up by it, which is why it is not `TranscriptEntryID`.
+            var name: String
+            var shape: String
+            /// What `TranscriptRowInk` expected before anything was drawn.
+            var drawsNothing: Bool
+            /// What has been measured, or nothing if nobody has measured it. Nought here with
+            /// `drawsNothing` false is the silence.
+            var known: Double?
+            /// What the table is told, which is `known` when there is one.
+            var assumed: Double
+            var measuredNothing: Bool
+            var needsMeasuring: Bool
+            /// What the table is actually drawing the row at now.
+            var told: Double
+            /// Where the row starts in the document, so a report can add the heights up against
+            /// what the reader can see. A document taller than the content it draws is the gap.
+            var top: Double
+            /// Whether the table is holding a cell for it, which a silenced row never is.
+            var hasCell: Bool
         }
     }
 }

--- a/Sources/Bloom/Views/Transcript/TranscriptTable.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTable.swift
@@ -1926,7 +1926,8 @@ struct TranscriptTable: NSViewRepresentable {
                     ),
                     told: Double(tableView?.rect(ofRow: row).height ?? 0),
                     top: Double(tableView?.rect(ofRow: row).minY ?? 0),
-                    hasCell: tableView?.view(atColumn: 0, row: row, makeIfNecessary: false) != nil
+                    hasCell: tableView?.view(atColumn: 0, row: row, makeIfNecessary: false) != nil,
+                    redrawsItself: entry.id.redrawsItself
                 )
             }
         }
@@ -1969,6 +1970,11 @@ struct TranscriptTable: NSViewRepresentable {
             var top: Double
             /// Whether the table is holding a cell for it, which a silenced row never is.
             var hasCell: Bool
+            /// One of the three entries that re-render from their own observation. Nought is never
+            /// held against one of these: the streaming tail draws nothing between turns and is
+            /// measured on every pass, so a report that counted them counted one per pass. See
+            /// `viewFor`, which exempts them from the silence guard.
+            var redrawsItself: Bool
         }
     }
 }

--- a/Sources/Bloom/Views/Transcript/TranscriptTable.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTable.swift
@@ -781,9 +781,9 @@ struct TranscriptTable: NSViewRepresentable {
             guard let row = index[entryID], entries.indices.contains(row),
                   entries[row].contentKey == contentKey else { return }
             // The other half of the same question `measureExactly` asks: a row the reader was
-            // being shown, reporting that it drew nothing after all. See
-            // `TranscriptHoldCensus.silenced`.
-            if height == 0, !entries[row].drawsNothing {
+            // being shown, reporting that it drew nothing after all. The three that redraw
+            // themselves are left out here for the reason they are left out there.
+            if height == 0, !entries[row].drawsNothing, !entryID.redrawsItself {
                 noteSilence(row: row, entry: entries[row], source: "drawn")
             }
             guard heights.note(height, for: contentKey, shape: entries[row].shape) else { return }
@@ -1825,7 +1825,13 @@ struct TranscriptTable: NSViewRepresentable {
                 // reader never sees again: nought is remembered as an answer, so `viewFor` will
                 // not build it and `needsMeasuring` will not ask again. See
                 // `TranscriptHoldCensus.silenced`, and `ComposerProbe`, which is reading it.
-                if height == 0, !entry.drawsNothing {
+                //
+                // **Not the three entries that redraw themselves**, and leaving them in was this
+                // instrument's own false positive: the streaming tail draws nothing between turns
+                // and is measured on every pass, so a probe run counted one silence per pass and
+                // read as a climbing fault. `viewFor` exempts them from the guard for the same
+                // reason, so nought is never held against them.
+                if height == 0, !entry.drawsNothing, !entry.id.redrawsItself {
                     noteSilence(row: row, entry: entry, source: "measureExactly")
                 }
                 let taken = heights.note(height, for: entry.contentKey, shape: entry.shape)

--- a/Sources/Bloom/Views/Transcript/TranscriptTable.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTable.swift
@@ -797,10 +797,12 @@ struct TranscriptTable: NSViewRepresentable {
                     reportedWidth: Double(size.width),
                     cacheWidth: heights.measure?.width ?? 0,
                     columnWidth: Double(columnWidth),
-                    cellWidth: Double(
-                        tableView?.view(atColumn: 0, row: row, makeIfNecessary: false)?
-                            .frame.width ?? 0
-                    ),
+                    // Minus one for "the table is holding no view for this row", which is a
+                    // different fact from a view that is nought wide and was conflated with it
+                    // the first time this was written. See `Mismatch.cellWidth`.
+                    cellWidth: tableView?
+                        .view(atColumn: 0, row: row, makeIfNecessary: false)
+                        .map { Double($0.frame.width) } ?? -1,
                     reportedHeight: Double(height),
                     knownHeight: heights.height(for: contentKey) ?? -1
                 ))

--- a/Sources/Bloom/Views/Transcript/TranscriptTable.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTable.swift
@@ -656,8 +656,8 @@ struct TranscriptTable: NSViewRepresentable {
             let identifier = NSUserInterfaceItemIdentifier("bloom.transcript.cell")
             let cell = tableView.makeView(withIdentifier: identifier, owner: self)
                 as? TranscriptTableCell ?? TranscriptTableCell(identifier: identifier)
-            cell.onHeightChange = { [weak self] id, key, height in
-                self?.noted(height: height, of: key, for: id)
+            cell.onMeasured = { [weak self] id, key, size in
+                self?.noted(size: size, of: key, for: id)
             }
             // **Every row in the visible rect gets one of these, and this is where a row's SwiftUI
             // graph is actually built.** It is outside the pane's own layout pass, so
@@ -771,8 +771,12 @@ struct TranscriptTable: NSViewRepresentable {
         /// The guard costs one comparison and closes the class: a height is about the content it
         /// was taken from, so a report whose content has been replaced is not evidence about what
         /// is there now.
+        /// **And it carries the width it was laid out at**, because a height is a fact about a
+        /// width and this is the path that had no guard on one. See
+        /// `TranscriptRowHeights.isEvidence`, and `TranscriptHoldCensus.reportedAtAnotherWidth`,
+        /// which counts what this refuses so the reason a cell was laid out narrow can be found.
         private func noted(
-            height: CGFloat, of contentKey: TranscriptContentKey, for entryID: TranscriptEntryID
+            size: CGSize, of contentKey: TranscriptContentKey, for entryID: TranscriptEntryID
         ) {
             // The tail goes on growing inside its frozen cell while a pane is dragged, and a
             // height taken from it would be filed against the entry list this pass is not
@@ -780,13 +784,35 @@ struct TranscriptTable: NSViewRepresentable {
             guard !isHeld else { return }
             guard let row = index[entryID], entries.indices.contains(row),
                   entries[row].contentKey == contentKey else { return }
+            let height = size.height
+            // Counted before it is refused, and counted whatever the height was: what is being
+            // watched for is a cell laid out at a width the table is not, and a report that
+            // happens to agree about the height is the same event.
+            if !TranscriptRowHeights.isEvidence(
+                measuredAt: Double(size.width), forCacheAt: heights.measure?.width
+            ) {
+                TranscriptHoldCensus.reportedAtAnotherWidth(TranscriptHoldCensus.Mismatch(
+                    row: row,
+                    shape: String(describing: entries[row].shape),
+                    reportedWidth: Double(size.width),
+                    cacheWidth: heights.measure?.width ?? 0,
+                    columnWidth: Double(columnWidth),
+                    reportedHeight: Double(height),
+                    knownHeight: heights.height(for: contentKey) ?? -1
+                ))
+            }
             // The other half of the same question `measureExactly` asks: a row the reader was
             // being shown, reporting that it drew nothing after all. The three that redraw
             // themselves are left out here for the reason they are left out there.
             if height == 0, !entries[row].drawsNothing, !entryID.redrawsItself {
                 noteSilence(row: row, entry: entries[row], source: "drawn")
             }
-            guard heights.note(height, for: contentKey, shape: entries[row].shape) else { return }
+            guard heights.note(
+                height,
+                for: contentKey,
+                shape: entries[row].shape,
+                measuredAt: Double(size.width)
+            ) else { return }
             // **News to the cache is not always news to the table.** A row the table is already
             // drawing at this height needs no `noteHeightOfRows`, and the whole of a correction's
             // cost is that call: it moves the document's total and makes AppKit lay out every row
@@ -1572,7 +1598,11 @@ struct TranscriptTable: NSViewRepresentable {
                 let key = entry.contentKey
                 guard heights.height(for: key) == nil || heights.isStale(key) else { continue }
                 let taken = heights.note(
-                    measure(entry, at: CGFloat(sizing.width)), for: key, shape: entry.shape
+                    measure(entry, at: CGFloat(sizing.width)),
+                    for: key,
+                    shape: entry.shape,
+                    // The sizer is handed the cache's own width, so this always is evidence.
+                    measuredAt: sizing.width
                 )
                 if taken { moved.insert(row) }
                 // Between rows rather than after all of them, so the cost of being interrupted is
@@ -1834,7 +1864,9 @@ struct TranscriptTable: NSViewRepresentable {
                 if height == 0, !entry.drawsNothing, !entry.id.redrawsItself {
                     noteSilence(row: row, entry: entry, source: "measureExactly")
                 }
-                let taken = heights.note(height, for: entry.contentKey, shape: entry.shape)
+                let taken = heights.note(
+                    height, for: entry.contentKey, shape: entry.shape, measuredAt: sizing.width
+                )
                 if taken { moved.insert(row) }
             }
             return moved
@@ -2006,7 +2038,7 @@ struct TranscriptTable: NSViewRepresentable {
 /// the", session `369a630d`, file chips in user bubbles at seq 387 and 948.
 private struct HostedRow: View {
     let content: AnyView
-    let report: @MainActor (CGFloat) -> Void
+    let report: @MainActor (CGSize) -> Void
     /// Whether this copy is the one in a cell, which has a row's height to fill, or the one being
     /// measured, which has none. Everything else about the two is identical on purpose: a
     /// measurement taken through a different set of modifiers from the one that draws is a
@@ -2030,8 +2062,14 @@ private struct HostedRow: View {
             .background(
                 GeometryReader { proxy in
                     Color.clear
-                        .onChange(of: proxy.size.height, initial: true) { _, height in
-                            report(height)
+                        // **The size and not the height, because a height is a fact about a
+                        // width.** A report taken from a pass that laid this row out narrow says
+                        // nothing about how tall it is at the width the cache is for, and two of
+                        // them are what emptied the owner's transcript. See
+                        // `TranscriptRowHeights.isEvidence`. Still woken by the height alone: a
+                        // width that moves without the height moving changes no answer.
+                        .onChange(of: proxy.size.height, initial: true) { _, _ in
+                            report(proxy.size)
                         }
                 }
             )
@@ -2069,11 +2107,11 @@ private struct TranscriptCellRoot: View {
     var content: AnyView?
     var id: TranscriptEntryID?
     var environment: TranscriptRowEnvironment?
-    var report: (@MainActor (CGFloat) -> Void)?
+    var report: (@MainActor (CGSize) -> Void)?
 
     var body: some View {
         if let content, let id, let environment {
-            HostedRow(content: content, report: { height in report?(height) })
+            HostedRow(content: content, report: { size in report?(size) })
                 // A recycled cell is handed an unrelated row, and without an identity SwiftUI
                 // treats that as the same view changing rather than a different view arriving,
                 // which is what gives it something to animate between. It is also what makes
@@ -2109,7 +2147,7 @@ final class TranscriptTableCell: NSView {
     private var unclip: Task<Void, Never>?
     /// The content a height was measured for goes back with it, because an entry id alone does
     /// not say which conversation it belongs to. See `Coordinator.noted`.
-    var onHeightChange: (@MainActor (TranscriptEntryID, TranscriptContentKey, CGFloat) -> Void)?
+    var onMeasured: (@MainActor (TranscriptEntryID, TranscriptContentKey, CGSize) -> Void)?
 
     init(identifier: NSUserInterfaceItemIdentifier) {
         host = NSHostingView(rootView: TranscriptCellRoot())
@@ -2170,7 +2208,7 @@ final class TranscriptTableCell: NSView {
             content: entry.content(),
             id: id,
             environment: environment,
-            report: { [weak self] height in self?.onHeightChange?(id, key, height) }
+            report: { [weak self] size in self?.onMeasured?(id, key, size) }
         )
         return true
     }

--- a/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
+++ b/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
@@ -199,6 +199,13 @@ public struct TranscriptRowHeights: Equatable, Sendable {
     /// second, and it is about one transcript pane at the height a dragged composer leaves it: the
     /// probe's viewport was 446 points at the end of its drag. So the rule this states is that no
     /// row nobody has looked at may fill the screen on its own.
+    ///
+    /// **No run has exercised it, and a later reader should not think it has been validated.** On
+    /// the probe run that followed the median landing, the largest number handed to an unmeasured
+    /// row was 154 points, so this never fired: the median alone did the work and this stood
+    /// behind it. What would exercise it is a conversation whose rows genuinely are tall, and
+    /// there is no such run. 450 is a reasoned ceiling rather than a measured one, and what would
+    /// move it is a session where a shape's honest middle is above it.
     public static let mostEstimated: Double = 450
 
     /// How many drawn rows it takes before the estimate stops moving.

--- a/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
+++ b/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
@@ -169,17 +169,23 @@ public struct TranscriptRowHeights: Equatable, Sendable {
     /// **What that cost, measured on the owner's own conversation.** Two rows reported heights
     /// from a layout pass during a composer drag and then reported the truth again afterwards:
     /// a three line paragraph whose height is 54 points reported 1,972, and a user message whose
-    /// height is 444 reported 10,806. Both ratios are a row wrapped into a column about fifteen
-    /// points wide. The 10,806 settled the `message` shape's estimate at 6,025 points, which was
-    /// then handed to every unmeasured row of that shape in a 2,650 row table, and the document
-    /// came out 885,212 points long against a true 172,208. That is the blank transcript the owner
-    /// filmed: a viewport inside rows drawn thousands of points tall.
+    /// height is 444 reported 10,806. The 10,806 settled the `message` shape's estimate at 6,025
+    /// points, which was then handed to every unmeasured row of that shape in a 2,650 row table,
+    /// and the document came out 885,212 points long against a true 172,208. That is the blank
+    /// transcript the owner filmed: a viewport inside rows drawn thousands of points tall.
     ///
-    /// **What is known and what is not.** That it happened is measured, from four probe runs where
-    /// exactly one shows the two spikes and three do not. WHY a cell was laid out at a fraction of
-    /// its width for a pass is not known, and this rule does not answer it: it stops the app
-    /// believing the answer, which is a different thing from understanding the question.
-    /// `TranscriptHoldCensus.reportedAtAnotherWidth` counts them so the thread can be picked up.
+    /// **And the case caught with the instrument watching, which is what says where they come
+    /// from.** Row 2593, an `answer`, reported **2,568 points against a known 75, from a layout 24
+    /// points wide, by a cell the table was holding no view for**. A cell that misses the reuse
+    /// pool is built at `frame: .zero` and is handed its content before the table frames it, so
+    /// its graph is laid out against a proposal of nothing and the content bottoms out at its own
+    /// minimum of 24 points. A paragraph wrapped into 24 points is 34 times taller than the same
+    /// paragraph at 420. See `TranscriptHoldCensus.reportedAtAnotherWidth`, which carries the
+    /// reading, the rate of four in fifty one cells built, and why two of those four were harmless.
+    ///
+    /// **This rule refuses the report. It does not stop the report being made**, and the two are
+    /// worth keeping apart: the cause is a cell asked to measure before it has a width, and the
+    /// fix for that is upstream in `TranscriptTable`'s `viewFor` rather than here.
     ///
     /// **Refusing costs nothing**, which is what makes this safe rather than a trade. A row whose
     /// report is refused stays unmeasured for another pass and is drawn from its estimate, which

--- a/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
+++ b/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
@@ -157,6 +157,42 @@ public struct TranscriptRowHeights: Equatable, Sendable {
         abs(one - other) <= 0.5
     }
 
+    /// **Whether a height taken at this width is evidence about the width the cache is for.**
+    ///
+    /// A height is a fact about a width. `reset` and `rewidth` have both refused a width they
+    /// cannot use since the day they were written, and `narrowest`'s own comment says why: a table
+    /// that has not been laid out reports a width of nought or one, and a row measured against
+    /// that is a row one point tall. That guard was on the measuring path and missing from the
+    /// REPORTING one, which is the authoritative half: `note`'s own comment says a report from a
+    /// row that has actually been drawn outranks anything measured off screen.
+    ///
+    /// **What that cost, measured on the owner's own conversation.** Two rows reported heights
+    /// from a layout pass during a composer drag and then reported the truth again afterwards:
+    /// a three line paragraph whose height is 54 points reported 1,972, and a user message whose
+    /// height is 444 reported 10,806. Both ratios are a row wrapped into a column about fifteen
+    /// points wide. The 10,806 settled the `message` shape's estimate at 6,025 points, which was
+    /// then handed to every unmeasured row of that shape in a 2,650 row table, and the document
+    /// came out 885,212 points long against a true 172,208. That is the blank transcript the owner
+    /// filmed: a viewport inside rows drawn thousands of points tall.
+    ///
+    /// **What is known and what is not.** That it happened is measured, from four probe runs where
+    /// exactly one shows the two spikes and three do not. WHY a cell was laid out at a fraction of
+    /// its width for a pass is not known, and this rule does not answer it: it stops the app
+    /// believing the answer, which is a different thing from understanding the question.
+    /// `TranscriptHoldCensus.reportedAtAnotherWidth` counts them so the thread can be picked up.
+    ///
+    /// **Refusing costs nothing**, which is what makes this safe rather than a trade. A row whose
+    /// report is refused stays unmeasured for another pass and is drawn from its estimate, which
+    /// is the state every row in a conversation starts in; it is laid out again at the right width
+    /// on the next pass and reports again, and that is the same mechanism that repairs every wrong
+    /// height in this file today. What it cannot do is leave a row unmeasured for ever: the width
+    /// the cache is for comes from `columnWidth`, which is the table's own width, and a cell is
+    /// laid out inside that table, so the two agree except across the pass that changes them.
+    public static func isEvidence(measuredAt width: Double, forCacheAt cacheWidth: Double?) -> Bool {
+        guard let cacheWidth else { return false }
+        return isSameWidth(cacheWidth, width)
+    }
+
     /// The most rows remembered before the cache is emptied and started again.
     ///
     /// **A pane keeps the heights of every conversation it has drawn**, which is what makes
@@ -683,9 +719,15 @@ public struct TranscriptRowHeights: Equatable, Sendable {
     /// which is what every row was told before there were shapes at all.
     @discardableResult
     public mutating func note(
-        _ height: Double, for contentKey: TranscriptContentKey, shape: TranscriptRowShape = .other
+        _ height: Double,
+        for contentKey: TranscriptContentKey,
+        shape: TranscriptRowShape = .other,
+        measuredAt width: Double
     ) -> Bool {
-        guard measure != nil else { return false }
+        // **A height is a fact about a width**, and one taken at another width is not news about
+        // this one. See `isEvidence`, which carries the two rows that reported 1,972 and 10,806
+        // points from a pass that laid them out fifteen points wide.
+        guard Self.isEvidence(measuredAt: width, forCacheAt: measure?.width) else { return false }
         // Before the news test below, so a row that turns out to be exactly as tall as it was at
         // the old width still stops being owed a measurement.
         stale.remove(contentKey)

--- a/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
+++ b/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
@@ -31,8 +31,10 @@ import Foundation
 /// Building the four hundred `NSHostingView`s a window used to open with was the whole of "opening
 /// a workspace or a tab with a chat in it is slow", and none of them was for a row anybody saw.
 ///
-/// The estimate is the running mean of what HAS been measured here, which after one screen of a
-/// real conversation is a better number than any constant, and `assumedRowHeight` until then. What
+/// The estimate is the middle of what HAS been measured here, which after one screen of a real
+/// conversation is a better number than any constant, and `assumedRowHeight` until then. Never
+/// more than `mostEstimated`, because a guess that fills the screen on its own is worse than no
+/// rows at all: see `Running.middle` for the conversation that was drawn 885,212 points long. What
 /// keeps this honest is that no placement is ever resolved against an estimate: the caller
 /// measures the screen it is about to show, exactly, before it shows it.
 ///
@@ -83,11 +85,11 @@ import Foundation
 /// draws from its top down, so the difference is blank under every one of them.
 ///
 /// A conversation does not have one row height. It has a handful of clusters, and which cluster a
-/// row is in is known from the row before anything is drawn: see `TranscriptRowShape`. So the mean
-/// is kept per shape as well as over the whole conversation, and an unmeasured row is told its own
-/// shape's number as soon as there is one. `settleShapeAfter` is how much evidence "one" takes,
-/// and it is deliberately small, because rows of one shape cluster: three folds say more about the
-/// fourth fold than twenty-four paragraphs do.
+/// row is in is known from the row before anything is drawn: see `TranscriptRowShape`. So the
+/// number is kept per shape as well as over the whole conversation, and an unmeasured row is told
+/// its own shape's number as soon as there is one. `settleShapeAfter` is how much evidence "one"
+/// takes, and it is deliberately small, because rows of one shape cluster: three folds say more
+/// about the fourth fold than twenty-four paragraphs do.
 ///
 /// What this cannot do is remove the gap. A row nobody has measured is a guess whatever it is
 /// grouped with, and prose is genuinely unpredictable: two answers in the same conversation differ
@@ -175,6 +177,29 @@ public struct TranscriptRowHeights: Equatable, Sendable {
     /// is deliberately nearer the short end. Guessing high would open every conversation with a
     /// document several times the height of its content and a scroller to match.
     public static let assumedRowHeight: Double = 64
+
+    /// **The most a row nobody has looked at may be told it is.**
+    ///
+    /// A ceiling on the GUESS and never on a measurement: a row that really is ten thousand points
+    /// tall is told ten thousand the moment anything measures it. This is only about what the
+    /// table is handed for the rows it has not asked about, which on a long conversation is nearly
+    /// all of them.
+    ///
+    /// **The asymmetry is the whole argument, and it is not symmetric at all.** Guessing low costs
+    /// a row that grows when it is drawn, which is the design already: every height is corrected
+    /// by `note` the moment the row is laid out, and the document gets longer under rows nobody is
+    /// looking at. Guessing high costs a screenful of white with nothing in it, which a reader
+    /// cannot tell from a broken app, and which they cannot get out of by scrolling because the
+    /// next screen is more of the same row.
+    ///
+    /// **The number is from the data rather than from taste.** Two `ComposerProbe` runs over the
+    /// owner's own conversation produced six settled shape estimates that were plausible (24,
+    /// 37.7, 303.2, 346.8, 361.3 and 417.7 points) and two that were the bug (790.7, and 6,025.3
+    /// for four rows at once). 450 is above every one of the first group and below both of the
+    /// second, and it is about one transcript pane at the height a dragged composer leaves it: the
+    /// probe's viewport was 446 points at the end of its drag. So the rule this states is that no
+    /// row nobody has looked at may fill the screen on its own.
+    public static let mostEstimated: Double = 450
 
     /// How many drawn rows it takes before the estimate stops moving.
     ///
@@ -285,12 +310,22 @@ public struct TranscriptRowHeights: Equatable, Sendable {
     /// shape, and they are the same three decisions each time: what the mean is, when it stops
     /// moving, and when it is worth taking again.
     private struct Running: Equatable, Sendable {
-        /// The sum of the sampled heights, kept in step on every write so the mean costs nothing
-        /// to ask.
-        var total: Double = 0
-        /// How many of the sampled rows are more than nothing, which is what the mean divides by.
-        /// See `estimate` for why a mean over the rows that drew nothing was the wrong number.
+        /// How many of the sampled rows are more than nothing, which is what a rank is taken over.
+        /// See `middle` for why the rows that drew nothing are not in it.
         var inked = 0
+        /// **The sample, as a count per height, which is what makes a median affordable here.**
+        ///
+        /// A tally rather than a list, and the difference is what `absorb(_:replacing:)` needs: a
+        /// row that reports again has to come out of the sample it went into exactly, and a list
+        /// of recent values could not do that for the streaming tail, which reports on every frame
+        /// of a turn.
+        ///
+        /// Keyed on the height itself rather than on a band of them, because `note` has already
+        /// rounded every measurement up to a whole point: the key is what it stores, so the median
+        /// is the true one rather than a bucket's middle, and there is no width to justify. What
+        /// bounds this is the number of DISTINCT heights in a conversation, which is a few hundred
+        /// where the rows are tens of thousands.
+        var counts: [Int: Int] = [:]
         /// The estimate once it has stopped moving, or nothing while it is still being formed. See
         /// `settleAfter`, which carries what a drifting one costs.
         var settled: Double?
@@ -301,7 +336,40 @@ public struct TranscriptRowHeights: Equatable, Sendable {
         /// What this says a row is worth, or nothing if it has nothing to say yet.
         var estimate: Double? {
             if let settled { return settled }
-            return inked == 0 ? nil : total / Double(inked)
+            return middle
+        }
+
+        /// **The median of the sample, and it was a mean.**
+        ///
+        /// The old argument for the mean is worth keeping and it was a cost one: the sum is held
+        /// as it is written, so asking is free, where a median would mean keeping the numbers
+        /// sorted. That is true, it lost to a correctness argument measured on the owner's own
+        /// conversation with `ComposerProbe`, and the cost turned out to be a tally of a few
+        /// hundred distinct heights sorted a handful of times a session. See `counts`.
+        ///
+        /// **A transcript's row heights are not a distribution a mean describes.** Of 408 rows in
+        /// one band, 26 had ever been measured at more than nothing; their mean was 651 points and
+        /// their largest was 10,806, against a typical row of a few dozen. `settleShapeAfter` is
+        /// three, so three samples settle a shape's number for every unmeasured row of it, and one
+        /// long answer in a sample of five is what handed 54 unmeasured rows 347 points each and,
+        /// before it re-settled, four rows 6,025 points each. Fourteen screens, for content nobody
+        /// had looked at. The document came out 885,212 points long against a true 172,208, and a
+        /// viewport inside rows drawn like that is the blank transcript the owner filmed.
+        ///
+        /// A median has none of that: one row of ten thousand points moves it by one rank. And it
+        /// errs SHORT on a distribution with a tail, which is the direction that costs nothing:
+        /// see `mostEstimated`.
+        ///
+        /// The lower median for an even sample, for the same reason.
+        var middle: Double? {
+            guard inked > 0 else { return nil }
+            let wanted = (inked - 1) / 2
+            var seen = 0
+            for height in counts.keys.sorted() {
+                seen += counts[height] ?? 0
+                if seen > wanted { return Double(height) }
+            }
+            return nil
         }
 
         /// Takes a measurement in, and the one it replaces out.
@@ -310,27 +378,38 @@ public struct TranscriptRowHeights: Equatable, Sendable {
         /// frame of a turn and any row corrected after it was drawn, what it said before comes out
         /// again: the sample is one contribution per row, not one per report.
         mutating func absorb(_ height: Double, replacing previous: Double, settlingAfter: Int) {
-            total += height - previous
-            if previous > 0 { inked -= 1 }
-            if height > 0 { inked += 1 }
+            remove(previous)
+            add(height)
             settleIfItIsTime(settlingAfter: settlingAfter)
         }
 
         /// Takes a measurement back out, for a row that is moving to another shape's sample.
         mutating func release(_ height: Double) {
-            total -= height
-            if height > 0 { inked -= 1 }
+            remove(height)
+        }
+
+        private mutating func add(_ height: Double) {
+            guard height > 0 else { return }
+            counts[Int(height), default: 0] += 1
+            inked += 1
+        }
+
+        private mutating func remove(_ height: Double) {
+            guard height > 0 else { return }
+            let key = Int(height)
+            guard let count = counts[key] else { return }
+            if count <= 1 { counts[key] = nil } else { counts[key] = count - 1 }
+            inked -= 1
         }
 
         /// Takes the estimate, if there is enough to take it from and it is worth taking again.
         ///
         /// Once at `settlingAfter`, and after that only when the sample has doubled AND the
-        /// running mean disagrees with what is held by more than `resettleDrift`. Both of those,
+        /// running median disagrees with what is held by more than `resettleDrift`. Both of those,
         /// so that a good first sample settles the number for the whole session and a bad one is
         /// not permanent.
         private mutating func settleIfItIsTime(settlingAfter: Int) {
-            guard inked >= settlingAfter else { return }
-            let running = total / Double(inked)
+            guard inked >= settlingAfter, let running = middle else { return }
             guard let settled else { return take(running) }
             guard inked >= settledFrom * 2 else { return }
             guard abs(running - settled) > settled * TranscriptRowHeights.resettleDrift else {
@@ -502,16 +581,23 @@ public struct TranscriptRowHeights: Equatable, Sendable {
         heights[contentKey] == 0
     }
 
-    /// The mean over the rows of THIS conversation that have been measured here and drew
-    /// something, or `assumedRowHeight` before there is one. See `showing(_:)` for why the
-    /// conversation is in that sentence.
+    /// The middle of the rows of THIS conversation that have been measured here and drew
+    /// something, or `assumedRowHeight` before there is one, and never more than `mostEstimated`.
+    /// See `showing(_:)` for why the conversation is in that sentence.
     ///
     /// **It is the fallback rather than the answer now.** What an unmeasured row is actually told
     /// is `estimate(for:)`, which is this number only while the row's own kind has too little
     /// evidence to speak for itself.
     ///
-    /// A mean rather than a median, because it is kept as a running total and a median would mean
-    /// holding the numbers sorted for an answer that is corrected the moment the row is drawn.
+    /// **It was a mean, and the argument for that was: kept as a running total, so asking is free,
+    /// where a median would mean holding the numbers sorted for an answer that is corrected the
+    /// moment the row is drawn.** That is a cost argument and it was true. It lost to a
+    /// correctness one, measured rather than argued: a transcript's row heights run from nothing
+    /// to ten thousand points, a mean over a handful of them is whatever the longest answer in the
+    /// sample says, and the document it produced was 885,212 points long against a true 172,208.
+    /// The cost the old argument was avoiding turned out to be a tally of the few hundred
+    /// DISTINCT heights a conversation has, sorted a handful of times a session. See
+    /// `Running.counts` and `Running.middle`, which carry the whole measurement.
     ///
     /// **The rows that drew nothing are deliberately not in it, and they used to be.** Most of a
     /// session is stream events that draw no view at all, so a mean over every measurement is a
@@ -520,21 +606,22 @@ public struct TranscriptRowHeights: Equatable, Sendable {
     /// consulting this at all, so including them made the one number this still answers worse for
     /// no one's benefit.
     ///
-    /// **And it stops moving once a screenful has been drawn.** See `settleAfter`: a running mean
-    /// is the right answer to "how tall is a row I know nothing about" and the wrong answer to
-    /// "how tall is this document", and the second question is the one a reader feels.
+    /// **And it stops moving once a screenful has been drawn.** See `settleAfter`: a running
+    /// number is the right answer to "how tall is a row I know nothing about" and the wrong answer
+    /// to "how tall is this document", and the second question is the one a reader feels.
     public var estimate: Double {
-        overall.estimate ?? Self.assumedRowHeight
+        min(Self.mostEstimated, overall.estimate ?? Self.assumedRowHeight)
     }
 
     /// **What an unmeasured row OF THIS SHAPE is worth**, which is the answer a reader scrolling
     /// back sees and the whole of the second fix.
     ///
-    /// The shape's own mean once `settleShapeAfter` rows of it have been drawn, and the
-    /// conversation's mean until then. Falling back rather than waiting, because a shape with no
-    /// evidence yet is exactly the state the old single number was always in, so the fallback can
-    /// only be as wrong as today and the shape can only be better: the two clusters a shape
-    /// separates are separated by more than the noise inside either of them.
+    /// The shape's own number once `settleShapeAfter` rows of it have been drawn, and the
+    /// conversation's until then, and neither of them above `mostEstimated`. Falling back rather
+    /// than waiting, because a shape with no evidence yet is exactly the state the old single
+    /// number was always in, so the fallback can only be as wrong as today and the shape can only
+    /// be better: the two clusters a shape separates are separated by more than the noise inside
+    /// either of them.
     ///
     /// See `TranscriptRowShape` for why a fold's line is the case that settles this: the same
     /// height every time it is drawn, one per turn all the way back through the conversation, and
@@ -548,7 +635,9 @@ public struct TranscriptRowHeights: Equatable, Sendable {
         guard shape != .other, let running = shapes[shape],
               running.inked >= Self.settleShapeAfter, let answer = running.estimate
         else { return estimate }
-        return answer
+        // Capped here as well as in `estimate`, because these are the two spellings of one
+        // question and a caller must not be able to reach the unbounded one. See `mostEstimated`.
+        return min(Self.mostEstimated, answer)
     }
 
     /// **The number to tell a table**: what is known, what is known to be nothing, or what is

--- a/Sources/BloomCore/Transcript/TranscriptTableUpdate.swift
+++ b/Sources/BloomCore/Transcript/TranscriptTableUpdate.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// What a transcript table is told about a pass: the rows that moved, or the whole thing again.
+///
+/// **This exists because telling it both in one pass beach balled the app for three minutes.**
+/// A `sample` of 1.1.0 on the owner's machine put all 1,388 samples of the main thread in one
+/// stack: `Coordinator.apply` into `-[NSTableView reloadData]`, then `purgeRowViewData`,
+/// `removeAllKnownSubviews`, `_removeRowsBeingAnimatedOff`, and per row
+/// `_removeViewAndAddToReuse:forRow:` into `removeFromSuperviewWithoutNeedingDisplay`. The leaves
+/// were `NSHostingView.viewWillMove(toWindow:)` calling `removeObserver:forKeyPath:`, inside
+/// `_NSKeyValueObservationInfoCreateByRemoving` and `NSKeyValueShareableObservationInfoNSHTHash`.
+/// That is the window's observation info being rebuilt and rehashed once per hosting view removed,
+/// which is O(n) each and therefore O(n²) for n rows coming off the window at once.
+///
+/// **`_removeRowsBeingAnimatedOff` is what names the pass.** AppKit only holds a row view there
+/// after `removeRowsAtIndexes:withAnimation:`, and the one place a removal was followed by a full
+/// reload was `apply`: `.shrank` staged rows out through `rowsLeft`, and then the environment
+/// having moved reloaded the table on top of it, so the reload had every one of those staged
+/// views to tear down as well as the ones on screen. Told one thing rather than two, the reload
+/// is the only edit and the removal never happens. (Not proven from AppKit's own code: if
+/// `removeAllKnownSubviews` routes ordinary row views through the same helper then the call site
+/// this was read off flips, and nothing else here changes.)
+///
+/// **It is not a regression.** `TranscriptTable` is eleven lines different between 1.0.1 and
+/// 1.1.0 and all eleven are a guard added elsewhere, so 1.0.1 does exactly the same thing. What
+/// made it show up on the first launch after an update is the unread mark:
+/// `TranscriptListView.mustReachIndex` opens the drawn window around the first unread row rather
+/// than at the tail, which is the middle of the conversation, and the middle is where the runs of
+/// rows that draw nothing are. Those are answered with a hundredth of a point until something has
+/// measured them, so a viewport holds hundreds or thousands of them and the table builds a real
+/// `NSHostingView` for every one. Read once, the mark is cleared and the next launch opens on the
+/// last eighty rows, which is why quitting and reopening did not do it again.
+///
+/// What this does NOT fix is the number of realised rows, which is what makes n large in the
+/// first place. See `TranscriptRowHeights.assumed` and `TranscriptTable`'s `viewFor` guard, which
+/// only skips a row once it has been measured at nothing.
+public enum TranscriptTableUpdate {
+    /// The one edit a pass may make to the table's rows.
+    public enum Plan: Equatable, Sendable {
+        /// The list is the same list. Whatever changed is inside the rows, and the caller reloads
+        /// those by index.
+        case nothing
+        /// Rows in or out, at the runs the change names. The cheap path, and the whole point of
+        /// `TranscriptEntryChange`.
+        case rows(TranscriptEntryChange)
+        /// Every cell thrown away and the visible ones built again.
+        case reload
+    }
+
+    /// **One edit per pass, and never a staged removal underneath a reload.**
+    ///
+    /// A moved environment is every cell whatever else happened, because a cell holds the values
+    /// it was built in: see `TranscriptRowEnvironment`, and `cellGeneration`, which is what stops
+    /// the reuse pool handing the same cells back. So it answers `.reload` and the rows are not
+    /// staged at all. A rebuilt list is the same answer for its own reason, which is that the two
+    /// lists share no run a table could be told about.
+    ///
+    /// `.same` is `.nothing` rather than `.rows(.same)`: there is no row edit to make, and saying
+    /// so here means the caller has no empty branch to forget about.
+    public static func plan(change: TranscriptEntryChange, environmentMoved: Bool) -> Plan {
+        if environmentMoved || change == .rebuilt { return .reload }
+        return change == .same ? .nothing : .rows(change)
+    }
+}

--- a/Tests/BloomCoreTests/TranscriptBlankOnResizeTests.swift
+++ b/Tests/BloomCoreTests/TranscriptBlankOnResizeTests.swift
@@ -127,8 +127,8 @@ struct TranscriptBlankOnResizeTests {
         var heights = TranscriptRowHeights()
         let first = heights.reset(width: 900, scale: 1, leading: 1.7)
         #expect(first)
-        heights.note(240, for: key("row.7"), shape: .answer)
-        heights.note(22, for: key("row.8"), shape: .fold)
+        heights.note(240, for: key("row.7"), shape: .answer, measuredAt: 900)
+        heights.note(22, for: key("row.8"), shape: .fold, measuredAt: 900)
 
         // The pane is half as tall as it was. Nothing above changed, so nothing here may.
         let again = heights.reset(width: 900, scale: 1, leading: 1.7)
@@ -144,7 +144,7 @@ struct TranscriptBlankOnResizeTests {
     func rewidthIsAWidthQuestion() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 900, scale: 1, leading: 1.7)
-        heights.note(240, for: key("row.7"), shape: .answer)
+        heights.note(240, for: key("row.7"), shape: .answer, measuredAt: 900)
 
         let moved = heights.rewidth(to: 900)
         #expect(!moved)
@@ -159,7 +159,7 @@ struct TranscriptBlankOnResizeTests {
     func staysReady() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 900, scale: 1, leading: 1.7)
-        heights.note(240, for: key("row.7"), shape: .answer)
+        heights.note(240, for: key("row.7"), shape: .answer, measuredAt: 900)
         heights.forget()
         #expect(heights.isReady)
         let refused = heights.reset(width: 0.5, scale: 1, leading: 1.7)
@@ -176,8 +176,8 @@ struct TranscriptBlankOnResizeTests {
     func silencesNothing() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 900, scale: 1, leading: 1.7)
-        heights.note(240, for: key("row.7"), shape: .answer)
-        heights.note(0, for: key("row.8"), shape: .notice)
+        heights.note(240, for: key("row.7"), shape: .answer, measuredAt: 900)
+        heights.note(0, for: key("row.8"), shape: .notice, measuredAt: 900)
 
         let same = heights.reset(width: 900, scale: 1, leading: 1.7)
         #expect(!same)

--- a/Tests/BloomCoreTests/TranscriptRowHeightsTests.swift
+++ b/Tests/BloomCoreTests/TranscriptRowHeightsTests.swift
@@ -296,14 +296,17 @@ struct TranscriptRowHeightsTests {
         #expect(heights.assumed(for: key("row.7")) == TranscriptRowHeights.assumedRowHeight)
     }
 
+    /// The MIDDLE of what has been measured, and it was the mean. See `Running.middle`: a
+    /// transcript's row heights run from nothing to ten thousand points, so a mean over a handful
+    /// of them is whatever the longest answer in the sample says.
     @Test("what has been measured is what the rest is assumed to be")
-    func assumesTheMeanOfWhatIsKnown() {
+    func assumesTheMiddleOfWhatIsKnown() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
         heights.note(100, for: key("row.1"))
         heights.note(200, for: key("row.2"))
-        #expect(heights.estimate == 150)
-        #expect(heights.assumed(for: key("row.99")) == 150)
+        #expect(heights.estimate == 100)
+        #expect(heights.assumed(for: key("row.99")) == 100)
         // And the measured ones are still themselves.
         #expect(heights.assumed(for: key("row.1")) == 100)
     }
@@ -405,7 +408,7 @@ struct TranscriptRowHeightsTests {
         heights.note(100, for: key("row.1"))
         heights.note(200, for: key("row.2"))
         for row in 0..<50 { heights.note(0, for: key("blank.\(row)")) }
-        #expect(heights.estimate == 150)
+        #expect(heights.estimate == 100)
         // The noughts are still remembered, and still nought.
         #expect(heights.height(for: key("blank.7")) == 0)
         #expect(heights.count == 52)
@@ -462,9 +465,11 @@ struct TranscriptRowHeightsTests {
         // leaves forty seven drawn rows against the twenty four it settled from.
         for row in 0..<23 { heights.note(20, for: key("row.\(row)")) }
         #expect(heights.estimate == 400)
-        // The forty eighth doubles it, and 210 is the mean of the two halves.
+        // The forty eighth doubles it, and twenty is what half the rows in this conversation
+        // actually are. The mean this used to take answered 210, which is a height no row in the
+        // sample has and which every unmeasured row would have been drawn at.
         heights.note(20, for: key("row.23"))
-        #expect(heights.estimate == 210)
+        #expect(heights.estimate == 20)
     }
 
     /// A number that is nearly right must not move, because the whole point of settling is that a
@@ -483,7 +488,11 @@ struct TranscriptRowHeightsTests {
     }
 
     /// Before it settles it still tracks, because the first screenful is all there is to go on and
-    /// a constant is worse than a mean of two real rows.
+    /// a constant is worse than two real rows.
+    ///
+    /// **What it no longer does is track the outlier.** A second row three times the first used to
+    /// move the answer to 200, a height neither row has; the middle of the two is the shorter one,
+    /// and the taller row is measured on its own account anyway.
     @Test("the estimate tracks until it settles")
     func tracksUntilItSettles() {
         var heights = TranscriptRowHeights()
@@ -491,7 +500,7 @@ struct TranscriptRowHeightsTests {
         heights.note(100, for: key("row.1"))
         #expect(heights.estimate == 100)
         heights.note(300, for: key("row.2"))
-        #expect(heights.estimate == 200)
+        #expect(heights.estimate == 100)
     }
 
     /// A width or a text size change empties the cache, and the number formed at the old one goes
@@ -520,7 +529,7 @@ struct TranscriptRowHeightsTests {
         #expect(heights.estimate == 100)
         heights.note(300, for: key("row.2"))
         // Two drawn rows is not a screenful, so it is still tracking.
-        #expect(heights.estimate == 200)
+        #expect(heights.estimate == 100)
     }
 
     /// The running total has to survive an overwrite, which is what every drawn row does to what
@@ -552,7 +561,7 @@ struct TranscriptRowHeightsTests {
         heights.note(100, for: key("row.1"))
         heights.note(200, for: key("row.2"))
         heights.rewidth(to: 600)
-        #expect(heights.estimate == 150)
+        #expect(heights.estimate == 100)
     }
 
     // MARK: - The estimate belongs to the conversation on screen
@@ -642,8 +651,9 @@ struct TranscriptRowHeightsTests {
         heights.reset(width: 800, scale: 1, leading: 1.7)
         heights.note(100, for: key("row.1"))
         for step in 1...20 { heights.note(Double(100 + step * 10), for: key("tail")) }
-        // The tail's last word and one other row: 300 and 100.
-        #expect(heights.estimate == 200)
+        // The tail's last word and one other row: 300 and 100, whose middle is 100. Counted per
+        // report rather than per row it would be a sample of twenty one tail heights.
+        #expect(heights.estimate == 100)
     }
 
     @Test("saying the same conversation again changes nothing")
@@ -833,7 +843,10 @@ struct TranscriptRowHeightsTests {
         for row in 0..<TranscriptRowHeights.settleAfter {
             heights.note(800, for: key("answer.\(row)"), shape: .answer)
         }
-        #expect(heights.estimate == 703.5)
+        // The bound, doing its job: the middle of this sample is the 800 point answer, and no row
+        // nobody has looked at may be told more than `mostEstimated`. See its own comment for why
+        // guessing high is the expensive direction.
+        #expect(heights.estimate == TranscriptRowHeights.mostEstimated)
         // The head grow: twelve folds nobody has measured, each of them truly 28 points.
         var blank = 0.0
         for fold in 3..<15 {
@@ -846,7 +859,10 @@ struct TranscriptRowHeightsTests {
         for fold in 3..<15 {
             wasBlank += heights.assumed(for: key("fold.\(fold)")) - 28
         }
-        #expect(wasBlank == 8_106)
+        // Five thousand points of blank, which is five screens of it. It was 8,106 before the
+        // estimate was bounded, and both numbers are the same fault: a fold's line given a
+        // paragraph's height because nothing had measured a fold.
+        #expect(wasBlank == 5_064)
     }
 
     /// A shape with too little evidence is not a shape yet, and the honest answer for one is the
@@ -860,8 +876,8 @@ struct TranscriptRowHeightsTests {
         // Two is not enough to speak for a kind of row. See `settleShapeAfter`.
         heights.note(28, for: key("fold.1"), shape: .fold)
         heights.note(28, for: key("fold.2"), shape: .fold)
-        // Ten answers and two folds, which is the conversation's own mean and not a fold's.
-        #expect(heights.estimate(for: .fold) == 2_056.0 / 12)
+        // Ten answers and two folds, which is the conversation's own number and not a fold's.
+        #expect(heights.estimate(for: .fold) == 200)
         // The third is.
         heights.note(28, for: key("fold.3"), shape: .fold)
         #expect(heights.estimate(for: .fold) == 28)
@@ -875,7 +891,7 @@ struct TranscriptRowHeightsTests {
         heights.reset(width: 831, scale: 1, leading: 1.7)
         heights.note(100, for: key("a"), shape: .tool)
         heights.note(300, for: key("b"), shape: .answer)
-        #expect(heights.estimate == 200)
+        #expect(heights.estimate == 100)
     }
 
     /// **`.other` keeps no sample of its own**, because it is the shape for a row nothing has
@@ -888,8 +904,10 @@ struct TranscriptRowHeightsTests {
         for row in 0..<10 { heights.note(40, for: key("tool.\(row)"), shape: .tool) }
         heights.note(900, for: key("tail"), shape: .other)
         #expect(heights.estimate(for: .other) == heights.estimate)
-        // And the unclassified row is in the conversation's mean like any other.
-        #expect(heights.estimate == 1_300.0 / 11)
+        // And the unclassified row is in the conversation's sample like any other. A mean would
+        // have answered 118 for a conversation of forty point rows, on the strength of the one
+        // tall row in it.
+        #expect(heights.estimate == 40)
     }
 
     /// A shape's number holds still for the reason the conversation's does: a table caches every
@@ -917,8 +935,9 @@ struct TranscriptRowHeightsTests {
         for row in 0..<3 { heights.note(300, for: key("tool.\(row)"), shape: .tool) }
         #expect(heights.estimate(for: .tool) == 300)
         for row in 3..<6 { heights.note(30, for: key("tool.\(row)"), shape: .tool) }
-        // Six against the three it settled from, and half the sample says thirty.
-        #expect(heights.estimate(for: .tool) == 165)
+        // Six against the three it settled from, and half the sample says thirty. The mean this
+        // used to take answered 165, which is a height no tool row in the sample has.
+        #expect(heights.estimate(for: .tool) == 30)
     }
 
     /// A shape that is nearly right must not move, for the same reason the conversation's number
@@ -953,8 +972,8 @@ struct TranscriptRowHeightsTests {
         for row in 0..<2 { heights.note(40, for: key("tool.\(row)"), shape: .tool) }
         heights.note(100, for: key("tool.0"), shape: .tool)
         heights.note(40, for: key("tool.2"), shape: .tool)
-        // 100, 40 and 40, rather than 40, 40, 100 and 40.
-        #expect(heights.estimate(for: .tool) == 60)
+        // 100, 40 and 40, rather than 40, 40, 100 and 40, and the middle of those three is 40.
+        #expect(heights.estimate(for: .tool) == 40)
     }
 
     /// A measured height belongs to a row and is kept for ever; every estimate formed from them
@@ -965,7 +984,10 @@ struct TranscriptRowHeightsTests {
         heights.reset(width: 831, scale: 1, leading: 1.7)
         heights.showing(SessionID("prose"))
         for row in 0..<3 { heights.note(900, for: key("answer.\(row)"), shape: .answer) }
-        #expect(heights.estimate(for: .answer) == 900)
+        // Nine hundred is what the sample says and `mostEstimated` is what an unmeasured row is
+        // allowed to be told, which is the point of the bound: those three rows are drawn at 900
+        // because they were measured, and the fourth is not.
+        #expect(heights.estimate(for: .answer) == TranscriptRowHeights.mostEstimated)
         heights.showing(SessionID("tools"))
         #expect(heights.estimate(for: .answer) == TranscriptRowHeights.assumedRowHeight)
     }
@@ -989,5 +1011,94 @@ struct TranscriptRowHeightsTests {
         for row in 0..<3 { heights.note(30, for: key("tool.\(row)"), shape: .tool) }
         heights.forget()
         #expect(heights.estimate(for: .tool) == TranscriptRowHeights.assumedRowHeight)
+    }
+
+    // MARK: - The blank transcript, which is what a guess out by an order of magnitude looks like
+
+    /// **The owner's own conversation, and the whole of why the estimate is not a mean.**
+    ///
+    /// `ComposerProbe` measured it: of 408 rows in one band, 26 had ever been measured at more
+    /// than nothing, their mean was 651 points and their largest was 10,806. `settleShapeAfter`
+    /// is three, so a sample of that shape settles a number for every unmeasured row of it. The
+    /// mean of this sample is 3,635 points a row. The middle of it is 60.
+    ///
+    /// A row nobody has looked at, drawn 3,635 points tall, is eight screens of white with a line
+    /// of text at the top. That is the transcript the reader filmed going blank.
+    @Test("one enormous row does not decide what every other row is")
+    func aTailDoesNotDecideTheEstimate() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 420, scale: 1, leading: 1.7)
+        heights.showing(SessionID("his"))
+        heights.note(40, for: key("answer.1"), shape: .answer)
+        heights.note(60, for: key("answer.2"), shape: .answer)
+        heights.note(10_806, for: key("answer.3"), shape: .answer)
+        #expect(heights.estimate(for: .answer) == 60)
+        #expect(heights.assumed(for: key("answer.unseen"), shape: .answer) == 60)
+        // And the row that really is ten thousand points tall is still ten thousand points tall.
+        #expect(heights.assumed(for: key("answer.3"), shape: .answer) == 10_806)
+    }
+
+    /// **What that costs a document, which is the number the reader actually feels.**
+    ///
+    /// The 2,242 rows above the band in the probe run, none of them measured. A mean over the
+    /// sample above hands them over eight million points. The middle hands them 134,520. The
+    /// truth, once every one of them had been measured, was 145,686.
+    @Test("the rows nobody has measured do not add up to a document of fiction")
+    func aDocumentOfEstimatesIsNotFiction() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 420, scale: 1, leading: 1.7)
+        heights.showing(SessionID("his"))
+        heights.note(40, for: key("answer.1"), shape: .answer)
+        heights.note(60, for: key("answer.2"), shape: .answer)
+        heights.note(10_806, for: key("answer.3"), shape: .answer)
+        var document = 0.0
+        for row in 0..<2_242 {
+            document += heights.assumed(for: key("above.\(row)"), shape: .answer)
+        }
+        #expect(document == 134_520)
+    }
+
+    // MARK: - What a row nobody has looked at may be told
+
+    /// **The bound, and the asymmetry behind it.** Guessing low costs a row that grows when it is
+    /// drawn, which is the design already. Guessing high costs a screenful of white a reader
+    /// cannot tell from a broken app, and that they cannot scroll out of, because the next screen
+    /// is more of the same row. See `mostEstimated`.
+    @Test("no row nobody has looked at may fill the screen on its own")
+    func theGuessIsBounded() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 420, scale: 1, leading: 1.7)
+        for row in 0..<TranscriptRowHeights.settleAfter {
+            heights.note(6_025, for: key("answer.\(row)"), shape: .answer)
+        }
+        #expect(heights.estimate == TranscriptRowHeights.mostEstimated)
+        #expect(heights.estimate(for: .answer) == TranscriptRowHeights.mostEstimated)
+        #expect(
+            heights.assumed(for: key("unseen"), shape: .answer)
+                == TranscriptRowHeights.mostEstimated
+        )
+    }
+
+    /// The bound is on the GUESS and never on a measurement. A row that has been measured at six
+    /// thousand points is drawn at six thousand points, because that is what it is.
+    @Test("a measured row is its own height however tall it is")
+    func theBoundIsOnlyOnTheGuess() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 420, scale: 1, leading: 1.7)
+        heights.note(6_025, for: key("answer.1"), shape: .answer)
+        #expect(heights.height(for: key("answer.1")) == 6_025)
+        #expect(heights.assumed(for: key("answer.1"), shape: .answer) == 6_025)
+    }
+
+    /// A conversation whose rows are genuinely short is not pushed up to the bound. It is a
+    /// ceiling rather than a number.
+    @Test("the bound does not touch an estimate that is already sensible")
+    func theBoundLeavesASensibleEstimateAlone() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 420, scale: 1, leading: 1.7)
+        for row in 0..<TranscriptRowHeights.settleAfter {
+            heights.note(24, for: key("row.\(row)"))
+        }
+        #expect(heights.estimate == 24)
     }
 }

--- a/Tests/BloomCoreTests/TranscriptRowHeightsTests.swift
+++ b/Tests/BloomCoreTests/TranscriptRowHeightsTests.swift
@@ -16,7 +16,7 @@ struct TranscriptRowHeightsTests {
     func remembersAHeight() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7|assistant"))
+        heights.note(120, for: key("row.7|assistant"), measuredAt: 800)
         #expect(heights.height(for: key("row.7|assistant")) == 120)
     }
 
@@ -24,7 +24,7 @@ struct TranscriptRowHeightsTests {
     func contentIsPartOfTheKey() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7|folded"))
+        heights.note(120, for: key("row.7|folded"), measuredAt: 800)
         #expect(heights.height(for: key("row.7|unfolded")) == nil)
     }
 
@@ -34,7 +34,7 @@ struct TranscriptRowHeightsTests {
     func widthInvalidates() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7"))
+        heights.note(120, for: key("row.7"), measuredAt: 800)
         // Called before the expectation rather than inside it: `reset` is mutating, and `#expect`
         // rewrites its argument into a closure that takes the value immutably.
         let invalidated = heights.reset(width: 600, scale: 1, leading: 1.7)
@@ -47,7 +47,7 @@ struct TranscriptRowHeightsTests {
     func scaleInvalidates() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7"))
+        heights.note(120, for: key("row.7"), measuredAt: 800)
         let invalidated = heights.reset(width: 800, scale: 1.3, leading: 1.7)
         #expect(invalidated)
         #expect(heights.height(for: key("row.7")) == nil)
@@ -60,7 +60,7 @@ struct TranscriptRowHeightsTests {
     func leadingInvalidates() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7"))
+        heights.note(120, for: key("row.7"), measuredAt: 800)
         let invalidated = heights.reset(width: 800, scale: 1, leading: 1.4)
         #expect(invalidated)
         #expect(heights.height(for: key("row.7")) == nil)
@@ -85,9 +85,9 @@ struct TranscriptRowHeightsTests {
     func doesNotHoldEveryWidthItHasSeen() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7"))
+        heights.note(120, for: key("row.7"), measuredAt: 800)
         heights.reset(width: 600, scale: 1, leading: 1.7)
-        heights.note(180, for: key("row.7"))
+        heights.note(180, for: key("row.7"), measuredAt: 600)
         heights.reset(width: 800, scale: 1, leading: 1.7)
         #expect(heights.count == 0)
     }
@@ -99,7 +99,7 @@ struct TranscriptRowHeightsTests {
     func toleratesAFraction() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 831.5, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7"))
+        heights.note(120, for: key("row.7"), measuredAt: 831.5)
         let invalidated = heights.reset(width: 831.75, scale: 1, leading: 1.7)
         #expect(!invalidated)
         #expect(heights.height(for: key("row.7")) == 120)
@@ -132,7 +132,9 @@ struct TranscriptRowHeightsTests {
     @Test("nothing is remembered before a width has arrived")
     func refusesHeightsWithoutAWidth() {
         var heights = TranscriptRowHeights()
-        let changed = heights.note(120, for: key("row.7"))
+        // A report at a perfectly good width, refused because the cache is for no width at all
+        // and a height is a fact about one. See `isEvidence`.
+        let changed = heights.note(120, for: key("row.7"), measuredAt: 800)
         #expect(!changed)
         #expect(heights.height(for: key("row.7")) == nil)
     }
@@ -155,8 +157,8 @@ struct TranscriptRowHeightsTests {
     func aDrawnRowWins() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7"))
-        let changed = heights.note(340, for: key("row.7"))
+        heights.note(120, for: key("row.7"), measuredAt: 800)
+        let changed = heights.note(340, for: key("row.7"), measuredAt: 800)
         #expect(changed)
         #expect(heights.height(for: key("row.7")) == 340)
     }
@@ -167,12 +169,12 @@ struct TranscriptRowHeightsTests {
     func ignoresAnUnchangedHeight() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        let changed = heights.note(120, for: key("row.7"))
+        let changed = heights.note(120, for: key("row.7"), measuredAt: 800)
         #expect(changed)
-        let changedAgain = heights.note(120, for: key("row.7"))
+        let changedAgain = heights.note(120, for: key("row.7"), measuredAt: 800)
         #expect(!changedAgain)
         // Rounds up to the same 120, so a fraction of a point of drift says nothing either.
-        let changedByAFraction = heights.note(119.6, for: key("row.7"))
+        let changedByAFraction = heights.note(119.6, for: key("row.7"), measuredAt: 800)
         #expect(!changedByAFraction)
     }
 
@@ -182,7 +184,7 @@ struct TranscriptRowHeightsTests {
     func nothingIsAnAnswer() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        let changed = heights.note(0, for: key("row.7"))
+        let changed = heights.note(0, for: key("row.7"), measuredAt: 800)
         #expect(changed)
         #expect(heights.height(for: key("row.7")) == 0)
     }
@@ -203,7 +205,7 @@ struct TranscriptRowHeightsTests {
     func rewidthEstimates() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7"))
+        heights.note(120, for: key("row.7"), measuredAt: 800)
         let moved = heights.rewidth(to: 600)
         #expect(moved)
         #expect(heights.height(for: key("row.7")) == 120)
@@ -216,9 +218,9 @@ struct TranscriptRowHeightsTests {
     func measuringClearsTheDebt() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7"))
+        heights.note(120, for: key("row.7"), measuredAt: 800)
         heights.rewidth(to: 600)
-        heights.note(180, for: key("row.7"))
+        heights.note(180, for: key("row.7"), measuredAt: 600)
         #expect(!heights.isStale(key("row.7")))
         #expect(heights.staleCount == 0)
     }
@@ -230,9 +232,9 @@ struct TranscriptRowHeightsTests {
     func anUnchangedHeightStillSettlesTheDebt() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7"))
+        heights.note(120, for: key("row.7"), measuredAt: 800)
         heights.rewidth(to: 600)
-        let changed = heights.note(120, for: key("row.7"))
+        let changed = heights.note(120, for: key("row.7"), measuredAt: 600)
         #expect(!changed)
         #expect(!heights.isStale(key("row.7")))
     }
@@ -241,7 +243,7 @@ struct TranscriptRowHeightsTests {
     func rewidthToTheSameWidth() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7"))
+        heights.note(120, for: key("row.7"), measuredAt: 800)
         let rewidened = heights.rewidth(to: 800.25)
         #expect(!rewidened)
         #expect(!heights.isStale(key("row.7")))
@@ -265,7 +267,7 @@ struct TranscriptRowHeightsTests {
     func resetClearsTheDebt() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7"))
+        heights.note(120, for: key("row.7"), measuredAt: 800)
         heights.rewidth(to: 600)
         heights.reset(width: 600, scale: 1.3, leading: 1.7)
         #expect(heights.staleCount == 0)
@@ -276,7 +278,7 @@ struct TranscriptRowHeightsTests {
     func forgettingClearsTheDebt() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7"))
+        heights.note(120, for: key("row.7"), measuredAt: 800)
         heights.rewidth(to: 600)
         heights.forget()
         #expect(heights.staleCount == 0)
@@ -303,8 +305,8 @@ struct TranscriptRowHeightsTests {
     func assumesTheMiddleOfWhatIsKnown() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(100, for: key("row.1"))
-        heights.note(200, for: key("row.2"))
+        heights.note(100, for: key("row.1"), measuredAt: 800)
+        heights.note(200, for: key("row.2"), measuredAt: 800)
         #expect(heights.estimate == 100)
         #expect(heights.assumed(for: key("row.99")) == 100)
         // And the measured ones are still themselves.
@@ -321,7 +323,7 @@ struct TranscriptRowHeightsTests {
     func measuredNothingIsNothing() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(0, for: key("blank"))
+        heights.note(0, for: key("blank"), measuredAt: 800)
         #expect(heights.measuredNothing(key("blank")))
     }
 
@@ -344,8 +346,8 @@ struct TranscriptRowHeightsTests {
     func somethingIsNotNothing() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(24, for: key("row.1"))
-        heights.note(0.4, for: key("row.2"))
+        heights.note(24, for: key("row.1"), measuredAt: 800)
+        heights.note(0.4, for: key("row.2"), measuredAt: 800)
         #expect(!heights.measuredNothing(key("row.1")))
         #expect(!heights.measuredNothing(key("row.2")))
         #expect(heights.height(for: key("row.2")) == 1)
@@ -358,7 +360,7 @@ struct TranscriptRowHeightsTests {
     func gainingContentMissesTheCache() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(0, for: key("row.7.empty"))
+        heights.note(0, for: key("row.7.empty"), measuredAt: 800)
         #expect(heights.measuredNothing(key("row.7.empty")))
         // The same row, now with something in it, and therefore a different content key.
         #expect(!heights.measuredNothing(key("row.7.full")))
@@ -370,7 +372,7 @@ struct TranscriptRowHeightsTests {
     func forgettingUnsilencesEverything() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(0, for: key("blank"))
+        heights.note(0, for: key("blank"), measuredAt: 800)
         heights.forget()
         #expect(!heights.measuredNothing(key("blank")))
     }
@@ -383,7 +385,7 @@ struct TranscriptRowHeightsTests {
     func assumesNothingForABlankRow() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(100, for: key("row.1"))
+        heights.note(100, for: key("row.1"), measuredAt: 800)
         #expect(heights.assumed(for: key("blank"), drawsNothing: true) == 0)
         #expect(heights.assumed(for: key("blank")) == 100)
     }
@@ -394,7 +396,7 @@ struct TranscriptRowHeightsTests {
     func measurementBeatsTheClaim() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(42, for: key("row.1"))
+        heights.note(42, for: key("row.1"), measuredAt: 800)
         #expect(heights.assumed(for: key("row.1"), drawsNothing: true) == 42)
     }
 
@@ -405,9 +407,9 @@ struct TranscriptRowHeightsTests {
     func noughtsAreNotInTheMean() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(100, for: key("row.1"))
-        heights.note(200, for: key("row.2"))
-        for row in 0..<50 { heights.note(0, for: key("blank.\(row)")) }
+        heights.note(100, for: key("row.1"), measuredAt: 800)
+        heights.note(200, for: key("row.2"), measuredAt: 800)
+        for row in 0..<50 { heights.note(0, for: key("blank.\(row)"), measuredAt: 800) }
         #expect(heights.estimate == 100)
         // The noughts are still remembered, and still nought.
         #expect(heights.height(for: key("blank.7")) == 0)
@@ -420,9 +422,9 @@ struct TranscriptRowHeightsTests {
     func aRowThatEmptiesLeavesTheMean() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(100, for: key("row.1"))
-        heights.note(300, for: key("row.2"))
-        heights.note(0, for: key("row.2"))
+        heights.note(100, for: key("row.1"), measuredAt: 800)
+        heights.note(300, for: key("row.2"), measuredAt: 800)
+        heights.note(0, for: key("row.2"), measuredAt: 800)
         #expect(heights.estimate == 100)
     }
 
@@ -435,14 +437,14 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
         for row in 0..<TranscriptRowHeights.settleAfter {
-            heights.note(100, for: key("row.\(row)"))
+            heights.note(100, for: key("row.\(row)"), measuredAt: 800)
         }
         #expect(heights.estimate == 100)
         // Everything after this is measured on its own account and changes nothing for the rows
         // nobody has drawn, until the sample it was formed from has doubled. Twenty three of these
         // is forty seven drawn rows against the twenty four it settled from, so it holds even
         // though every one of them disagrees.
-        for row in 0..<23 { heights.note(900, for: key("late.\(row)")) }
+        for row in 0..<23 { heights.note(900, for: key("late.\(row)"), measuredAt: 800) }
         #expect(heights.estimate == 100)
         #expect(heights.assumed(for: key("never.drawn")) == 100)
     }
@@ -457,18 +459,18 @@ struct TranscriptRowHeightsTests {
         heights.reset(width: 800, scale: 1, leading: 1.7)
         // The tail: a screenful of tall rows, which settles it at 400.
         for row in 0..<TranscriptRowHeights.settleAfter {
-            heights.note(400, for: key("tail.\(row)"))
+            heights.note(400, for: key("tail.\(row)"), measuredAt: 800)
         }
         #expect(heights.estimate == 400)
         // The conversation behind it, which is what the session is really made of. Nothing moves
         // until the sample has doubled, however wrong the held number is: twenty three of these
         // leaves forty seven drawn rows against the twenty four it settled from.
-        for row in 0..<23 { heights.note(20, for: key("row.\(row)")) }
+        for row in 0..<23 { heights.note(20, for: key("row.\(row)"), measuredAt: 800) }
         #expect(heights.estimate == 400)
         // The forty eighth doubles it, and twenty is what half the rows in this conversation
         // actually are. The mean this used to take answered 210, which is a height no row in the
         // sample has and which every unmeasured row would have been drawn at.
-        heights.note(20, for: key("row.23"))
+        heights.note(20, for: key("row.23"), measuredAt: 800)
         #expect(heights.estimate == 20)
     }
 
@@ -479,11 +481,11 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
         for row in 0..<TranscriptRowHeights.settleAfter {
-            heights.note(100, for: key("row.\(row)"))
+            heights.note(100, for: key("row.\(row)"), measuredAt: 800)
         }
         #expect(heights.estimate == 100)
         // A tenth out over hundreds of rows, which is inside the drift this tolerates.
-        for row in 0..<400 { heights.note(110, for: key("more.\(row)")) }
+        for row in 0..<400 { heights.note(110, for: key("more.\(row)"), measuredAt: 800) }
         #expect(heights.estimate == 100)
     }
 
@@ -497,9 +499,9 @@ struct TranscriptRowHeightsTests {
     func tracksUntilItSettles() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(100, for: key("row.1"))
+        heights.note(100, for: key("row.1"), measuredAt: 800)
         #expect(heights.estimate == 100)
-        heights.note(300, for: key("row.2"))
+        heights.note(300, for: key("row.2"), measuredAt: 800)
         #expect(heights.estimate == 100)
     }
 
@@ -510,11 +512,11 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
         for row in 0..<TranscriptRowHeights.settleAfter {
-            heights.note(100, for: key("row.\(row)"))
+            heights.note(100, for: key("row.\(row)"), measuredAt: 800)
         }
         heights.forget()
         #expect(heights.estimate == TranscriptRowHeights.assumedRowHeight)
-        heights.note(40, for: key("fresh"))
+        heights.note(40, for: key("fresh"), measuredAt: 800)
         #expect(heights.estimate == 40)
     }
 
@@ -524,10 +526,10 @@ struct TranscriptRowHeightsTests {
     func noughtsDoNotSettleIt() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        for row in 0..<200 { heights.note(0, for: key("blank.\(row)")) }
-        heights.note(100, for: key("row.1"))
+        for row in 0..<200 { heights.note(0, for: key("blank.\(row)"), measuredAt: 800) }
+        heights.note(100, for: key("row.1"), measuredAt: 800)
         #expect(heights.estimate == 100)
-        heights.note(300, for: key("row.2"))
+        heights.note(300, for: key("row.2"), measuredAt: 800)
         // Two drawn rows is not a screenful, so it is still tracking.
         #expect(heights.estimate == 100)
     }
@@ -538,8 +540,8 @@ struct TranscriptRowHeightsTests {
     func meanFollowsAnOverwrite() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(100, for: key("row.1"))
-        heights.note(300, for: key("row.1"))
+        heights.note(100, for: key("row.1"), measuredAt: 800)
+        heights.note(300, for: key("row.1"), measuredAt: 800)
         #expect(heights.estimate == 300)
     }
 
@@ -547,7 +549,7 @@ struct TranscriptRowHeightsTests {
     func meanIsEmptiedWithTheCache() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(400, for: key("row.1"))
+        heights.note(400, for: key("row.1"), measuredAt: 800)
         heights.forget()
         #expect(heights.estimate == TranscriptRowHeights.assumedRowHeight)
     }
@@ -558,8 +560,8 @@ struct TranscriptRowHeightsTests {
     func meanSurvivesAResize() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(100, for: key("row.1"))
-        heights.note(200, for: key("row.2"))
+        heights.note(100, for: key("row.1"), measuredAt: 800)
+        heights.note(200, for: key("row.2"), measuredAt: 800)
         heights.rewidth(to: 600)
         #expect(heights.estimate == 100)
     }
@@ -578,7 +580,7 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.showing(SessionID("prose"))
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        for row in 0..<2_000 { heights.note(400, for: key("prose.\(row)")) }
+        for row in 0..<2_000 { heights.note(400, for: key("prose.\(row)"), measuredAt: 800) }
         #expect(heights.estimate == 400)
 
         let switched = heights.showing(SessionID("tools"))
@@ -594,10 +596,10 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.showing(SessionID("prose"))
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        for row in 0..<2_000 { heights.note(400, for: key("prose.\(row)")) }
+        for row in 0..<2_000 { heights.note(400, for: key("prose.\(row)"), measuredAt: 800) }
         heights.showing(SessionID("tools"))
         for row in 0..<TranscriptRowHeights.settleAfter {
-            heights.note(24, for: key("tools.\(row)"))
+            heights.note(24, for: key("tools.\(row)"), measuredAt: 800)
         }
         #expect(heights.estimate == 24)
         #expect(heights.assumed(for: key("tools.never.drawn")) == 24)
@@ -611,7 +613,7 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.showing(SessionID("one"))
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("one.row.7"))
+        heights.note(120, for: key("one.row.7"), measuredAt: 800)
         heights.showing(SessionID("two"))
         #expect(heights.height(for: key("one.row.7")) == 120)
         let back = heights.showing(SessionID("one"))
@@ -629,7 +631,7 @@ struct TranscriptRowHeightsTests {
         heights.showing(SessionID("one"))
         heights.reset(width: 800, scale: 1, leading: 1.7)
         for row in 0..<TranscriptRowHeights.settleAfter {
-            heights.note(300, for: key("one.\(row)"))
+            heights.note(300, for: key("one.\(row)"), measuredAt: 800)
         }
         heights.showing(SessionID("two"))
         let back = heights.showing(SessionID("one"))
@@ -637,7 +639,7 @@ struct TranscriptRowHeightsTests {
         #expect(heights.estimate == TranscriptRowHeights.assumedRowHeight)
         // The screen the reader lands on, reporting what it has always been.
         for row in 0..<TranscriptRowHeights.settleAfter {
-            heights.note(300, for: key("one.\(row)"))
+            heights.note(300, for: key("one.\(row)"), measuredAt: 800)
         }
         #expect(heights.estimate == 300)
     }
@@ -649,8 +651,8 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.showing(SessionID("one"))
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(100, for: key("row.1"))
-        for step in 1...20 { heights.note(Double(100 + step * 10), for: key("tail")) }
+        heights.note(100, for: key("row.1"), measuredAt: 800)
+        for step in 1...20 { heights.note(Double(100 + step * 10), for: key("tail"), measuredAt: 800) }
         // The tail's last word and one other row: 300 and 100, whose middle is 100. Counted per
         // report rather than per row it would be a sample of twenty one tail heights.
         #expect(heights.estimate == 100)
@@ -662,7 +664,7 @@ struct TranscriptRowHeightsTests {
         heights.showing(SessionID("one"))
         heights.reset(width: 800, scale: 1, leading: 1.7)
         for row in 0..<TranscriptRowHeights.settleAfter {
-            heights.note(300, for: key("one.\(row)"))
+            heights.note(300, for: key("one.\(row)"), measuredAt: 800)
         }
         let again = heights.showing(SessionID("one"))
         #expect(!again)
@@ -678,10 +680,10 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
         for row in 0..<TranscriptRowHeights.mostRows {
-            heights.note(Double(row % 400) + 1, for: key("row.\(row)"))
+            heights.note(Double(row % 400) + 1, for: key("row.\(row)"), measuredAt: 800)
         }
         #expect(heights.count == TranscriptRowHeights.mostRows)
-        heights.note(120, for: key("one.too.many"))
+        heights.note(120, for: key("one.too.many"), measuredAt: 800)
         #expect(heights.count == 1)
         #expect(heights.height(for: key("one.too.many")) == 120)
         // The width is kept, because the pane is still the width it was.
@@ -693,9 +695,9 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
         for row in 0..<TranscriptRowHeights.mostRows {
-            heights.note(Double(row % 400) + 1, for: key("row.\(row)"))
+            heights.note(Double(row % 400) + 1, for: key("row.\(row)"), measuredAt: 800)
         }
-        heights.note(999, for: key("row.0"))
+        heights.note(999, for: key("row.0"), measuredAt: 800)
         #expect(heights.count == TranscriptRowHeights.mostRows)
         #expect(heights.height(for: key("row.0")) == 999)
     }
@@ -708,11 +710,11 @@ struct TranscriptRowHeightsTests {
         #expect(!TranscriptRowHeights.isSameHeight(24, 25))
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(24, for: key("row.1"))
+        heights.note(24, for: key("row.1"), measuredAt: 800)
         // Rounded up to 25, which is a point away and therefore news.
-        let news = heights.note(24.4, for: key("row.1"))
+        let news = heights.note(24.4, for: key("row.1"), measuredAt: 800)
         #expect(news)
-        let again = heights.note(25, for: key("row.1"))
+        let again = heights.note(25, for: key("row.1"), measuredAt: 800)
         #expect(!again)
     }
 
@@ -735,7 +737,7 @@ struct TranscriptRowHeightsTests {
     func aMeasuredRowIsNotOwed() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7"))
+        heights.note(120, for: key("row.7"), measuredAt: 800)
         #expect(!heights.needsMeasuring(key("row.7"), redrawsItself: false))
     }
 
@@ -744,7 +746,7 @@ struct TranscriptRowHeightsTests {
     func aStaleRowIsOwed() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7"))
+        heights.note(120, for: key("row.7"), measuredAt: 800)
         let moved = heights.rewidth(to: 600)
         #expect(moved)
         #expect(heights.needsMeasuring(key("row.7"), redrawsItself: false))
@@ -759,7 +761,7 @@ struct TranscriptRowHeightsTests {
     func anEntryThatRedrawsItselfIsAlwaysOwed() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(480, for: key("streaming.session-a"))
+        heights.note(480, for: key("streaming.session-a"), measuredAt: 800)
         #expect(heights.height(for: key("streaming.session-a")) == 480)
         #expect(heights.needsMeasuring(key("streaming.session-a"), redrawsItself: true))
     }
@@ -777,7 +779,7 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
         let fold = TranscriptEntryID.fold(41)
-        heights.note(0, for: key("fold.41|shows-nothing"))
+        heights.note(0, for: key("fold.41|shows-nothing"), measuredAt: 800)
         #expect(!fold.redrawsItself)
         #expect(!heights.needsMeasuring(key("fold.41|shows-nothing"), redrawsItself: fold.redrawsItself))
     }
@@ -817,7 +819,7 @@ struct TranscriptRowHeightsTests {
     func forgets() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 800, scale: 1, leading: 1.7)
-        heights.note(120, for: key("row.7"))
+        heights.note(120, for: key("row.7"), measuredAt: 800)
         heights.forget()
         #expect(heights.height(for: key("row.7")) == nil)
         #expect(heights.isReady)
@@ -839,9 +841,9 @@ struct TranscriptRowHeightsTests {
         heights.reset(width: 831, scale: 1, leading: 1.7)
         heights.showing(SessionID("chat"))
         // The arrival: three folds and a screenful of the answer the pane opened on.
-        for fold in 0..<3 { heights.note(28, for: key("fold.\(fold)"), shape: .fold) }
+        for fold in 0..<3 { heights.note(28, for: key("fold.\(fold)"), shape: .fold, measuredAt: 831) }
         for row in 0..<TranscriptRowHeights.settleAfter {
-            heights.note(800, for: key("answer.\(row)"), shape: .answer)
+            heights.note(800, for: key("answer.\(row)"), shape: .answer, measuredAt: 831)
         }
         // The bound, doing its job: the middle of this sample is the 800 point answer, and no row
         // nobody has looked at may be told more than `mostEstimated`. See its own comment for why
@@ -872,14 +874,14 @@ struct TranscriptRowHeightsTests {
     func tooLittleOfAShapeFallsBack() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 831, scale: 1, leading: 1.7)
-        for row in 0..<10 { heights.note(200, for: key("answer.\(row)"), shape: .answer) }
+        for row in 0..<10 { heights.note(200, for: key("answer.\(row)"), shape: .answer, measuredAt: 831) }
         // Two is not enough to speak for a kind of row. See `settleShapeAfter`.
-        heights.note(28, for: key("fold.1"), shape: .fold)
-        heights.note(28, for: key("fold.2"), shape: .fold)
+        heights.note(28, for: key("fold.1"), shape: .fold, measuredAt: 831)
+        heights.note(28, for: key("fold.2"), shape: .fold, measuredAt: 831)
         // Ten answers and two folds, which is the conversation's own number and not a fold's.
         #expect(heights.estimate(for: .fold) == 200)
         // The third is.
-        heights.note(28, for: key("fold.3"), shape: .fold)
+        heights.note(28, for: key("fold.3"), shape: .fold, measuredAt: 831)
         #expect(heights.estimate(for: .fold) == 28)
     }
 
@@ -889,8 +891,8 @@ struct TranscriptRowHeightsTests {
     func shapesStillFeedTheWholeConversation() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 831, scale: 1, leading: 1.7)
-        heights.note(100, for: key("a"), shape: .tool)
-        heights.note(300, for: key("b"), shape: .answer)
+        heights.note(100, for: key("a"), shape: .tool, measuredAt: 831)
+        heights.note(300, for: key("b"), shape: .answer, measuredAt: 831)
         #expect(heights.estimate == 100)
     }
 
@@ -901,8 +903,8 @@ struct TranscriptRowHeightsTests {
     func otherIsTheConversation() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 831, scale: 1, leading: 1.7)
-        for row in 0..<10 { heights.note(40, for: key("tool.\(row)"), shape: .tool) }
-        heights.note(900, for: key("tail"), shape: .other)
+        for row in 0..<10 { heights.note(40, for: key("tool.\(row)"), shape: .tool, measuredAt: 831) }
+        heights.note(900, for: key("tail"), shape: .other, measuredAt: 831)
         #expect(heights.estimate(for: .other) == heights.estimate)
         // And the unclassified row is in the conversation's sample like any other. A mean would
         // have answered 118 for a conversation of forty point rows, on the strength of the one
@@ -917,13 +919,13 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.reset(width: 831, scale: 1, leading: 1.7)
         for row in 0..<TranscriptRowHeights.settleShapeAfter {
-            heights.note(30, for: key("tool.\(row)"), shape: .tool)
+            heights.note(30, for: key("tool.\(row)"), shape: .tool, measuredAt: 831)
         }
         #expect(heights.estimate(for: .tool) == 30)
         // Two more, which is five drawn tool rows against the three it settled from. Not doubled,
         // so it holds however wrong it now is.
-        heights.note(300, for: key("tool.wide.1"), shape: .tool)
-        heights.note(300, for: key("tool.wide.2"), shape: .tool)
+        heights.note(300, for: key("tool.wide.1"), shape: .tool, measuredAt: 831)
+        heights.note(300, for: key("tool.wide.2"), shape: .tool, measuredAt: 831)
         #expect(heights.estimate(for: .tool) == 30)
     }
 
@@ -932,9 +934,9 @@ struct TranscriptRowHeightsTests {
     func aShapeResettles() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 831, scale: 1, leading: 1.7)
-        for row in 0..<3 { heights.note(300, for: key("tool.\(row)"), shape: .tool) }
+        for row in 0..<3 { heights.note(300, for: key("tool.\(row)"), shape: .tool, measuredAt: 831) }
         #expect(heights.estimate(for: .tool) == 300)
-        for row in 3..<6 { heights.note(30, for: key("tool.\(row)"), shape: .tool) }
+        for row in 3..<6 { heights.note(30, for: key("tool.\(row)"), shape: .tool, measuredAt: 831) }
         // Six against the three it settled from, and half the sample says thirty. The mean this
         // used to take answered 165, which is a height no tool row in the sample has.
         #expect(heights.estimate(for: .tool) == 30)
@@ -946,8 +948,8 @@ struct TranscriptRowHeightsTests {
     func aShapeDoesNotResettleForSmallDrift() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 831, scale: 1, leading: 1.7)
-        for row in 0..<3 { heights.note(100, for: key("fold.\(row)"), shape: .fold) }
-        for row in 3..<40 { heights.note(105, for: key("fold.\(row)"), shape: .fold) }
+        for row in 0..<3 { heights.note(100, for: key("fold.\(row)"), shape: .fold, measuredAt: 831) }
+        for row in 3..<40 { heights.note(105, for: key("fold.\(row)"), shape: .fold, measuredAt: 831) }
         #expect(heights.estimate(for: .fold) == 100)
     }
 
@@ -957,8 +959,8 @@ struct TranscriptRowHeightsTests {
     func noughtsDoNotFormAShape() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 831, scale: 1, leading: 1.7)
-        for row in 0..<50 { heights.note(0, for: key("blank.\(row)"), shape: .tool) }
-        for row in 0..<3 { heights.note(40, for: key("tool.\(row)"), shape: .tool) }
+        for row in 0..<50 { heights.note(0, for: key("blank.\(row)"), shape: .tool, measuredAt: 831) }
+        for row in 0..<3 { heights.note(40, for: key("tool.\(row)"), shape: .tool, measuredAt: 831) }
         #expect(heights.estimate(for: .tool) == 40)
     }
 
@@ -969,9 +971,9 @@ struct TranscriptRowHeightsTests {
     func aShapeFollowsAnOverwrite() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 831, scale: 1, leading: 1.7)
-        for row in 0..<2 { heights.note(40, for: key("tool.\(row)"), shape: .tool) }
-        heights.note(100, for: key("tool.0"), shape: .tool)
-        heights.note(40, for: key("tool.2"), shape: .tool)
+        for row in 0..<2 { heights.note(40, for: key("tool.\(row)"), shape: .tool, measuredAt: 831) }
+        heights.note(100, for: key("tool.0"), shape: .tool, measuredAt: 831)
+        heights.note(40, for: key("tool.2"), shape: .tool, measuredAt: 831)
         // 100, 40 and 40, rather than 40, 40, 100 and 40, and the middle of those three is 40.
         #expect(heights.estimate(for: .tool) == 40)
     }
@@ -983,7 +985,7 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.reset(width: 831, scale: 1, leading: 1.7)
         heights.showing(SessionID("prose"))
-        for row in 0..<3 { heights.note(900, for: key("answer.\(row)"), shape: .answer) }
+        for row in 0..<3 { heights.note(900, for: key("answer.\(row)"), shape: .answer, measuredAt: 831) }
         // Nine hundred is what the sample says and `mostEstimated` is what an unmeasured row is
         // allowed to be told, which is the point of the bound: those three rows are drawn at 900
         // because they were measured, and the fourth is not.
@@ -998,7 +1000,7 @@ struct TranscriptRowHeightsTests {
     func shapesSurviveAResize() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 831, scale: 1, leading: 1.7)
-        for row in 0..<3 { heights.note(30, for: key("tool.\(row)"), shape: .tool) }
+        for row in 0..<3 { heights.note(30, for: key("tool.\(row)"), shape: .tool, measuredAt: 831) }
         heights.rewidth(to: 600)
         #expect(heights.estimate(for: .tool) == 30)
     }
@@ -1008,9 +1010,92 @@ struct TranscriptRowHeightsTests {
     func forgettingEmptiesTheShapes() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 831, scale: 1, leading: 1.7)
-        for row in 0..<3 { heights.note(30, for: key("tool.\(row)"), shape: .tool) }
+        for row in 0..<3 { heights.note(30, for: key("tool.\(row)"), shape: .tool, measuredAt: 831) }
         heights.forget()
         #expect(heights.estimate(for: .tool) == TranscriptRowHeights.assumedRowHeight)
+    }
+
+    // MARK: - A height is a fact about a width
+
+    /// **The two rows that emptied the owner's transcript**, from the one probe run of four that
+    /// caught them. A three line paragraph whose height is 54 points reported 1,972, and a user
+    /// message whose height is 444 reported 10,806, both only during a composer drag and both
+    /// correct again afterwards. Both ratios are a row wrapped into a column about fifteen points
+    /// wide: reports taken from a layout pass at a width the table was not.
+    ///
+    /// `reset` and `rewidth` have refused a width they cannot use since they were written. This is
+    /// the same rule on the REPORTING path, which is the authoritative one.
+    @Test("a height reported at another width is not news about this one")
+    func aReportAtAnotherWidthIsRefused() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 420, scale: 1, leading: 1.7)
+        heights.note(54, for: key("row.19554"), measuredAt: 420)
+        // The spike, from a pass that laid the row out fifteen points wide.
+        let took = heights.note(1_972, for: key("row.19554"), measuredAt: 15)
+        #expect(!took)
+        #expect(heights.height(for: key("row.19554")) == 54)
+    }
+
+    /// And the row that did the real damage: 444 points of user message reported as 10,806, which
+    /// settled its shape's estimate at 6,025 and was then handed to every unmeasured row of that
+    /// shape in a 2,650 row table.
+    @Test("a spike from a narrow pass does not reach the estimate either")
+    func aReportAtAnotherWidthDoesNotMoveTheEstimate() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 420, scale: 1, leading: 1.7)
+        for row in 0..<3 {
+            heights.note(444, for: key("message.\(row)"), shape: .message, measuredAt: 420)
+        }
+        #expect(heights.estimate(for: .message) == 444)
+        heights.note(10_806, for: key("message.3"), shape: .message, measuredAt: 17)
+        #expect(heights.estimate(for: .message) == 444)
+        #expect(heights.assumed(for: key("message.unseen"), shape: .message) == 444)
+    }
+
+    /// A report at the width the cache is for is evidence, which is the ordinary case and the one
+    /// everything else in this file depends on.
+    @Test("a height reported at this width is news")
+    func aReportAtThisWidthIsKept() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 420, scale: 1, leading: 1.7)
+        let took = heights.note(120, for: key("row.7"), measuredAt: 420)
+        #expect(took)
+        #expect(heights.height(for: key("row.7")) == 120)
+    }
+
+    /// Half a point, the same tolerance a resize is judged by, because a clip view's own
+    /// arithmetic lands on fractions and a row laid out at 419.75 is the same row.
+    @Test("a fraction of a point is the same width")
+    func aFractionIsTheSameWidth() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 420, scale: 1, leading: 1.7)
+        let took = heights.note(120, for: key("row.7"), measuredAt: 419.75)
+        #expect(took)
+    }
+
+    /// **Refusing costs a pass, not a measurement**, which is the whole reason this is safe. The
+    /// row is laid out again at the right width and reports again, and that is the same mechanism
+    /// that repairs every wrong height in this file today.
+    @Test("a refused row is measured by the next report at the right width")
+    func aRefusedRowIsMeasuredOnTheNextPass() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 420, scale: 1, leading: 1.7)
+        heights.note(9_000, for: key("row.7"), measuredAt: 15)
+        #expect(heights.height(for: key("row.7")) == nil)
+        heights.note(120, for: key("row.7"), measuredAt: 420)
+        #expect(heights.height(for: key("row.7")) == 120)
+    }
+
+    /// The rule on its own, without a cache, because the decision is what is being tested and a
+    /// caller should be able to ask it.
+    @Test("the rule, said on its own")
+    func theEvidenceRule() {
+        #expect(TranscriptRowHeights.isEvidence(measuredAt: 420, forCacheAt: 420))
+        #expect(TranscriptRowHeights.isEvidence(measuredAt: 419.75, forCacheAt: 420))
+        #expect(!TranscriptRowHeights.isEvidence(measuredAt: 15, forCacheAt: 420))
+        #expect(!TranscriptRowHeights.isEvidence(measuredAt: 420, forCacheAt: 747))
+        // A cache that is for no width at all cannot be told anything.
+        #expect(!TranscriptRowHeights.isEvidence(measuredAt: 420, forCacheAt: nil))
     }
 
     // MARK: - The blank transcript, which is what a guess out by an order of magnitude looks like
@@ -1029,9 +1114,9 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.reset(width: 420, scale: 1, leading: 1.7)
         heights.showing(SessionID("his"))
-        heights.note(40, for: key("answer.1"), shape: .answer)
-        heights.note(60, for: key("answer.2"), shape: .answer)
-        heights.note(10_806, for: key("answer.3"), shape: .answer)
+        heights.note(40, for: key("answer.1"), shape: .answer, measuredAt: 420)
+        heights.note(60, for: key("answer.2"), shape: .answer, measuredAt: 420)
+        heights.note(10_806, for: key("answer.3"), shape: .answer, measuredAt: 420)
         #expect(heights.estimate(for: .answer) == 60)
         #expect(heights.assumed(for: key("answer.unseen"), shape: .answer) == 60)
         // And the row that really is ten thousand points tall is still ten thousand points tall.
@@ -1048,9 +1133,9 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.reset(width: 420, scale: 1, leading: 1.7)
         heights.showing(SessionID("his"))
-        heights.note(40, for: key("answer.1"), shape: .answer)
-        heights.note(60, for: key("answer.2"), shape: .answer)
-        heights.note(10_806, for: key("answer.3"), shape: .answer)
+        heights.note(40, for: key("answer.1"), shape: .answer, measuredAt: 420)
+        heights.note(60, for: key("answer.2"), shape: .answer, measuredAt: 420)
+        heights.note(10_806, for: key("answer.3"), shape: .answer, measuredAt: 420)
         var document = 0.0
         for row in 0..<2_242 {
             document += heights.assumed(for: key("above.\(row)"), shape: .answer)
@@ -1069,7 +1154,7 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.reset(width: 420, scale: 1, leading: 1.7)
         for row in 0..<TranscriptRowHeights.settleAfter {
-            heights.note(6_025, for: key("answer.\(row)"), shape: .answer)
+            heights.note(6_025, for: key("answer.\(row)"), shape: .answer, measuredAt: 420)
         }
         #expect(heights.estimate == TranscriptRowHeights.mostEstimated)
         #expect(heights.estimate(for: .answer) == TranscriptRowHeights.mostEstimated)
@@ -1085,7 +1170,7 @@ struct TranscriptRowHeightsTests {
     func theBoundIsOnlyOnTheGuess() {
         var heights = TranscriptRowHeights()
         heights.reset(width: 420, scale: 1, leading: 1.7)
-        heights.note(6_025, for: key("answer.1"), shape: .answer)
+        heights.note(6_025, for: key("answer.1"), shape: .answer, measuredAt: 420)
         #expect(heights.height(for: key("answer.1")) == 6_025)
         #expect(heights.assumed(for: key("answer.1"), shape: .answer) == 6_025)
     }
@@ -1097,7 +1182,7 @@ struct TranscriptRowHeightsTests {
         var heights = TranscriptRowHeights()
         heights.reset(width: 420, scale: 1, leading: 1.7)
         for row in 0..<TranscriptRowHeights.settleAfter {
-            heights.note(24, for: key("row.\(row)"))
+            heights.note(24, for: key("row.\(row)"), measuredAt: 420)
         }
         #expect(heights.estimate == 24)
     }

--- a/Tests/BloomCoreTests/TranscriptRowHeightsTests.swift
+++ b/Tests/BloomCoreTests/TranscriptRowHeightsTests.swift
@@ -1052,6 +1052,30 @@ struct TranscriptRowHeightsTests {
         #expect(heights.assumed(for: key("message.unseen"), shape: .message) == 444)
     }
 
+    /// **The one caught with the instrument watching, which is the argument for the rule.**
+    ///
+    /// Row 2593 of the owner's conversation, an `answer`, reported 2,568 points against a known 75
+    /// from a layout 24 points wide, by a cell the table was holding no view for. A cell that
+    /// misses the reuse pool is built at `frame: .zero` and handed its content before the table
+    /// frames it, so its graph lays out against a proposal of nothing and the content bottoms out
+    /// at its own minimum. Thirty four times the truth, from a row three lines long.
+    ///
+    /// Four such reports in fifty one cells built, about eight per cent, and two of those four
+    /// were harmless because they came from a stale WIDER frame: a wider layout under-states a
+    /// height and draws a row short, where a narrower one over-states it by an order of magnitude
+    /// and empties the screen. The rate and the sign both belong here: somebody reading this in six
+    /// months should know it is common and know why only half of it is visible.
+    @Test("the row that was caught: 2,568 points from a layout 24 points wide")
+    func theRowThatWasCaught() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 420, scale: 1, leading: 1.7)
+        heights.note(75, for: key("row.2593"), shape: .answer, measuredAt: 420)
+        let took = heights.note(2_568, for: key("row.2593"), shape: .answer, measuredAt: 24)
+        #expect(!took)
+        #expect(heights.height(for: key("row.2593")) == 75)
+        #expect(heights.estimate(for: .answer) == 75)
+    }
+
     /// A report at the width the cache is for is evidence, which is the ordinary case and the one
     /// everything else in this file depends on.
     @Test("a height reported at this width is news")

--- a/Tests/BloomCoreTests/TranscriptTableUpdateTests.swift
+++ b/Tests/BloomCoreTests/TranscriptTableUpdateTests.swift
@@ -1,0 +1,97 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+/// **The three minute beach ball on the first launch after updating to 1.1.0.**
+///
+/// A `sample` of the wedged process put all 1,388 samples of the main thread in one stack:
+/// `TranscriptTable.Coordinator.apply` into `-[NSTableView reloadData]`, then `purgeRowViewData`,
+/// `removeAllKnownSubviews` and `_removeRowsBeingAnimatedOff`, tearing down one row view after
+/// another inside `NSHostingView.viewWillMove(toWindow:)` and the KVO deregistration under it,
+/// which is O(n) per view removed and so O(n²) for the lot.
+///
+/// AppKit only holds a row view in `_removeRowsBeingAnimatedOff` after
+/// `removeRowsAtIndexes:withAnimation:`, and `apply` was the one place that staged a removal and
+/// then reloaded the whole table in the same pass: the rows went out because the list had shrunk,
+/// and the reload followed because the environment had moved. So the reload had every staged view
+/// to tear off the window as well as the ones on screen.
+///
+/// Every case below is "what is the table told", and the rule the suite exists to hold is that
+/// the answer is never two things at once.
+@Suite("What a transcript table is told about a pass")
+struct TranscriptTableUpdateTests {
+    // MARK: - The hang
+
+    /// The pass from the sample: the drawn list shrank, and the environment moved on the same
+    /// pass. It used to stage the removal and then reload on top of it.
+    @Test("a shrink with a moved environment is a reload and no removal")
+    func shrinkWithAMovedEnvironmentStagesNothing() {
+        let change = TranscriptEntryChange.shrank(head: 0..<40, tail: 0..<0)
+        #expect(
+            TranscriptTableUpdate.plan(change: change, environmentMoved: true) == .reload
+        )
+    }
+
+    /// The same for rows arriving, which is the commoner shape and the same mistake.
+    @Test("a growth with a moved environment is a reload and no insertion")
+    func growthWithAMovedEnvironmentStagesNothing() {
+        let change = TranscriptEntryChange.grew(head: 0..<400, tail: 0..<0)
+        #expect(
+            TranscriptTableUpdate.plan(change: change, environmentMoved: true) == .reload
+        )
+    }
+
+    /// The invariant said once rather than case by case: whatever the rows did, a moved
+    /// environment never asks for a row edit as well.
+    @Test("a moved environment never stages rows, whatever the change was")
+    func aMovedEnvironmentNeverStagesRows() {
+        let changes: [TranscriptEntryChange] = [
+            .same,
+            .grew(head: 0..<3, tail: 0..<0),
+            .grew(head: 0..<0, tail: 7..<9),
+            .shrank(head: 0..<3, tail: 0..<0),
+            .shrank(head: 0..<0, tail: 7..<9),
+            .rebuilt,
+        ]
+        for change in changes {
+            #expect(TranscriptTableUpdate.plan(change: change, environmentMoved: true) == .reload)
+        }
+    }
+
+    // MARK: - And the cheap path is still the cheap path
+
+    /// The whole point of `TranscriptEntryChange`: a row landing while the environment sits still
+    /// is one insertion and not a reload. A regression here is the scroll stall coming back.
+    @Test("a row arriving is an insertion")
+    func aRowArrivingIsAnInsertion() {
+        let change = TranscriptEntryChange.grew(head: 0..<0, tail: 12..<13)
+        #expect(
+            TranscriptTableUpdate.plan(change: change, environmentMoved: false)
+                == .rows(.grew(head: 0..<0, tail: 12..<13))
+        )
+    }
+
+    @Test("rows leaving are a removal")
+    func rowsLeavingAreARemoval() {
+        let change = TranscriptEntryChange.shrank(head: 4..<9, tail: 0..<0)
+        #expect(
+            TranscriptTableUpdate.plan(change: change, environmentMoved: false)
+                == .rows(.shrank(head: 4..<9, tail: 0..<0))
+        )
+    }
+
+    /// A list that did not move asks for no row edit at all. `.nothing` rather than
+    /// `.rows(.same)`, so the caller has no empty branch to forget: the rows whose content moved
+    /// are reloaded by index afterwards and are not this decision's business.
+    @Test("the same list is no row edit at all")
+    func theSameListIsNoEdit() {
+        #expect(TranscriptTableUpdate.plan(change: .same, environmentMoved: false) == .nothing)
+    }
+
+    /// A session being replaced. Two lists that share no run cannot be expressed as rows in and
+    /// out, so this one was always a reload and stays one.
+    @Test("a rebuilt list is a reload")
+    func aRebuiltListIsAReload() {
+        #expect(TranscriptTableUpdate.plan(change: .rebuilt, environmentMoved: false) == .reload)
+    }
+}


### PR DESCRIPTION
Three ways the transcript's idea of its own row heights goes wrong, found from the top down over one night of probe runs against the owner's own conversation.

**A report taken at the wrong width, which is the cause.** Two rows reported heights only during a composer drag and reported the truth again afterwards: three lines of prose whose height is 54 points reported 1,972, and a user message whose height is 444 reported 10,806. Both ratios are a row wrapped into a column about fifteen points wide, and neither can have come from the off-screen sizer, so both came from a cell that was on screen. `reset` and `rewidth` have refused a width they cannot use since they were written; the reporting path, which is the authoritative one, had no such guard. `TranscriptRowHeights.isEvidence` is that rule, `note` takes the width it was measured at, and `HostedRow` reports its size so there is a width to take. Refusing costs a pass and not a measurement: the row is laid out again at the right width and reports again, which is the mechanism that repairs every wrong height today.

**An estimate poisoned by that report, which is what turned one bad row into a blank screen.** The 10,806 settled its shape's estimate at 6,025 points, which was handed to every unmeasured row of that shape in a 2,650 row table, and the document came out 885,212 points long against a true 172,208. The estimate is a median now, kept as a tally of the few hundred distinct heights a conversation has, and it is bounded: no row nobody has looked at may fill the screen on its own. Measured on the same conversation at the same 420 point pane, the largest height handed to an unmeasured row falls from 317 to 66 and the guess against a real row from 5.5 to 1.7. Worth having on its own account, because it is what stops one bad row deciding what two thousand unmeasured rows are, even on the runs where the first fault never fires.

**And a reload that pays for both.** The three minute beach ball after updating to 1.1.0: all 1,388 samples of the main thread in one `reloadData` teardown, in the KVO deregistration each `NSHostingView` does as it leaves the window, which is O(n) per view. `apply` was staging rows out and then reloading on top of them, so the reload had every staged row view to tear off as well as the ones on screen. One edit per pass now, in the core with the suite that names the hang. Not a regression: `TranscriptTable` is eleven lines different between 1.0.1 and 1.1.0. What made it show up after an update is the unread mark opening the drawn window mid conversation, where nothing has been measured.

`ComposerProbe` is how the last two were found and the first was confirmed. It drags the composer divider at a stated pane width, refuses to run at any other, and reports what the cache and the table each believe row by row. It counts refused reports, so the next run says whether a cell being laid out narrow is ordinary or a once-in-four accident. Why it happens at all is not known, and the comments say so rather than implying the guard explains it.