### PR TITLE
Polish chat typography, native chrome and empty-state layout

### DIFF
--- a/Sources/Bloom/Design/ProseLeadingGallery.swift
+++ b/Sources/Bloom/Design/ProseLeadingGallery.swift
@@ -53,7 +53,7 @@ struct ProseLeadingGallery: View {
                 prose(leading: Self.wasFixed)
                     .environment(\.fontScale, size.scale)
             }
-            column("Prose, 1.7 of the size") { size in
+            column("Prose, \(ChatLineHeight.defaultChoice.ratio) of the size") { size in
                 prose()
                     .environment(\.fontScale, size.scale)
             }
@@ -104,7 +104,7 @@ struct ProseLeadingGallery: View {
                         .font(Typo.micro)
                         .foregroundStyle(Palette.textTertiary)
                     prose()
-                        .environment(\.fontScale, ChatTextSize.standard.scale)
+                        .environment(\.fontScale, ChatTextSize.defaultChoice.scale)
                         .environment(\.chatLineHeight, step)
                 }
             }
@@ -116,7 +116,7 @@ struct ProseLeadingGallery: View {
     /// off the picture rather than trusted.
     private func caption(for size: ChatTextSize) -> String {
         let leading = TranscriptLayout.proseLeading(
-            Typo.body, scale: size.scale, face: face, lineHeight: .standard
+            Typo.body, scale: size.scale, face: face, lineHeight: .defaultChoice
         )
         return "\(size.title), prose +\(Int(leading))pt"
     }
@@ -125,7 +125,7 @@ struct ProseLeadingGallery: View {
     /// default text size.
     private func caption(for step: ChatLineHeight) -> String {
         let leading = TranscriptLayout.proseLeading(
-            Typo.body, scale: ChatTextSize.standard.scale, face: face, lineHeight: step
+            Typo.body, scale: ChatTextSize.defaultChoice.scale, face: face, lineHeight: step
         )
         return "\(step.title), \(step.ratio) of the size, prose +\(Int(leading))pt"
     }

--- a/Sources/Bloom/Design/Theme.swift
+++ b/Sources/Bloom/Design/Theme.swift
@@ -982,32 +982,9 @@ enum Motion {
 
 // MARK: - Materials
 
-/// Every ground in this window is a colour, and there is deliberately no `NSVisualEffectView`
-/// anywhere for one to be reached for from.
-///
-/// There was: a `VisualEffectBackground` representable and a `headerMaterial()`, both of them
-/// under this heading with nothing calling either, directly above the two measurements that say
-/// why nothing should. Machinery kept under an argument against itself is an invitation to put
-/// the argued-against thing back, so it is gone and the measurements are below.
+/// Content strips stay opaque. The window title bar and navigation sidebar use their existing
+/// native materials, not per-view effect layers added to the scrolling surfaces here.
 extension View {
-    /// The sidebar's ground.
-    ///
-    /// A named colour rather than `NSVisualEffectView(.sidebar)`, and this is the one place where
-    /// dropping a system material is the right call. Sidebar vibrancy blends with the desktop
-    /// behind the window, so the column's colour is set by whatever wallpaper the user happens to
-    /// have: measured on this machine it rendered `#232833` in dark, a blue nobody picked, and it
-    /// would render green over a green wallpaper. A themed ramp cannot survive that. Everything
-    /// vibrancy was buying beyond the tint, the rounded window corner and the toolbar unification,
-    /// belongs to the window rather than to this view and is unaffected.
-    ///
-    /// The same answer came back for the strips of small controls, which is why they take this
-    /// colour too rather than a material of their own: `NSVisualEffectView(.headerView)` measured
-    /// `#292C33` over a `#0A1A25` pane, a neutral grey with nothing to do with what was behind it,
-    /// so every strip in the window read as a piece of a different app laid over it.
-    func sidebarMaterial() -> some View {
-        background(Palette.sidebar)
-    }
-
     /// The strip a tab bar sits in: the chrome colour with the pane's top edge already on it.
     ///
     /// The rule belongs here, behind the tabs, rather than in an overlay over them. Drawn over the

--- a/Sources/Bloom/Design/TranscriptLayoutProbe.swift
+++ b/Sources/Bloom/Design/TranscriptLayoutProbe.swift
@@ -38,8 +38,12 @@ enum TranscriptLayoutProbe {
                 id: .row(row), contentKey: TranscriptContentKey { $0.combine(row) },
                 shape: .answer,
                 content: {
-                    AnyView(Text(String(repeating: "A transcript row that wraps when resized. ", count: row % 9 + 1))
-                        .font(Typo.body).proseLeading().padding(8))
+                    let prose = String(repeating: "A transcript row that wraps when resized. ", count: row % 9 + 1)
+                    if row.isMultiple(of: 3) {
+                        return AnyView(MarkdownView("1. \(prose)\n2. Another item with `inline code` and **emphasis**.\n   - [x] A nested [linked checklist](https://example.com) that wraps when the pane gets narrow.\n\n- [x] A compact checklist\n- [ ] Still to do")
+                            .font(Typo.body).proseLeading().padding(8))
+                    }
+                    return AnyView(Text(prose).font(Typo.body).proseLeading().padding(8))
                 }
             )
         }

--- a/Sources/Bloom/Design/TranscriptLayoutProbe.swift
+++ b/Sources/Bloom/Design/TranscriptLayoutProbe.swift
@@ -47,6 +47,8 @@ enum TranscriptLayoutProbe {
             id: .streaming, contentKey: TranscriptContentKey { $0.combine("tail") },
             content: { AnyView(TailRow(tail: tail)) }
         ))
+        let tailIndex = entries.count - 1
+        entries.append(.bottomSpacing)
         let view = TranscriptTable(
             entries: entries, session: SessionID("layout-probe"), controller: controller,
             scale: ChatTextSize.defaultChoice.scale,
@@ -88,6 +90,11 @@ enum TranscriptLayoutProbe {
                 guard let top = row.drawnTop, let height = row.drawnHeight else { return true }
                 return abs(top - row.top) <= 0.5 && abs(height - row.told) <= 0.5
             }, "\(phase): rendered cell disagrees with its scrollable row rectangle")
+            if controller.geometry.isAtEnd, let table = controller.scrollView?.documentView as? NSTableView {
+                let gap = table.frame.height - table.rect(ofRow: tailIndex).maxY
+                check(abs(gap - TranscriptLayout.block) <= 0.5,
+                      "\(phase): final content is not clear of the composer by eight points")
+            }
         }
 
         // The live report had correct cached heights but every realised row was 92 points
@@ -154,7 +161,7 @@ enum TranscriptLayoutProbe {
         for height in [260.0, 40] {
             tail.height = height
             await settle(window)
-            check(abs(table.rect(ofRow: entries.count - 1).height - height) <= 0.5,
+            check(abs(table.rect(ofRow: tailIndex).height - height) <= 0.5,
                   "live scroll: tail did not adopt height \(height)")
         }
         NotificationCenter.default.post(name: NSScrollView.didEndLiveScrollNotification, object: scroll)

--- a/Sources/Bloom/Design/TranscriptLayoutProbe.swift
+++ b/Sources/Bloom/Design/TranscriptLayoutProbe.swift
@@ -39,7 +39,7 @@ enum TranscriptLayoutProbe {
                 shape: .answer,
                 content: {
                     AnyView(Text(String(repeating: "A transcript row that wraps when resized. ", count: row % 9 + 1))
-                        .font(.system(size: 15)).padding(8))
+                        .font(Typo.body).proseLeading().padding(8))
                 }
             )
         }
@@ -49,11 +49,11 @@ enum TranscriptLayoutProbe {
         ))
         let view = TranscriptTable(
             entries: entries, session: SessionID("layout-probe"), controller: controller,
-            scale: 1,
+            scale: ChatTextSize.defaultChoice.scale,
             rowEnvironment: TranscriptRowEnvironment(
                 app: app, hoverHost: TranscriptHoverHost(), bubbleWidth: TranscriptBubbleWidth(),
-                linkActions: TranscriptLinkActions(), fontScale: 1, chatFont: .standard,
-                lineHeight: .standard, reduceMotion: true
+                linkActions: TranscriptLinkActions(), fontScale: ChatTextSize.defaultChoice.scale,
+                chatFont: .standard, lineHeight: .defaultChoice, reduceMotion: true
             ),
             onGeometryChange: { _ in }, onSettled: {}, onLiveScrollChange: { _ in }
         )

--- a/Sources/Bloom/Views/Archive/ArchivedWorkspaceView.swift
+++ b/Sources/Bloom/Views/Archive/ArchivedWorkspaceView.swift
@@ -52,9 +52,9 @@ struct ArchivedWorkspaceView: View {
     /// The same three settings the live conversation is drawn with, scoped to the same subtree,
     /// so a transcript does not change size or line height when it is read from here instead of
     /// from there.
-    @AppStorage(ChatTextSize.defaultsKey) private var textSize = ChatTextSize.standard
+    @AppStorage(ChatTextSize.defaultsKey) private var textSize = ChatTextSize.defaultChoice
     @AppStorage(ChatFont.defaultsKey) private var chatFontID = ChatFont.standardID
-    @AppStorage(ChatLineHeight.defaultsKey) private var lineHeight = ChatLineHeight.standard
+    @AppStorage(ChatLineHeight.defaultsKey) private var lineHeight = ChatLineHeight.defaultChoice
 
     private var workspace: Workspace { model.workspace }
 

--- a/Sources/Bloom/Views/Ask/AskView.swift
+++ b/Sources/Bloom/Views/Ask/AskView.swift
@@ -24,9 +24,9 @@ struct AskView: View {
     @State private var isTranscriptScrolledUp = false
     @State private var room = ComposerRoom()
 
-    @AppStorage(ChatTextSize.defaultsKey) private var textSize = ChatTextSize.standard
+    @AppStorage(ChatTextSize.defaultsKey) private var textSize = ChatTextSize.defaultChoice
     @AppStorage(ChatFont.defaultsKey) private var chatFontID = ChatFont.standardID
-    @AppStorage(ChatLineHeight.defaultsKey) private var lineHeight = ChatLineHeight.standard
+    @AppStorage(ChatLineHeight.defaultsKey) private var lineHeight = ChatLineHeight.defaultChoice
 
     var body: some View {
         VStack(spacing: 0) {

--- a/Sources/Bloom/Views/Center/Panes/ChatPaneView.swift
+++ b/Sources/Bloom/Views/Center/Panes/ChatPaneView.swift
@@ -41,12 +41,12 @@ struct ChatPaneView: View {
     /// The conversation's text size, applied here because this pane is exactly what the setting is
     /// scoped to: what was said and what you are about to say. The sidebar, the inspector and the
     /// toolbar are chrome and keep the size macOS gives them.
-    @AppStorage(ChatTextSize.defaultsKey) private var textSize = ChatTextSize.standard
+    @AppStorage(ChatTextSize.defaultsKey) private var textSize = ChatTextSize.defaultChoice
     /// And the face, scoped to exactly the same subtree for exactly the same reason.
     @AppStorage(ChatFont.defaultsKey) private var chatFontID = ChatFont.standardID
     /// And the line height, which is the third thing the appearance pane moves about the
     /// conversation and is scoped with the other two.
-    @AppStorage(ChatLineHeight.defaultsKey) private var lineHeight = ChatLineHeight.standard
+    @AppStorage(ChatLineHeight.defaultsKey) private var lineHeight = ChatLineHeight.defaultChoice
 
     /// What the transcript has nothing to draw for, and nil the moment its rows are on screen.
     ///

--- a/Sources/Bloom/Views/Center/Panes/ReviewPaneView.swift
+++ b/Sources/Bloom/Views/Center/Panes/ReviewPaneView.swift
@@ -56,9 +56,9 @@ struct ReviewPaneView: View {
     /// as `ChatPaneView` applies them to its whole subtree. Without this the same composer would
     /// change as the reader moved between the conversation and the review, which reads as a bug
     /// rather than a setting.
-    @AppStorage(ChatTextSize.defaultsKey) private var textSize = ChatTextSize.standard
+    @AppStorage(ChatTextSize.defaultsKey) private var textSize = ChatTextSize.defaultChoice
     @AppStorage(ChatFont.defaultsKey) private var chatFontID = ChatFont.standardID
-    @AppStorage(ChatLineHeight.defaultsKey) private var lineHeight = ChatLineHeight.standard
+    @AppStorage(ChatLineHeight.defaultsKey) private var lineHeight = ChatLineHeight.defaultChoice
 
     var body: some View {
         VStack(spacing: 0) {

--- a/Sources/Bloom/Views/Center/Panes/SubagentOutputView.swift
+++ b/Sources/Bloom/Views/Center/Panes/SubagentOutputView.swift
@@ -52,9 +52,9 @@ struct SubagentOutputView: View {
     /// The conversation's text size, face and line height, read here for the reason `ChatPaneView`
     /// reads them: this pane is a conversation, and a reader who has set the transcript larger has
     /// not asked for a subagent's half of it to stay small.
-    @AppStorage(ChatTextSize.defaultsKey) private var textSize = ChatTextSize.standard
+    @AppStorage(ChatTextSize.defaultsKey) private var textSize = ChatTextSize.defaultChoice
     @AppStorage(ChatFont.defaultsKey) private var chatFontID = ChatFont.standardID
-    @AppStorage(ChatLineHeight.defaultsKey) private var lineHeight = ChatLineHeight.standard
+    @AppStorage(ChatLineHeight.defaultsKey) private var lineHeight = ChatLineHeight.defaultChoice
 
     private var subagent: Subagent? {
         model.activeTranscript?.subagents[subagentID]

--- a/Sources/Bloom/Views/Chrome/Settings/AppearanceSettingsView.swift
+++ b/Sources/Bloom/Views/Chrome/Settings/AppearanceSettingsView.swift
@@ -29,9 +29,9 @@ import BloomCore
 /// worth adjusting only after the size and the face are settled.
 struct AppearanceSettingsView: View {
     @AppStorage("appearance") private var appearance = "system"
-    @AppStorage(ChatTextSize.defaultsKey) private var chatTextSize = ChatTextSize.standard
+    @AppStorage(ChatTextSize.defaultsKey) private var chatTextSize = ChatTextSize.defaultChoice
     @AppStorage(ChatFont.defaultsKey) private var chatFontID = ChatFont.standardID
-    @AppStorage(ChatLineHeight.defaultsKey) private var chatLineHeight = ChatLineHeight.standard
+    @AppStorage(ChatLineHeight.defaultsKey) private var chatLineHeight = ChatLineHeight.defaultChoice
     @AppStorage(TerminalGhostty.defaultsKey) private var usesGhosttyTheme = true
     /// Zero means "no override, follow Ghostty". Read here as well as in `TerminalTextSize` so the
     /// pane redraws when a Cmd+Plus in a terminal moves it while this window is open.

--- a/Sources/Bloom/Views/Chrome/TextZoom.swift
+++ b/Sources/Bloom/Views/Chrome/TextZoom.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import BloomCore
 
 /// What the View menu's Zoom In, Zoom Out and Actual Size act on.
 ///
@@ -22,14 +23,14 @@ enum TextZoom {
 
     static func zoomOut() { adjust(by: -1) }
 
-    /// Home for each: `standard` for the conversation, no override at all for a terminal, which is
+    /// Home for each: the default choice for the conversation, no override for a terminal, which is
     /// how a shell goes back to following the size in the user's Ghostty config rather than to
     /// some number Bloom picked.
     static func actualSize() {
         if focusedTerminal != nil {
             TerminalTextSize.override = nil
         } else {
-            ChatTextSize.current = .standard
+            ChatTextSize.current = .defaultChoice
         }
     }
 
@@ -39,7 +40,7 @@ enum TextZoom {
 
     static var canResetSize: Bool {
         if focusedTerminal != nil { return TerminalTextSize.override != nil }
-        return ChatTextSize.current != .standard
+        return ChatTextSize.current != .defaultChoice
     }
 
     private static func adjust(by steps: Int) {

--- a/Sources/Bloom/Views/Chrome/Window/WindowChrome.swift
+++ b/Sources/Bloom/Views/Chrome/Window/WindowChrome.swift
@@ -1,22 +1,10 @@
 import AppKit
 import SwiftUI
 
-/// Paints the title bar in Bloom's own chrome colour, and puts the workspace's own strip in it.
-///
-/// The toolbar is `.unified`, so AppKit draws the whole title bar strip with a window material
-/// that blends with the desktop behind the window. That is right for an app whose surfaces are
-/// the system's, and wrong for one with a ramp of its own: measured against the new palette the
-/// strip came out `#282B33`, a neutral grey sitting across the top of a deep blue window, which
-/// read as a piece of another application resting on ours.
-///
-/// `titlebarAppearsTransparent` hands the strip to the window's own background colour, which is
-/// the same `Palette.sidebar` the column below it is painted in. That is also what a unified
-/// toolbar is meant to look like: one continuous piece of chrome from the traffic lights down the
-/// sidebar. The traffic lights and the toolbar items stay exactly where AppKit puts them; only the
-/// paint behind them changes. The title is the one exception now, and `apply` says why.
-///
-/// The colour is an `NSColor` with an appearance provider rather than a resolved value, so the
-/// title bar follows a switch between light and dark without this modifier being told about it.
+/// Keeps the unified title bar on its native material and adds the workspace's own strip.
+/// The sidebar also uses its system background, so navigation chrome follows appearance,
+/// inactive-window state and accessibility preferences together. Reading surfaces stay opaque;
+/// no material layers are added to scrolling content.
 ///
 /// The trailing end of the same strip is `TitleBarStrip`, added as a title bar accessory. See
 /// that file for why an accessory rather than content drawn under a transparent title bar.
@@ -38,8 +26,8 @@ struct WindowChrome: ViewModifier {
 
     private func apply() {
         guard let window else { return }
-        window.titlebarAppearsTransparent = true
-        window.backgroundColor = Palette.sidebarNSColor
+        window.titlebarAppearsTransparent = false
+        window.backgroundColor = .windowBackgroundColor
         // AppKit's own title text, off. `WindowTitleControl` draws it as a toolbar item instead,
         // so that a double click on the NAME can start a rename without taking the double click on
         // the BAR that Desktop & Dock has already spent on Zoom or Minimise.

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -144,7 +144,9 @@ struct DiffView: View {
             switch mode {
             case .diff:
                 content
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    // Empty states have an intrinsic size; centre them in the whole pane.
+                    // The actual diff fills this frame and owns its top-leading scroll anchor.
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                     // Both of these hang on the diff rather than on the view around it, and that
                     // is not tidiness: a second `.alert` and a second `.sheet` on one view is one
                     // presentation modifier of each kind too many, and which of the pair wins is

--- a/Sources/Bloom/Views/Markdown/MarkdownView.swift
+++ b/Sources/Bloom/Views/Markdown/MarkdownView.swift
@@ -181,6 +181,11 @@ private struct MarkdownBlockView: View {
     @Environment(\.markdownLineSpacingOverride) private var lineSpacingOverride
 
     private var markerWidth: CGFloat { MarkdownMetrics.markerWidth * fontScale }
+    private var proseListLineSpacing: CGFloat {
+        TranscriptLayout.proseLeading(
+            Typo.body, scale: fontScale, face: chatFont, lineHeight: chatLineHeight
+        )
+    }
     private var listLineSpacing: CGFloat {
         TranscriptLayout.proseLeading(
             Typo.body,
@@ -190,11 +195,11 @@ private struct MarkdownBlockView: View {
         )
     }
 
-    /// The same rhythm `listLineSpacing` sets an item's own lines in, applied between the items.
-    /// See `ListLeading`, which holds why the two are one number.
-    private func listItemGap(tight: Bool) -> CGFloat {
+    /// Prose lists separate ideas; checklists keep their tighter scanning rhythm.
+    private func listItemGap(tight: Bool, prose: Bool = false) -> CGFloat {
         TranscriptLayout.listItemGap(
-            Typo.body, scale: fontScale, face: chatFont, lineHeight: chatLineHeight, tight: tight
+            Typo.body, scale: fontScale, face: chatFont, lineHeight: chatLineHeight,
+            tight: tight, prose: prose
         )
     }
 
@@ -257,7 +262,9 @@ private struct MarkdownBlockView: View {
     /// for the second or two its sentence is being written, and it becomes pressable the moment
     /// the turn settles, which nobody will ever notice.
     @ViewBuilder
-    private func inlineText(_ inline: [MarkdownInline], rung: ScaledFont, color: Color) -> some View {
+    private func inlineText(
+        _ inline: [MarkdownInline], rung: ScaledFont, color: Color, spacing: CGFloat? = nil
+    ) -> some View {
         let font = rung.resolved(scale: fontScale, face: chatFont)
         if !isStreaming, InlineNSAttributes.hasLink(inline) {
             TranscriptTextView(
@@ -271,7 +278,7 @@ private struct MarkdownBlockView: View {
                     // number through the environment; asking for a heading's own here would set
                     // a heading with a link in it differently from the heading beside it and
                     // change what the row measures at.
-                    lineSpacing: lineSpacingOverride ?? TranscriptLayout.proseLeading(
+                    lineSpacing: spacing ?? lineSpacingOverride ?? TranscriptLayout.proseLeading(
                         Typo.body, scale: fontScale, face: chatFont, lineHeight: chatLineHeight
                     )
                 ),
@@ -304,15 +311,15 @@ private struct MarkdownBlockView: View {
     }
 
     private func list(items: [[MarkdownBlock]], start: Int?, tight: Bool) -> some View {
-        VStack(alignment: .leading, spacing: listItemGap(tight: tight)) {
+        VStack(alignment: .leading, spacing: listItemGap(tight: tight, prose: true)) {
             ForEach(items.indices, id: \.self) { offset in
                 // Baseline, not top: this is the alignment the task list beside it already used,
                 // and top alignment sat the marker a fraction above the line it marks.
                 HStack(alignment: .firstTextBaseline, spacing: Metrics.spacingSmall) {
                     marker(start.map { "\($0 + offset)." } ?? "\u{2022}")
                     MarkdownBlocksView(blocks: items[offset], foreground: foreground)
-                        .lineSpacing(listLineSpacing)
-                        .environment(\.markdownLineSpacingOverride, listLineSpacing)
+                        .lineSpacing(proseListLineSpacing)
+                        .environment(\.markdownLineSpacingOverride, proseListLineSpacing)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
@@ -331,7 +338,9 @@ private struct MarkdownBlockView: View {
                         .foregroundStyle(item.checked ? Palette.positive : Palette.textTertiary)
                         .frame(width: markerWidth, alignment: .trailing)
                         .accessibilityLabel(item.checked ? "Done" : "Not done")
-                    inlineText(item.inline, rung: Typo.body, color: foreground)
+                    // The AppKit link renderer reads spacing here, before a modifier below can
+                    // override the environment. Nested checklists must not inherit prose leading.
+                    inlineText(item.inline, rung: Typo.body, color: foreground, spacing: listLineSpacing)
                         .lineSpacing(listLineSpacing)
                         .environment(\.markdownLineSpacingOverride, listLineSpacing)
                 }

--- a/Sources/Bloom/Views/RootView.swift
+++ b/Sources/Bloom/Views/RootView.swift
@@ -37,12 +37,8 @@ struct RootView: View {
                 // The system toggle offers an irrelevant label-style context menu on macOS 26.
                 // BloomWindowToolbar replaces it with the same image-only action.
                 .toolbar(removing: .sidebarToggle)
-                // The sidebar's ground is set here rather than inside `SidebarView`, because what has
-                // to be replaced is the `List`'s own scroll background, and that is a property of the
-                // column rather than of anything the sidebar draws. See `sidebarMaterial` for why a
-                // named colour beats the system's vibrant one in a window with a themed ramp.
-                .scrollContentBackground(.hidden)
-                .sidebarMaterial()
+                // Leave the native source-list background in place so the sidebar and unified
+                // title bar share the system's appearance and accessibility treatment.
                 // The rule down the sidebar's trailing edge.
                 //
                 // `NavigationSplitView` draws none: measured across the boundary, the sidebar's last

--- a/Sources/Bloom/Views/Sidebar/SidebarStatusBar.swift
+++ b/Sources/Bloom/Views/Sidebar/SidebarStatusBar.swift
@@ -79,13 +79,7 @@ struct SidebarStatusBar: View {
             .padding(.horizontal, Metrics.spacingSmall)
             .frame(height: Metrics.barHeight)
         }
-        // `Palette.sidebar`, not `.bar`. Home grew a status bar of its own at the foot of the
-        // detail column, so these two strips now run side by side across the bottom of the window
-        // and have to read as one line rather than as two competing ones. `.bar` is a material: it
-        // sat a few units off the column it stands in, and it would have sat a few units off the
-        // flat strip next to it. The palette already names one colour for "the sidebar column, the
-        // title bar, and every strip of small controls", and this is one of those.
-        .background(Palette.sidebar)
+        // Let the native sidebar ground continue behind these controls without a second material.
     }
 
     /// Whether the pane is showing what it shows when nothing has been asked of it.

--- a/Sources/Bloom/Views/Transcript/TranscriptBottomSpacing.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptBottomSpacing.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+import BloomCore
+
+extension TranscriptTableEntry {
+    /// Part of the document, not an overlay or a smaller viewport: the final row can scroll
+    /// fully clear of the composer, while scrolling through history keeps the whole pane usable.
+    /// A stable entry after the queue also avoids re-keying the previous last row on each arrival.
+    static var bottomSpacing: Self {
+        Self(
+            id: .bottomSpacing,
+            contentKey: TranscriptContentKey {
+                $0.combine("bottomSpacing")
+                $0.combine(TranscriptLayout.block)
+            },
+            content: {
+                AnyView(Color.clear.frame(height: TranscriptLayout.block).accessibilityHidden(true))
+            }
+        )
+    }
+}

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -811,6 +811,7 @@ struct TranscriptListView: View {
                 }
             ))
         }
+        out.append(.bottomSpacing)
         // One increment and one add for the whole pass. See `TranscriptHoldCensus.entryPasses`:
         // this is the count that says whether a scroll is paying for the window rather than for
         // the screen.

--- a/Sources/Bloom/Views/Transcript/TranscriptProseLeading.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptProseLeading.swift
@@ -172,5 +172,5 @@ extension EnvironmentValues {
     /// Here rather than beside `ChatLineHeight` the way `chatFont` sits beside `ChatFont`, because
     /// that type is in the core and the core imports no UI framework. This file is how a view
     /// reaches the leading rule, and an environment value is exactly that.
-    @Entry var chatLineHeight: ChatLineHeight = .standard
+    @Entry var chatLineHeight: ChatLineHeight = .defaultChoice
 }

--- a/Sources/Bloom/Views/Transcript/TranscriptProseLeading.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptProseLeading.swift
@@ -62,14 +62,20 @@ extension TranscriptLayout {
     /// answer. The rule it applies is `ListLeading` in the core, which says why the gap is the
     /// item's own leading rather than a constant off the spacing scale.
     ///
-    /// The list ratio, not the prose one, for the reason `MarkdownView.listLineSpacing` uses it:
-    /// the wrapped lines inside an item are already led by it, and this has to be that same
-    /// number or the two disagree about the same list.
+    /// Prose lists use the selected paragraph ratio and extra item separation; checklists use
+    /// the compact list ratio for both their wrapped lines and the gaps between them.
     @MainActor
     static func listItemGap(
-        _ rung: ScaledFont, scale: CGFloat, face: ChatFont, lineHeight: ChatLineHeight, tight: Bool
+        _ rung: ScaledFont, scale: CGFloat, face: ChatFont, lineHeight: ChatLineHeight,
+        tight: Bool, prose: Bool = false
     ) -> CGFloat {
         let font = rung.resolvedNSFont(scale: scale, face: face)
+        if prose {
+            return CGFloat(ListLeading.betweenProseItems(
+                tight: tight, lineHeight: Double(lineBox(of: font)),
+                pointSize: Double(font.pointSize), ratio: lineHeight.ratio
+            ))
+        }
         return CGFloat(ListLeading.betweenItems(
             tight: tight,
             lineHeight: Double(lineBox(of: font)),

--- a/Sources/Bloom/Views/Transcript/TurnFooterView.swift
+++ b/Sources/Bloom/Views/Transcript/TurnFooterView.swift
@@ -65,7 +65,9 @@ struct TurnFooterView: View {
             // with a time floating next to it. Six of its own above and two below: the answer
             // carries its own eight point rung, so fourteen points sit over the rule and eight
             // under it, where before it was fourteen and twelve.
-            Hairline()
+            Rectangle()
+                .fill(Palette.border)
+                .frame(height: Metrics.outline)
                 .padding(.horizontal, TranscriptLayout.inset)
                 .padding(.top, TranscriptLayout.inset)
                 .padding(.bottom, TranscriptLayout.tight)

--- a/Sources/BloomCore/Presentation/ChatLineHeight.swift
+++ b/Sources/BloomCore/Presentation/ChatLineHeight.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// How much air the conversation is given between its lines.
 ///
-/// The owner asked for the line height to be a setting, with what had just landed as its default.
-/// So 1.7 stopped being the answer and became the middle of five, and the five ratios below are
-/// the whole of that decision. They are here rather than beside the picker for the reason the
+/// The ratios keep their stored meanings even when the default selection changes. The current
+/// default pairs 1.55 leading with larger prose; a saved choice still reads exactly as before.
+/// They are here rather than beside the picker for the reason the
 /// three-target split exists: a number chosen inside a view is a number nothing can test.
 ///
 /// **Named steps rather than a slider or a raw ratio.** That is `ChatTextSize`'s argument and it
@@ -25,7 +25,7 @@ import Foundation
 ///     17 / 20        4     6     9    11    14
 ///     20 / 23        5     8    11    14    17
 ///
-/// Every step differs from its neighbour at every text size, by two points at the default one.
+/// Every step differs from its neighbour at every text size.
 /// A tenth apart would have collapsed rows of that table onto each other, which is a picker whose
 /// middle segments do nothing; a fifth apart would have put the ends outside the range worth
 /// offering. `ChatLineHeightTests` is that table, so a ratio cannot be nudged without the
@@ -53,6 +53,8 @@ public enum ChatLineHeight: String, CaseIterable, Identifiable, Sendable {
     /// The same `UserDefaults` slot the settings picker binds to. See `current`.
     public static let defaultsKey = "chat.lineHeight"
 
+    public static let defaultChoice: Self = .tighter
+
     public var id: String { rawValue }
 
     /// What a line of prose comes to, as a multiple of the size it is set at.
@@ -76,14 +78,12 @@ public enum ChatLineHeight: String, CaseIterable, Identifiable, Sendable {
         1.3 + (ratio - 1.4) / 2
     }
 
-    /// Comparatives rather than adjectives, so the control says which way each segment moves and
-    /// where the range stops. "Tight" and "Relaxed" next to each other read as two named densities
-    /// with no order between them; these cannot.
+    /// The labels follow the density order, with the actual fallback marked as Default.
     public var title: String {
         switch self {
-        case .tightest: "Tightest"
-        case .tighter: "Tighter"
-        case .standard: "Default"
+        case .tightest: "Tight"
+        case .tighter: "Default"
+        case .standard: "Loose"
         case .looser: "Looser"
         case .loosest: "Loosest"
         }
@@ -102,10 +102,11 @@ extension ChatLineHeight {
     /// render at a named step) would otherwise reach for `UserDefaults` by hand and spell the
     /// fallback differently.
     public static var current: ChatLineHeight {
-        get {
-            UserDefaults.standard.string(forKey: defaultsKey)
-                .flatMap(ChatLineHeight.init(rawValue:)) ?? .standard
-        }
+        get { read(from: .standard) }
         set { UserDefaults.standard.set(newValue.rawValue, forKey: defaultsKey) }
+    }
+
+    public static func read(from defaults: UserDefaults) -> Self {
+        defaults.string(forKey: defaultsKey).flatMap(Self.init(rawValue:)) ?? defaultChoice
     }
 }

--- a/Sources/BloomCore/Presentation/ChatTextSize.swift
+++ b/Sources/BloomCore/Presentation/ChatTextSize.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 /// How large the conversation is set.
 ///
@@ -11,18 +10,21 @@ import SwiftUI
 /// The multipliers are chosen so that every rung of `Typo` still lands on a different whole point
 /// at every step. At 0.85 the caption and the micro rung both round to 9 and the transcript loses
 /// a level of hierarchy, which is why the small step is 0.9.
-enum ChatTextSize: String, CaseIterable, Identifiable, Sendable {
+public enum ChatTextSize: String, CaseIterable, Identifiable, Sendable {
     case small
     case standard
     case large
     case extraLarge
     case largest
 
-    static let defaultsKey = "chat.textSize"
+    public static let defaultsKey = "chat.textSize"
 
-    var id: String { rawValue }
+    /// Larger prose without changing the meaning of a previously saved size.
+    public static let defaultChoice: Self = .large
 
-    var scale: CGFloat {
+    public var id: String { rawValue }
+
+    public var scale: CGFloat {
         switch self {
         case .small: 0.9
         case .standard: 1
@@ -32,11 +34,11 @@ enum ChatTextSize: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
-    var title: String {
+    public var title: String {
         switch self {
-        case .small: "Small"
-        case .standard: "Default"
-        case .large: "Large"
+        case .small: "Smallest"
+        case .standard: "Smaller"
+        case .large: "Default"
         case .extraLarge: "Larger"
         case .largest: "Largest"
         }
@@ -47,12 +49,13 @@ extension ChatTextSize {
     /// Read and written outside SwiftUI, by the View menu. `@AppStorage` keeps a raw-value enum as
     /// its raw string, so this is the same slot the Settings picker binds to and every open window
     /// follows a change to it at once.
-    static var current: ChatTextSize {
-        get {
-            UserDefaults.standard.string(forKey: defaultsKey)
-                .flatMap(ChatTextSize.init(rawValue:)) ?? .standard
-        }
+    public static var current: ChatTextSize {
+        get { read(from: .standard) }
         set { UserDefaults.standard.set(newValue.rawValue, forKey: defaultsKey) }
+    }
+
+    public static func read(from defaults: UserDefaults) -> Self {
+        defaults.string(forKey: defaultsKey).flatMap(Self.init(rawValue:)) ?? defaultChoice
     }
 
     /// The step `offset` places away, or nil when there is none that way.
@@ -60,7 +63,7 @@ extension ChatTextSize {
     /// Walks the cases rather than multiplying the scale, because the steps are what the type is
     /// for: arithmetic on 0.9 lands on the 0.85 the comment above rules out, and it has no end to
     /// stop at, which is what tells a menu item to grey itself.
-    func stepped(by offset: Int) -> ChatTextSize? {
+    public func stepped(by offset: Int) -> ChatTextSize? {
         let steps = Self.allCases
         guard let index = steps.firstIndex(of: self) else { return nil }
         let moved = index + offset

--- a/Sources/BloomCore/Presentation/ListLeading.swift
+++ b/Sources/BloomCore/Presentation/ListLeading.swift
@@ -28,6 +28,19 @@ import Foundation
 /// because a reader asks for it by name; at that step the lines inside an item are a point apart
 /// as well, and a list as dense as the prose around it is exactly what was asked for.
 public enum ListLeading {
+    /// Paragraph-like bullets and numbered items keep prose leading, plus a small separation
+    /// between ideas. Add rather than clamp so every line-height preference still reaches the
+    /// gap. Checklists retain `betweenItems` and their compact rhythm.
+    public static func betweenProseItems(
+        tight: Bool, lineHeight: Double, pointSize: Double, ratio: Double
+    ) -> Double {
+        let leading = TextLeading.overPointSize(
+            lineHeight: lineHeight, pointSize: pointSize, ratio: ratio
+        )
+        let separation = (pointSize * 0.2).rounded()
+        return leading * (tight ? 1 : 2) + separation
+    }
+
     /// - Parameters:
     ///   - tight: markdown's own flag for a list whose items are not separated by blank lines. A
     ///     task list carries no such flag and is always tight, the way it is written.

--- a/Sources/BloomCore/Presentation/TextLeading.swift
+++ b/Sources/BloomCore/Presentation/TextLeading.swift
@@ -25,17 +25,9 @@ public enum TextLeading {
     /// What a line of prose comes to, as a multiple of the size it is set at, when the reader has
     /// not said otherwise.
     ///
-    /// 1.7, from the page the owner asked for. It is also where the readability advice sits for a
-    /// column of this measure: the WCAG 1.4.12 floor is 1.5, and the range typography guides give
-    /// for body text on a screen is 1.5 to 1.8, so 1.7 is the generous end of that rather than a
-    /// number past it. The transcript is the one surface in the window that is read a line at a
-    /// time instead of scanned, which is why it gets the generous end and nothing else does.
-    ///
-    /// It is `ChatLineHeight.standard.ratio` rather than a literal, because the owner then asked
-    /// for the line height to be a setting and 1.7 became the middle of five. Two places saying
-    /// 1.7 is one place that can be moved and one that will not be, and this is the one every
-    /// caller that has no reader to ask reaches for.
-    public static let proseRatio: Double = ChatLineHeight.standard.ratio
+    /// Follow the same fallback as Settings, rather than keeping a second default that drifts
+    /// when the conversation's typography changes.
+    public static let proseRatio: Double = ChatLineHeight.defaultChoice.ratio
 
     /// What a line of wrapped code comes to, as a multiple of its own line box.
     ///

--- a/Sources/BloomCore/Transcript/TranscriptEntryID.swift
+++ b/Sources/BloomCore/Transcript/TranscriptEntryID.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-/// What one entry of a drawn transcript is: a stored row, or one of the five things that are not
-/// stored rows.
+/// What one entry of a drawn transcript is: a stored row, live content, or decoration.
 ///
 /// **A type rather than the `String` the spike had, and the reason is the one `Identifier.swift`
 /// gives for every other id in this app.** A drawn transcript names five different things, and
@@ -38,8 +37,10 @@ public enum TranscriptEntryID: Hashable, Sendable, CustomStringConvertible {
     case streaming
     /// A queued message, waiting to be sent.
     case pending(DeliveryID)
+    /// Breathing room after all content, including streaming output and queued messages.
+    case bottomSpacing
 
-    /// The sequence number this entry names, or nothing for the five that are not stored rows.
+    /// The sequence number this entry names, or nothing for entries that are not stored rows.
     ///
     /// What the pane writes down as the reader's place. Nothing else may guess at it: the whole
     /// point of the type is that a caller cannot mistake the streaming tail for row zero. A fold
@@ -60,7 +61,7 @@ public enum TranscriptEntryID: Hashable, Sendable, CustomStringConvertible {
     /// anything that treats "measured at nought" as "will always be nought" would leave a running
     /// turn with no view to appear in.
     ///
-    /// Here rather than beside the table because it is a claim about these six cases, and a
+    /// Here rather than beside the table because it is a claim about these cases, and a
     /// caller acting on it is deciding whether to build a row's view at all.
     ///
     /// **This used to be `seq == nil`, and the coincidence ended with `fold`.** A fold's line
@@ -69,7 +70,7 @@ public enum TranscriptEntryID: Hashable, Sendable, CustomStringConvertible {
     /// promise that holds until the key moves.
     public var redrawsItself: Bool {
         switch self {
-        case .row, .fold: false
+        case .row, .fold, .bottomSpacing: false
         case .setup, .sending, .streaming, .pending: true
         }
     }
@@ -82,6 +83,7 @@ public enum TranscriptEntryID: Hashable, Sendable, CustomStringConvertible {
         case .sending: "sending"
         case .streaming: "streaming"
         case .pending(let id): "pending.\(id)"
+        case .bottomSpacing: "bottomSpacing"
         }
     }
 }

--- a/Tests/BloomCoreTests/ChatLineHeightTests.swift
+++ b/Tests/BloomCoreTests/ChatLineHeightTests.swift
@@ -13,10 +13,11 @@ struct ChatLineHeightTests {
         (12, 15), (13, 16), (15, 18), (17, 20), (20, 23),
     ]
 
-    @Test("the middle step is what the transcript was already set at")
-    func theDefaultIsWhereItWas() {
+    @Test("the new default leaves the old middle step unchanged")
+    func theDefaultPreservesExistingSteps() {
         #expect(ChatLineHeight.standard.ratio == 1.7)
-        #expect(TextLeading.proseRatio == ChatLineHeight.standard.ratio)
+        #expect(ChatLineHeight.defaultChoice == .tighter)
+        #expect(TextLeading.proseRatio == 1.55)
         #expect(ChatLineHeight.allCases.count == 5)
         #expect(ChatLineHeight.allCases[2] == .standard)
     }
@@ -39,8 +40,8 @@ struct ChatLineHeightTests {
         }
     }
 
-    @Test("the default text size answers two points a step, from two to ten")
-    func theDefaultSizeIsAnEvenLadder() {
+    @Test("the original 13 point size still answers two points a step, from two to ten")
+    func theOriginalSizeIsAnEvenLadder() {
         let points = ChatLineHeight.allCases.map {
             TextLeading.overPointSize(lineHeight: 16, pointSize: 13, ratio: $0.ratio)
         }
@@ -80,7 +81,7 @@ struct ChatLineHeightTests {
     func titlesAreDistinct() {
         let titles = ChatLineHeight.allCases.map(\.title)
         #expect(Set(titles).count == titles.count)
-        #expect(ChatLineHeight.standard.title == "Default")
+        #expect(ChatLineHeight.defaultChoice.title == "Default")
     }
 
     /// The code block is a separate decision against a separate denominator, and this setting

--- a/Tests/BloomCoreTests/ChatTypographyPreferencesTests.swift
+++ b/Tests/BloomCoreTests/ChatTypographyPreferencesTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Chat defaults preserve the reader's saved typography")
+struct ChatTypographyPreferencesTests {
+    @Test("missing and unrecognised preferences use the new defaults without writing them",
+          arguments: [nil, "unknown"] as [String?])
+    func defaultsWithoutMigration(rawValue: String?) throws {
+        let domain = "bloom-test-typography-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: domain))
+        defer { defaults.removePersistentDomain(forName: domain) }
+        defaults.set(rawValue, forKey: ChatTextSize.defaultsKey)
+        defaults.set(rawValue, forKey: ChatLineHeight.defaultsKey)
+
+        #expect(ChatTextSize.read(from: defaults) == .large)
+        #expect(ChatLineHeight.read(from: defaults) == .tighter)
+        #expect(ChatTextSize.read(from: defaults).scale == 1.15)
+        #expect(ChatLineHeight.read(from: defaults).ratio == 1.55)
+        #expect(defaults.string(forKey: ChatTextSize.defaultsKey) == rawValue)
+        #expect(defaults.string(forKey: ChatLineHeight.defaultsKey) == rawValue)
+    }
+
+    @Test("every saved text size keeps its original scale")
+    func savedTextSizes() throws {
+        let domain = "bloom-test-typography-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: domain))
+        defer { defaults.removePersistentDomain(forName: domain) }
+        let choices: [(String, CGFloat)] = [
+            ("small", 0.9), ("standard", 1), ("large", 1.15),
+            ("extraLarge", 1.3), ("largest", 1.5),
+        ]
+        for (rawValue, scale) in choices {
+            defaults.set(rawValue, forKey: ChatTextSize.defaultsKey)
+            let size = ChatTextSize.read(from: defaults)
+            #expect(size.rawValue == rawValue)
+            #expect(size.scale == scale)
+        }
+    }
+
+    @Test("every saved line height keeps its original ratio")
+    func savedLineHeights() throws {
+        let domain = "bloom-test-typography-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: domain))
+        defer { defaults.removePersistentDomain(forName: domain) }
+        let choices: [(String, Double)] = [
+            ("tightest", 1.4), ("tighter", 1.55), ("standard", 1.7),
+            ("looser", 1.85), ("loosest", 2),
+        ]
+        for (rawValue, ratio) in choices {
+            defaults.set(rawValue, forKey: ChatLineHeight.defaultsKey)
+            let height = ChatLineHeight.read(from: defaults)
+            #expect(height.rawValue == rawValue)
+            #expect(height.ratio == ratio)
+        }
+    }
+
+    @Test("Settings marks exactly the fallback choice as Default")
+    func pickerDefaults() {
+        #expect(ChatTextSize.allCases.filter { $0.title == "Default" } == [.defaultChoice])
+        #expect(ChatLineHeight.allCases.filter { $0.title == "Default" } == [.defaultChoice])
+        #expect(Set(ChatTextSize.allCases.map(\.title)).count == ChatTextSize.allCases.count)
+        #expect((13 * ChatTextSize.defaultChoice.scale).rounded() == 15)
+    }
+
+    @Test("zoom walks the existing steps on both sides of the new default")
+    func zoomSteps() {
+        #expect(ChatTextSize.defaultChoice.stepped(by: -1) == .standard)
+        #expect(ChatTextSize.defaultChoice.stepped(by: 1) == .extraLarge)
+        #expect(ChatTextSize.small.stepped(by: -1) == nil)
+        #expect(ChatTextSize.largest.stepped(by: 1) == nil)
+    }
+}

--- a/Tests/BloomCoreTests/ListLeadingTests.swift
+++ b/Tests/BloomCoreTests/ListLeadingTests.swift
@@ -4,6 +4,38 @@ import Foundation
 
 @Suite("The gap a markdown list puts between its items")
 struct ListLeadingTests {
+    @Test("prose list items have breathing room at the current defaults")
+    func proseDefault() {
+        let tight = ListLeading.betweenProseItems(
+            tight: true, lineHeight: 18, pointSize: 15, ratio: ChatLineHeight.defaultChoice.ratio
+        )
+        let loose = ListLeading.betweenProseItems(
+            tight: false, lineHeight: 18, pointSize: 15, ratio: ChatLineHeight.defaultChoice.ratio
+        )
+        #expect(tight == 8)
+        #expect(loose == 13)
+    }
+
+    @Test("prose gaps follow every size and line-height preference without tightening wrapped lines")
+    func prosePreferences() {
+        for step in Self.bodySteps {
+            for tight in [true, false] {
+                var previous = 0.0
+                for choice in ChatLineHeight.allCases {
+                    let leading = TextLeading.overPointSize(
+                        lineHeight: step.box, pointSize: step.size, ratio: choice.ratio
+                    )
+                    let gap = ListLeading.betweenProseItems(
+                        tight: tight, lineHeight: step.box, pointSize: step.size, ratio: choice.ratio
+                    )
+                    #expect(gap > leading)
+                    #expect(gap >= previous)
+                    previous = gap
+                }
+            }
+        }
+    }
+
     /// The five steps of `ChatTextSize` resolved against the body rung on macOS 26: the point size
     /// San Francisco comes out at, and the line box `NSLayoutManager` lays it out in. The same
     /// table `ChatLineHeightTests` and `TextLeadingTests` measured, and measured rather than

--- a/Tests/BloomCoreTests/TextLeadingTests.swift
+++ b/Tests/BloomCoreTests/TextLeadingTests.swift
@@ -23,9 +23,9 @@ struct TextLeadingTests {
         }
     }
 
-    @Test("the default chat size gets six points where it used to get three")
+    @Test("the new 15 point default adds five points to its native line box")
     func theDefaultMoves() {
-        #expect(TextLeading.overPointSize(lineHeight: 16, pointSize: 13) == 6)
+        #expect(TextLeading.overPointSize(lineHeight: 18, pointSize: 15) == 5)
     }
 
     @Test("a fixed three points is what the ratio is not")
@@ -80,10 +80,10 @@ struct TextLeadingTests {
 
     @Test("code is measured against its box and prose against its size, and they do not agree")
     func theTwoDenominatorsAreNotOneDecision() {
-        // A guard against somebody folding the two ratios together later: at the same eleven
+        // A guard against somebody folding the two ratios together later: at the same thirteen
         // point rung the two rules answer differently, and that is the point of there being two.
-        let prose = TextLeading.overPointSize(lineHeight: 13, pointSize: 11)
-        let code = TextLeading.overLineBox(lineHeight: 13)
+        let prose = TextLeading.overPointSize(lineHeight: 16, pointSize: 13)
+        let code = TextLeading.overLineBox(lineHeight: 16)
         #expect(prose != code)
     }
 }

--- a/Tests/BloomCoreTests/TranscriptEntryChangeTests.swift
+++ b/Tests/BloomCoreTests/TranscriptEntryChangeTests.swift
@@ -15,7 +15,8 @@ struct TranscriptEntryChangeTests {
     private func drawn(
         _ seqs: [Int], pending: [String] = []
     ) -> [TranscriptEntryID] {
-        [.setup] + rows(seqs) + [.sending, .streaming] + pending.map { .pending(DeliveryID($0)) }
+        [.setup] + rows(seqs) + [.sending, .streaming]
+            + pending.map { .pending(DeliveryID($0)) } + [.bottomSpacing]
     }
 
     // MARK: - Nothing moved
@@ -170,7 +171,7 @@ struct TranscriptEntryChangeTests {
     /// The turn here opens with the reader's message at row 0, and `fold.1` is the line over its
     /// working.
     private func turn(_ entries: [TranscriptEntryID]) -> [TranscriptEntryID] {
-        [.setup, .row(0)] + entries + [.sending, .streaming]
+        [.setup, .row(0)] + entries + [.sending, .streaming, .bottomSpacing]
     }
 
     /// A turn's line joins the list at the second row of its working, long before it can fold.

--- a/Tests/BloomCoreTests/TranscriptEntryIDTests.swift
+++ b/Tests/BloomCoreTests/TranscriptEntryIDTests.swift
@@ -4,6 +4,14 @@ import Foundation
 
 @Suite("What a transcript entry's id promises")
 struct TranscriptEntryIDTests {
+    @Test("bottom spacing is stable decoration, not a stored or self-updating row")
+    func bottomSpacingIsDecoration() {
+        #expect(TranscriptEntryID.bottomSpacing.seq == nil)
+        #expect(!TranscriptEntryID.bottomSpacing.redrawsItself)
+        #expect(TranscriptEntryID.bottomSpacing != .streaming)
+        #expect(TranscriptEntryID.bottomSpacing.description == "bottomSpacing")
+    }
+
     /// **The rule behind giving a row no view at all.** A row measured at nought is given no cell,
     /// which is most of a real session, and the whole safety of that is that a stored row cannot
     /// change what it draws without its content key moving.


### PR DESCRIPTION
## Summary

- Set the conversation defaults to the existing 1.15 text-size step (15 pt system body text) and 1.55 prose line height.
- Preserve every saved raw value and its original scale/ratio. No preference migration or write occurs when reading a default.
- Keep Settings, all conversation surfaces, the line-height environment, and View > Actual Size consistent. Only the new fallback choices are labelled Default.
- Move the UI-independent text-size preference into BloomCore so compatibility and zoom steps can be tested.
- Update the typography gallery and native layout regression to exercise the current defaults.
- Soften the turn-footer separators from 1 pt to 0.5 pt without changing structural pane borders.
- Add a stable 8 pt bottom-spacing entry after all transcript content, including streaming output and queued messages. The spacing belongs to the scrollable document, not an overlay over the final row.
- Give ordinary numbered and bulleted lists paragraph line spacing and clearer item separation (8 pt tight / 13 pt loose at the default body size). Preserve compact checklists, including linked nested items.
- Restore native sidebar and unified-titlebar backgrounds while keeping transcript and content strips opaque. Preserve title-bar controls, status bands, pane geometry and structural dividers.
- Centre diff notices and gated empty states in the available pane, retaining native ContentUnavailableView fonts. Actual diffs retain their top-leading scroll anchor.

## Screenshot review

The main pane borders and spacing between turns remain unchanged. The blank area below the final tool row is the composer, not a transcript gap. Following the owner's confirmation, this PR also includes quieter turn-footer separators and a little more clearance above the composer.

## Validation

- `swift build --jobs 4`: passed without warnings.
- `make lint` and `make swiftlint`: passed.
- Targeted typography, transcript entry identity/diffing, and row-height suites: 149 tests passed.
- Follow-up list typography, text leading, line-height and row-height suites: 117 tests passed, including two new prose-list spacing regressions.
- Native layout regression: all 55 checks passed in both debug and the packaged release binary, covering width/height resizing, live-end anchoring, realised row alignment, live row-height changes, and exact bottom clearance. Fixtures include wrapping numbered items, inline code, emphasis and nested linked checklists. Ran in an isolated background app with its own database and preference domain.
- Native window-material screenshots remain unverified: background window capture failed and its fallback omitted AppKit panes.
- Review lanes: correctness and security complete with no outstanding findings. PHP simplification, Spatie PHP conventions, Laravel and React lanes are not applicable to this Swift-only diff.

No production application, database, or preferences were changed. Existing saved choices remain visible until the user selects the new Default options.
