### PR TITLE
Smooth chat streaming and fix archive, focus, terminal and merge controls

### DIFF
--- a/Sources/Bloom/BloomApp.swift
+++ b/Sources/Bloom/BloomApp.swift
@@ -72,6 +72,8 @@ struct BloomApp: App {
         // resize. It is how somebody finally watches the transcript go blank. See `ComposerProbe`.
         if ComposerProbe.isRequested { ComposerProbe.schedule() }
         if TranscriptLayoutProbe.isRequested { TranscriptLayoutProbe.schedule() }
+        if CommentFocusProbe.isRequested { CommentFocusProbe.schedule() }
+        if MessageArrivalProbe.isRequested { MessageArrivalProbe.schedule() }
 
         // And the one that answers "the battery menu says Bloom is using significant energy":
         // `Bloom --idle-probe <out.json> --idle-worktrees <list>` runs the diff stat pass the six

--- a/Sources/Bloom/BloomApp.swift
+++ b/Sources/Bloom/BloomApp.swift
@@ -74,6 +74,9 @@ struct BloomApp: App {
         if TranscriptLayoutProbe.isRequested { TranscriptLayoutProbe.schedule() }
         if CommentFocusProbe.isRequested { CommentFocusProbe.schedule() }
         if MessageArrivalProbe.isRequested { MessageArrivalProbe.schedule() }
+        if ArchiveFailureProbe.isRequested { ArchiveFailureProbe.schedule() }
+        if StreamingRenderingProbe.isRequested { StreamingRenderingProbe.schedule() }
+        if MergeContrastProbe.isRequested { MergeContrastProbe.schedule() }
 
         // And the one that answers "the battery menu says Bloom is using significant energy":
         // `Bloom --idle-probe <out.json> --idle-worktrees <list>` runs the diff stat pass the six

--- a/Sources/Bloom/Design/ArchiveFailureProbe.swift
+++ b/Sources/Bloom/Design/ArchiveFailureProbe.swift
@@ -1,0 +1,92 @@
+import AppKit
+import BloomCore
+
+/// Runs only in a disposable probe bundle. Its repository and unrecognised worktree are fresh
+/// temporary folders, so the refusal path cannot remove a user's checkout or stop their agents.
+@MainActor
+enum ArchiveFailureProbe {
+    private static let harness = ProbeHarness(subject: "archive-failure")
+    static var isRequested: Bool { harness.isRequested }
+
+    static func schedule() { Task { @MainActor in await run() } }
+
+    private static func run() async {
+        guard Bundle.main.bundleIdentifier?.hasPrefix("be.spatie.bloom.typography-") == true else {
+            harness.fail("requires a disposable probe bundle")
+        }
+        _ = await harness.window()
+        guard let app = AppModel.probeInstance, let store = app.store else {
+            harness.fail("no app store")
+        }
+        do {
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("bloom-archive-probe-\(UUID().uuidString)")
+            let folder = root.appendingPathComponent("unrecognised-worktree")
+            try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+            let marker = folder.appendingPathComponent("keep.txt")
+            try Data("keep this work".utf8).write(to: marker)
+            let repo = Repo(name: "Archive refusal probe", path: root.path)
+            let workspace = Workspace(
+                repoID: repo.id, name: "Unrecognised checkout", branch: "probe",
+                path: folder.path, baseBranch: "main"
+            )
+            try await store.upsert(repo)
+            try await store.upsert(workspace)
+            let session = Session(workspaceID: workspace.id, title: "Archive probe")
+            try await store.upsert(session)
+            await app.reload()
+            app.selection = .workspace(workspace.id)
+            try? await Task.sleep(for: .milliseconds(400))
+            var failures: [String] = []
+            guard let model = app.existingModel(for: workspace.id) else { harness.fail("no workspace model") }
+            let transcript = model.transcript(for: session)
+            transcript.draft = "Keep this draft"
+            app.hideFromSidebar(workspace.id)
+            await transcript.submit("Do not start a real agent")
+            if transcript.draft != "Keep this draft" { failures.append("archive accepted a new prompt") }
+            let pending = try await store.pendingDeliveries(sessionID: session.id)
+            if !pending.isEmpty { failures.append("archive queued a new prompt") }
+            app.restoreToSidebar(workspace)
+            var observations = 0
+            var lostSelection = 0
+            var lostInspector = 0
+            for _ in 0..<5 {
+                await app.archive(workspace, deleteBranch: false, alwaysConfirm: true)
+                guard let request = app.pendingArchive else { harness.fail("no refusal confirmation") }
+                let archive = Task { await app.confirmArchive(request) }
+                for _ in 0..<100 {
+                    observations += 1
+                    if app.selection != .workspace(workspace.id) { lostSelection += 1 }
+                    if app.selectedWorkspace == nil { lostInspector += 1 }
+                    try? await Task.sleep(for: .milliseconds(2))
+                }
+                await archive.value
+                if model.existingTranscript(for: session.id) !== transcript {
+                    failures.append("refused archive discarded its transcript model")
+                }
+                if app.alert == nil { failures.append("failed archive did not explain its refusal") }
+                app.alert = nil
+            }
+            if lostSelection > 0 { failures.append("failed archive changed the detail selection") }
+            if lostInspector > 0 { failures.append("failed archive removed the inspector subject") }
+            await app.archive(workspace, deleteBranch: false, alwaysConfirm: true)
+            guard let request = app.pendingArchive else { harness.fail("no second refusal") }
+            let navigation = Task { await app.confirmArchive(request) }
+            while !app.isArchiving(workspace.id) { await Task.yield() }
+            app.selection = .home
+            await navigation.value
+            if app.selection != .home { failures.append("refusal overrode newer navigation") }
+            let saved = try await store.workspace(id: workspace.id)
+            if saved?.state != .active { failures.append("refused workspace was archived") }
+            if try Data(contentsOf: marker) != Data("keep this work".utf8) {
+                failures.append("refused archive changed the folder")
+            }
+            harness.write(.object([
+                "passed": .bool(failures.isEmpty), "failures": .strings(failures),
+                "observations": .integer(observations), "lostSelection": .integer(lostSelection),
+                "lostInspector": .integer(lostInspector), "fixture": .string(root.path),
+            ]))
+            exit(failures.isEmpty ? 0 : 1)
+        } catch { harness.fail(error.localizedDescription) }
+    }
+}

--- a/Sources/Bloom/Design/CommentFocusProbe.swift
+++ b/Sources/Bloom/Design/CommentFocusProbe.swift
@@ -1,0 +1,76 @@
+import AppKit
+import BloomCore
+import SwiftUI
+
+/// Exercises the real editor in an unshown window, including a focus request made before the
+/// representable has a window. No key events, application activation or user drafts are involved.
+@MainActor
+enum CommentFocusProbe {
+    private static let harness = ProbeHarness(subject: "comment-focus")
+    static var isRequested: Bool { harness.isRequested }
+
+    static func schedule() {
+        Task { @MainActor in await run() }
+    }
+
+    private static func run() async {
+        _ = await harness.window()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 180),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        var failures: [String] = []
+        var checks = 0
+        func check(_ condition: Bool, _ message: String) {
+            checks += 1
+            if !condition { failures.append(message) }
+        }
+
+        // Force the representable to update while unattached, the ordering a lazy diff permits.
+        let host = NSHostingView(rootView: ComposerTextEditor(
+            text: .constant(""), caret: .constant(0), isFocused: .constant(true),
+            onHeightChange: { _ in }, onKey: { _ in false }, onAttach: { _, _ in false }
+        ))
+        host.frame = NSRect(x: 0, y: 0, width: 500, height: 60)
+        host.layoutSubtreeIfNeeded()
+        try? await Task.sleep(for: .milliseconds(150))
+        let unattached = textView(in: host)
+        check(unattached != nil && unattached?.window == nil, "editor was not built before attachment")
+        window.contentView = host
+        window.layoutIfNeeded()
+        try? await Task.sleep(for: .milliseconds(150))
+        check(window.firstResponder === unattached, "pre-attachment request did not focus the editor")
+
+        // The complete empty diff comment also requests focus without needing a second click.
+        let comment = NSHostingView(rootView: ReviewCommentField(
+            text: .constant(""), placeholder: "Leave a comment", onSubmit: {}, onCancel: {}
+        ).padding(12))
+        window.contentView = comment
+        window.layoutIfNeeded()
+        try? await Task.sleep(for: .milliseconds(200))
+        let field = textView(in: comment)
+        check(field != nil && window.firstResponder === field, "new empty comment did not receive focus")
+
+        // A real responder change must still win over the field's stale SwiftUI binding.
+        let other = NSTextView(frame: NSRect(x: 0, y: 80, width: 100, height: 30))
+        comment.addSubview(other)
+        window.makeFirstResponder(other)
+        comment.layoutSubtreeIfNeeded()
+        try? await Task.sleep(for: .milliseconds(150))
+        check(window.firstResponder === other, "comment took focus back after it was moved elsewhere")
+        check(!window.isKeyWindow && !window.isVisible, "probe unexpectedly showed or activated its window")
+        harness.write(.object([
+            "checks": .integer(checks), "passed": .bool(failures.isEmpty),
+            "failures": .strings(failures),
+        ]))
+        exit(failures.isEmpty ? 0 : 1)
+    }
+
+    private static func textView(in view: NSView) -> ComposerTextView? {
+        if let text = view as? ComposerTextView { return text }
+        for child in view.subviews {
+            if let text = textView(in: child) { return text }
+        }
+        return nil
+    }
+}

--- a/Sources/Bloom/Design/MergeContrastProbe.swift
+++ b/Sources/Bloom/Design/MergeContrastProbe.swift
@@ -1,0 +1,53 @@
+import AppKit
+import BloomCore
+import SwiftUI
+
+/// Renders only its own offscreen controls, never the desktop or a real pull request.
+@MainActor
+enum MergeContrastProbe {
+    private static let harness = ProbeHarness(subject: "merge-contrast")
+    static var isRequested: Bool { harness.isRequested }
+    static func schedule() { Task { @MainActor in await run() } }
+
+    private static func run() async {
+        _ = await harness.window()
+        for (name, appearance) in [("light", NSAppearance.Name.aqua), ("dark", .darkAqua)] {
+            await render(name: name, appearance: appearance, titlebar: false)
+            await render(name: name, appearance: appearance, titlebar: true)
+        }
+        harness.write(.object(["rendered": .bool(true)]))
+        exit(0)
+    }
+
+    private static func render(name: String, appearance: NSAppearance.Name, titlebar: Bool) async {
+        let host = NSHostingView(rootView: MergeSplitButton(
+            method: .merge, fill: Color(red: 0, green: 0.45, blue: 0.4),
+            canMerge: true, choose: { _ in }, merge: {}
+        ).padding(20).background(Color.white).environment(\.controlActiveState, .active))
+        host.appearance = NSAppearance(named: appearance)
+        host.frame = NSRect(x: 0, y: 0, width: 220, height: 80)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 300),
+            styleMask: titlebar ? [.titled] : [], backing: .buffered, defer: false
+        )
+        window.appearance = NSAppearance(named: appearance)
+        if titlebar {
+            window.toolbar = NSToolbar(identifier: "merge-contrast")
+            window.toolbarStyle = .unified
+            let accessory = NSTitlebarAccessoryViewController()
+            accessory.view = host
+            accessory.layoutAttribute = .trailing
+            window.addTitlebarAccessoryViewController(accessory)
+        } else {
+            window.contentView = host
+        }
+        window.layoutIfNeeded()
+        try? await Task.sleep(for: .milliseconds(200))
+        guard let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else {
+            harness.fail("no bitmap")
+        }
+        host.cacheDisplay(in: host.bounds, to: bitmap)
+        let path = harness.outputPath + ".\(name)\(titlebar ? "-titlebar" : "").png"
+        try? bitmap.representation(using: .png, properties: [:])?.write(to: URL(fileURLWithPath: path))
+    }
+}

--- a/Sources/Bloom/Design/MessageArrivalEffect.swift
+++ b/Sources/Bloom/Design/MessageArrivalEffect.swift
@@ -1,0 +1,38 @@
+import BloomCore
+import SwiftUI
+
+extension View {
+    func messageArrival(_ arrival: MessageArrival?) -> some View {
+        modifier(MessageArrivalEffect(arrival: arrival))
+    }
+}
+
+/// Time belongs to the message, not the hosting cell. This survives the instant-to-saved handoff
+/// and ignores the table's animation-free layout transaction. Only these drawing attributes tick;
+/// the supplied content is not rebuilt or re-parsed by the timeline closure.
+private struct MessageArrivalEffect: ViewModifier {
+    let arrival: MessageArrival?
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var finishedArrival: MessageArrival?
+
+    func body(content: Content) -> some View {
+        if let arrival {
+            let finished = finishedArrival == arrival
+            TimelineView(.animation(paused: finished || reduceMotion)) { context in
+                let pose = finished ? .settled : arrival.pose(at: context.date, reduceMotion: reduceMotion)
+                content
+                    .opacity(pose.opacity)
+                    .scaleEffect(pose.scale, anchor: .bottomTrailing)
+                    .offset(y: pose.rise)
+            }
+            .task(id: arrival) {
+                let remaining = arrival.remaining(at: Date())
+                if remaining > 0 { try? await Task.sleep(for: .seconds(remaining)) }
+                guard !Task.isCancelled else { return }
+                finishedArrival = arrival
+            }
+        } else {
+            content
+        }
+    }
+}

--- a/Sources/Bloom/Design/MessageArrivalProbe.swift
+++ b/Sources/Bloom/Design/MessageArrivalProbe.swift
@@ -1,0 +1,65 @@
+import AppKit
+import BloomCore
+import SwiftUI
+
+/// Samples only its own offscreen hosting view. Checks that the real drawing fades, that a new
+/// hosting view continues the same arrival, and that the effect never changes the row's size.
+@MainActor
+enum MessageArrivalProbe {
+    private static let harness = ProbeHarness(subject: "message-arrival")
+    static var isRequested: Bool { harness.isRequested }
+
+    static func schedule() { Task { @MainActor in await run() } }
+
+    private static func run() async {
+        _ = await harness.window()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 100),
+            styleMask: [], backing: .buffered, defer: false
+        )
+        let arrival = MessageArrival(style: .sent)
+        func host(_ ticket: MessageArrival?) -> NSView {
+            NSHostingView(rootView: Color.red.frame(width: 120, height: 40)
+                .messageArrival(ticket).padding(20).background(Color.white))
+        }
+        func sample(_ view: NSView) -> Double {
+            view.layoutSubtreeIfNeeded()
+            guard let bitmap = view.bitmapImageRepForCachingDisplay(in: view.bounds) else { return -1 }
+            view.cacheDisplay(in: view.bounds, to: bitmap)
+            return Double(bitmap.colorAt(x: bitmap.pixelsWide / 2, y: bitmap.pixelsHigh / 2)?
+                .usingColorSpace(.deviceRGB)?.greenComponent ?? -1)
+        }
+        let first = host(arrival)
+        window.contentView = first
+        window.layoutIfNeeded()
+        let size = first.fittingSize
+        let beginning = sample(first)
+        try? await Task.sleep(for: .milliseconds(80))
+        let middle = sample(first)
+        let saved = host(arrival)
+        window.contentView = saved
+        window.layoutIfNeeded()
+        let handoff = sample(saved)
+        try? await Task.sleep(for: .milliseconds(400))
+        let end = sample(saved)
+        let history = host(nil)
+        window.contentView = history
+        let baseline = sample(history)
+        var failures: [String] = []
+        if !(beginning > middle && middle > end && end >= 0) {
+            failures.append("offscreen drawing did not expose intermediate fade frames")
+        }
+        if !(handoff <= middle + 0.1 && handoff >= end) {
+            failures.append("saved row restarted or lost its arrival")
+        }
+        if size != saved.fittingSize { failures.append("arrival changed layout dimensions") }
+        if abs(end - baseline) > 0.01 { failures.append("arrival did not settle at full opacity") }
+        harness.write(.object([
+            "passed": .bool(failures.isEmpty), "failures": .strings(failures),
+            "greenSamples": .numbers([beginning, middle, handoff, end]),
+            "baseline": .number(baseline),
+            "stableSize": .bool(size == saved.fittingSize),
+        ]))
+        exit(failures.isEmpty ? 0 : 1)
+    }
+}

--- a/Sources/Bloom/Design/StreamingRenderingProbe.swift
+++ b/Sources/Bloom/Design/StreamingRenderingProbe.swift
@@ -1,0 +1,63 @@
+import AppKit
+import BloomCore
+import QuartzCore
+import SwiftUI
+
+/// Measures the real streaming markdown row without an agent, a user transcript or synthetic
+/// input. This isolates rendering cost; it does not claim to measure foreground auto-scrolling.
+@MainActor
+enum StreamingRenderingProbe {
+    private static let harness = ProbeHarness(subject: "streaming-rendering")
+    static var isRequested: Bool { harness.isRequested }
+    static func schedule() { Task { @MainActor in await run() } }
+
+    private static func run() async {
+        guard Bundle.main.bundleIdentifier?.hasPrefix("be.spatie.bloom.typography-") == true else {
+            harness.fail("requires a disposable probe bundle")
+        }
+        _ = await harness.window()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 760, height: 900),
+            styleMask: [], backing: .buffered, defer: false
+        )
+        let app = AppModel()
+        let workspace = Workspace(
+            repoID: RepoID(UUID().uuidString), name: "Streaming rendering probe", branch: "probe",
+            path: "/nonexistent-bloom-rendering-probe", baseBranch: "main"
+        )
+        let transcript = TranscriptModel(
+            session: Session(workspaceID: workspace.id, title: "Probe"), workspace: workspace, app: app
+        )
+        let host = NSHostingView(rootView: ScrollView {
+            StreamingRowView(transcript: transcript).frame(width: 760)
+        })
+        host.sizingOptions = []
+        window.contentView = host
+        let paragraph = "A completed paragraph with **emphasis**, `inline code` and enough words to wrap across several lines while the next paragraph arrives.\n\n"
+        let prefix = String(repeating: paragraph, count: 40)
+        await transcript.acceptForProbe(.streamDelta(.text(prefix)))
+        try? await Task.sleep(for: .milliseconds(500))
+        let recorder = FrameRecorder(view: host) { CGFloat(transcript.streamingText.count) }
+        recorder.start()
+        harness.markStarted()
+        let cpu = ProbeHarness.mainThreadCPUSeconds()
+        let start = CACurrentMediaTime()
+        let chunk = "More **streamed** words arriving in this paragraph. "
+        for index in 0..<200 {
+            await transcript.acceptForProbe(.streamDelta(.text(chunk + (index % 4 == 3 ? "\n\n" : ""))))
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        try? await Task.sleep(for: .milliseconds(100))
+        let elapsed = CACurrentMediaTime() - start
+        let consumed = ProbeHarness.mainThreadCPUSeconds() - cpu
+        recorder.stop()
+        let expected = prefix.count + chunk.count * 200 + 100
+        harness.write(.object([
+            "characters": .integer(transcript.streamingText.count),
+            "complete": .bool(transcript.streamingText.count == expected),
+            "wallSeconds": .number(elapsed), "mainThreadCpuMs": .number(consumed * 1000),
+            "frames": .object(ProbeHarness.frameTimings(recorder.intervals.map { $0 * 1000 })),
+        ].merging(harness.conditions(window: window)) { mine, _ in mine }))
+        exit(0)
+    }
+}

--- a/Sources/Bloom/State/AppModel+Archive.swift
+++ b/Sources/Bloom/State/AppModel+Archive.swift
@@ -258,7 +258,8 @@ extension AppModel {
         // That trade is deliberate and it is the reason the archive script's failure message says
         // so rather than claiming the workspace is untouched. Moving the teardown after the
         // script would mean the script running while an agent still writes, which is worse.
-        workspaceModels[workspace.id]?.teardown()
+        guard hideFromSidebar(workspace.id) else { return }
+        workspaceModels[workspace.id]?.stopEverything()
 
         // Out of the sidebar now, before a single byte moves.
         //
@@ -272,9 +273,9 @@ extension AppModel {
         // made before this method was called, so the row can go at once and the disk can catch
         // up. If the disk refuses, the `catch` below reloads from the store, where the row is
         // still active, and it comes back with the reason in front of it.
-        let previousSelection = selection
-        hideFromSidebar(workspace.id)
-        if selection.workspaceID == workspace.id { selection = .home }
+        // Do not visit Home speculatively. On refusal its List was immediately dismantled again
+        // while the inspector was resizing, the suspected trigger of the macOS 27 crash.
+        // The sidebar can hide the row, but the selected content stays until Git has succeeded.
 
         do {
             try await manager.archive(
@@ -284,10 +285,12 @@ extension AppModel {
                 force: force,
                 isPullRequestMerged: hazards.isPullRequestMerged
             )
+            if selection.workspaceID == workspace.id { selection = .home }
             // The worktree is gone from disk now. Its shells are sitting in a directory that no
             // longer exists and its dev servers are still holding their ports, and nothing else in
             // the app will ever come back for them.
             await TerminalSessionStore.shared.discard(workspaceID: workspace.id)
+            workspaceModels[workspace.id]?.teardown()
             // Everything at once, and after the discard rather than before it. The store agrees
             // the workspace is archived by now, so the reload filter has nothing left to protect,
             // and holding it across one more await can only keep a row from flickering back.
@@ -297,7 +300,7 @@ extension AppModel {
             await offerUndo(of: workspace, repo: repo, report: report)
             Log.archive.info("archived \(workspace.name, privacy: .public)")
         } catch let error as WorkspaceError {
-            await undoOptimisticArchive(workspace, restoring: previousSelection)
+            await undoOptimisticArchive(workspace)
             switch error {
             case .archiveScriptFailed(let status, let output):
                 Log.archive.error(
@@ -334,7 +337,7 @@ extension AppModel {
                 await reportArchiveFailure(error, workspace: workspace)
             }
         } catch {
-            await undoOptimisticArchive(workspace, restoring: previousSelection)
+            await undoOptimisticArchive(workspace)
             Log.archive.error(
                 "could not archive \(workspace.name, privacy: .public): \(error.readableMessage, privacy: .public)"
             )
@@ -360,14 +363,13 @@ extension AppModel {
 
     /// Puts a workspace back in the sidebar after the disk refused to let it go.
     ///
-    /// Reloaded from the store rather than reinstated from a copy held in memory. `Workspace.state`
-    /// is only written once the removal has actually happened, so a failed archive leaves the row
-    /// exactly as it was, and reading it back is the one version that cannot disagree with what
-    /// every other part of the app is about to read.
-    private func undoOptimisticArchive(_ workspace: Workspace, restoring selection: SidebarSelection) async {
-        stopHidingFromSidebar(workspace.id)
+    /// The presentation is restored synchronously, then refreshed from the store. There must not
+    /// be an await between removing the in-flight fallback and putting the row back: that would
+    /// briefly remove the inspector and start another pane resize on a refused archive.
+    private func undoOptimisticArchive(_ workspace: Workspace) async {
+        restoreToSidebar(workspace)
         await reload()
-        self.selection = selection
+        // A user who navigated away while Git was working keeps their new selection.
     }
 
     /// Offers Edit > Undo for an archive that really can be taken back.

--- a/Sources/Bloom/State/AppModel.swift
+++ b/Sources/Bloom/State/AppModel.swift
@@ -264,11 +264,11 @@ final class AppModel {
     /// reload knows about a decision the store has not caught up with yet. See
     /// `WorkspaceListReconciliation.afterStoreReload`.
     ///
-    /// Outside observation deliberately: nothing draws from it, `reload` is the only reader, and
-    /// the write that matters to the UI is the one it makes to `workspaces`. It sits up here with
-    /// the stored state rather than down beside the archive, because Swift has no stored property
-    /// in an extension and the archive is one now.
-    @ObservationIgnored private var archivingWorkspaceIDs: Set<WorkspaceID> = []
+    /// Observed so the retained pane becomes read-only during removal. The selected workspace
+    /// stays resolvable through its model while the sidebar hides its row.
+    private var archivingWorkspaceIDs: Set<WorkspaceID> = []
+
+    func isArchiving(_ id: WorkspaceID) -> Bool { archivingWorkspaceIDs.contains(id) }
 
     /// Workspaces the owner has asked for whose worktree is still being cut.
     ///
@@ -278,10 +278,7 @@ final class AppModel {
     /// finished. See `PendingWorkspace` for why these are not `Workspace` values and are not in
     /// `workspaces`.
     ///
-    /// Observed, unlike the archiving set, and the difference is what each one is for. That one
-    /// exists so `reload` can subtract from a list it is about to publish, and the write the
-    /// window sees is the write to `workspaces`. This one is drawn: the sidebar reads it directly,
-    /// so it has to invalidate when a row is added or taken away.
+    /// Observed because the sidebar draws these rows directly.
     ///
     /// Written only by `showPending` and `forgetPending`, and emptied by `reload` the moment the
     /// stored row it is standing in for arrives.
@@ -998,7 +995,10 @@ final class AppModel {
 
     var selectedWorkspace: Workspace? {
         guard let id = selection.workspaceID else { return nil }
+        // The row may leave the sidebar before Git accepts an archive. Keep the selected pane
+        // and its inspector alive until that succeeds, including across concurrent reloads.
         return workspaces.first { $0.id == id }
+            ?? (archivingWorkspaceIDs.contains(id) ? workspaceModels[id]?.workspace : nil)
     }
 
     /// Whether the inspector is actually on screen, rather than merely switched on.
@@ -1031,7 +1031,8 @@ final class AppModel {
     /// `WorkspaceMenuSubject`, which also hears about a row highlighted on Home, and which decides
     /// per item whether an archived workspace can answer it at all.
     var menuWorkspace: Workspace? {
-        selectedWorkspace ?? selectedArchivedWorkspace
+        if let id = selection.workspaceID, isArchiving(id) { return nil }
+        return selectedWorkspace ?? selectedArchivedWorkspace
     }
 
     /// The live model for a workspace: created if needed, and handed the workspace value to
@@ -1174,9 +1175,18 @@ final class AppModel {
     /// `AppModel+Archive.swift` because `private` is file scoped, and `workspaces` is a property
     /// this file's header claims to be the only writer of. A seam taking nothing but an id keeps
     /// that claim true.
-    func hideFromSidebar(_ id: WorkspaceID) {
-        archivingWorkspaceIDs.insert(id)
+    @discardableResult
+    func hideFromSidebar(_ id: WorkspaceID) -> Bool {
+        guard archivingWorkspaceIDs.insert(id).inserted else { return false }
         workspaces.removeAll { $0.id == id }
+        return true
+    }
+
+    /// Restore the presentation before dropping its in-flight fallback. Reload then refreshes
+    /// this snapshot from the store; no snapshot is ever written back to the database.
+    func restoreToSidebar(_ workspace: Workspace) {
+        if !workspaces.contains(where: { $0.id == workspace.id }) { workspaces.append(workspace) }
+        stopHidingFromSidebar(workspace.id)
     }
 
     /// Stops filtering a workspace out of a reload, for an archive that did not happen. Before

--- a/Sources/Bloom/State/Bridges.swift
+++ b/Sources/Bloom/State/Bridges.swift
@@ -45,17 +45,19 @@ enum Reveal {
         NSWorkspace.shared.selectFile(path, inFileViewerRootedAtPath: (path as NSString).deletingLastPathComponent)
     }
 
-    static func inTerminal(_ path: String) {
-        // Backslash first, then the quote: escaping quotes alone left a trailing backslash
-        // in a path free to swallow the closing quote, and with it the rest of the line
-        // became part of a string handed to `do script`.
-        let escaped = path
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-        let script = "tell application \"Terminal\" to do script \"cd \(escaped)\""
-        guard let apple = NSAppleScript(source: script) else { return }
+    /// Returns a launch error rather than silently leaving the user looking at an empty shell.
+    static func inTerminal(directory: String, executable: String, arguments: [String]) -> String? {
+        let script = TerminalLaunchScript.appleScript(
+            directory: directory, executable: executable, arguments: arguments
+        )
+        guard let apple = NSAppleScript(source: script) else {
+            return "The sign-in command could not be prepared. Try again."
+        }
         var error: NSDictionary?
         apple.executeAndReturnError(&error)
+        guard let error else { return nil }
+        return error[NSAppleScript.errorMessage] as? String
+            ?? "Terminal could not run the sign-in command. Try again."
     }
 
     /// Opens a path in the editor this project was last opened in.

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -133,6 +133,7 @@ final class TranscriptModel {
     /// Text and thinking arriving live, before the completed block is persisted.
     private(set) var streamingText = ""
     private(set) var streamingThinking = ""
+    @ObservationIgnored private(set) var messageArrivals = MessageArrivals()
     private(set) var streamingToolName: String?
     private(set) var thinkingTokens = 0
     private(set) var statusLabel: String?
@@ -437,6 +438,7 @@ final class TranscriptModel {
 
     /// The same fold, straight onto the model, for the rows that arrive while the session is open.
     private func absorb(_ message: Message, decisions: [String: String] = [:]) {
+        messageArrivals.persisted(seq: message.seq, kind: message.kind, sending: sending?.id)
         Self.absorb(message, decisions: decisions, into: &rows, indexByRefID: &indexByRefID)
         // The stored row has arrived, so the bubble drawn from the queue is now the same sentence
         // drawn twice. Retired here rather than after the send returns, because the pump can read
@@ -555,6 +557,7 @@ final class TranscriptModel {
         // bubble that goes on screen are one object with one id. Drawn twice under two ids is the
         // duplicate that would appear the moment the queue was read back.
         let delivery = Delivery(targetSessionID: session.id, body: body)
+        messageArrivals.sent(delivery.id)
         if queuesNextMessage {
             pendingDeliveries.append(delivery)
         } else {
@@ -1277,8 +1280,10 @@ final class TranscriptModel {
             // through. That is the only signal there is: the CLI announces a retry and never
             // announces a recovery, so the recovery is the next event of any kind.
             settleRetryRun()
-            clearStreaming()
             await appendLatestMessages()
+            // Keep the live drawing while the store is awaited. Clearing first leaves an empty
+            // frame between the stream and its saved row, interrupting the shared arrival.
+            clearStreaming()
 
         case .error(let failure):
             // The agent died without ever producing a result: a model it does not know, expired
@@ -1577,10 +1582,12 @@ final class TranscriptModel {
     /// Puts what has arrived on screen, in one write per property rather than one per delta.
     private func flushStream() {
         if !buffer.text.isEmpty {
+            if streamingText.isEmpty { messageArrivals.beganStream(.assistantText) }
             streamingText += buffer.text
             buffer.text = ""
         }
         if !buffer.thinking.isEmpty {
+            if streamingThinking.isEmpty { messageArrivals.beganStream(.thinking) }
             streamingThinking += buffer.thinking
             buffer.thinking = ""
         }

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -548,6 +548,7 @@ final class TranscriptModel {
     /// in: as a sent bubble if nothing is holding the queue, as a pending one if something is. See
     /// `sending`.
     func submit(_ text: String) async {
+        guard !isWorkspaceArchiving else { return }
         let body = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !body.isEmpty, let store else { return }
 
@@ -664,7 +665,7 @@ final class TranscriptModel {
     /// for at that moment, and both are covered by the queue simply sitting there, visibly, until
     /// somebody says something.
     func drain() async {
-        guard let store else { return }
+        guard !isWorkspaceArchiving, let store else { return }
         await refreshQueue()
 
         // The list is taken once and walked, rather than the queue being re-asked for a front
@@ -673,7 +674,7 @@ final class TranscriptModel {
         for next in Delivery.deliverable(
             from: pendingDeliveries, hold: deliveryHold, on: session.agentKind
         ) {
-            guard deliveryHold.allowsDelivery(on: session.agentKind) else { return }
+            guard !isWorkspaceArchiving, deliveryHold.allowsDelivery(on: session.agentKind) else { return }
             // Deleted, or steered out, since the list was taken.
             guard pendingDeliveries.contains(where: { $0.id == next.id }) else { continue }
 
@@ -843,7 +844,7 @@ final class TranscriptModel {
     /// retire-then-deliver order for the same reason, which is that a delivery still marked
     /// pending while its turn is starting is drawn twice.
     private func sendSteered(_ delivery: Delivery) async {
-        guard let store else { return }
+        guard !isWorkspaceArchiving, let store else { return }
         // A turn was started while this one was dying, which takes the owner typing into the
         // composer inside that second: `submit` drains, and the drain does not know a Steer is
         // booked. Two sends into one runner is the one outcome to avoid, and the cost of avoiding
@@ -888,6 +889,10 @@ final class TranscriptModel {
     /// on a backend that takes a message mid turn and must stop at the first that did not.
     @discardableResult
     private func deliver(_ delivery: Delivery) async -> Bool {
+        guard !isWorkspaceArchiving else {
+            await abandon(delivery, saying: "The workspace is being archived.")
+            return false
+        }
         // A bare `return` used to stand here, and the sentence went nowhere: `drain` has already
         // retired this delivery from the queue and drawn it as sent, so a quiet return leaves a
         // bubble claiming to have been said to an agent that was never built. It takes a database
@@ -1129,6 +1134,10 @@ final class TranscriptModel {
         }
     }
 
+    private var isWorkspaceArchiving: Bool {
+        workspace.map { app.isArchiving($0.id) } ?? false
+    }
+
     /// Starts the runner and the event pump on first use. The pump is rebuilt whenever it is
     /// missing, so no path can leave a live runner with nothing reading its events.
     ///
@@ -1146,6 +1155,7 @@ final class TranscriptModel {
     /// second caller of this would take the app down. There is no reason for the guarantee to be
     /// somewhere other than here.
     private func ensureRunner() -> (any SessionRunner)? {
+        guard !isWorkspaceArchiving else { return nil }
         guard let store else { return nil }
         let preferences = RunnerPreferences(session: session)
         if runner != nil, runnerPreferences != preferences {

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -1137,7 +1137,7 @@ final class WorkspaceModel {
     /// Through the same `setupTask` the first run uses, so archiving or quitting stops a
     /// `composer install` started from here exactly as it stops one started at creation.
     func runSetupAgain() {
-        guard canRunSetup, let repo, let manager = app.manager else { return }
+        guard !app.isArchiving(workspace.id), canRunSetup, let repo, let manager = app.manager else { return }
         setupTask?.cancel()
         setupGeneration += 1
         let generation = setupGeneration

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -1215,8 +1215,14 @@ final class WorkspaceModel {
         // Those are exactly the moments a commit can have appeared, and the six second poll is
         // already four git calls without adding a `log` for a menu nobody has opened.
         let wantsCommits = reason == .requested
+        let manager = app.manager
+        let observedWorkspace = workspace
 
         let task = Task.detached(priority: .userInitiated) { () -> Result<ChangesAnswer, GitFailure> in
+            // Also on arrival and manual refresh, so returning to a renamed branch does not
+            // wait for the background poll. The Store feed updates the sidebar and this model.
+            // Quiet refreshes follow refreshDiffStat, which has already read HEAD this tick.
+            if wantsCommits { await manager?.refreshBranch(workspace: observedWorkspace) }
             do {
                 // All three together rather than one after another. They ask three different
                 // questions of the same worktree and none of them reads another's answer, so

--- a/Sources/Bloom/Views/Archive/ArchiveInteractionShield.swift
+++ b/Sources/Bloom/Views/Archive/ArchiveInteractionShield.swift
@@ -1,0 +1,20 @@
+import AppKit
+import SwiftUI
+
+/// Keep the pane mounted without leaving an AppKit terminal or editor able to accept input.
+/// SwiftUI's disabled environment alone does not stop a native view that is first responder.
+struct ArchiveInteractionShield: NSViewRepresentable {
+    func makeNSView(context: Context) -> Shield { Shield() }
+    func updateNSView(_ view: Shield, context: Context) {}
+
+    final class Shield: NSView {
+        override var acceptsFirstResponder: Bool { true }
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            window?.makeFirstResponder(self)
+        }
+        override func keyDown(with event: NSEvent) {}
+        override func mouseDown(with event: NSEvent) {}
+        override func rightMouseDown(with event: NSEvent) {}
+    }
+}

--- a/Sources/Bloom/Views/Center/Composer/ComposerTextEditor.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerTextEditor.swift
@@ -146,6 +146,10 @@ struct ComposerTextEditor: NSViewRepresentable {
         textView.onFocusChange = { [weak coordinator = context.coordinator] focused in
             coordinator?.focusChanged(to: focused)
         }
+        textView.onWindowChange = { [weak coordinator = context.coordinator, weak textView] in
+            guard let coordinator, let textView else { return }
+            coordinator.applyFocus(to: textView)
+        }
         textView.onAttach = { [weak coordinator = context.coordinator] sources, range in
             guard let coordinator else { return false }
             return coordinator.parent.onAttach(sources, coordinator.draftRange(range, in: textView))
@@ -241,18 +245,7 @@ struct ComposerTextEditor: NSViewRepresentable {
         // written down: the binding is one turn behind the view whenever the view has just
         // resigned, and re-asserting on that stale value took the keyboard back off a browser page
         // the reader had clicked into, so Cmd+C reached a composer with nothing selected.
-        let holdsKeyboard = textView.window?.firstResponder === textView
-        if ComposerFocus.shouldTakeKeyboard(
-            wantsFocus: isFocused,
-            holdsKeyboard: holdsKeyboard,
-            isReportingChange: context.coordinator.isReportingFocus
-        ) {
-            textView.window?.makeFirstResponder(textView)
-        } else if ComposerFocus.shouldGiveUpKeyboard(
-            wantsFocus: isFocused, holdsKeyboard: holdsKeyboard
-        ) {
-            textView.window?.makeFirstResponder(nil)
-        }
+        context.coordinator.applyFocus(to: textView)
 
         context.coordinator.reportHeight(of: textView)
     }
@@ -278,6 +271,23 @@ struct ComposerTextEditor: NSViewRepresentable {
 
         init(_ parent: ComposerTextEditor) {
             self.parent = parent
+        }
+
+        /// An update can precede attachment to a window, even from a SwiftUI task. Retry the
+        /// current request on attachment, without retaining a stale request after focus moved.
+        func applyFocus(to textView: ComposerTextView) {
+            guard let window = textView.window else { return }
+            let holdsKeyboard = window.firstResponder === textView
+            if ComposerFocus.shouldTakeKeyboard(
+                wantsFocus: parent.isFocused, holdsKeyboard: holdsKeyboard,
+                isReportingChange: isReportingFocus
+            ) {
+                window.makeFirstResponder(textView)
+            } else if ComposerFocus.shouldGiveUpKeyboard(
+                wantsFocus: parent.isFocused, holdsKeyboard: holdsKeyboard
+            ) {
+                window.makeFirstResponder(nil)
+            }
         }
 
         func textDidChange(_ notification: Notification) {

--- a/Sources/Bloom/Views/Center/Composer/ComposerTextView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerTextView.swift
@@ -11,6 +11,7 @@ final class ComposerTextView: NSTextView {
     var keyHandler: (@MainActor (NSEvent, NSRange) -> Bool)?
     var onWidthChange: (@MainActor () -> Void)?
     var onFocusChange: (@MainActor (Bool) -> Void)?
+    var onWindowChange: (@MainActor () -> Void)?
     /// Offered everything dropped or pasted into the editor that is not text, together with the
     /// stretch of text it should take the place of. Returns true when the composer took it, which
     /// is what stops AppKit from doing what it does by default: typing the file's path into the
@@ -47,6 +48,11 @@ final class ComposerTextView: NSTextView {
         let accepted = super.becomeFirstResponder()
         if accepted { onFocusChange?(true) }
         return accepted
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window != nil { onWindowChange?() }
     }
 
     override func resignFirstResponder() -> Bool {

--- a/Sources/Bloom/Views/Chrome/Settings/AgentsSettingsView.swift
+++ b/Sources/Bloom/Views/Chrome/Settings/AgentsSettingsView.swift
@@ -18,6 +18,7 @@ struct AgentsSettingsView: View {
     @State private var isLoading = true
     @State private var isRefreshing = false
     @State private var saveFailure: String?
+    @State private var loginFailure: String?
     @State private var pathDraft = ""
     /// Which agent `pathDraft` belongs to. `selection` has already moved on by the time the
     /// change handler runs, so committing against it would file one agent's path under another.
@@ -50,6 +51,14 @@ struct AgentsSettingsView: View {
                 Section {
                     ErrorBanner(title: "Could not save", message: saveFailure) {
                         self.saveFailure = nil
+                    }
+                }
+            }
+
+            if let loginFailure {
+                Section {
+                    ErrorBanner(title: "Could not start sign-in", message: loginFailure) {
+                        self.loginFailure = nil
                     }
                 }
             }
@@ -285,12 +294,15 @@ struct AgentsSettingsView: View {
 
     // MARK: - Actions
 
-    /// The login flows are interactive, so they cannot run inline. `Reveal.inTerminal` opens a
-    /// Terminal window sitting at a path, and the command is appended to that so it runs in the
-    /// window the user is now looking at.
+    /// Detection may have found an override or an installation the external terminal cannot find
+    /// on PATH. Run that exact binary, with the directory and arguments kept separate throughout.
     private func runLogin() {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        Reveal.inTerminal("\(home) && \(selection.loginCommand)")
+        guard let executable = status?.executablePath else { return }
+        loginFailure = Reveal.inTerminal(
+            directory: AgentScratchDirectory.current(),
+            executable: executable,
+            arguments: selection.loginArguments
+        )
     }
 
     private func chooseExecutable() {

--- a/Sources/Bloom/Views/DetailColumn.swift
+++ b/Sources/Bloom/Views/DetailColumn.swift
@@ -120,6 +120,10 @@ struct DetailColumn: View {
             // probe run turned it on. See `SwitchTrace`.
             let _ = SwitchTrace.mark("column.body", workspace: id)
             CenterColumnView(model: model)
+                .disabled(app.isArchiving(id))
+                .overlay {
+                    if app.isArchiving(id) { ArchiveInteractionShield() }
+                }
         } else {
             HomeView()
         }

--- a/Sources/Bloom/Views/Inspector/InspectorPane.swift
+++ b/Sources/Bloom/Views/Inspector/InspectorPane.swift
@@ -16,6 +16,7 @@ import SwiftUI
 /// left here is the one question this column answers.
 struct InspectorPane: View {
     let model: WorkspaceModel?
+    @Environment(AppModel.self) private var app
 
     var body: some View {
         content
@@ -26,6 +27,7 @@ struct InspectorPane: View {
     private var content: some View {
         if let model {
             InspectorView(model: model)
+                .disabled(app.isArchiving(model.workspace.id))
                 // Rebuilt per workspace, so a diff selection never leaks across a switch.
                 .id(model.workspace.id)
         } else {

--- a/Sources/Bloom/Views/Inspector/MergeSplitButton.swift
+++ b/Sources/Bloom/Views/Inspector/MergeSplitButton.swift
@@ -132,22 +132,39 @@ struct MergeSplitButton: View {
 private struct MergeControlHost<Content: View>: NSViewRepresentable {
     var content: Content
 
-    func makeNSView(context: Context) -> NSHostingView<AnyView> {
-        let host = NSHostingView(rootView: root(context))
+    func makeNSView(context: Context) -> MergeHostingView {
+        let host = MergeHostingView(rootView: root(context))
         host.appearance = NSAppearance(named: .darkAqua)
         host.sizingOptions = [.intrinsicContentSize]
         return host
     }
 
-    func updateNSView(_ host: NSHostingView<AnyView>, context: Context) {
+    func updateNSView(_ host: MergeHostingView, context: Context) {
         host.rootView = root(context)
+        host.needsLayout = true
     }
 
-    func sizeThatFits(_ proposal: ProposedViewSize, nsView: NSHostingView<AnyView>, context: Context) -> CGSize? {
+    func sizeThatFits(_ proposal: ProposedViewSize, nsView: MergeHostingView, context: Context) -> CGSize? {
         nsView.fittingSize
     }
 
     private func root(_ context: Context) -> AnyView {
         AnyView(content.environment(\.self, context.environment).environment(\.colorScheme, .dark))
+    }
+
+    final class MergeHostingView: NSHostingView<AnyView> {
+        override func layout() {
+            super.layout()
+            applyControlAppearance(in: self)
+        }
+
+        // SwiftUI explicitly gives the embedded native control the title bar's appearance.
+        // Override only controls owned by this host, after they have been created and laid out.
+        private func applyControlAppearance(in view: NSView) {
+            if let control = view as? NSControl, control.appearance?.name != .darkAqua {
+                control.appearance = NSAppearance(named: .darkAqua)
+            }
+            for child in view.subviews { applyControlAppearance(in: child) }
+        }
     }
 }

--- a/Sources/Bloom/Views/Inspector/MergeSplitButton.swift
+++ b/Sources/Bloom/Views/Inspector/MergeSplitButton.swift
@@ -23,9 +23,9 @@ import BloomCore
 /// do is take a colour. Measured on this SDK, rendered offscreen at `controlActiveState.active`:
 /// a `Button` with `.borderedProminent` and `.tint(.red)` comes out red, and the same modifiers on
 /// a `Menu` come out as the neutral capsule, prominent or not, glass or not. So the state's colour
-/// is painted as a rounded rect behind the control and the label is asked for in dark appearance,
-/// which is what makes the system draw it, its chevron and its hairline white. That is two lines
-/// over a native control, against hand drawing a capsule, a divider, a chevron and a tick.
+/// is painted as a rounded rect behind the control. A dedicated AppKit host gives this one control
+/// dark appearance, making its label, chevron and hairline light even inside a light title bar.
+/// A SwiftUI colour-scheme override alone is ignored in a native title-bar accessory.
 ///
 /// The band's colour is a hard requirement rather than decoration: `PullRequestTint.fill` is the
 /// rule that the one prominent button carries the colour of the band it stands in, so a red
@@ -63,7 +63,8 @@ struct MergeSplitButton: View {
         // form below it was never once drawn. The candidates carry their own, on `control`, which
         // is what makes each of them report the width its label really wants. See
         // `PullRequestSummary.continueButton`, where the same slip was on four more.
-        styled.labelStyle(.titleAndIcon)
+        MergeControlHost(content: styled.labelStyle(.titleAndIcon))
+        .fixedSize()
         // **The label and the tick are one value, and this is what makes that true.** A `Menu`'s
         // content is not evaluated when the view is rebuilt; it is evaluated when the menu opens,
         // out of the closure SwiftUI stored, and the tick is drawn from the selection that closure
@@ -78,10 +79,6 @@ struct MergeSplitButton: View {
         control
             .buttonStyle(.borderedProminent)
             .buttonBorderShape(.roundedRectangle(radius: Metrics.corner))
-            // The label, the chevron and the hairline in white. See the type's note: the system
-            // will not tint this control, so the only lever left over its ink is the appearance
-            // it draws itself for.
-            .environment(\.colorScheme, .dark)
             .background(
                 // Dimmed rather than hidden when the press is not available, which is how AppKit
                 // draws a disabled prominent button and therefore how this one has to look beside
@@ -128,5 +125,29 @@ struct MergeSplitButton: View {
     /// Writing to it changes the mode. There is deliberately no path from here to a merge.
     private var binding: Binding<GitHub.MergeMethod> {
         Binding(get: { method }, set: { choose($0) })
+    }
+}
+
+/// Scope AppKit appearance to the split control, not its window or neighbouring title-bar items.
+private struct MergeControlHost<Content: View>: NSViewRepresentable {
+    var content: Content
+
+    func makeNSView(context: Context) -> NSHostingView<AnyView> {
+        let host = NSHostingView(rootView: root(context))
+        host.appearance = NSAppearance(named: .darkAqua)
+        host.sizingOptions = [.intrinsicContentSize]
+        return host
+    }
+
+    func updateNSView(_ host: NSHostingView<AnyView>, context: Context) {
+        host.rootView = root(context)
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, nsView: NSHostingView<AnyView>, context: Context) -> CGSize? {
+        nsView.fittingSize
+    }
+
+    private func root(_ context: Context) -> AnyView {
+        AnyView(content.environment(\.self, context.environment).environment(\.colorScheme, .dark))
     }
 }

--- a/Sources/Bloom/Views/Inspector/ReviewCommentField.swift
+++ b/Sources/Bloom/Views/Inspector/ReviewCommentField.swift
@@ -58,16 +58,8 @@ struct ReviewCommentField: View {
         // click. `ComposerTextEditor` reports focus back the moment AppKit gives it, so this is a
         // request rather than a claim.
         //
-        // **In a `task` and not in `onAppear`, which is why the caret used to stay where it was.**
-        // The request is applied by `ComposerTextEditor.updateNSView`, which asks the text view's
-        // WINDOW for first responder, and a view a representable has only just made is not in a
-        // window yet: `MenuKeyHost` and `MenuSearchField` both write that measurement down.
-        // Written on the appear pass, the request was answered by a nil window, nothing else
-        // invalidated this box, so `updateNSView` never ran again and the ask was dropped in
-        // silence. Escape went with it, because Escape is answered in the text view's own
-        // `keyDown` and a box that is not first responder is never offered the key. A task runs a
-        // hop later, by which time there is a window to ask; the conversation's own box takes the
-        // keyboard the same way, in `ComposerView.prepare`.
+        // The bridge also retries on window attachment. A task alone does not guarantee that
+        // an editor in a lazy diff row has a window yet.
         .task { isFocused = true }
     }
 

--- a/Sources/Bloom/Views/Terminal/TerminalView.swift
+++ b/Sources/Bloom/Views/Terminal/TerminalView.swift
@@ -441,6 +441,21 @@ final class BloomTerminalView: LocalProcessTerminalView {
             return super.performKeyEquivalent(with: event)
         }
 
+        // Claim this before Archive Workspace's menu equivalent. Sending the original event
+        // through the terminal keeps enhanced keyboard protocols intact; legacy shells need
+        // Ctrl+U because SwiftTerm does not handle AppKit's deleteToBeginningOfLine selector.
+        if let input = TerminalEditingShortcut.input(
+            key: key,
+            isPlainCommand: !shift,
+            usesEnhancedKeyboard: !getTerminal().keyboardEnhancementFlags.isEmpty
+        ) {
+            switch input {
+            case .text(let text): send(txt: text)
+            case .keyEvent: keyDown(with: event)
+            }
+            return true
+        }
+
         switch key {
         case "k" where !shift:
             clearScreen()

--- a/Sources/Bloom/Views/Transcript/StreamingRowView.swift
+++ b/Sources/Bloom/Views/Transcript/StreamingRowView.swift
@@ -38,9 +38,8 @@ import SwiftUI
 ///
 /// What was actually popping is the moment the answer starts: the turn shows "Working", and then
 /// a paragraph of prose is on screen in one frame where a status line was. That is a block
-/// arriving in front of the reader in exactly the sense `RowArrival` was written for, so it gets
-/// the same settle a tool row gets, at the same length, honouring the same Reduce Motion setting.
-/// Once per block, which is once or twice a turn, and nothing per delta.
+/// arriving in front of the reader. `MessageArrival` gives it a short fade with a clock that
+/// follows it into the saved row, honouring Reduce Motion. Once per block, nothing per delta.
 struct StreamingRowView: View {
     let transcript: TranscriptModel
 
@@ -58,7 +57,7 @@ struct StreamingRowView: View {
                     tokens: transcript.thinkingTokens
                 )
                 .transaction { $0.animation = nil }
-                .arrivingRow(true)
+                .messageArrival(transcript.messageArrivals.stream(.thinking))
             }
 
             if !transcript.streamingText.isEmpty {
@@ -80,7 +79,7 @@ struct StreamingRowView: View {
                     // modifier clears the animation for what it wraps, and the opacity this adds
                     // sits above it, so the block's own settle survives while the text under it
                     // stays as sudden as it was.
-                    .arrivingRow(true)
+                    .messageArrival(transcript.messageArrivals.stream(.assistantText))
             }
 
             // Before the status line and in place of it, because it is the same slot answering

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -682,6 +682,7 @@ struct TranscriptListView: View {
                             // row: the row is inserted at its full height exactly as it always
                             // was, so nothing moves, nothing reflows, and nothing below it shifts.
                             .arrivingRow(settles && arrivals.isArriving(row.seq))
+                            .messageArrival(transcript.messageArrivals.row(row.seq))
                             .padding(.horizontal, TranscriptLayout.inset)
                             .frame(maxWidth: .infinity, alignment: .leading)
                         )
@@ -723,12 +724,7 @@ struct TranscriptListView: View {
                             )
                         }
                     }
-                    // The owner's own bubble settles in like every other row that turns up. It is
-                    // the one thing on this screen the reader made happen, and it was the only
-                    // arrival with no settle at all: pressing Return put a bubble on screen in a
-                    // single frame. Always true rather than asked of the tracker, because this
-                    // view has no seq to ask about.
-                    .arrivingRow(true)
+                    .messageArrival(transcript.messageArrivals.delivery(sending.id))
                     .padding(.horizontal, TranscriptLayout.inset)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 )
@@ -805,6 +801,7 @@ struct TranscriptListView: View {
                             onEdit: { Task { await transcript.editPending(delivery) } },
                             onDelete: { transcript.askToDiscard(delivery) }
                         )
+                        .messageArrival(transcript.messageArrivals.delivery(delivery.id))
                         .padding(.horizontal, TranscriptLayout.inset)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     )

--- a/Sources/BloomCore/Model/Models.swift
+++ b/Sources/BloomCore/Model/Models.swift
@@ -723,11 +723,16 @@ public enum AgentKind: String, Sendable, Codable, CaseIterable, Identifiable {
 
     /// Interactive, so it has to be handed to a terminal rather than run inline.
     public var loginCommand: String {
+        ([executableName] + loginArguments).joined(separator: " ")
+    }
+
+    /// Kept separate from the executable so Settings can use the binary it actually detected,
+    /// including an override outside the external terminal's PATH.
+    public var loginArguments: [String] {
         switch self {
-        case .claudeCode: "claude /login"
-        case .codex: "codex login"
-        case .cursor: "cursor-agent login"
-        case .openCode: "opencode auth login"
+        case .claudeCode: ["/login"]
+        case .codex, .cursor: ["login"]
+        case .openCode: ["auth", "login"]
         }
     }
 

--- a/Sources/BloomCore/Persistence/Store.swift
+++ b/Sources/BloomCore/Persistence/Store.swift
@@ -1471,6 +1471,22 @@ public actor Store {
         )
     }
 
+    /// A filesystem refresh owns only the branch. A rename, restore or archive that landed while
+    /// git was running wins over this older observation. An unchanged answer writes nothing, so
+    /// the background poll does not wake every workspace observer on an idle checkout.
+    public func updateCheckedOutBranch(_ branch: String, observed: Workspace) throws {
+        guard observed.state == .active, branch != observed.branch,
+              branch != "HEAD", Git.isValidBranchName(branch),
+              let current = try workspace(id: observed.id),
+              current.state == .active, current.path == observed.path,
+              current.branch == observed.branch, branch != current.baseBranch,
+              let project = try repo(id: current.repoID), branch != project.defaultBranch else { return }
+        try db.run(
+            "UPDATE workspaces SET branch = ? WHERE id = ?",
+            [.text(branch), .text(observed.id)]
+        )
+    }
+
     /// Writes the pull request this workspace is about, and only when it has actually changed.
     ///
     /// The same shape and the same reason as `updateDiffStat` above it: this runs behind a poll,

--- a/Sources/BloomCore/Presentation/MessageArrival.swift
+++ b/Sources/BloomCore/Presentation/MessageArrival.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// A short, absolute-time arrival shared by the temporary and persisted drawings of a message.
+/// A new view resumes the same curve instead of starting another fade when SQLite catches up.
+public struct MessageArrival: Hashable, Sendable {
+    public enum Style: Hashable, Sendable { case sent, reply }
+
+    public let style: Style
+    public let startedAt: Date
+
+    public init(style: Style, startedAt: Date = Date()) {
+        self.style = style
+        self.startedAt = startedAt
+    }
+
+    public var duration: TimeInterval { style == .sent ? 0.32 : 0.22 }
+
+    public func remaining(at date: Date) -> TimeInterval {
+        max(0, duration - max(0, date.timeIntervalSince(startedAt)))
+    }
+
+    public struct Pose: Equatable, Sendable {
+        public let opacity: Double
+        public let rise: Double
+        public let scale: Double
+
+        public static let settled = Pose(opacity: 1, rise: 0, scale: 1)
+    }
+
+    public func pose(at date: Date, reduceMotion: Bool) -> Pose {
+        guard !reduceMotion else { return .settled }
+        let fraction = min(1, max(0, date.timeIntervalSince(startedAt) / duration))
+        // A cubic ease out, with no overshoot or moving layout dimensions.
+        let remainder = pow(1 - fraction, 3)
+        return Pose(
+            opacity: 1 - remainder,
+            rise: style == .sent ? 10 * remainder : 0,
+            scale: style == .sent ? 1 - 0.025 * remainder : 1
+        )
+    }
+}
+
+/// Ephemeral presentation state, never loaded from history or written into agent messages.
+/// Only live model events call this. The row cache is bounded even in a days-long conversation.
+public struct MessageArrivals: Sendable {
+    private var deliveries: [DeliveryID: MessageArrival] = [:]
+    private var streams: [MessageKind: MessageArrival] = [:]
+    private var rows: [Int: MessageArrival] = [:]
+
+    public init() {}
+
+    public mutating func sent(_ id: DeliveryID, at date: Date = Date()) {
+        deliveries = deliveries.filter { $0.value.remaining(at: date) > 0 }
+        deliveries[id] = MessageArrival(style: .sent, startedAt: date)
+    }
+
+    public func delivery(_ id: DeliveryID) -> MessageArrival? { deliveries[id] }
+    public func row(_ seq: Int) -> MessageArrival? { rows[seq] }
+    public func stream(_ kind: MessageKind) -> MessageArrival? { streams[kind] }
+
+    public mutating func beganStream(_ kind: MessageKind, at date: Date = Date()) {
+        guard kind == .assistantText || kind == .thinking else { return }
+        streams[kind] = MessageArrival(style: .reply, startedAt: date)
+    }
+
+    public mutating func persisted(
+        seq: Int, kind: MessageKind, sending: DeliveryID? = nil, at date: Date = Date()
+    ) {
+        rows = rows.filter { $0.value.remaining(at: date) > 0 }
+        switch kind {
+        case .user:
+            if let sending {
+                // An expired queued arrival must not restart when it finally goes to the agent.
+                rows[seq] = deliveries.removeValue(forKey: sending)
+            } else {
+                rows[seq] = MessageArrival(style: .sent, startedAt: date)
+            }
+        case .assistantText, .thinking:
+            rows[seq] = streams.removeValue(forKey: kind)
+                ?? MessageArrival(style: .reply, startedAt: date)
+        default: break
+        }
+        if rows.count > 64 {
+            for key in rows.keys.sorted().prefix(rows.count - 64) { rows[key] = nil }
+        }
+    }
+}

--- a/Sources/BloomCore/Presentation/TerminalEditingShortcut.swift
+++ b/Sources/BloomCore/Presentation/TerminalEditingShortcut.swift
@@ -1,0 +1,20 @@
+/// Editing keys claimed before the application menu sees them. The caller must first establish
+/// that this terminal is the first responder, so an unfocused pane cannot steal Archive.
+public enum TerminalEditingShortcut {
+    public enum Input: Equatable, Sendable {
+        case text(String)
+        case keyEvent
+    }
+
+    /// SwiftTerm's legacy text interpreter does not implement deleteToBeginningOfLine. Ordinary
+    /// shells therefore need Ctrl+U, while an application which negotiated enhanced keyboard
+    /// reporting must receive the original key and its modifiers through SwiftTerm's encoder.
+    public static func input(
+        key: String,
+        isPlainCommand: Bool,
+        usesEnhancedKeyboard: Bool
+    ) -> Input? {
+        guard isPlainCommand, key == "\u{7f}" || key == "\u{8}" else { return nil }
+        return usesEnhancedKeyboard ? .keyEvent : .text("\u{15}")
+    }
+}

--- a/Sources/BloomCore/Presentation/TerminalLaunchScript.swift
+++ b/Sources/BloomCore/Presentation/TerminalLaunchScript.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// A Terminal AppleScript carries a shell command inside another language's string literal.
+/// Escaping only the AppleScript layer leaves spaces and shell operators in paths executable.
+public enum TerminalLaunchScript {
+    public static func shellCommand(directory: String, executable: String, arguments: [String]) -> String {
+        "cd " + shellQuoted(directory) + " && "
+            + ([executable] + arguments).map(shellQuoted).joined(separator: " ")
+    }
+
+    public static func appleScript(directory: String, executable: String, arguments: [String]) -> String {
+        let command = shellCommand(directory: directory, executable: executable, arguments: arguments)
+        let escaped = command
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\n", with: "\\n")
+        return "tell application \"Terminal\" to do script \"\(escaped)\""
+    }
+
+    private static func shellQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/Sources/BloomCore/Presentation/TranscriptMotion.swift
+++ b/Sources/BloomCore/Presentation/TranscriptMotion.swift
@@ -39,6 +39,8 @@ public enum TranscriptMotion {
     /// take the owner's own message away and bring it back, which is the flicker the instant echo
     /// exists to remove.
     ///
+    /// These three use `MessageArrivals` instead: one clock shared across the temporary and
+    /// saved drawings, so persisting a message does not restart its effect.
     /// Everything else genuinely arrives.
     ///
     /// **The second list is written out rather than left to a `default`.** The three above are

--- a/Sources/BloomCore/Transcript/MarkdownInlineCache.swift
+++ b/Sources/BloomCore/Transcript/MarkdownInlineCache.swift
@@ -1,0 +1,45 @@
+import Synchronization
+
+/// Exact inline source is independent of the surrounding document. Keeping its immutable parse
+/// avoids rescanning completed lines on every streaming prefix. Both source bytes and entry count
+/// are capped; a single very long line is parsed without being retained.
+final class MarkdownInlineCache: Sendable {
+    private struct State {
+        var values: [[UInt8]: [MarkdownInline]] = [:]
+        var order: [[UInt8]] = []
+        var bytes = 0
+    }
+
+    private let state = Mutex(State())
+    private let maximumEntries: Int
+    private let maximumBytes: Int
+
+    init(maximumEntries: Int = 512, maximumBytes: Int = 512 * 1_024) {
+        self.maximumEntries = max(0, maximumEntries)
+        self.maximumBytes = max(0, maximumBytes)
+    }
+
+    func value(for source: String, build: () -> [MarkdownInline]) -> [MarkdownInline] {
+        // String equality normalises Unicode. Code examples must retain the exact source bytes.
+        let key = Array(source.utf8)
+        if let cached = state.withLock({ $0.values[key] }) { return cached }
+        // Parsing can recursively parse emphasis and links through this same cache. It must
+        // happen outside the lock, and duplicate work from concurrent misses is harmless.
+        let result = build()
+        let bytes = key.count
+        guard maximumEntries > 0, bytes <= maximumBytes else { return result }
+        state.withLock { storage in
+            guard storage.values[key] == nil else { return }
+            while !storage.order.isEmpty,
+                  storage.order.count >= maximumEntries || storage.bytes + bytes > maximumBytes {
+                let oldest = storage.order.removeFirst()
+                storage.values[oldest] = nil
+                storage.bytes -= oldest.count
+            }
+            storage.values[key] = result
+            storage.order.append(key)
+            storage.bytes += bytes
+        }
+        return result
+    }
+}

--- a/Sources/BloomCore/Transcript/MarkdownParser.swift
+++ b/Sources/BloomCore/Transcript/MarkdownParser.swift
@@ -446,6 +446,8 @@ private func tableCells(_ source: String) -> [String] {
 }
 
 private enum InlineParser {
+    private static let cache = MarkdownInlineCache()
+
     static func parseLines(_ lines: [String]) -> [MarkdownInline] {
         var output: [MarkdownInline] = []
         for (offset, raw) in lines.enumerated() {
@@ -465,8 +467,10 @@ private enum InlineParser {
     }
 
     static func parse(_ source: String) -> [MarkdownInline] {
-        var scanner = Scanner(source)
-        return coalesced(scanner.run())
+        cache.value(for: source) {
+            var scanner = Scanner(source)
+            return coalesced(scanner.run())
+        }
     }
 
     private static func coalesced(_ input: [MarkdownInline]) -> [MarkdownInline] {

--- a/Sources/BloomCore/Workspace/WorkspaceBranchRefresh.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceBranchRefresh.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+extension WorkspaceManager {
+    /// An agent can rename a branch without changing Bloom's workspace row. Read
+    /// HEAD alongside the existing file refresh, not on a second polling loop. The root comes
+    /// back in the same git call so an empty directory left by a removed worktree cannot make
+    /// git walk up and tell us the parent repository's branch instead.
+    public func refreshBranch(workspace: Workspace) async {
+        guard workspace.state == .active, !Task.isCancelled,
+              let result = try? await Git.run(
+                  ["rev-parse", "--show-toplevel", "--abbrev-ref", "HEAD"], in: workspace.path
+              ), result.ok else { return }
+        let lines = result.lines
+        guard lines.count == 2,
+              URL(fileURLWithPath: lines[0]).resolvingSymlinksInPath().path
+                == URL(fileURLWithPath: workspace.path).resolvingSymlinksInPath().path,
+              lines[1] != "HEAD", Git.isValidBranchName(lines[1]),
+              lines[1] != workspace.branch, lines[1] != workspace.baseBranch,
+              let repo = try? await store.repo(id: workspace.repoID),
+              lines[1] != repo.defaultBranch,
+              !Task.isCancelled else { return }
+
+        // A checkout is not a rename. The recorded branch is also what archive may delete, so
+        // following a temporary checkout of main would silently transfer ownership to main.
+        // Only a genuinely missing old local ref permits adoption; an error is not absence.
+        guard Git.isValidBranchName(workspace.branch),
+              let old = try? await Git.run(
+                  ["show-ref", "--verify", "--quiet", "--", "refs/heads/\(workspace.branch)"],
+                  in: workspace.path
+              ), old.status == 1, !Task.isCancelled else { return }
+        try? await store.updateCheckedOutBranch(lines[1], observed: workspace)
+    }
+}

--- a/Sources/BloomCore/Workspace/WorkspaceManager.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceManager.swift
@@ -748,6 +748,9 @@ public struct WorkspaceManager: Sendable {
     /// Deliberately leaves the stored counts alone when git fails, rather than writing zeroes.
     /// A stale count is a small lie; "0 files changed" on a workspace full of work is a big one.
     public func refreshDiffStat(workspace: Workspace) async {
+        // Branch discovery must survive a missing base ref: an agent may rename that ref too,
+        // which makes the diff fail but leaves HEAD perfectly readable.
+        await refreshBranch(workspace: workspace)
         guard let stat = try? await Git.diffStat(worktree: workspace.path, base: workspace.baseBranch) else {
             return
         }

--- a/Tests/BloomCoreTests/ConcurrencySafetyTests.swift
+++ b/Tests/BloomCoreTests/ConcurrencySafetyTests.swift
@@ -8,6 +8,18 @@ import Testing
 @Suite("Concurrency safety")
 struct ConcurrencySafetyTests {
 
+    @Test("a satisfied condition is observed even at the polling deadline")
+    func observesConditionAtDeadline() async throws {
+        try await waitUntil({ true }, timeout: .zero)
+    }
+
+    @Test("an unsatisfied polling deadline stops the test")
+    func rejectsUnsatisfiedCondition() async {
+        await #expect(throws: ConditionTimeout.self) {
+            try await waitUntil({ false }, timeout: .zero)
+        }
+    }
+
     // MARK: - StreamingProcess
 
     @Test("keeps every line a process wrote just before it exited", .timeLimit(.minutes(1)))
@@ -199,12 +211,16 @@ private func waitUntil(
     timeout: Duration = .seconds(5)
 ) async throws {
     let deadline = ContinuousClock.now.advanced(by: timeout)
-    while ContinuousClock.now < deadline {
+    while true {
+        // A loaded CI runner can resume after the deadline even though the condition became
+        // true during the sleep. Observe it once more before declaring a timeout.
         if await condition() { return }
+        guard ContinuousClock.now < deadline else { throw ConditionTimeout() }
         try await Task.sleep(for: .milliseconds(5))
     }
-    Issue.record("condition never became true")
 }
+
+private struct ConditionTimeout: Error {}
 
 // MARK: - AgentCatalog
 

--- a/Tests/BloomCoreTests/MarkdownInlineCacheTests.swift
+++ b/Tests/BloomCoreTests/MarkdownInlineCacheTests.swift
@@ -1,0 +1,79 @@
+import Testing
+@testable import BloomCore
+
+@Suite("Streaming inline parse cache")
+struct MarkdownInlineCacheTests {
+    @Test("Unicode code examples retain their exact source bytes")
+    func unicodeSource() {
+        let cache = MarkdownInlineCache()
+        for source in ["é", "e\u{0301}", "é"] {
+            let value = cache.value(for: source) { [.code(source)] }
+            guard case .code(let code) = value.first else { Issue.record("missing code"); return }
+            #expect(Array(code.utf8) == Array(source.utf8))
+        }
+    }
+
+    @Test("exact source is reused but different whitespace and markup are not")
+    func exactSource() {
+        let cache = MarkdownInlineCache()
+        var builds = 0
+        for source in ["hello", "hello", "hello ", "**hello**", "hello"] {
+            let value = cache.value(for: source) { builds += 1; return [.text(source)] }
+            #expect(value == [.text(source)])
+        }
+        #expect(builds == 3)
+    }
+
+    @Test("entry and source-byte budgets evict old prefixes", arguments: [true, false])
+    func bounded(byCount: Bool) {
+        let cache = MarkdownInlineCache(maximumEntries: byCount ? 2 : 10, maximumBytes: byCount ? 100 : 4)
+        var builds = 0
+        for source in ["aa", "bb", "cc", "aa"] {
+            _ = cache.value(for: source) { builds += 1; return [.text(source)] }
+        }
+        #expect(builds == 4)
+    }
+
+    @Test("oversized lines are not retained")
+    func oversized() {
+        let cache = MarkdownInlineCache(maximumBytes: 2)
+        var builds = 0
+        for _ in 0..<2 {
+            _ = cache.value(for: "large") { builds += 1; return [.text("large")] }
+        }
+        #expect(builds == 2)
+    }
+
+    @Test("nested parsing does not hold the cache lock")
+    func recursive() {
+        let cache = MarkdownInlineCache()
+        let value = cache.value(for: "**word**") {
+            [.strong(cache.value(for: "word") { [.text("word")] })]
+        }
+        #expect(value == [.strong([.text("word")])])
+    }
+
+    @Test("concurrent readers cannot mix source values")
+    func concurrent() async {
+        let cache = MarkdownInlineCache(maximumEntries: 4)
+        await withTaskGroup(of: Void.self) { group in
+            for index in 0..<100 {
+                group.addTask {
+                    let source = "line \(index % 9)"
+                    let value = cache.value(for: source) { [.text(source)] }
+                    #expect(value == [.text(source)])
+                }
+            }
+        }
+    }
+
+    @Test("cached text keeps soft and hard line breaks distinct")
+    func lineBreakContext() {
+        for _ in 0..<3 {
+            #expect(MarkdownParser.parse("one\ntwo") == [.paragraph(inline: [.text("one two")])])
+            #expect(MarkdownParser.parse("one  \ntwo") == [
+                .paragraph(inline: [.text("one"), .lineBreak, .text("two")]),
+            ])
+        }
+    }
+}

--- a/Tests/BloomCoreTests/MessageArrivalTests.swift
+++ b/Tests/BloomCoreTests/MessageArrivalTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Message arrival continuity")
+struct MessageArrivalTests {
+    private let start = Date(timeIntervalSince1970: 1000)
+
+    @Test func sentBubbleLiftsAndSettlesWithoutOvershoot() {
+        let arrival = MessageArrival(style: .sent, startedAt: start)
+        let first = arrival.pose(at: start, reduceMotion: false)
+        #expect(first.opacity == 0)
+        #expect(first.rise == 10)
+        #expect(first.scale == 0.975)
+        let middle = arrival.pose(at: start.addingTimeInterval(0.16), reduceMotion: false)
+        #expect(middle.opacity > 0 && middle.opacity < 1)
+        #expect(middle.rise > 0 && middle.rise < 10)
+        #expect(middle.scale > first.scale && middle.scale < 1)
+        #expect(arrival.pose(at: start.addingTimeInterval(1), reduceMotion: false) == .settled)
+    }
+
+    @Test func repliesOnlyFade() {
+        let pose = MessageArrival(style: .reply, startedAt: start)
+            .pose(at: start.addingTimeInterval(0.1), reduceMotion: false)
+        #expect(pose.opacity > 0 && pose.opacity < 1)
+        #expect(pose.rise == 0)
+        #expect(pose.scale == 1)
+    }
+
+    @Test func reduceMotionAlwaysDrawsTheFinishedMessage() {
+        for style in [MessageArrival.Style.sent, .reply] {
+            #expect(MessageArrival(style: style, startedAt: start)
+                .pose(at: start, reduceMotion: true) == .settled)
+        }
+    }
+
+    @Test func aClockMovingBackwardsCannotExtendTheAnimation() {
+        let arrival = MessageArrival(style: .sent, startedAt: start)
+        #expect(arrival.remaining(at: start.addingTimeInterval(-5)) == arrival.duration)
+    }
+
+    @Test func loadingHistoryDoesNotCreateArrivals() {
+        let arrivals = MessageArrivals()
+        #expect(arrivals.row(1) == nil)
+        #expect(arrivals.delivery(DeliveryID("restored")) == nil)
+        #expect(arrivals.stream(.assistantText) == nil)
+    }
+
+    @Test func savedBubbleResumesTheInstantEchoInsteadOfFadingTwice() {
+        var arrivals = MessageArrivals()
+        let id = DeliveryID("sent")
+        arrivals.sent(id, at: start)
+        let echo = arrivals.delivery(id)
+        arrivals.persisted(seq: 1, kind: .user, sending: id, at: start.addingTimeInterval(0.05))
+        #expect(arrivals.row(1) == echo)
+        #expect(arrivals.delivery(id) == nil)
+    }
+
+    @Test func queuedMessageDoesNotArriveAgainWhenItIsDelivered() {
+        var arrivals = MessageArrivals()
+        let id = DeliveryID("queued")
+        arrivals.sent(id, at: start)
+        arrivals.sent(DeliveryID("next"), at: start.addingTimeInterval(5))
+        arrivals.persisted(seq: 1, kind: .user, sending: id, at: start.addingTimeInterval(10))
+        #expect(arrivals.row(1) == nil)
+    }
+
+    @Test func streamedBlockKeepsItsClockWhenPersisted() {
+        var arrivals = MessageArrivals()
+        arrivals.beganStream(.assistantText, at: start)
+        let live = arrivals.stream(.assistantText)
+        arrivals.persisted(seq: 1, kind: .assistantText, at: start.addingTimeInterval(0.08))
+        #expect(arrivals.row(1) == live)
+        #expect(arrivals.stream(.assistantText) == nil)
+        arrivals.beganStream(.assistantText, at: start.addingTimeInterval(1))
+        #expect(arrivals.stream(.assistantText) != live)
+    }
+
+    @Test func longStreamDoesNotReplayWhenSaved() {
+        var arrivals = MessageArrivals()
+        arrivals.beganStream(.assistantText, at: start)
+        let finish = start.addingTimeInterval(30)
+        arrivals.persisted(seq: 1, kind: .assistantText, at: finish)
+        #expect(arrivals.row(1)?.pose(at: finish, reduceMotion: false) == .settled)
+    }
+
+    @Test func nonStreamingReplyArrivesButToolsKeepTheirExistingEffect() {
+        var arrivals = MessageArrivals()
+        arrivals.persisted(seq: 1, kind: .assistantText, at: start)
+        arrivals.persisted(seq: 2, kind: .toolUse, at: start)
+        #expect(arrivals.row(1)?.startedAt == start)
+        #expect(arrivals.row(2) == nil)
+    }
+
+    @Test func oldRowsExpireAndBurstsStayBounded() {
+        var arrivals = MessageArrivals()
+        for seq in 1...100 { arrivals.persisted(seq: seq, kind: .assistantText, at: start) }
+        #expect(arrivals.row(36) == nil)
+        #expect(arrivals.row(37) != nil)
+        arrivals.persisted(seq: 101, kind: .assistantText, at: start.addingTimeInterval(1))
+        #expect(arrivals.row(100) == nil)
+        #expect(arrivals.row(101) != nil)
+    }
+}

--- a/Tests/BloomCoreTests/TerminalEditingShortcutTests.swift
+++ b/Tests/BloomCoreTests/TerminalEditingShortcutTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import BloomCore
+
+@Suite("Terminal editing shortcut precedence")
+struct TerminalEditingShortcutTests {
+    @Test("Command-Backspace sends a line kill to ordinary shells", arguments: ["\u{7f}", "\u{8}"])
+    func deletesShellInput(key: String) {
+        #expect(TerminalEditingShortcut.input(
+            key: key, isPlainCommand: true, usesEnhancedKeyboard: false
+        ) == .text("\u{15}"))
+    }
+
+    @Test("Enhanced terminal applications keep the original Command-Backspace event")
+    func preservesEnhancedKeyboard() {
+        #expect(TerminalEditingShortcut.input(
+            key: "\u{7f}", isPlainCommand: true, usesEnhancedKeyboard: true
+        ) == .keyEvent)
+    }
+
+    @Test("Extra modifiers and non-Command editing keys are not claimed", arguments: [false, true])
+    func leavesOtherModifiers(enhanced: Bool) {
+        #expect(TerminalEditingShortcut.input(
+            key: "\u{7f}", isPlainCommand: false, usesEnhancedKeyboard: enhanced
+        ) == nil)
+    }
+
+    @Test("Other app shortcuts and forward delete keep their existing routing",
+          arguments: ["k", "c", "v", "w", "d", "+", "-", "0", "\u{f728}", ""])
+    func leavesOtherKeys(key: String) {
+        #expect(TerminalEditingShortcut.input(
+            key: key, isPlainCommand: true, usesEnhancedKeyboard: false
+        ) == nil)
+    }
+}

--- a/Tests/BloomCoreTests/TerminalLaunchScriptTests.swift
+++ b/Tests/BloomCoreTests/TerminalLaunchScriptTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Agent sign-in terminal launch")
+struct TerminalLaunchScriptTests {
+    @Test("Each agent's displayed command and execution arguments agree")
+    func loginArguments() {
+        #expect(AgentKind.claudeCode.loginArguments == ["/login"])
+        #expect(AgentKind.codex.loginArguments == ["login"])
+        #expect(AgentKind.cursor.loginArguments == ["login"])
+        #expect(AgentKind.openCode.loginArguments == ["auth", "login"])
+        for kind in AgentKind.allCases {
+            #expect(kind.loginCommand == ([kind.executableName] + kind.loginArguments).joined(separator: " "))
+        }
+    }
+
+    @Test("The detected executable is separate from the working directory", arguments: AgentKind.allCases)
+    func usesDetectedExecutable(kind: AgentKind) {
+        let executable = "/opt/custom tools/" + kind.executableName
+        let command = TerminalLaunchScript.shellCommand(
+            directory: "/tmp/agent scratch", executable: executable, arguments: kind.loginArguments
+        )
+        let arguments = kind.loginArguments.map { "'\($0)'" }.joined(separator: " ")
+        #expect(command == "cd '/tmp/agent scratch' && '\(executable)' \(arguments)")
+    }
+
+    @Test("Shell metacharacters in a path or argument remain literal")
+    func quotesShellInput() {
+        let command = TerminalLaunchScript.shellCommand(
+            directory: "/tmp/it's a folder",
+            executable: "/tmp/tool; echo unwanted",
+            arguments: ["$(printf unwanted)", "a\"b\\c", ""]
+        )
+        #expect(command == #"cd '/tmp/it'\''s a folder' && '/tmp/tool; echo unwanted' '$(printf unwanted)' 'a"b\c' ''"#)
+    }
+
+    @Test("AppleScript quotes the complete shell command as one string")
+    func quotesAppleScript() {
+        let script = TerminalLaunchScript.appleScript(
+            directory: "/tmp/a\"b\\c", executable: "/opt/bin/codex", arguments: ["login"]
+        )
+        #expect(script == #"tell application "Terminal" to do script "cd '/tmp/a\"b\\c' && '/opt/bin/codex' 'login'""#)
+    }
+
+    @Test("Line breaks cannot escape the AppleScript string")
+    func quotesLineBreaks() {
+        let script = TerminalLaunchScript.appleScript(
+            directory: "/tmp/a\nb\rc", executable: "/opt/bin/codex", arguments: ["login"]
+        )
+        #expect(!script.contains("\n"))
+        #expect(!script.contains("\r"))
+        #expect(script.contains(#"a\nb\rc"#))
+    }
+
+    @Test("The shell runs an absolute executable with spaces and quotes without interpreting its arguments")
+    func executesQuotedCommand() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bloom-terminal-launch-\(UUID().uuidString)")
+            .appendingPathComponent("space ' quote; dollar$")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        let executable = root.appendingPathComponent("test ' executable")
+        try FileManager.default.createSymbolicLink(atPath: executable.path, withDestinationPath: "/usr/bin/printf")
+        let argument = #"literal $(printf unwanted); 'quoted' "double" \slash"#
+        let command = TerminalLaunchScript.shellCommand(
+            directory: root.path, executable: executable.path, arguments: ["%s\n", argument]
+        )
+        let result = try await Shell.run("/bin/sh", ["-c", command], cwd: root.path)
+        #expect(result.ok)
+        #expect(result.stdout == argument + "\n")
+        #expect(result.stderr.isEmpty)
+    }
+}

--- a/Tests/BloomCoreTests/WorkspaceBranchRefreshTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceBranchRefreshTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Refreshing an externally changed branch", .tags(.git, .destructive), .scratchDirectory)
+struct WorkspaceBranchRefreshTests {
+    private struct Fixture {
+        let repo: TempRepo
+        let store: Store
+        let manager: WorkspaceManager
+        let workspace: Workspace
+    }
+
+    private func fixture() async throws -> Fixture {
+        let repo = try await TempRepo()
+        let store = try makeTestStore("branch-refresh")
+        let manager = WorkspaceManager(store: store)
+        let registered = try await manager.addRepository(at: repo.path)
+        let created = try await manager.createWorkspace(repo: registered, prompt: "Fix draft tickets")
+        let workspace = try #require(try await store.workspace(id: created.id))
+        return Fixture(repo: repo, store: store, manager: manager, workspace: workspace)
+    }
+
+    @Test("the regular diff refresh adopts an agent's branch rename")
+    func renamedBranch() async throws {
+        let fixture = try await fixture()
+        defer { fixture.repo.cleanUp() }
+        try await Git.renameBranch(fixture.workspace.branch, to: "add-delete-draft-tickets", in: fixture.workspace.path)
+
+        await fixture.manager.refreshDiffStat(workspace: fixture.workspace)
+
+        let saved = try #require(try await fixture.store.workspace(id: fixture.workspace.id))
+        #expect(saved.branch == "add-delete-draft-tickets")
+        #expect(saved.name == fixture.workspace.name)
+        #expect(saved.path == fixture.workspace.path)
+        #expect(saved.baseBranch == fixture.workspace.baseBranch)
+        #expect(try await Git.currentBranch(of: saved.path) == saved.branch)
+    }
+
+    @Test("an unreadable diff base does not prevent the branch label updating")
+    func missingBase() async throws {
+        let fixture = try await fixture()
+        defer { fixture.repo.cleanUp() }
+        try await Git.renameBranch(fixture.workspace.branch, to: "renamed", in: fixture.workspace.path)
+        let observed = try #require(try await fixture.store.update(workspaceID: fixture.workspace.id) {
+            $0.baseBranch = "missing-base"
+        })
+
+        await fixture.manager.refreshDiffStat(workspace: observed)
+
+        #expect(try await fixture.store.workspace(id: observed.id)?.branch == "renamed")
+    }
+
+    @Test("a detached HEAD keeps the last known branch")
+    func detachedHead() async throws {
+        let fixture = try await fixture()
+        defer { fixture.repo.cleanUp() }
+        try await Shell.check("git", ["checkout", "--detach", "HEAD"], cwd: fixture.workspace.path)
+
+        await fixture.manager.refreshBranch(workspace: fixture.workspace)
+
+        #expect(try await fixture.store.workspace(id: fixture.workspace.id)?.branch == fixture.workspace.branch)
+    }
+
+    @Test("checking out another branch does not transfer workspace ownership")
+    func temporaryCheckout() async throws {
+        let fixture = try await fixture()
+        defer { fixture.repo.cleanUp() }
+        try await Shell.check("git", ["checkout", "-b", "temporary-branch"], cwd: fixture.workspace.path)
+
+        await fixture.manager.refreshBranch(workspace: fixture.workspace)
+
+        #expect(try await fixture.store.workspace(id: fixture.workspace.id)?.branch == fixture.workspace.branch)
+    }
+
+    @Test("checking out the base never makes archive own it, even after deleting the old branch")
+    func baseCheckout() async throws {
+        let fixture = try await fixture()
+        defer { fixture.repo.cleanUp() }
+        try await Shell.check(
+            "git", ["checkout", "--ignore-other-worktrees", "main"], cwd: fixture.workspace.path
+        )
+        await fixture.manager.refreshBranch(workspace: fixture.workspace)
+        #expect(try await fixture.store.workspace(id: fixture.workspace.id)?.branch == fixture.workspace.branch)
+
+        try await Git.deleteBranch(fixture.workspace.branch, in: fixture.workspace.path, force: true)
+        await fixture.manager.refreshBranch(workspace: fixture.workspace)
+        #expect(try await fixture.store.workspace(id: fixture.workspace.id)?.branch == fixture.workspace.branch)
+    }
+
+    @Test("the project default stays protected when this workspace uses a different base")
+    func defaultCheckout() async throws {
+        let fixture = try await fixture()
+        defer { fixture.repo.cleanUp() }
+        let observed = try #require(try await fixture.store.update(workspaceID: fixture.workspace.id) {
+            $0.baseBranch = "another-base"
+        })
+        try await Shell.check(
+            "git", ["checkout", "--ignore-other-worktrees", "main"], cwd: fixture.workspace.path
+        )
+        try await Git.deleteBranch(fixture.workspace.branch, in: fixture.workspace.path, force: true)
+
+        await fixture.manager.refreshBranch(workspace: observed)
+        try await fixture.store.updateCheckedOutBranch("main", observed: observed)
+
+        #expect(try await fixture.store.workspace(id: observed.id)?.branch == fixture.workspace.branch)
+    }
+
+    @Test("a missing worktree never borrows the parent repository's branch")
+    func missingWorktree() async throws {
+        let fixture = try await fixture()
+        defer { fixture.repo.cleanUp() }
+        let observed = try #require(try await fixture.store.update(workspaceID: fixture.workspace.id) {
+            $0.path = fixture.repo.path + "/missing-worktree"
+        })
+
+        await fixture.manager.refreshBranch(workspace: observed)
+
+        #expect(try await fixture.store.workspace(id: observed.id)?.branch == fixture.workspace.branch)
+    }
+
+    @Test("an empty replacement directory cannot report its parent repository's branch")
+    func nonRootDirectory() async throws {
+        let fixture = try await fixture()
+        defer { fixture.repo.cleanUp() }
+        let path = fixture.repo.path + "/empty-worktree"
+        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+        let observed = try #require(try await fixture.store.update(workspaceID: fixture.workspace.id) {
+            $0.path = path
+        })
+
+        await fixture.manager.refreshBranch(workspace: observed)
+
+        #expect(try await fixture.store.workspace(id: observed.id)?.branch == fixture.workspace.branch)
+    }
+
+    @Test("branch refresh preserves concurrent changes and the recorded pull request")
+    func fieldIsolation() async throws {
+        let fixture = try await fixture()
+        defer { fixture.repo.cleanUp() }
+        let latest = try #require(try await fixture.store.update(workspaceID: fixture.workspace.id) {
+            $0.name = "My name"
+            $0.pinned = true
+            $0.unread = true
+            $0.additions = 42
+            $0.pullRequestNumber = 387
+        })
+
+        try await fixture.store.updateCheckedOutBranch("renamed", observed: fixture.workspace)
+
+        let saved = try #require(try await fixture.store.workspace(id: fixture.workspace.id))
+        #expect(saved == latest.with { $0.branch = "renamed" })
+    }
+
+    @Test("an old observation cannot undo a newer branch, archive or path change")
+    func staleObservation() async throws {
+        let fixture = try await fixture()
+        defer { fixture.repo.cleanUp() }
+        let changedBranch = try #require(try await fixture.store.update(workspaceID: fixture.workspace.id) {
+            $0.branch = "newer-branch"
+        })
+        try await fixture.store.updateCheckedOutBranch("stale-branch", observed: fixture.workspace)
+        #expect(try await fixture.store.workspace(id: fixture.workspace.id) == changedBranch)
+
+        let moved = try #require(try await fixture.store.update(workspaceID: fixture.workspace.id) {
+            $0.path += "/moved"
+        })
+        try await fixture.store.updateCheckedOutBranch("stale-branch", observed: changedBranch)
+        #expect(try await fixture.store.workspace(id: fixture.workspace.id) == moved)
+
+        try await fixture.store.update(workspaceID: fixture.workspace.id) {
+            $0.archive()
+        }
+        let archived = try #require(try await fixture.store.workspace(id: fixture.workspace.id))
+        try await fixture.store.updateCheckedOutBranch("stale-branch", observed: moved)
+        #expect(try await fixture.store.workspace(id: fixture.workspace.id) == archived)
+    }
+
+    @Test("unchanged and invalid branch answers leave the stored workspace alone")
+    func unchangedOrInvalid() async throws {
+        let fixture = try await fixture()
+        defer { fixture.repo.cleanUp() }
+        for branch in [fixture.workspace.branch, "HEAD", "", "not a branch"] {
+            try await fixture.store.updateCheckedOutBranch(branch, observed: fixture.workspace)
+        }
+        #expect(try await fixture.store.workspace(id: fixture.workspace.id) == fixture.workspace)
+    }
+}


### PR DESCRIPTION
## Changes

- Add a restrained arrival animation to sent messages and a short fade to new AI blocks. Loaded history stays still, streaming does not restart the animation, and Reduce Motion is respected.
- Reduce repeated Markdown parsing during streaming with a bounded, thread-safe inline cache. Keys preserve exact Unicode source bytes, including code examples.
- Keep the selected chat, inspector and draft mounted when an archive is refused. Do not briefly navigate to Home and tear its native List down during inspector resizing. Block new input while removal is in progress and preserve newer navigation on failure.
- Fix Merge split-button contrast in a native title-bar accessory, including light appearance.
- Focus new diff comments as soon as their text view attaches to the window.
- Keep Cmd+Delete in the focused terminal instead of invoking Archive Workspace.
- Run Settings sign-in through the detected CLI executable with safely quoted arguments and visible Terminal handoff failures.
- Refresh externally renamed branches without adopting temporary checkouts or overwriting concurrent workspace changes.
- Correct a concurrency-test polling helper to check completion before its deadline and throw on timeout instead of continuing with failed setup.

SwiftTerm is retained following the Ghostty feasibility investigation.

Freek has authorised merging and a new release after verification; the earlier Dev-only hold is lifted.

## Verification

- 121 targeted tests for the original arrival/focus/terminal/branch changes passed.
- 141 archive, concurrency and write-isolation tests passed.
- 77 Markdown, cache, concurrency and arrival tests passed, including byte-exact Unicode, recursive parsing and concurrent cache access.
- All 55 native transcript resize/layout checks passed.
- An isolated archive-refusal probe passed six attempts, preserved the draft and transcript model, left its fixture folder intact, and retained newer navigation. No selection or inspector loss in 500 observations (the original code lost both in 13).
- Streaming rendering used 1,111 ms main-thread CPU versus 1,969–1,994 ms before, for the same 15,940-character stream. This is an isolated debug rendering benchmark, not a foreground FPS measurement.
- Native arrival and comment-focus probes passed for the original optimised Dev build.
- Full app build, house-rule lint, SwiftLint and diff checks passed locally. Full CI runs on this PR before merging.

## Limits

- The archive probe reproduces the transient Home/inspector teardown associated with the reported macOS 27 stack, not the exact AttributeGraph SIGABRT. This removes that suspected trigger without bypassing worktree safety checks.
- Real sign-in was not launched. The detected-path, quoting and silent-error cases are covered; the exact reported login failure was not reproduced.
