### PR TITLE
Fix transcript gaps during resize and reduce layout work

### DIFF
--- a/Sources/Bloom/BloomApp.swift
+++ b/Sources/Bloom/BloomApp.swift
@@ -71,6 +71,7 @@ struct BloomApp: App {
         // and the table each believe before it, after it, after a scroll and after a window
         // resize. It is how somebody finally watches the transcript go blank. See `ComposerProbe`.
         if ComposerProbe.isRequested { ComposerProbe.schedule() }
+        if TranscriptLayoutProbe.isRequested { TranscriptLayoutProbe.schedule() }
 
         // And the one that answers "the battery menu says Bloom is using significant energy":
         // `Bloom --idle-probe <out.json> --idle-worktrees <list>` runs the diff stat pass the six

--- a/Sources/Bloom/Design/ComposerProbe.swift
+++ b/Sources/Bloom/Design/ComposerProbe.swift
@@ -583,7 +583,9 @@ enum ComposerProbe {
             "documentMinDuringDrag": .number(low),
             "documentMaxDuringDrag": .number(high),
             "documentGrewDuringDrag": .bool(grew),
-            "reproduced": .bool(swing >= 2),
+            // Height agreement alone misses realised rows displaced beyond the scrollable end.
+            "reproduced": .bool(swing >= 2 || [before, afterTaller, afterScrolling, afterWindowResize]
+                .contains { number($0, "misplacedCells") > 0 }),
 
             "before": .object(before),
             "afterTaller": .object(afterTaller),

--- a/Sources/Bloom/Design/TranscriptLayoutProbe.swift
+++ b/Sources/Bloom/Design/TranscriptLayoutProbe.swift
@@ -4,7 +4,8 @@ import Observation
 import SwiftUI
 
 /// Exercises the real table and hosting views with deterministic rows. Unlike the core tests,
-/// this catches disagreement between SwiftUI's measurements and AppKit's cached row rectangles.
+/// this checks both SwiftUI's measurements and the realised positions against AppKit's row
+/// rectangles. Correct cached heights alone missed content drawn beyond the scrollable end.
 /// Run in an isolated app with --transcript-layout-probe <report.json> --window-hidden.
 @MainActor
 enum TranscriptLayoutProbe {
@@ -83,7 +84,42 @@ enum TranscriptLayoutProbe {
                 return abs(row.told - max(0.01, known)) <= 0.5
                     && (row.redrawsItself || !row.needsMeasuring)
             }, "\(phase): visible row has a gap, overlap or stale measurement")
+            check(rows.allSatisfy { row in
+                guard let top = row.drawnTop, let height = row.drawnHeight else { return true }
+                return abs(top - row.top) <= 0.5 && abs(height - row.told) <= 0.5
+            }, "\(phase): rendered cell disagrees with its scrollable row rectangle")
         }
+
+        // The live report had correct cached heights but every realised row was 92 points
+        // below rect(ofRow:). Reproduce that state explicitly: ordinary layout and notifying
+        // the same row heights did not repair it in the running app.
+        guard let scroll = controller.scrollView,
+              let table = scroll.documentView as? NSTableView else { harness.fail("no scroll view") }
+        table.enumerateAvailableRowViews { row, _ in
+            row.setFrameOrigin(NSPoint(x: row.frame.minX, y: row.frame.minY + 92))
+        }
+        var displaced = false
+        table.enumerateAvailableRowViews { row, index in
+            if abs(row.frame.minY - table.rect(ofRow: index).minY) > 90 { displaced = true }
+        }
+        check(displaced, "failed to reproduce displaced row views")
+        table.needsLayout = true
+        table.layoutSubtreeIfNeeded()
+        checkRows("after repairing displaced rows")
+
+        guard let alignedTable = table as? TranscriptTableView else { harness.fail("no aligned table") }
+        alignedTable.deferRowAlignment(for: 0.2)
+        table.enumerateAvailableRowViews { row, _ in
+            row.setFrameOrigin(NSPoint(x: row.frame.minX, y: row.frame.minY + 20))
+        }
+        alignedTable.alignRowOrigins()
+        var keptAnimation = false
+        table.enumerateAvailableRowViews { row, index in
+            if abs(row.frame.minY - table.rect(ofRow: index).minY) > 19 { keptAnimation = true }
+        }
+        check(keptAnimation, "row repair interrupted a deliberate animation")
+        await settle(window)
+        checkRows("after animation")
 
         for height in [180.0, 420, 1, 300, 600] {
             window.setContentSize(NSSize(width: 640, height: height))
@@ -112,8 +148,6 @@ enum TranscriptLayoutProbe {
 
         controller.goToEnd()
         await settle(window)
-        guard let scroll = controller.scrollView,
-              let table = scroll.documentView as? NSTableView else { harness.fail("no scroll view") }
         // Keep the gesture open while an already visible row changes size. The former queue
         // refused every height correction until didEndLiveScroll, leaving 180 points of blank.
         NotificationCenter.default.post(name: NSScrollView.willStartLiveScrollNotification, object: scroll)

--- a/Sources/Bloom/Design/TranscriptLayoutProbe.swift
+++ b/Sources/Bloom/Design/TranscriptLayoutProbe.swift
@@ -1,0 +1,143 @@
+import AppKit
+import BloomCore
+import Observation
+import SwiftUI
+
+/// Exercises the real table and hosting views with deterministic rows. Unlike the core tests,
+/// this catches disagreement between SwiftUI's measurements and AppKit's cached row rectangles.
+/// Run in an isolated app with --transcript-layout-probe <report.json> --window-hidden.
+@MainActor
+enum TranscriptLayoutProbe {
+    private static let harness = ProbeHarness(subject: "transcript-layout")
+    static var isRequested: Bool { harness.isRequested }
+
+    @Observable
+    final class Tail {
+        var height: CGFloat = 80
+    }
+
+    private struct TailRow: View {
+        let tail: Tail
+        var body: some View {
+            Color.blue.frame(height: tail.height)
+        }
+    }
+
+    static func schedule() {
+        Task { @MainActor in await run() }
+    }
+
+    private static func run() async {
+        let (window, _) = await harness.window()
+        guard let app = ProbeHarness.appModel else { harness.fail("no app model") }
+        let controller = TranscriptTableController()
+        let tail = Tail()
+        var entries = (0..<120).map { row in
+            TranscriptTableEntry(
+                id: .row(row), contentKey: TranscriptContentKey { $0.combine(row) },
+                shape: .answer,
+                content: {
+                    AnyView(Text(String(repeating: "A transcript row that wraps when resized. ", count: row % 9 + 1))
+                        .font(.system(size: 15)).padding(8))
+                }
+            )
+        }
+        entries.append(TranscriptTableEntry(
+            id: .streaming, contentKey: TranscriptContentKey { $0.combine("tail") },
+            content: { AnyView(TailRow(tail: tail)) }
+        ))
+        let view = TranscriptTable(
+            entries: entries, session: SessionID("layout-probe"), controller: controller,
+            scale: 1,
+            rowEnvironment: TranscriptRowEnvironment(
+                app: app, hoverHost: TranscriptHoverHost(), bubbleWidth: TranscriptBubbleWidth(),
+                linkActions: TranscriptLinkActions(), fontScale: 1, chatFont: .standard,
+                lineHeight: .standard, reduceMotion: true
+            ),
+            onGeometryChange: { _ in }, onSettled: {}, onLiveScrollChange: { _ in }
+        )
+        let host = NSHostingView(rootView: view)
+        window.contentView = host
+        window.setContentSize(NSSize(width: 640, height: 600))
+        await settle(window)
+        controller.arrived()
+        controller.goToEnd()
+        await settle(window)
+
+        var failures: [String] = []
+        var checks = 0
+        func check(_ condition: Bool, _ message: String) {
+            checks += 1
+            if !condition { failures.append(message) }
+        }
+        func checkRows(_ phase: String) {
+            guard let hold = TranscriptStateDump.holdView(in: host),
+                  let coordinator = hold.delegate as? TranscriptTable.Coordinator else {
+                check(false, "\(phase): no table")
+                return
+            }
+            let rows = coordinator.rowFacts(for: coordinator.visibleRowRange)
+            check(!rows.isEmpty, "\(phase): blank viewport")
+            check(rows.allSatisfy { row in
+                guard let known = row.known else { return false }
+                return abs(row.told - max(0.01, known)) <= 0.5
+                    && (row.redrawsItself || !row.needsMeasuring)
+            }, "\(phase): visible row has a gap, overlap or stale measurement")
+        }
+
+        for height in [180.0, 420, 1, 300, 600] {
+            window.setContentSize(NSSize(width: 640, height: height))
+            await settle(window)
+            if height > 1 {
+                check(controller.geometry.isAtEnd, "height \(height): lost live end")
+                checkRows("height \(height)")
+            }
+        }
+        controller.scroll(to: .row(60), delta: 12)
+        await settle(window)
+        let place = controller.topmostPlace
+        for height in [220.0, 560] {
+            window.setContentSize(NSSize(width: 640, height: height))
+            await settle(window)
+            check(controller.topmostPlace?.seq == place?.seq, "reading resize: changed row")
+            check(abs((controller.topmostPlace?.delta ?? 0) - (place?.delta ?? 0)) <= 1,
+                  "reading resize: changed offset within row")
+            checkRows("reading resize")
+        }
+        for width in [420.0, 900, 640] {
+            window.setContentSize(NSSize(width: width, height: 560))
+            await settle(window)
+            checkRows("width \(width)")
+        }
+
+        controller.goToEnd()
+        await settle(window)
+        guard let scroll = controller.scrollView,
+              let table = scroll.documentView as? NSTableView else { harness.fail("no scroll view") }
+        // Keep the gesture open while an already visible row changes size. The former queue
+        // refused every height correction until didEndLiveScroll, leaving 180 points of blank.
+        NotificationCenter.default.post(name: NSScrollView.willStartLiveScrollNotification, object: scroll)
+        for height in [260.0, 40] {
+            tail.height = height
+            await settle(window)
+            check(abs(table.rect(ofRow: entries.count - 1).height - height) <= 0.5,
+                  "live scroll: tail did not adopt height \(height)")
+        }
+        NotificationCenter.default.post(name: NSScrollView.didEndLiveScrollNotification, object: scroll)
+        await settle(window)
+        controller.goToEnd()
+        await settle(window)
+        checkRows("after live scroll")
+        harness.write(.object([
+            "checks": .integer(checks), "passed": .bool(failures.isEmpty),
+            "failures": .array(failures.map(JSONValue.string)),
+        ]))
+        exit(failures.isEmpty ? 0 : 1)
+    }
+
+    private static func settle(_ window: NSWindow) async {
+        window.layoutIfNeeded()
+        try? await Task.sleep(for: .milliseconds(500))
+        window.layoutIfNeeded()
+    }
+}

--- a/Sources/Bloom/Design/TranscriptStateDump.swift
+++ b/Sources/Bloom/Design/TranscriptStateDump.swift
@@ -167,6 +167,9 @@ enum TranscriptStateDump {
         let count = pane.table?.numberOfRows ?? -1
         let visible = range?.length ?? -1
         let facts = rowFacts(pane, band: band)
+        let displacements = facts.compactMap { fact in
+            fact.drawnTop.map { abs($0 - fact.top) }
+        }
         // **Not the three that redraw themselves.** The streaming tail and the bubble on its way
         // out draw nothing between turns and are measured on every pass, so counting them made
         // `lostRows` two before anything had gone wrong. `viewFor` exempts them from the silence
@@ -209,6 +212,8 @@ enum TranscriptStateDump {
             "silences": .array(TranscriptHoldCensus.silences.map { json(of: $0) }),
             "numberOfRows": .integer(count),
             "visibleRows": .integer(visible),
+            "misplacedCells": .integer(displacements.filter { $0 > 0.5 }.count),
+            "largestCellDisplacement": .number(displacements.max() ?? 0),
             "firstVisibleRow": .integer(range.map { $0.length > 0 ? $0.location : -1 } ?? -1),
             "rowViews": .integer(pane.table?.subviews.count ?? -1),
             "hostedRows": .integer(hostingViewCount(in: pane.table)),
@@ -319,6 +324,8 @@ enum TranscriptStateDump {
             "needsMeasuring": .bool(fact.needsMeasuring),
             "told": .number(fact.told),
             "top": .number(fact.top),
+            "drawnTop": fact.drawnTop.map(JSONValue.number) ?? .null,
+            "drawnHeight": fact.drawnHeight.map(JSONValue.number) ?? .null,
             "redrawsItself": .bool(fact.redrawsItself),
             "hasCell": .bool(fact.hasCell),
         ])

--- a/Sources/Bloom/Views/Transcript/TranscriptTable.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTable.swift
@@ -202,7 +202,7 @@ struct TranscriptTable: NSViewRepresentable {
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     func makeNSView(context: Context) -> TranscriptHoldView {
-        let table = NSTableView()
+        let table = TranscriptTableView()
         table.headerView = nil
         table.style = .plain
         table.rowSizeStyle = .custom
@@ -1037,6 +1037,7 @@ struct TranscriptTable: NSViewRepresentable {
         /// change in this file that somebody asked for. See `unfoldSeconds`.
         private func noteHeights(_ rows: IndexSet, over seconds: Double = 0) {
             guard let tableView, !rows.isEmpty else { return }
+            (tableView as? TranscriptTableView)?.deferRowAlignment(for: seconds)
             if seconds > 0 {
                 // Only while the row travels, and only the rows travelling. A cell is exactly its
                 // row, and its content is already at the height it is growing towards, so without
@@ -1385,6 +1386,7 @@ struct TranscriptTable: NSViewRepresentable {
         private func rowsArrived(
             head: Range<Int>, tail: Range<Int>, fading: Bool, in tableView: NSTableView
         ) {
+            (tableView as? TranscriptTableView)?.deferRowAlignment(for: fading ? Motion.hoverSeconds : 0)
             NSAnimationContext.beginGrouping()
             NSAnimationContext.current.duration = fading ? Motion.hoverSeconds : 0
             tableView.beginUpdates()
@@ -1402,6 +1404,7 @@ struct TranscriptTable: NSViewRepresentable {
         private func rowsLeft(
             head: Range<Int>, tail: Range<Int>, fading: Bool, in tableView: NSTableView
         ) {
+            (tableView as? TranscriptTableView)?.deferRowAlignment(for: fading ? Motion.hoverSeconds : 0)
             NSAnimationContext.beginGrouping()
             NSAnimationContext.current.duration = fading ? Motion.hoverSeconds : 0
             tableView.beginUpdates()
@@ -1558,6 +1561,7 @@ struct TranscriptTable: NSViewRepresentable {
                     reportGeometry()
                     isSettlingResizeAtEnd = false
                 }
+                (tableView as? TranscriptTableView)?.alignRowOrigins()
                 censusOfTheScreen(settled: true)
                 // **A transcript with rows in it and none of them on screen, once it has stopped
                 // moving.** The blank pane has been chased three times from mechanisms caught
@@ -1721,6 +1725,7 @@ struct TranscriptTable: NSViewRepresentable {
                 // Layout must finish before measuring the newly exposed rows. In particular,
                 // never place the reader against a transient zero-height clip view.
                 keepPlace(wasAtEnd: place.wasAtEnd, anchor: place.anchor)
+                (tableView as? TranscriptTableView)?.alignRowOrigins()
                 viewportPlace = nil
                 reportGeometry()
                 scheduleSettle()
@@ -2034,6 +2039,8 @@ struct TranscriptTable: NSViewRepresentable {
             rows.compactMap { row in
                 guard entries.indices.contains(row) else { return nil }
                 let entry = entries[row]
+                let cell = tableView?.view(atColumn: 0, row: row, makeIfNecessary: false)
+                let drawn = cell.map { $0.convert($0.bounds, to: tableView) }
                 return RowFact(
                     row: row,
                     name: String(describing: entry.id),
@@ -2049,7 +2056,9 @@ struct TranscriptTable: NSViewRepresentable {
                     ),
                     told: Double(tableView?.rect(ofRow: row).height ?? 0),
                     top: Double(tableView?.rect(ofRow: row).minY ?? 0),
-                    hasCell: tableView?.view(atColumn: 0, row: row, makeIfNecessary: false) != nil,
+                    drawnTop: drawn.map { Double($0.minY) },
+                    drawnHeight: drawn.map { Double($0.height) },
+                    hasCell: cell != nil,
                     redrawsItself: entry.id.redrawsItself
                 )
             }
@@ -2091,6 +2100,10 @@ struct TranscriptTable: NSViewRepresentable {
             /// Where the row starts in the document, so a report can add the heights up against
             /// what the reader can see. A document taller than the content it draws is the gap.
             var top: Double
+            /// The actual cell in document coordinates. AppKit can report the correct row rect
+            /// while leaving its realised view at an older origin, beyond the scrollable end.
+            var drawnTop: Double?
+            var drawnHeight: Double?
             /// Whether the table is holding a cell for it, which a silenced row never is.
             var hasCell: Bool
             /// One of the three entries that re-render from their own observation. Nought is never

--- a/Sources/Bloom/Views/Transcript/TranscriptTable.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTable.swift
@@ -1703,7 +1703,7 @@ struct TranscriptTable: NSViewRepresentable {
         /// Save the reader's position before AppKit resizes the clip view and emits bounds
         /// notifications. Reading it afterwards mistakes a shorter viewport for scrolling up.
         private func viewportWillResize() {
-            guard !isHeld, viewportPlace == nil, heights.isReady else { return }
+            guard !isHeld, !isLiveScrolling, viewportPlace == nil, heights.isReady else { return }
             viewportPlace = HeldPlace(
                 wasAtEnd: holdsEnd || isFollowingAlong, anchor: anchorEntry()
             )

--- a/Sources/Bloom/Views/Transcript/TranscriptTable.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTable.swift
@@ -146,7 +146,7 @@ final class TranscriptTableController {
     }
 }
 
-/// The transcript's scroll view, which differs from `NSScrollView` in exactly one answer.
+/// The transcript's scroll view, which forwards vertical wheel events and brackets resizing.
 ///
 /// **A markdown table stopped the transcript scrolling under the pointer.** A table and a code
 /// fence each sit in a `ScrollView(.horizontal)` of their own, and an inner scroll view already at
@@ -158,6 +158,16 @@ final class TranscriptTableController {
 /// an inner view at its edge in that axis and decides the predominant axis itself, so a wide table
 /// still scrolls sideways.
 final class TranscriptScrollView: NSScrollView {
+    var willResizeViewport: (() -> Void)?
+    var didResizeViewport: (() -> Void)?
+
+    override func setFrameSize(_ newSize: NSSize) {
+        let changed = newSize != frame.size
+        if changed { willResizeViewport?() }
+        super.setFrameSize(newSize)
+        if changed { didResizeViewport?() }
+    }
+
     override func wantsForwardedScrollEvents(for axis: NSEvent.GestureAxis) -> Bool {
         axis == .vertical
     }
@@ -291,6 +301,8 @@ struct TranscriptTable: NSViewRepresentable {
         /// A reflow saying its placement a second time. See `rewidth`.
         private var placeWork: Task<Void, Never>?
         private var resizeWork: Task<Void, Never>?
+        private var viewportWork: Task<Void, Never>?
+        private var viewportPlace: HeldPlace?
         private var endWork: Task<Void, Never>?
         private var reaimWork: Task<Void, Never>?
         /// Rows whose height turned out to be wrong once they were drawn, batched so a pass over
@@ -395,6 +407,10 @@ struct TranscriptTable: NSViewRepresentable {
         func attach(table: NSTableView, scroll: NSScrollView) {
             tableView = table
             scrollView = scroll
+            if let scroll = scroll as? TranscriptScrollView {
+                scroll.willResizeViewport = { [weak self] in self?.viewportWillResize() }
+                scroll.didResizeViewport = { [weak self] in self?.viewportDidResize() }
+            }
             scroll.contentView.postsBoundsChangedNotifications = true
             scroll.postsFrameChangedNotifications = true
             let centre = NotificationCenter.default
@@ -656,6 +672,9 @@ struct TranscriptTable: NSViewRepresentable {
             let identifier = NSUserInterfaceItemIdentifier("bloom.transcript.cell")
             let cell = tableView.makeView(withIdentifier: identifier, owner: self)
                 as? TranscriptTableCell ?? TranscriptTableCell(identifier: identifier)
+            // SwiftUI can evaluate a newly assigned root before AppKit installs the cell.
+            // Give that first proposal the real column width instead of a zero-sized frame.
+            cell.setFrameSize(NSSize(width: columnWidth, height: max(Self.hair, height(of: entry))))
             cell.onMeasured = { [weak self] id, key, size in
                 self?.noted(size: size, of: key, for: id)
             }
@@ -806,6 +825,7 @@ struct TranscriptTable: NSViewRepresentable {
                     reportedHeight: Double(height),
                     knownHeight: heights.height(for: contentKey) ?? -1
                 ))
+                return
             }
             // The other half of the same question `measureExactly` asks: a row the reader was
             // being shown, reporting that it drew nothing after all. The three that redraw
@@ -813,12 +833,12 @@ struct TranscriptTable: NSViewRepresentable {
             if height == 0, !entries[row].drawsNothing, !entryID.redrawsItself {
                 noteSilence(row: row, entry: entries[row], source: "drawn")
             }
-            guard heights.note(
+            heights.note(
                 height,
                 for: contentKey,
                 shape: entries[row].shape,
                 measuredAt: Double(size.width)
-            ) else { return }
+            )
             // **News to the cache is not always news to the table.** A row the table is already
             // drawing at this height needs no `noteHeightOfRows`, and the whole of a correction's
             // cost is that call: it moves the document's total and makes AppKit lay out every row
@@ -839,17 +859,16 @@ struct TranscriptTable: NSViewRepresentable {
         /// takes the queue out of flight, and if the hold turns out not to have changed the width
         /// then everything in it is still true and has to be said. See `holdEnded`.
         private func drainOwedHeights() {
-            // A height correction moves the table's document and restoring the visible anchor
-            // moves the clip view. Both are correct while the view is still, but either one fights
-            // AppKit's own offset while a trackpad gesture or its momentum is in flight. Keep
-            // taking the measurements into the cache, then tell the table once the reader lets go.
-            guard owedWork == nil, !owedHeights.isEmpty, !isLiveScrolling else { return }
+            // Waiting for the entire gesture to end leaves newly exposed rows at their old
+            // heights throughout a flick: blank space below short rows and overlapping tall
+            // ones. Batch reports for one frame, including during momentum, and preserve the
+            // current visible row when applying them.
+            guard owedWork == nil, !owedHeights.isEmpty, !isHeld else { return }
             owedWork = Task { @MainActor [weak self] in
-                guard let self else { return }
+                try? await Task.sleep(for: .milliseconds(16))
+                guard !Task.isCancelled, let self else { return }
                 owedWork = nil
-                // The task begins on a later main-actor turn. A gesture can start between being
-                // scheduled and arriving here, so check again before taking the queue out.
-                guard !isLiveScrolling else { return }
+                guard !isHeld else { return }
                 let owed = owedHeights
                 owedHeights = []
                 // **Where each of them is NOW.** An id that has left the list is dropped, which is
@@ -990,7 +1009,8 @@ struct TranscriptTable: NSViewRepresentable {
         /// such a row can be. Counting those would have this report a screenful of alarms for the
         /// change that removed the alarms.
         private func isGuessed(_ entry: TranscriptTableEntry) -> Bool {
-            heights.height(for: entry.contentKey) == nil && !entry.drawsNothing
+            (heights.height(for: entry.contentKey) == nil || heights.isStale(entry.contentKey))
+                && !entry.drawsNothing
         }
 
         /// The height this row ought to be drawn at: what was measured, what it is claimed to be,
@@ -1318,6 +1338,9 @@ struct TranscriptTable: NSViewRepresentable {
         /// Somebody is taking the view somewhere that is not the end, so every standing claim on
         /// it comes down first.
         private func aimingElsewhere() {
+            viewportWork?.cancel()
+            viewportWork = nil
+            viewportPlace = nil
             isFollowerDriving = false
             releaseEnd()
         }
@@ -1442,7 +1465,8 @@ struct TranscriptTable: NSViewRepresentable {
             // must still be able to scroll up and stay there. So the position itself is the last
             // word: if the view is no longer at the end and this file did not put it there, then
             // nobody is holding it any more.
-            if holdsEnd, !isPutting, !isSettlingResizeAtEnd, !currentGeometry.isAtEnd {
+            if holdsEnd, !isPutting, viewportPlace == nil, !isHeld,
+               !isSettlingResizeAtEnd, !currentGeometry.isAtEnd {
                 releaseEnd()
             }
             // The reader is moving, so whatever was being prepared for them is now on their frame.
@@ -1510,9 +1534,7 @@ struct TranscriptTable: NSViewRepresentable {
             guard isLiveScrolling else { return }
             isLiveScrolling = false
             onLiveScrollChange?(false)
-            // Rows first seen during the gesture have reported their exact heights, but applying
-            // those reports was held so the content could not be pushed against the reader's
-            // movement. Apply them now as one anchored correction.
+            // Flush any reports still waiting for the next frame's anchored correction.
             drainOwedHeights()
             // Not the settle itself. Where the reader ends up is written down when the view has
             // stopped moving, and a flick that ends with momentum still running has not.
@@ -1677,6 +1699,34 @@ struct TranscriptTable: NSViewRepresentable {
 
         // MARK: - Being held while a pane is resized
 
+        /// A composer drag changes only the viewport height, so the width hold never sees it.
+        /// Save the reader's position before AppKit resizes the clip view and emits bounds
+        /// notifications. Reading it afterwards mistakes a shorter viewport for scrolling up.
+        private func viewportWillResize() {
+            guard !isHeld, viewportPlace == nil, heights.isReady else { return }
+            viewportPlace = HeldPlace(
+                wasAtEnd: holdsEnd || isFollowingAlong, anchor: anchorEntry()
+            )
+        }
+
+        private func viewportDidResize() {
+            guard !isHeld, viewportPlace != nil else { return }
+            viewportWork?.cancel()
+            viewportWork = Task { @MainActor [weak self] in
+                guard !Task.isCancelled, let self, !isHeld, !isLiveScrolling,
+                      let place = viewportPlace,
+                      TranscriptAnchor.canPlace(viewportHeight: Double(currentGeometry.viewportHeight))
+                else { return }
+                viewportWork = nil
+                // Layout must finish before measuring the newly exposed rows. In particular,
+                // never place the reader against a transient zero-height clip view.
+                keepPlace(wasAtEnd: place.wasAtEnd, anchor: place.anchor)
+                viewportPlace = nil
+                reportGeometry()
+                scheduleSettle()
+            }
+        }
+
         /// A hold has begun. What it is holding is the whole of the difference.
         ///
         /// **An arrival stops nothing**, because the work it is waiting for is this pane's own
@@ -1692,7 +1742,12 @@ struct TranscriptTable: NSViewRepresentable {
             // sitting on it. `clipMoved` sees that and drops the standing instruction, so a reader
             // who had not moved at all would be anchored back to their top row by a drag. Nothing
             // under them moves while the hold is on, so this answer is still true when it is used.
-            heldPlace = HeldPlace(wasAtEnd: isFollowingAlong, anchor: anchorEntry())
+            heldPlace = viewportPlace ?? HeldPlace(
+                wasAtEnd: holdsEnd || isFollowingAlong, anchor: anchorEntry()
+            )
+            viewportWork?.cancel()
+            viewportWork = nil
+            viewportPlace = nil
             // Queued against the width being left behind, and picked up again by `rewidth`.
             resizeWork?.cancel()
             resizeWork = nil
@@ -1775,6 +1830,9 @@ struct TranscriptTable: NSViewRepresentable {
             holdView = view
             guard shownSession != session else { return }
             shownSession = session
+            viewportWork?.cancel()
+            viewportWork = nil
+            viewportPlace = nil
             // Nothing in the reuse pool belongs to this conversation, whatever key it says it
             // holds. See `cellGeneration`.
             cellGeneration += 1
@@ -1821,7 +1879,10 @@ struct TranscriptTable: NSViewRepresentable {
             reportGeometry()
             let eager = TranscriptPaneHold.eager(visible: visibleRows, count: entries.count)
             measureExactly(eager)
-            noteHeights(IndexSet(integersIn: entries.indices))
+            // Offscreen rows kept their old heights as estimates. Re-asking the entire table
+            // also replaces every unknown row with a newly settled estimate, moving thousands
+            // of rows during one resize. Only the measured landing needs new geometry now.
+            noteHeights(heightUpdates(in: eager))
             // **The standing instruction rather than a movement, for a reader who was at the end.**
             //
             // A movement is short of the end the moment anything below it changes size, and a
@@ -1914,10 +1975,18 @@ struct TranscriptTable: NSViewRepresentable {
             guard range.length > 0 else { return }
             let rows = range.location..<(range.location + range.length)
             measureExactly(rows)
-            // Every row of the landing, not only the ones this pass measured. A row whose height
-            // the cache already knows and the table does not is exactly the bug this file shipped,
-            // and re-asking sixty rows for a number they already have costs nothing.
-            noteHeights(IndexSet(integersIn: rows))
+            // Include cached measurements AppKit has not heard yet, but do not retile a
+            // correct landing on every viewport resize or live-end placement.
+            noteHeights(heightUpdates(in: rows))
+        }
+
+        private func heightUpdates(in rows: some Sequence<Int>) -> IndexSet {
+            guard let tableView else { return IndexSet() }
+            return IndexSet(rows.filter { row in
+                entries.indices.contains(row) && !TranscriptRowHeights.isSameHeight(
+                    Double(tableView.rect(ofRow: row).height), owedHeight(of: entries[row])
+                )
+            })
         }
 
         /// The rows the pane can see, in the entries' own indices.
@@ -2088,9 +2157,10 @@ private struct HostedRow: View {
                         // width.** A report taken from a pass that laid this row out narrow says
                         // nothing about how tall it is at the width the cache is for, and two of
                         // them are what emptied the owner's transcript. See
-                        // `TranscriptRowHeights.isEvidence`. Still woken by the height alone: a
-                        // width that moves without the height moving changes no answer.
-                        .onChange(of: proxy.size.height, initial: true) { _, _ in
+                        // `TranscriptRowHeights.isEvidence`. A width change can make a
+                        // previously rejected report valid even when the
+                        // height stays the same (a one-line row, for example).
+                        .onChange(of: proxy.size, initial: true) { _, _ in
                             report(proxy.size)
                         }
                 }

--- a/Sources/Bloom/Views/Transcript/TranscriptTableView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTableView.swift
@@ -1,0 +1,44 @@
+import AppKit
+
+/// AppKit can retain realised row origins after a resize even though rect(ofRow:) and the
+/// document height have already changed. In a live transcript the final cells were 92 points
+/// below their reported rectangles, outside the scrollable document. Retiling and reporting
+/// the heights again did not repair it. Reconcile the realised origins after layout instead;
+/// this neither creates offscreen cells nor measures SwiftUI content.
+@MainActor
+final class TranscriptTableView: NSTableView {
+    private var isAligningRows = false
+    private var alignmentWork: Task<Void, Never>?
+
+    override func layout() {
+        super.layout()
+        alignRowOrigins()
+    }
+
+    func alignRowOrigins() {
+        guard !isAligningRows, alignmentWork == nil else { return }
+        isAligningRows = true
+        defer { isAligningRows = false }
+        enumerateAvailableRowViews { row, index in
+            guard index >= 0, index < self.numberOfRows else { return }
+            let target = self.rect(ofRow: index).minY
+            if abs(row.frame.minY - target) > 0.5 {
+                row.setFrameOrigin(NSPoint(x: row.frame.minX, y: target))
+            }
+        }
+    }
+
+    /// A deliberate fold or insertion owns its intermediate positions until its animation
+    /// finishes. Measurement corrections have zero duration and need no such grace period.
+    func deferRowAlignment(for seconds: Double) {
+        guard seconds > 0 else { return }
+        alignmentWork?.cancel()
+        alignmentWork = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(seconds))
+            guard !Task.isCancelled, let self else { return }
+            alignmentWork = nil
+            needsLayout = true
+            layoutSubtreeIfNeeded()
+        }
+    }
+}

--- a/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
+++ b/Sources/BloomCore/Transcript/TranscriptRowHeights.swift
@@ -458,9 +458,12 @@ public struct TranscriptRowHeights: Equatable, Sendable {
         /// so that a good first sample settles the number for the whole session and a bad one is
         /// not permanent.
         private mutating func settleIfItIsTime(settlingAfter: Int) {
-            guard inked >= settlingAfter, let running = middle else { return }
+            guard inked >= settlingAfter else { return }
+            // A settled sample cannot change until it doubles. Avoid sorting every distinct
+            // height on each streamed report while the answer is guaranteed to stay the same.
+            if settled != nil, inked < settledFrom * 2 { return }
+            guard let running = middle else { return }
             guard let settled else { return take(running) }
-            guard inked >= settledFrom * 2 else { return }
             guard abs(running - settled) > settled * TranscriptRowHeights.resettleDrift else {
                 return
             }
@@ -626,8 +629,9 @@ public struct TranscriptRowHeights: Equatable, Sendable {
     ///
     /// Exactly nought rather than `isSameHeight`, because `note` rounds a height UP: a row that
     /// drew four tenths of a point is remembered as one and is not this.
+    /// A stale measurement cannot silence a view: it needs a chance to report at the new width.
     public func measuredNothing(_ contentKey: TranscriptContentKey) -> Bool {
-        heights[contentKey] == 0
+        heights[contentKey] == 0 && !stale.contains(contentKey)
     }
 
     /// The middle of the rows of THIS conversation that have been measured here and drew

--- a/Tests/BloomCoreTests/TranscriptRowHeightsTests.swift
+++ b/Tests/BloomCoreTests/TranscriptRowHeightsTests.swift
@@ -327,6 +327,35 @@ struct TranscriptRowHeightsTests {
         #expect(heights.measuredNothing(key("blank")))
     }
 
+    @Test("a stale empty measurement cannot prevent a row being drawn after resizing")
+    func staleNothingIsNotEvidence() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 800, scale: 1, leading: 1.7)
+        heights.note(0, for: key("row"), measuredAt: 800)
+        heights.rewidth(to: 600)
+        #expect(!heights.measuredNothing(key("row")))
+        #expect(heights.needsMeasuring(key("row"), redrawsItself: false))
+
+        // A delayed report from the old layout cannot silence the row again.
+        heights.note(0, for: key("row"), measuredAt: 800)
+        #expect(!heights.measuredNothing(key("row")))
+        heights.note(24, for: key("row"), measuredAt: 600)
+        #expect(heights.height(for: key("row")) == 24)
+        #expect(!heights.needsMeasuring(key("row"), redrawsItself: false))
+    }
+
+    @Test("a row still empty at the new width can be silenced again")
+    func confirmsNothingAtTheNewWidth() {
+        var heights = TranscriptRowHeights()
+        heights.reset(width: 800, scale: 1, leading: 1.7)
+        heights.note(0, for: key("row"), measuredAt: 800)
+        heights.rewidth(to: 600)
+        let changed = heights.note(0, for: key("row"), measuredAt: 600)
+        #expect(!changed)
+        #expect(heights.measuredNothing(key("row")))
+        #expect(!heights.isStale(key("row")))
+    }
+
     /// **The one that keeps the gaps from coming back.** A row nobody has measured is not known to
     /// draw nothing, whatever `TranscriptRowInk` guessed about it: it is built, it reports, and
     /// that report is what would catch the guess being wrong.


### PR DESCRIPTION
Fix disappearing, gapped and unreachable chat content when resizing the composer or window.

The reported conversation reproduced the remaining fault in the running dev app: realised table rows sat 92 points below `rect(ofRow:)`. Cached heights, document height and the scrollbar all agreed, but the final content was outside the scrollable document. Ordinary layout and repeating height notifications did not repair those origins; explicitly aligning the realised rows did.

Changes:

- Reconcile realised row origins after table layout and viewport resizing. Visit existing row views only, without creating offscreen cells or measuring SwiftUI content. Let deliberate fold/insertion animations finish before alignment.
- Preserve the reader's end position or reading anchor before viewport resizing. Active scrolling takes precedence over a pending resize placement.
- Retry stale empty measurements, observe row width changes even when height stays constant, and correct differences between cached heights and AppKit's row rectangles.
- Batch height corrections during scrolling, pre-size new cells, skip redundant height notifications and avoid repeatedly sorting settled estimates.
- Include actual cell positions in diagnostic reports so correct cached geometry cannot conceal misplaced content again.

Validation:

- The new native layout probe injects the exact 92-point displacement. It fails on the previous code and passes with the correction. All 48 checks pass, covering height/width resizing, tiny viewports, end/reading anchors, animation deferral and live-scroll height changes.
- All 126 targeted core tests pass, covering transcript row heights, blank-on-resize handling and anchors.
- The affected conversation passes composer growth, scrolling and window-resize probes at 420 and 777.5 points: no misplaced or missing visible cells, no blank viewport, and the final content remains within the scrollable document (within pixel rounding).
- The app builds and both linters pass. Bloom Dev is installed from `da9df18c` and passes signature verification. All 48 native layout checks also pass using its release executable.
- CI is green on `da9df18c`. The first full-suite attempt hit the unchanged agent-shutdown timeout test in `RuntimeSafetyTests.swift`; rerunning the failed job passed without code changes.

Performance measurements from the initial changes reduced release composer height-update calls from 85 to 25 and row indexes notified from 8,278 to 30 at a 420-point pane width. Cold scrolling measurements were mixed (roughly 46 versus 45 median FPS), and traversed different estimated document lengths, so they do not establish a throughput improvement. Main-thread samples still show substantial SwiftUI graph and AppKit layout work. Physical trackpad smoothness needs a manual check; this PR does not claim to eliminate every hitch.

Probes use hidden windows and temporary data. The release packaging step emits existing AppIntents conformance warnings; the regular Swift build is warning-free.

Reference: [Apple's row-height invalidation API](https://developer.apple.com/documentation/appkit/nstableview/noteheightofrows(withindexeschanged:)).
