### PR TITLE
Put the reading placeholder where the reading is

### DIFF
--- a/Sources/Bloom/Views/Center/Panes/CenterPaneView.swift
+++ b/Sources/Bloom/Views/Center/Panes/CenterPaneView.swift
@@ -56,40 +56,30 @@ struct CenterPaneView: View {
         return tabs.layout(of: tab).panes.map { tabs.content(of: $0, in: tab) }
     }
 
-    /// What a pane with nothing to draw is waiting for.
-    ///
-    /// Two of them, and they are two different moments of the same switch. Which one the user
-    /// actually meets depends on whether this launch has been here before, which is why neither
-    /// could be left out.
-    private enum Wait: Equatable, Sendable {
-        /// The store has not yet said which conversations this workspace has. The first visit of a
-        /// launch only, since `WorkspaceModel.hasReadSessions` stays true afterwards.
-        case sessions(WorkspaceID)
-        /// The conversation is known and its rows are not on screen yet: either this launch has
-        /// never built its transcript, or the transcript exists and is still reading.
-        case conversation(SessionID)
-
-        /// In the register the file loader already uses: what is being read.
-        var label: String {
-            switch self {
-            case .sessions: "Opening the workspace"
-            case .conversation: "Reading the conversation"
-            }
-        }
-    }
-
     /// Nil whenever the pane has something to draw, which is the ordinary case and the one this
     /// must be cheap in.
     ///
-    /// `existingTranscript` is a plain dictionary lookup, and `isLoaded` is the one observed
-    /// property read here, so a pane that is drawing a conversation depends on nothing that moves
-    /// until that conversation is read.
-    private var waiting: Wait? {
+    /// **A transcript that exists and is still reading is deliberately not here, and that is a fix
+    /// rather than a tidying.** This is drawn as an overlay on the whole pane, and a pane drawing
+    /// a conversation is a transcript with a composer under it, so the wait was centred in the two
+    /// together: it sat half the composer's height below the middle of the transcript, which with
+    /// the divider dragged out to 348 points put it 174 points low and a couple of inches off the
+    /// bottom rule. Worse, it moved every time that divider did. `ChatPaneView` draws that one
+    /// over its own transcript now, which is where the missing content is. What is left here is a
+    /// pane with nothing in it at all, and the whole pane is exactly what that wait is about.
+    ///
+    /// `existingTranscript` is a plain dictionary lookup and `isLoaded` is not read here at all
+    /// any more, so a pane that is drawing a conversation depends on nothing that moves.
+    private var waiting: PaneWait? {
         switch showing {
         case .chat(let sessionID):
-            if let transcript = model.existingTranscript(for: sessionID) {
-                return transcript.isLoaded ? nil : .conversation(sessionID)
-            }
+            // The transcript exists, so the pane has a composer to draw and the wait belongs to
+            // the transcript rather than to the pane. See `ChatPaneView.waiting`.
+            //
+            // Handing one wait to the other costs nothing that can be seen: `prepare` builds the
+            // transcript on the next turn of the run loop, which is well inside the half second
+            // either of them stays quiet for, so only one of the two is ever drawn.
+            if model.existingTranscript(for: sessionID) != nil { return nil }
             if model.sessions.contains(where: { $0.id == sessionID }) {
                 return .conversation(sessionID)
             }
@@ -114,6 +104,10 @@ struct CenterPaneView: View {
             // Over the content rather than in place of it, so the pane that is being built keeps
             // its background, its size and its place in the hierarchy while the wait is drawn.
             // Nothing to hit: it is a readout, and the pane underneath still takes clicks.
+            //
+            // The whole pane is the right frame for the waits that are left here, because every
+            // one of them is a pane with nothing in it: `waitingSurface` fills it edge to edge and
+            // has no composer of its own. A conversation being read is not one of them any more.
             .overlay {
                 SlowLoadingView(subject: waiting, label: waiting?.label)
                     .allowsHitTesting(false)

--- a/Sources/Bloom/Views/Center/Panes/ChatPaneView.swift
+++ b/Sources/Bloom/Views/Center/Panes/ChatPaneView.swift
@@ -48,6 +48,20 @@ struct ChatPaneView: View {
     /// conversation and is scoped with the other two.
     @AppStorage(ChatLineHeight.defaultsKey) private var lineHeight = ChatLineHeight.standard
 
+    /// What the transcript has nothing to draw for, and nil the moment its rows are on screen.
+    ///
+    /// Here rather than in `CenterPaneView`, which owns the pane's other waits, because this one
+    /// belongs to the transcript and not to the pane: while a conversation is being read the
+    /// composer underneath is already drawn and already usable, so it is not part of what is
+    /// missing. Hung off the pane, the spinner was centred in the transcript and the composer
+    /// together and therefore sat half the composer's height below the middle of the transcript,
+    /// which is 174 points low with the divider dragged out to 348, and it moved on every drag of
+    /// that divider. Centred in the transcript it is a relationship to the pane rather than a
+    /// distance from an edge, so dragging the divider cannot move it off the middle again.
+    private var waiting: PaneWait? {
+        transcript.isLoaded ? nil : .conversation(transcript.session.id)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             TranscriptView(
@@ -56,6 +70,16 @@ struct ChatPaneView: View {
                 memory: TranscriptPaneMemory(model: model, pane: pane)
             ) { isTranscriptScrolledUp = $0 }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // The wait, over the transcript alone: see `waiting` above. It is the same overlay
+            // `TranscriptListView` hangs its empty placeholder off, on the same frame, so the two
+            // things a pane says about having no rows are said in the same place.
+            //
+            // Nothing to hit, because the composer below is not covered and the transcript under
+            // it still takes clicks.
+            .overlay {
+                SlowLoadingView(subject: waiting, label: waiting?.label)
+                    .allowsHitTesting(false)
+            }
             // On the transcript, not on the composer, and that is the whole of the change.
             //
             // The pill is a claim about the transcript ("there is more of this below, come and

--- a/Sources/Bloom/Views/Center/Panes/PaneWait.swift
+++ b/Sources/Bloom/Views/Center/Panes/PaneWait.swift
@@ -1,0 +1,31 @@
+import BloomCore
+
+/// What a pane with nothing to draw is waiting for.
+///
+/// Two of them, and they are two different moments of the same switch. Which one the user actually
+/// meets depends on whether this launch has been here before, which is why neither could be left
+/// out.
+///
+/// It has a file of its own rather than sitting inside `CenterPaneView` because the two waits are
+/// drawn in two different places, and both of them need these words. A pane waiting on
+/// `.sessions` has nothing in it at all, so the whole pane is what is missing and `CenterPaneView`
+/// draws that one over the whole pane. `.conversation` is a transcript being read, and a pane
+/// reading a transcript already has its composer on screen underneath it, so `ChatPaneView` draws
+/// that one over the transcript alone. See `ChatPaneView.waiting` for what one overlay doing both
+/// did to where the spinner landed.
+enum PaneWait: Equatable, Sendable {
+    /// The store has not yet said which conversations this workspace has. The first visit of a
+    /// launch only, since `WorkspaceModel.hasReadSessions` stays true afterwards.
+    case sessions(WorkspaceID)
+    /// The conversation is known and its rows are not on screen yet: either this launch has never
+    /// built its transcript, or the transcript exists and is still reading.
+    case conversation(SessionID)
+
+    /// In the register the file loader already uses: what is being read.
+    var label: String {
+        switch self {
+        case .sessions: "Opening the workspace"
+        case .conversation: "Reading the conversation"
+        }
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Notices/LoadingView.swift
+++ b/Sources/Bloom/Views/Chrome/Notices/LoadingView.swift
@@ -9,8 +9,38 @@ struct LoadingView: View {
     }
 
     var body: some View {
-        HStack(spacing: Metrics.gutter) {
+        // `spacingWide` rather than `gutter`, because this is a glyph and its label and not two
+        // groups of a row. It is the same rung the transcript spends on every one of its glyph
+        // columns, where it is called `TranscriptLayout.glyphGap`. At the gutter the pair measured
+        // thirteen points of daylight off a window capture, which is not a number anywhere in the
+        // scale: it was the gutter's twelve plus whatever the spinner and the first letter keep
+        // inside their own boxes.
+        //
+        // Centred, and deliberately NOT `.firstTextBaseline`, which is what `AgentQuestionCard`
+        // and every other glyph beside a label in this window aligns on. A spinner is not a glyph:
+        // it has no baseline of its own, so SwiftUI answers with the bottom edge of its box, which
+        // would stand the whole ring above the words with its centre nearly four points clear of
+        // theirs. Centring is right here and it is not a guess: `NSProgressIndicator` draws the
+        // ring centred in its box at all three control sizes, measured into a bitmap, and the
+        // system font's line box is centred on its own cap height to within a third of a point
+        // (callout: ascender 11.6, descender 2.53, leading 0.87, cap 8.46). So the two boxes
+        // agreeing is the two things a reader sees agreeing.
+        HStack(spacing: Metrics.spacingWide) {
             ProgressView()
+                // The size of the words beside it, rather than the size AppKit hands out.
+                //
+                // `ProgressView()` at the default control size is the regular spinner, which is 32
+                // points square. That is `NSProgressIndicator.intrinsicContentSize`, and it is the
+                // first of the three sizes `StatusColumnGallery` already writes down (32, 16, 10).
+                // The label it is introducing is `Typo.label`, whose line box is 15 points, so the
+                // spinner stood over twice the height of its own sentence and read as a control a
+                // line of text happened to be sitting next to. `.small` is a 16 point indicator,
+                // which is that line box, and it is what every other spinner in this window
+                // already asks for: `.small` in the setup sheet, the sign in sheet and the create
+                // window, `.mini` in the sidebar's status column. This one was the exception, and
+                // it is the only spinner drawn against a pane rather than inside a row, which is
+                // how it kept the default without anybody noticing.
+                .controlSize(.small)
 
             if let label {
                 Text(label)


### PR DESCRIPTION
"Reading the conversation" was an overlay on the whole chat pane, and a chat pane is a transcript with a composer under it, so it was centred in the two together: half the composer's height below the middle of the transcript. With the divider dragged out to 348 points that is 174 points low, near the floor of the empty area, and it moved on every drag of the divider. It is drawn over the transcript now, the same overlay `TranscriptListView` already hangs its empty placeholder off, so it is a relationship to the pane rather than a distance from an edge. The wait type moves out of `CenterPaneView` into `PaneWait` so both places can say the same words.

The spinner and its label: the gap was `Metrics.gutter`, the rung between the groups of a row, where a glyph and its label is `spacingWide` (the eight points the transcript spends as `TranscriptLayout.glyphGap`). And this was the app's only `ProgressView` left at the default control size, a 32 point indicator beside a 15 point line box; `.small` is 16, which is what every other spinner in the window asks for.

Not `.firstTextBaseline`. A spinner has no baseline, so SwiftUI answers with the bottom edge of its box and the ring would stand clear above the words. Measured into a bitmap, `NSProgressIndicator` draws its ring centred in its box at all three control sizes, and the system font's line box is centred on its cap height to within a third of a point, so centring the two boxes is centring the two things a reader sees.

`LoadingView` is shared, so the size and gap change reaches the other nine places it is drawn: the diff, the file preview and editor, the changed file list, the file tree, the checks list, the terminal pane, the agents settings pane and the detail column.