### PR TITLE
Record the list GPT-6 Astra arrives in, and pin the rank that puts it first

### DIFF
--- a/Sources/BloomCore/Agent/Codex/CodexModelCatalog.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexModelCatalog.swift
@@ -13,6 +13,24 @@ import Foundation
 /// five, and `gpt-5.5` and `gpt-5.2` four. A flat five-entry picker is wrong for three of the five
 /// models on offer, in both directions: it hides a level two models have and offers levels three
 /// models do not.
+///
+/// **Re-measured against codex-cli 0.153.0 on 2026-09-05, and every part of that list had moved.**
+/// `gpt-6-astra` is there, as the account default, with the same six levels and a default of
+/// `medium`; `gpt-5.2` has gone; `gpt-5.4-mini` and `gpt-5.3-codex-spark` have arrived with four
+/// each. Not one line of Bloom changed to offer any of it, which is the whole case for fetching:
+/// a generation nobody here had heard of was named, ranked and given its own effort picker on the
+/// strength of what the CLI said. Both captures are kept as fixtures, and
+/// `Tests/fixtures/codex-model-list-astra.json` is the newer one.
+///
+/// **What is on the wire and deliberately not read here.** Every model in that capture also
+/// carries `serviceTiers` and `additionalSpeedTiers`: a `priority` tier the CLI calls "Fast",
+/// worth 2x speed on `gpt-6-astra` and 1.5x on the `gpt-5.6` family, for more of the account's
+/// usage allowance. `turn/start` takes it as `serviceTier` and `serviceTierForTurn`, so it is a
+/// real control rather than an unreachable field, and Bloom sends neither, so every Codex turn
+/// runs at standard speed. It is left out on purpose and not for want of a place to put it: it
+/// spends the user's allowance faster, and Bloom's own "Fast mode" switch is already a different
+/// thing on the other backend (Claude Code's `--thinking disabled`, see `AgentRunner`), so a
+/// second control by that name needs a decision about both rather than a field being decoded.
 public struct CodexModel: Sendable, Hashable, Identifiable {
     public let id: String
     public let displayName: String

--- a/Sources/BloomCore/Agent/Codex/CodexModelRank.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexModelRank.swift
@@ -13,7 +13,10 @@ import Foundation
 ///
 /// 1. **Version, descending.** `gpt-5.6` above `gpt-5.5` above `gpt-5.4`. Parsed as numbers rather
 ///    than compared as text, because `gpt-5.10` sorts below `gpt-5.9` as a string and above it as
-///    a version, and the string answer is wrong.
+///    a version, and the string answer is wrong. A major with no minor after it is that major and
+///    zero, which is how `gpt-6-astra` came to lead the list the day it appeared without anything
+///    here being told about it. That is the case worth protecting: read a bare major as no version
+///    at all and the newest model on the account is offered below every model it replaces.
 /// 2. **Full models above cut-down ones at the same version.** `gpt-5.4` above `gpt-5.4-mini`.
 ///    The suffixes are the vendor's own words for a smaller model, and a smaller model is the
 ///    thing you pick on purpose rather than the thing you are offered first.

--- a/Tests/BloomCoreTests/CodexModelRankTests.swift
+++ b/Tests/BloomCoreTests/CodexModelRankTests.swift
@@ -65,6 +65,19 @@ struct CodexModelRankTests {
         #expect(ordered.map(\.id) == ["gpt-5.4", "codex-preview"])
     }
 
+    /// The shape a whole new generation arrives in: a major number with no minor after it at all.
+    /// `gpt-6-astra` is read as 6.0 and leads the list, above every `gpt-5.6` variant. The rule is
+    /// worth a test of its own because the failure is silent and total: a parser that insisted on
+    /// a dot would read no version at all, and the newest model on the account would be offered
+    /// under every model it replaces.
+    @Test("a version with no minor number is still a version")
+    func majorWithNoMinor() {
+        let ordered = CodexModelRank.ordered([
+            model("gpt-5.6-sol"), model("gpt-6-astra"), model("gpt-5.6-terra"),
+        ])
+        #expect(ordered.map(\.id) == ["gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra"])
+    }
+
     /// `isReduced` matches whole words, so a name that merely contains the letters is not demoted.
     @Test("a word inside another word is not a size")
     func wordBoundary() {

--- a/Tests/BloomCoreTests/CodexProtocolTests.swift
+++ b/Tests/BloomCoreTests/CodexProtocolTests.swift
@@ -408,6 +408,42 @@ private func events(_ name: String) throws -> [CodexEvent] {
         let models = CodexModel.decodeList(try codexFixtureJSON("codex-model-list.json"))
         #expect(models.filter(\.acceptsImages).count == models.count)
     }
+
+    // MARK: - A generation that arrived after this code was written
+
+    /// `codex-model-list-astra.json` is the same call answered by codex-cli 0.153.0 on this
+    /// machine on 2026-09-05, the day after GPT-6 Astra reached most accounts. The capture above
+    /// it is codex-cli 0.147.0 from 2026-08-21, and both are kept, because the pair is the
+    /// evidence for the decision `CodexModelCatalog` was written on: a whole generation arrived,
+    /// took over as the account default and brought its own reasoning levels, and nothing in
+    /// Bloom had to be edited to offer it. A hardcoded list would have missed all of it.
+    @Test func readsAGenerationOfModelsNothingHereHadHeardOf() throws {
+        let models = CodexModel.decodeList(try codexFixtureJSON("codex-model-list-astra.json"))
+        let astra = try #require(models.first { $0.id == "gpt-6-astra" })
+
+        // The name the picker draws is the server's, so a model Bloom has never heard of is still
+        // offered under the vendor's own spelling rather than a tidied id.
+        #expect(astra.displayName == "GPT-6-Astra")
+        #expect(astra.isDefault)
+        #expect(astra.acceptsImages)
+        // Six levels, which is the set `gpt-5.5` does not have: the flat picker would have hidden
+        // `ultra` and `max` from the account's own default model.
+        #expect(astra.effortIDs == ["low", "medium", "high", "xhigh", "max", "ultra"])
+        // Its own default rather than Bloom's `high`, which is why the model carries one.
+        #expect(astra.defaultEffort == "medium")
+        #expect(astra.resolvedEffort(preferring: "ultra") == "ultra")
+    }
+
+    /// What somebody opening the model menu actually sees: the new generation at the top, and
+    /// everything it supersedes underneath in the order the server sent.
+    @Test func offersTheNewGenerationAboveEverythingItSupersedes() throws {
+        let models = CodexModel.decodeList(try codexFixtureJSON("codex-model-list-astra.json"))
+        #expect(CodexModelRank.ordered(models).map(\.id) == [
+            "gpt-6-astra",
+            "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
+            "gpt-5.5", "gpt-5.4-mini", "gpt-5.3-codex-spark",
+        ])
+    }
 }
 
 @Suite struct CodexModelCatalogTests {

--- a/Tests/BloomCoreTests/DefaultBackendTests.swift
+++ b/Tests/BloomCoreTests/DefaultBackendTests.swift
@@ -229,6 +229,10 @@ struct DefaultBackendTests {
         #expect(ClaudeModelRank.recognises("claude-opus-5[1m]"))
         #expect(ClaudeModelRank.recognises("opus-5-1m"))
         #expect(!ClaudeModelRank.recognises("gpt-5.6-sol"))
+        // A Codex generation newer than anything written down here. It must stay unrecognised,
+        // because "recognised" means Claude Code and a GPT model opened there runs on the wrong
+        // CLI's default.
+        #expect(!ClaudeModelRank.recognises("gpt-6-astra"))
         #expect(!ClaudeModelRank.recognises("internal-preview-3"))
     }
 

--- a/Tests/fixtures/codex-model-list-astra.json
+++ b/Tests/fixtures/codex-model-list-astra.json
@@ -1,0 +1,360 @@
+{
+  "data": [
+    {
+      "id": "gpt-6-astra",
+      "model": "gpt-6-astra",
+      "upgrade": null,
+      "upgradeInfo": null,
+      "availabilityNux": {
+        "message": "This is GPT-6, a new generation of intelligence. Astra is state-of-the-art in coding, computer use, science, and professional work. Give it a hard problem, a half-formed idea, or anything you've been meaning to build. See where it takes you."
+      },
+      "displayName": "GPT-6-Astra",
+      "description": "Our most capable model for complex, demanding work.",
+      "modelSpecialty": null,
+      "hidden": false,
+      "supportedReasoningEfforts": [
+        {
+          "reasoningEffort": "low",
+          "description": "Fast responses with lighter reasoning"
+        },
+        {
+          "reasoningEffort": "medium",
+          "description": "Balances speed and reasoning depth for everyday tasks"
+        },
+        {
+          "reasoningEffort": "high",
+          "description": "Greater reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "xhigh",
+          "description": "Extra high reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "max",
+          "description": "Maximum reasoning depth for the hardest problems"
+        },
+        {
+          "reasoningEffort": "ultra",
+          "description": "Maximum reasoning with automatic task delegation"
+        }
+      ],
+      "defaultReasoningEffort": "medium",
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "supportsPersonality": false,
+      "multiAgentVersion": "v2",
+      "additionalSpeedTiers": [
+        "fast"
+      ],
+      "serviceTiers": [
+        {
+          "id": "priority",
+          "name": "Fast",
+          "description": "2x speed, increased usage"
+        }
+      ],
+      "defaultServiceTier": null,
+      "isDefault": true
+    },
+    {
+      "id": "gpt-5.6-sol",
+      "model": "gpt-5.6-sol",
+      "upgrade": null,
+      "upgradeInfo": null,
+      "availabilityNux": null,
+      "displayName": "GPT-5.6-Sol",
+      "description": "Reliable agentic workhorse for everyday tasks.",
+      "modelSpecialty": null,
+      "hidden": false,
+      "supportedReasoningEfforts": [
+        {
+          "reasoningEffort": "low",
+          "description": "Fast responses with lighter reasoning"
+        },
+        {
+          "reasoningEffort": "medium",
+          "description": "Balances speed and reasoning depth for everyday tasks"
+        },
+        {
+          "reasoningEffort": "high",
+          "description": "Greater reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "xhigh",
+          "description": "Extra high reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "max",
+          "description": "Maximum reasoning depth for the hardest problems"
+        },
+        {
+          "reasoningEffort": "ultra",
+          "description": "Maximum reasoning with automatic task delegation"
+        }
+      ],
+      "defaultReasoningEffort": "low",
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "supportsPersonality": false,
+      "multiAgentVersion": "v2",
+      "additionalSpeedTiers": [
+        "fast"
+      ],
+      "serviceTiers": [
+        {
+          "id": "priority",
+          "name": "Fast",
+          "description": "1.5x speed, increased usage"
+        }
+      ],
+      "defaultServiceTier": null,
+      "isDefault": false
+    },
+    {
+      "id": "gpt-5.6-terra",
+      "model": "gpt-5.6-terra",
+      "upgrade": null,
+      "upgradeInfo": null,
+      "availabilityNux": null,
+      "displayName": "GPT-5.6-Terra",
+      "description": "Balanced agentic coding model for everyday work.",
+      "modelSpecialty": null,
+      "hidden": false,
+      "supportedReasoningEfforts": [
+        {
+          "reasoningEffort": "low",
+          "description": "Fast responses with lighter reasoning"
+        },
+        {
+          "reasoningEffort": "medium",
+          "description": "Balances speed and reasoning depth for everyday tasks"
+        },
+        {
+          "reasoningEffort": "high",
+          "description": "Greater reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "xhigh",
+          "description": "Extra high reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "max",
+          "description": "Maximum reasoning depth for the hardest problems"
+        },
+        {
+          "reasoningEffort": "ultra",
+          "description": "Maximum reasoning with automatic task delegation"
+        }
+      ],
+      "defaultReasoningEffort": "medium",
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "supportsPersonality": false,
+      "multiAgentVersion": "v2",
+      "additionalSpeedTiers": [
+        "fast"
+      ],
+      "serviceTiers": [
+        {
+          "id": "priority",
+          "name": "Fast",
+          "description": "1.5x speed, increased usage"
+        }
+      ],
+      "defaultServiceTier": null,
+      "isDefault": false
+    },
+    {
+      "id": "gpt-5.6-luna",
+      "model": "gpt-5.6-luna",
+      "upgrade": null,
+      "upgradeInfo": null,
+      "availabilityNux": null,
+      "displayName": "GPT-5.6-Luna",
+      "description": "Fast and affordable agentic coding model.",
+      "modelSpecialty": null,
+      "hidden": false,
+      "supportedReasoningEfforts": [
+        {
+          "reasoningEffort": "low",
+          "description": "Fast responses with lighter reasoning"
+        },
+        {
+          "reasoningEffort": "medium",
+          "description": "Balances speed and reasoning depth for everyday tasks"
+        },
+        {
+          "reasoningEffort": "high",
+          "description": "Greater reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "xhigh",
+          "description": "Extra high reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "max",
+          "description": "Maximum reasoning depth for the hardest problems"
+        }
+      ],
+      "defaultReasoningEffort": "medium",
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "supportsPersonality": false,
+      "multiAgentVersion": "v1",
+      "additionalSpeedTiers": [
+        "fast"
+      ],
+      "serviceTiers": [
+        {
+          "id": "priority",
+          "name": "Fast",
+          "description": "1.5x speed, increased usage"
+        }
+      ],
+      "defaultServiceTier": null,
+      "isDefault": false
+    },
+    {
+      "id": "gpt-5.5",
+      "model": "gpt-5.5",
+      "upgrade": null,
+      "upgradeInfo": null,
+      "availabilityNux": null,
+      "displayName": "GPT-5.5",
+      "description": "Proven previous-generation model for coding and general work.",
+      "modelSpecialty": null,
+      "hidden": false,
+      "supportedReasoningEfforts": [
+        {
+          "reasoningEffort": "low",
+          "description": "Fast responses with lighter reasoning"
+        },
+        {
+          "reasoningEffort": "medium",
+          "description": "Balances speed and reasoning depth for everyday tasks"
+        },
+        {
+          "reasoningEffort": "high",
+          "description": "Greater reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "xhigh",
+          "description": "Extra high reasoning depth for complex problems"
+        }
+      ],
+      "defaultReasoningEffort": "medium",
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "supportsPersonality": true,
+      "multiAgentVersion": null,
+      "additionalSpeedTiers": [
+        "fast"
+      ],
+      "serviceTiers": [
+        {
+          "id": "priority",
+          "name": "Fast",
+          "description": "1.5x speed, increased usage"
+        }
+      ],
+      "defaultServiceTier": null,
+      "isDefault": false
+    },
+    {
+      "id": "gpt-5.4-mini",
+      "model": "gpt-5.4-mini",
+      "upgrade": "gpt-5.6-luna",
+      "upgradeInfo": {
+        "model": "gpt-5.6-luna",
+        "upgradeCopy": null,
+        "modelLink": null,
+        "migrationMarkdown": "GPT-5.4 Mini will be deprecated soon\n\nCodex now uses GPT-5.6 Luna in place of GPT-5.4 Mini. Switch to GPT-5.6 Luna to continue.\n",
+        "retirementAt": 1788202800
+      },
+      "availabilityNux": null,
+      "displayName": "GPT-5.4-Mini",
+      "description": "Small, fast, and cost-efficient model for simpler coding tasks.",
+      "modelSpecialty": null,
+      "hidden": false,
+      "supportedReasoningEfforts": [
+        {
+          "reasoningEffort": "low",
+          "description": "Fast responses with lighter reasoning"
+        },
+        {
+          "reasoningEffort": "medium",
+          "description": "Balances speed and reasoning depth for everyday tasks"
+        },
+        {
+          "reasoningEffort": "high",
+          "description": "Greater reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "xhigh",
+          "description": "Extra high reasoning depth for complex problems"
+        }
+      ],
+      "defaultReasoningEffort": "medium",
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "supportsPersonality": true,
+      "multiAgentVersion": null,
+      "additionalSpeedTiers": [],
+      "serviceTiers": [],
+      "defaultServiceTier": null,
+      "isDefault": false
+    },
+    {
+      "id": "gpt-5.3-codex-spark",
+      "model": "gpt-5.3-codex-spark",
+      "upgrade": null,
+      "upgradeInfo": null,
+      "availabilityNux": null,
+      "displayName": "GPT-5.3-Codex-Spark",
+      "description": "Ultra-fast coding model.",
+      "modelSpecialty": null,
+      "hidden": false,
+      "supportedReasoningEfforts": [
+        {
+          "reasoningEffort": "low",
+          "description": "Fast responses with lighter reasoning"
+        },
+        {
+          "reasoningEffort": "medium",
+          "description": "Balances speed and reasoning depth for everyday tasks"
+        },
+        {
+          "reasoningEffort": "high",
+          "description": "Greater reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "xhigh",
+          "description": "Extra high reasoning depth for complex problems"
+        }
+      ],
+      "defaultReasoningEffort": "high",
+      "inputModalities": [
+        "text"
+      ],
+      "supportsPersonality": true,
+      "multiAgentVersion": null,
+      "additionalSpeedTiers": [],
+      "serviceTiers": [],
+      "defaultServiceTier": null,
+      "isDefault": false
+    }
+  ],
+  "nextCursor": null
+}

--- a/docs/CODEX.md
+++ b/docs/CODEX.md
@@ -1,8 +1,9 @@
 # Codex in Bloom
 
 Ground truth plus the plan for the rest of the work. Everything under "Verified" was measured
-against `codex-cli 0.147.0` on this machine, driving the real binary, on 2026-08-21. Everything
-under "Plan" is a decision, not a measurement, and is meant to be argued with.
+against `codex-cli 0.147.0` on this machine, driving the real binary, on 2026-08-21, except where
+a section dates itself against a later build. Everything under "Plan" is a decision, not a
+measurement, and is meant to be argued with.
 
 Related: `AGENTS-INTEGRATION.md` (how the four CLIs are detected), `PROTOCOL.md` (Claude Code's
 stream-json), `PLAN.md`.
@@ -110,6 +111,41 @@ before anyone signs in. What it returned:
 wrong for three of these five, in both directions: it hides `ultra`, which two models take, and it
 offers `max` to two models that do not. Conductor hardcodes its list and is already stale: it names
 `gpt-5.4`, which no longer exists, and has none of the three `gpt-5.6` models. **Fetch it.**
+
+#### The same call again on 2026-09-05, against `codex-cli 0.153.0`
+
+A fortnight later, the day after GPT-6 Astra reached most paying accounts. Every part of the list
+had moved:
+
+| Model | Default | Reasoning efforts | Default effort |
+| --- | --- | --- | --- |
+| `gpt-6-astra` | yes | low, medium, high, xhigh, max, **ultra** | medium |
+| `gpt-5.6-sol` | | low, medium, high, xhigh, max, **ultra** | low |
+| `gpt-5.6-terra` | | low, medium, high, xhigh, max, **ultra** | medium |
+| `gpt-5.6-luna` | | low, medium, high, xhigh, max | medium |
+| `gpt-5.5` | | low, medium, high, xhigh | medium |
+| `gpt-5.4-mini` | | low, medium, high, xhigh | medium |
+| `gpt-5.3-codex-spark` | | low, medium, high, xhigh | high |
+
+`gpt-5.2` has gone. `includeHidden: true` adds two the picker never shows, `gpt-reserve` and
+`codex-auto-review`. `gpt-5.4-mini` now carries an `upgradeInfo` block naming `gpt-5.6-luna` and a
+retirement date, which nothing here reads yet.
+
+**Nothing in Bloom changed to offer the new generation.** It was fetched, drawn under the
+`displayName` the server sent, put at the head of the picker by `CodexModelRank` because 6 is above
+5.6, and given its own six-level effort list with its own default of `medium`. That is the whole
+return on fetching rather than hardcoding, and `Tests/fixtures/codex-model-list-astra.json` is the
+capture the tests read.
+
+**Fast mode is a service tier. It is not a model id and it is not a reasoning effort.** Every
+model in that capture carries `serviceTiers` and `additionalSpeedTiers` beside its efforts: one
+tier, `priority`, which the CLI labels "Fast" and describes as "2x speed, increased usage" on
+`gpt-6-astra` and "1.5x speed, increased usage" on the `gpt-5.6` family. `TurnStartParams` takes it
+two ways, `serviceTier` for this turn and the ones after it and `serviceTierForTurn` for this turn
+alone, with `"default"` meaning standard speed. **Bloom sends neither**, so every Codex turn runs
+at standard speed. Adding it is a decision about spending somebody's usage allowance faster, and
+about the name, because the composer's footer already has a Fast mode switch and that one is Claude
+Code's `--thinking disabled`.
 
 ---
 


### PR DESCRIPTION
`gpt-6-astra` needs no code to be offered, and this branch adds none. codex-cli 0.153.0 advertises it through `model/list` as the account default, Bloom fetches that list rather than shipping one, so it is already named from the server's own `displayName`, already carries its own six reasoning levels up to `ultra` with a default of `medium`, and is already first in the picker because `CodexModelRank` reads 6 as above 5.6. Nothing on screen changes: anyone whose Codex CLI advertises Astra saw it before this release too, and anyone whose CLI is older still does not.

What was missing is the test. Every existing ranking test names a minor version, and a new generation arrives as a bare major, so a tidy-up of the version parser that insisted on a dot would have read no version at all and dropped the newest model on the account below every model it replaces, silently. That case is pinned now, along with `gpt-6-astra` staying unrecognised by `ClaudeModelRank`, which is the same guard from the other side: recognised means Claude Code, and a GPT model opened there runs on the wrong CLI's default.

`Tests/fixtures/codex-model-list-astra.json` is the real response, recorded today beside the 0.147.0 capture rather than replacing it. The pair is the evidence for fetching over hardcoding: a whole generation arrived, took over as the default and brought its own effort set, and no line of Bloom had to be edited.

Also written down and deliberately not built: fast mode is a service tier, not a model id and not an effort. Every model carries `serviceTiers` with a `priority` tier the CLI labels Fast, 2x on Astra and 1.5x on the `gpt-5.6` family, and `turn/start` takes `serviceTier` and `serviceTierForTurn`. Bloom sends neither, so every Codex turn runs at standard speed. Two controls called Fast, one spending the user's allowance twice as fast and one turning Claude Code's thinking off, is a decision rather than a field to decode. `docs/CODEX.md` carries the measurement.
