### PR TITLE
Improve Codex subagents, question cards and native chat polish

### DIFF
--- a/Sources/Bloom/BloomApp.swift
+++ b/Sources/Bloom/BloomApp.swift
@@ -77,6 +77,7 @@ struct BloomApp: App {
         if ArchiveFailureProbe.isRequested { ArchiveFailureProbe.schedule() }
         if StreamingRenderingProbe.isRequested { StreamingRenderingProbe.schedule() }
         if MergeContrastProbe.isRequested { MergeContrastProbe.schedule() }
+        if WelcomeRestartProbe.isRequested { WelcomeRestartProbe.schedule() }
 
         // And the one that answers "the battery menu says Bloom is using significant energy":
         // `Bloom --idle-probe <out.json> --idle-worktrees <list>` runs the diff stat pass the six

--- a/Sources/Bloom/Design/Snapshot.swift
+++ b/Sources/Bloom/Design/Snapshot.swift
@@ -395,6 +395,7 @@ enum Snapshot {
         isRequested || isWindowCaptureRequested || isGalleryCaptureRequested
             || FrameProbe.isRequested || SwitchProbe.isRequested || ScrollProbe.isRequested
             || ResizeProbe.isRequested || TabProbe.isRequested || ComposerProbe.isRequested
+            || WelcomeRestartProbe.isRequested
             || CommandLine.arguments.contains("--menu-probe")
     }
 

--- a/Sources/Bloom/Design/WelcomeRestartProbe.swift
+++ b/Sources/Bloom/Design/WelcomeRestartProbe.swift
@@ -1,0 +1,68 @@
+import AppKit
+import BloomCore
+import SwiftUI
+
+/// Exercises the menu's real welcome lifecycle without showing or activating a window.
+/// Run in an isolated probe bundle with --setup-rehearsal all-clear.
+@MainActor
+enum WelcomeRestartProbe {
+    private static let harness = ProbeHarness(subject: "welcome-restart")
+    static var isRequested: Bool { harness.isRequested }
+
+    static func schedule() {
+        Task { @MainActor in await run() }
+    }
+
+    private static func run() async {
+        await harness.settle()
+        var failures: [String] = []
+        var checks = 0
+        func check(_ condition: Bool, _ message: String) {
+            checks += 1
+            if !condition { failures.append(message) }
+        }
+        let original = WelcomeWindow.prepare(trigger: .blocked)
+        await settle(original)
+        check(identifiers(in: original.contentView).contains("welcome-step-checks"),
+              "initial window did not open at the checks")
+
+        var previous = original
+        for visit in 0..<3 {
+            let completed = UserDefaults.standard.bool(forKey: OnboardingGate.completedKey)
+            let replay = WelcomeWindow.prepare(trigger: .firstRun, restarting: true)
+            await settle(replay)
+            check(replay !== previous, "visit \(visit) reused the previous wizard")
+            check(previous.contentViewController == nil, "visit \(visit) retained the old wizard")
+            check(identifiers(in: replay.contentView).contains("welcome-step-greeting"),
+                  "visit \(visit) did not restart at the greeting")
+            check(!replay.isVisible && !replay.isKeyWindow, "probe showed its window")
+            check(UserDefaults.standard.bool(forKey: OnboardingGate.completedKey) == completed,
+                  "restart changed the completion preference")
+            // Closing and asking again is the reported sequence. A second request while already
+            // open must work too, so the middle visit deliberately keeps its presentation alive.
+            if visit != 1 { replay.close() }
+            previous = replay
+        }
+        harness.write(.object([
+            "checks": .integer(checks), "passed": .bool(failures.isEmpty),
+            "failures": .strings(failures),
+        ]))
+        exit(failures.isEmpty ? 0 : 1)
+    }
+
+    private static func settle(_ window: NSWindow) async {
+        window.layoutIfNeeded()
+        try? await Task.sleep(for: .milliseconds(250))
+        window.contentView?.layoutSubtreeIfNeeded()
+    }
+
+    private static func identifiers(in root: Any?) -> Set<String> {
+        guard let element = root as? any NSAccessibilityProtocol else { return [] }
+        var result = Set<String>()
+        if let identifier = element.accessibilityIdentifier() { result.insert(identifier) }
+        for child in element.accessibilityChildren() ?? [] {
+            result.formUnion(identifiers(in: child))
+        }
+        return result
+    }
+}

--- a/Sources/Bloom/State/AskModel.swift
+++ b/Sources/Bloom/State/AskModel.swift
@@ -172,7 +172,7 @@ final class AskModel {
     /// right source rather than a shortcut: that query joins the workspaces table to answer "which
     /// worktrees have an agent in them", and this conversation is in none of them.
     var isRunning: Bool {
-        transcript?.isRunning ?? false
+        transcript?.isRunning == true || transcript?.subagents.isWorking == true
     }
 
     var isAwaitingPermission: Bool {

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -164,7 +164,10 @@ final class TranscriptModel {
     /// `SubagentRoster` for the argument, which is that the longest one of these is meant to live
     /// is a single session and the CLI's own record of it is already on disk.
     private(set) var subagents = SubagentRoster() {
-        didSet { if let id = workspace?.id { app.noteSubagentsChanged(workspaceID: id) } }
+        didSet {
+            if let id = workspace?.id { app.noteSubagentsChanged(workspaceID: id) }
+            if oldValue.isWorking != subagents.isWorking { app.noteAgentTurnsChanged() }
+        }
     }
 
     var draft = ""
@@ -252,6 +255,11 @@ final class TranscriptModel {
     private(set) var composerFocusRequests = 0
 
     private var runner: (any SessionRunner)?
+
+    func codexSubagentTranscript(for id: SubagentID) async -> SubagentTranscript? {
+        guard let codex = runner as? CodexRunner else { return nil }
+        return await codex.subagentTranscript(for: id)
+    }
     private var pumpTask: Task<Void, Never>?
     /// Preferences are captured when a runner is created. Comparing them at delivery time avoids
     /// reusing a process after the picker changed, even when persistence is still catching up.

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -406,14 +406,21 @@ final class WorkspaceModel {
     ///   when the chat is being opened FOR something and the name says which, as the pull request
     ///   and merge buttons do. See `PaneNaming` for why a chat is never named after its content.
     @discardableResult
-    func createSession(title: String? = nil) async -> Session? {
-        guard let store else { return nil }
-        let session = Session(
+    func createSession(title: String? = nil, controls: ComposerControls? = nil) async -> Session? {
+        guard !app.isArchiving(workspace.id), let store else { return nil }
+        var session = Session(
             workspaceID: workspace.id,
             title: title ?? PaneNaming.nextTitle(base: PaneNaming.chat, taken: sessions.map(\.title)),
             sortOrder: sessions.count
         )
+        if let controls {
+            session.model = controls.model
+            session.effort = controls.effort
+            session.agentKind = controls.agentKind
+            session.permissionMode = controls.permissionMode
+        }
         guard let stored = try? await store.upsert(session) else { return nil }
+        if let controls { await controls.store(sessionID: stored.id, in: store) }
         await reloadSessions()
         activeSessionID = stored.id
         return stored
@@ -458,6 +465,7 @@ final class WorkspaceModel {
     /// and the sidebar's mirror cannot come to three different conclusions about one chat.
     func isRunning(_ session: Session) -> Bool {
         AgentTurns.session(.running, state: session.state, live: liveTurn(for: session.id))
+            || transcripts[session.id]?.subagents.isWorking == true
     }
 
     func closeSession(_ session: Session) async {
@@ -820,7 +828,7 @@ final class WorkspaceModel {
         return AgentTurns.Live(
             sessionID: sessionID,
             workspaceID: workspace.id,
-            isRunning: transcript.isRunning,
+            isRunning: transcript.isRunning || transcript.subagents.isWorking,
             isAwaitingPermission: transcript.isAwaitingPermission
         )
     }

--- a/Sources/Bloom/Views/Center/Composer/ComposerView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerView.swift
@@ -65,6 +65,7 @@ struct ComposerView: View {
     /// column on `Session`, so the composer is where the chat's copy of it lives.
     @State private var codexContextWindow = CodexContextWindow.modelDefault
     @State private var draftSaveTask: Task<Void, Never>?
+    @State private var isClearingChat = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -390,6 +391,11 @@ struct ComposerView: View {
         guard canSend else { return }
         draftSaveTask?.cancel()
 
+        if ChatClearCommand.matches(transcript.draft) {
+            startFreshChat()
+            return
+        }
+
         // A file can be moved or deleted between being attached and the prompt going, and naming a
         // path that is not there any more only teaches the agent that Bloom lies about paths. The
         // chip carries a warning while it is on screen; this is the last check before it matters,
@@ -493,6 +499,28 @@ struct ComposerView: View {
                 return
             }
             await model.transcript(for: session).submit(text)
+        }
+    }
+
+    private func startFreshChat() {
+        guard !isClearingChat else { return }
+        isClearingChat = true
+        let previous = transcript
+        let controls = controls
+        Task { @MainActor in
+            defer { isClearingChat = false }
+            if let model {
+                guard await model.createSession(controls: controls) != nil else { return }
+            } else {
+                await app.ask.startFresh(controls: controls)
+                guard let current = app.ask.session, current.id != previous.session.id else { return }
+            }
+            // Only remove the command after the new conversation exists. Previous messages,
+            // pending attachments and review comments are not discarded by this action.
+            if ChatClearCommand.matches(previous.draft) {
+                previous.draft = ""
+                await previous.saveDraft()
+            }
         }
     }
 

--- a/Sources/Bloom/Views/Center/Panes/SubagentOutputView.swift
+++ b/Sources/Bloom/Views/Center/Panes/SubagentOutputView.swift
@@ -101,12 +101,12 @@ struct SubagentOutputView: View {
         // running case keeps re-reading inside the task rather than re-keying it: an id that
         // carried the elapsed seconds would tear the whole pane down and rebuild it once a second,
         // losing the scroll position and any brief the reader had just opened.
-        .task(id: subagentID) { await follow() }
+        .onChange(of: subagentID) { _, _ in isBriefExpanded = false }
+        .task(id: "\(subagentID.rawValue):\(SubagentPane.refreshes(subagent))") { await follow() }
     }
 
     /// Read the file, and keep reading it for as long as the task is running.
     private func follow() async {
-        isBriefExpanded = false
         await load()
         while !Task.isCancelled, SubagentPane.refreshes(subagent) {
             try? await Task.sleep(for: .seconds(SubagentPane.refreshSeconds))
@@ -120,6 +120,14 @@ struct SubagentOutputView: View {
     }
 
     private func load() async {
+        if let parsed = await model.activeTranscript?.codexSubagentTranscript(for: subagentID) {
+            guard !Task.isCancelled else { return }
+            let updated = await Task.detached { SubagentReading(parsed) }.value
+            guard !Task.isCancelled else { return }
+            reading = updated
+            failure = nil
+            return
+        }
         // Off the main actor. A subagent's transcript is small in the capture and is not promised
         // to be, and this now runs once a second rather than once. Folding the messages into rows
         // goes with it: pairing a result onto its call decodes the result payload, which is the
@@ -144,6 +152,7 @@ struct SubagentOutputView: View {
                 return live.isEmpty ? .failure(reason) : .success(SubagentReading(live))
             }
         }.value
+        guard !Task.isCancelled else { return }
         switch result {
         case .success(let parsed):
             reading = parsed

--- a/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
+++ b/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
@@ -555,20 +555,13 @@ struct BloomCommands: Commands {
         }
 
         CommandGroup(replacing: .help) {
-            // The docs, not the repository. This pointed at github.com/spatie/Bloom#readme,
-            // which is not where Bloom lives and would have 404'd for everyone who pressed it.
             MenuCommand(.help) {
-                guard let url = URL(string: "https://runbloom.app/docs") else { return }
-                NSWorkspace.shared.open(url)
+                NSWorkspace.shared.open(AppSite.helpURL)
             }
 
-            // The first run window, on demand. A real item rather than a debug flag: somebody who
-            // waved the welcome away and wants it back has exactly the same need as somebody who
-            // has never seen it, and "was anything wrong with my setup" is a Help menu question
-            // in every Mac app that can answer it. It re-checks on every visit, so it is also the
-            // shortest way to find out whether the CLI you just installed was found.
+            // Replay the wizard from its greeting, not the cached screen from the last visit.
             MenuCommand(.welcome) {
-                WelcomeWindow.show()
+                WelcomeWindow.show(trigger: .firstRun, restarting: true)
             }
 
             Divider()
@@ -592,7 +585,7 @@ struct BloomCommands: Commands {
             }
 
             // The third way, and the only one that goes on paper. Below the divider with the other
-            // two rather than above it with the docs, because this is the same question they
+            // two rather than above it with Help, because this is the same question they
             // answer, how do I reach these people, and a row about an address filed next to the
             // manual would read as documentation about a feature. It is also where somebody looks
             // after meeting the word once in the welcome sequence and wanting the address again.

--- a/Sources/Bloom/Views/Chrome/Notices/EmptyStateView.swift
+++ b/Sources/Bloom/Views/Chrome/Notices/EmptyStateView.swift
@@ -36,9 +36,10 @@ struct EmptyStateView: View {
         } actions: {
             if let actionTitle, let action {
                 Button(actionTitle, action: action)
-                    .buttonStyle(.borderedProminent)
-                    // Explicit so every primary action reads from the shared semantic token.
-                    .tint(Palette.controlAccent)
+                    // Recovery and setup controls should not borrow the chat bubble's filled
+                    // treatment. AppKit supplies the compact bezel, focus and pressed states.
+                    .buttonStyle(.bordered)
+                    .controlSize(.regular)
             }
         }
     }

--- a/Sources/Bloom/Views/Chrome/Window/WelcomeView.swift
+++ b/Sources/Bloom/Views/Chrome/Window/WelcomeView.swift
@@ -82,6 +82,7 @@ struct WelcomeView: View {
         }
         .frame(width: Self.width)
         .background(Palette.surface)
+        .accessibilityIdentifier("welcome-step-\(flow.step.rawValue)")
         // The answer comes off the disk, so it lands after the window is already up. Applied as it
         // arrives rather than read at the moment the checks footer draws, because a `body` that
         // asked would be asking on every redraw of a screen with four probes settling on it.

--- a/Sources/Bloom/Views/Chrome/Window/WelcomeWindow.swift
+++ b/Sources/Bloom/Views/Chrome/Window/WelcomeWindow.swift
@@ -50,9 +50,12 @@ enum WelcomeWindow {
     /// - Parameter mayActivate: whether Bloom is allowed to pull itself in front of whatever the
     ///   owner is doing. True for a menu item, which is somebody asking; false for the launch
     ///   probe, which is not.
-    static func show(trigger: OnboardingTrigger = .none, mayActivate: Bool = true) {
-        let existing = window ?? make(trigger: trigger)
-        window = existing
+    static func show(
+        trigger: OnboardingTrigger = .none,
+        mayActivate: Bool = true,
+        restarting: Bool = false
+    ) {
+        let existing = prepare(trigger: trigger, restarting: restarting)
         existing.makeKeyAndOrderFront(nil)
         // Only when Bloom is already the front application, or when somebody asked for this
         // window by name. `NSApp.activate()` was unconditional, and the caller behind it is an
@@ -64,6 +67,27 @@ enum WelcomeWindow {
         // Asked again for the same reason the probes are: somebody who came back may have run the
         // command in between, and a window that kept offering it would not have noticed.
         registration?.resolve()
+    }
+
+    /// Preparing is separate from presentation so the lifecycle can be exercised offscreen.
+    static func prepare(trigger: OnboardingTrigger, restarting: Bool = false) -> NSWindow {
+        if restarting {
+            // A retained hosting view also retains the wizard's SwiftUI state. Merely ordering
+            // it front cannot replay it. Dispose of this presentation, including an open login,
+            // without marking the wizard completed or changing the owner's saved preferences.
+            if let closeWatch { NotificationCenter.default.removeObserver(closeWatch) }
+            closeWatch = nil
+            inspection?.cancel()
+            registration?.cancel()
+            window?.close()
+            window?.contentViewController = nil
+            window = nil
+            inspection = nil
+            registration = nil
+        }
+        let existing = window ?? make(trigger: trigger)
+        window = existing
+        return existing
     }
 
     static func close() {
@@ -85,9 +109,8 @@ enum WelcomeWindow {
         registration = offer
 
         // Where the sequence opens is `OnboardingFlow.firstStep`, in the core with its tests: a
-        // first run is greeted, and the Help menu and a later broken launch open straight onto the
-        // checks, because somebody who came back came back for the checks. Back is offered from
-        // there either way, so the greeting is never a screen that has been taken away.
+        // first run and an explicit wizard replay are greeted. A later broken launch opens
+        // straight onto the checks so the person sees what needs attention.
         // A controller, not a bare `NSHostingView`, and that is the whole of the sizing.
         //
         // This was a hosting view with `.preferredContentSize` and one `setContentSize` at the

--- a/Sources/Bloom/Views/Chrome/Window/WindowChrome.swift
+++ b/Sources/Bloom/Views/Chrome/Window/WindowChrome.swift
@@ -1,10 +1,8 @@
 import AppKit
 import SwiftUI
 
-/// Keeps the unified title bar on its native material and adds the workspace's own strip.
-/// The sidebar also uses its system background, so navigation chrome follows appearance,
-/// inactive-window state and accessibility preferences together. Reading surfaces stay opaque;
-/// no material layers are added to scrolling content.
+/// Matches the unified title bar to the inactive tabs and adds the workspace's own strip.
+/// Reading surfaces stay opaque; no material layers are added to scrolling content.
 ///
 /// The trailing end of the same strip is `TitleBarStrip`, added as a title bar accessory. See
 /// that file for why an accessory rather than content drawn under a transparent title bar.
@@ -26,8 +24,8 @@ struct WindowChrome: ViewModifier {
 
     private func apply() {
         guard let window else { return }
-        window.titlebarAppearsTransparent = false
-        window.backgroundColor = .windowBackgroundColor
+        window.titlebarAppearsTransparent = true
+        window.backgroundColor = Palette.sidebarNSColor
         // AppKit's own title text, off. `WindowTitleControl` draws it as a toolbar item instead,
         // so that a double click on the NAME can start a rename without taking the double click on
         // the BAR that Desktop & Dock has already spent on Zoom or Minimise.

--- a/Sources/Bloom/Views/Transcript/AgentQuestionCard.swift
+++ b/Sources/Bloom/Views/Transcript/AgentQuestionCard.swift
@@ -136,7 +136,7 @@ struct AgentQuestionCard: View {
                     optionRow(question, option)
                 }
 
-                otherRow(question)
+                if question.allowsOther { otherRow(question) }
             }
         }
     }
@@ -218,7 +218,7 @@ struct AgentQuestionCard: View {
     /// The free text row every question gets. See the head of this file for why.
     @ViewBuilder
     private func otherRow(_ question: AgentQuestion) -> some View {
-        if box.draft.isWritingOther.contains(question.id) {
+        if question.options.isEmpty || box.draft.isWritingOther.contains(question.id) {
             HStack(alignment: .firstTextBaseline, spacing: TranscriptLayout.glyphGap) {
                 // Drawn chosen: the words being typed are the selection.
                 markView(
@@ -226,14 +226,17 @@ struct AgentQuestionCard: View {
                     isChosen: true
                 )
 
-                TextField(
-                    "Say what you would rather do…",
-                    text: Binding(
+                let answer = Binding(
                         get: { box.draft.other[question.id] ?? "" },
                         set: { box.draft.other[question.id] = $0 }
-                    ),
-                    axis: .vertical
                 )
+                Group {
+                    if question.isSecret {
+                        SecureField("Your answer", text: answer)
+                    } else {
+                        TextField("Your answer", text: answer, axis: .vertical)
+                    }
+                }
                 .textFieldStyle(.roundedBorder)
                 .font(Typo.label)
                 .lineLimit(1...4)

--- a/Sources/Bloom/Views/Transcript/BubbleTextAlignment.swift
+++ b/Sources/Bloom/Views/Transcript/BubbleTextAlignment.swift
@@ -1,0 +1,38 @@
+import AppKit
+import CoreText
+import BloomCore
+
+/// Only the two outer lines determine a bubble's visible vertical balance. Core Text supplies
+/// their real ink bounds, including fallback fonts and descending letters. The text view caches
+/// this calculation until its text or layout width changes; it never scans the whole message.
+enum BubbleTextAlignment {
+    static func offset(layout: NSLayoutManager, container: NSTextContainer) -> CGFloat {
+        guard let storage = layout.textStorage, layout.numberOfGlyphs > 0 else { return 0 }
+        let first = ink(at: 0, layout: layout, storage: storage)
+        let last = ink(at: layout.numberOfGlyphs - 1, layout: layout, storage: storage)
+        guard let first, let last else { return 0 }
+        return TranscriptTextMeasure.bubbleTextOffset(
+            height: layout.usedRect(for: container).height,
+            inkTop: first.minY,
+            inkBottom: last.maxY
+        )
+    }
+
+    private static func ink(at glyph: Int, layout: NSLayoutManager, storage: NSTextStorage) -> CGRect? {
+        var range = NSRange()
+        let fragment = layout.lineFragmentRect(forGlyphAt: glyph, effectiveRange: &range)
+        let characters = layout.characterRange(forGlyphRange: range, actualGlyphRange: nil)
+        let text = storage.attributedSubstring(from: characters)
+        // Attachments and deliberate blank lines keep their existing spacing.
+        var hasAttachment = false
+        text.enumerateAttribute(.attachment, in: NSRange(location: 0, length: text.length)) { value, _, _ in
+            if value != nil { hasAttachment = true }
+        }
+        guard !hasAttachment else { return nil }
+        let line = CTLineCreateWithAttributedString(text)
+        let bounds = CTLineGetBoundsWithOptions(line, .useGlyphPathBounds)
+        guard !bounds.isEmpty else { return nil }
+        let baseline = fragment.minY + layout.location(forGlyphAt: range.location).y
+        return CGRect(x: bounds.minX, y: baseline - bounds.maxY, width: bounds.width, height: bounds.height)
+    }
+}

--- a/Sources/Bloom/Views/Transcript/OutgoingBubbleShape.swift
+++ b/Sources/Bloom/Views/Transcript/OutgoingBubbleShape.swift
@@ -3,8 +3,7 @@ import SwiftUI
 /// A single outline shared by sent and queued messages. The tail has its own layout space, so
 /// it never changes the text's padding or relies on drawing beyond the row's measured bounds.
 struct OutgoingBubbleShape: InsettableShape {
-    static let tailWidth: CGFloat = 6
-    static let tailDrop: CGFloat = 3
+    static let tailDrop: CGFloat = 5
 
     var cornerRadius: CGFloat
     private var insetAmount: CGFloat = 0
@@ -15,8 +14,8 @@ struct OutgoingBubbleShape: InsettableShape {
 
     func path(in bounds: CGRect) -> Path {
         let rect = bounds.insetBy(dx: insetAmount, dy: insetAmount)
-        guard rect.width > Self.tailWidth, rect.height > Self.tailDrop else { return Path() }
-        let right = rect.maxX - Self.tailWidth
+        guard rect.width > 0, rect.height > Self.tailDrop else { return Path() }
+        let right = rect.maxX
         let bottom = rect.maxY - Self.tailDrop
         let radius = max(0, min(cornerRadius - insetAmount, (right - rect.minX) / 2, (bottom - rect.minY) / 2))
         var path = Path()
@@ -24,17 +23,23 @@ struct OutgoingBubbleShape: InsettableShape {
         path.addLine(to: CGPoint(x: right - radius, y: rect.minY))
         path.addQuadCurve(to: CGPoint(x: right, y: rect.minY + radius), control: CGPoint(x: right, y: rect.minY))
         path.addLine(to: CGPoint(x: right, y: bottom - radius))
+        // Round the side first, then let the tail grow from underneath it. Its tip stays inside
+        // the body's right edge, rather than making the side flare out beyond the bubble.
         path.addCurve(
-            to: CGPoint(x: rect.maxX, y: rect.maxY),
-            control1: CGPoint(x: right, y: bottom),
-            control2: CGPoint(x: right + 1, y: rect.maxY - 1)
+            to: CGPoint(x: right - radius * 0.35, y: bottom - radius * 0.25),
+            control1: CGPoint(x: right, y: bottom - radius * 0.5),
+            control2: CGPoint(x: right - radius * 0.25, y: bottom - radius * 0.35)
         )
         path.addCurve(
-            to: CGPoint(x: right - min(5, radius), y: bottom - min(2, radius)),
-            control1: CGPoint(x: right + 1, y: rect.maxY),
-            control2: CGPoint(x: right - min(3, radius), y: bottom)
+            to: CGPoint(x: right - radius * 0.35, y: rect.maxY),
+            control1: CGPoint(x: right - radius * 0.6, y: bottom + Self.tailDrop * 0.1),
+            control2: CGPoint(x: right - radius * 0.42, y: bottom + Self.tailDrop * 0.6)
         )
-        path.addQuadCurve(to: CGPoint(x: right - radius, y: bottom), control: CGPoint(x: right - radius / 2, y: bottom))
+        path.addCurve(
+            to: CGPoint(x: right - radius, y: bottom),
+            control1: CGPoint(x: right - radius * 0.45, y: rect.maxY),
+            control2: CGPoint(x: right - radius * 0.85, y: bottom + Self.tailDrop * 0.1)
+        )
         path.addLine(to: CGPoint(x: rect.minX + radius, y: bottom))
         path.addQuadCurve(to: CGPoint(x: rect.minX, y: bottom - radius), control: CGPoint(x: rect.minX, y: bottom))
         path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + radius))

--- a/Sources/Bloom/Views/Transcript/OutgoingBubbleShape.swift
+++ b/Sources/Bloom/Views/Transcript/OutgoingBubbleShape.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// A single outline shared by sent and queued messages. The tail has its own layout space, so
+/// it never changes the text's padding or relies on drawing beyond the row's measured bounds.
+struct OutgoingBubbleShape: InsettableShape {
+    static let tailWidth: CGFloat = 6
+    static let tailDrop: CGFloat = 3
+
+    var cornerRadius: CGFloat
+    private var insetAmount: CGFloat = 0
+
+    init(cornerRadius: CGFloat) {
+        self.cornerRadius = cornerRadius
+    }
+
+    func path(in bounds: CGRect) -> Path {
+        let rect = bounds.insetBy(dx: insetAmount, dy: insetAmount)
+        guard rect.width > Self.tailWidth, rect.height > Self.tailDrop else { return Path() }
+        let right = rect.maxX - Self.tailWidth
+        let bottom = rect.maxY - Self.tailDrop
+        let radius = max(0, min(cornerRadius - insetAmount, (right - rect.minX) / 2, (bottom - rect.minY) / 2))
+        var path = Path()
+        path.move(to: CGPoint(x: rect.minX + radius, y: rect.minY))
+        path.addLine(to: CGPoint(x: right - radius, y: rect.minY))
+        path.addQuadCurve(to: CGPoint(x: right, y: rect.minY + radius), control: CGPoint(x: right, y: rect.minY))
+        path.addLine(to: CGPoint(x: right, y: bottom - radius))
+        path.addCurve(
+            to: CGPoint(x: rect.maxX, y: rect.maxY),
+            control1: CGPoint(x: right, y: bottom),
+            control2: CGPoint(x: right + 1, y: rect.maxY - 1)
+        )
+        path.addCurve(
+            to: CGPoint(x: right - min(5, radius), y: bottom - min(2, radius)),
+            control1: CGPoint(x: right + 1, y: rect.maxY),
+            control2: CGPoint(x: right - min(3, radius), y: bottom)
+        )
+        path.addQuadCurve(to: CGPoint(x: right - radius, y: bottom), control: CGPoint(x: right - radius / 2, y: bottom))
+        path.addLine(to: CGPoint(x: rect.minX + radius, y: bottom))
+        path.addQuadCurve(to: CGPoint(x: rect.minX, y: bottom - radius), control: CGPoint(x: rect.minX, y: bottom))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + radius))
+        path.addQuadCurve(to: CGPoint(x: rect.minX + radius, y: rect.minY), control: CGPoint(x: rect.minX, y: rect.minY))
+        path.closeSubpath()
+        return path
+    }
+
+    func inset(by amount: CGFloat) -> Self {
+        var copy = self
+        copy.insetAmount += amount
+        return copy
+    }
+}

--- a/Sources/Bloom/Views/Transcript/PendingTurnRowView.swift
+++ b/Sources/Bloom/Views/Transcript/PendingTurnRowView.swift
@@ -133,10 +133,11 @@ struct PendingTurnRowView: View {
         CappedWidth(width: bubbleWidth?.cap ?? UserTurnRowView.uncappedFallback) {
             VStack(alignment: .leading, spacing: TranscriptLayout.block) {
                 if !displayText.isEmpty {
+                    let font = Typo.body.resolvedNSFont(scale: fontScale, face: chatFont)
                     TranscriptTextView(
                         text: TranscriptLink.attributedString(
                             sent: displayText,
-                            font: Typo.body.resolvedNSFont(scale: fontScale, face: chatFont),
+                            font: font,
                             color: NSColor(Palette.textSecondary),
                             lineSpacing: TranscriptLayout.proseLeading(
                                 Typo.body,
@@ -148,6 +149,7 @@ struct PendingTurnRowView: View {
                         ),
                         linkColor: NSColor(Palette.link),
                         selectionColor: .selectedTextBackgroundColor,
+                        alignsBubbleInk: true,
                         actions: linkActions.opening(file: open, hovering: { hovered = $0 })
                     )
                     .background { chipProbe }

--- a/Sources/Bloom/Views/Transcript/PendingTurnRowView.swift
+++ b/Sources/Bloom/Views/Transcript/PendingTurnRowView.swift
@@ -173,9 +173,11 @@ struct PendingTurnRowView: View {
             // takes the width they actually use, matching the sent bubble above it.
             .padding(Self.padding)
         }
-        .background(Palette.surfaceRaised, in: RoundedRectangle(cornerRadius: Self.corner))
+        .padding(.trailing, OutgoingBubbleShape.tailWidth)
+        .padding(.bottom, OutgoingBubbleShape.tailDrop)
+        .background(Palette.surfaceRaised, in: OutgoingBubbleShape(cornerRadius: Self.corner))
         .overlay {
-            RoundedRectangle(cornerRadius: Self.corner)
+            OutgoingBubbleShape(cornerRadius: Self.corner)
                 .strokeBorder(Palette.textTertiary, style: Self.dots)
         }
     }

--- a/Sources/Bloom/Views/Transcript/PendingTurnRowView.swift
+++ b/Sources/Bloom/Views/Transcript/PendingTurnRowView.swift
@@ -173,7 +173,6 @@ struct PendingTurnRowView: View {
             // takes the width they actually use, matching the sent bubble above it.
             .padding(Self.padding)
         }
-        .padding(.trailing, OutgoingBubbleShape.tailWidth)
         .padding(.bottom, OutgoingBubbleShape.tailDrop)
         .background(Palette.surfaceRaised, in: OutgoingBubbleShape(cornerRadius: Self.corner))
         .overlay {

--- a/Sources/Bloom/Views/Transcript/TranscriptTextView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTextView.swift
@@ -107,6 +107,7 @@ struct TranscriptTextView: NSViewRepresentable {
     /// What paints behind a selection. Handed in because the bubble is a dark surface whatever
     /// the page around it is doing, and AppKit cannot read the SwiftUI environment that says so.
     var selectionColor: NSColor
+    var alignsBubbleInk = false
     var actions = TranscriptLinkActions()
 
     func makeCoordinator() -> Coordinator { Coordinator(actions: actions) }
@@ -176,6 +177,7 @@ struct TranscriptTextView: NSViewRepresentable {
     private func apply(to view: LinkTextView) {
         if view.textStorage?.isEqual(to: text) != true {
             view.textStorage?.setAttributedString(text)
+            view.bubbleAlignmentWidth = nil
         }
         view.linkColor = linkColor
         // No underline at rest. The pointing hand is asked for here and set for real in
@@ -218,6 +220,15 @@ struct TranscriptTextView: NSViewRepresentable {
         let wanted = CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
         if container.containerSize != wanted { container.containerSize = wanted }
         layout.ensureLayout(for: container)
+        if alignsBubbleInk {
+            if nsView.bubbleAlignmentWidth != width {
+                nsView.bubbleInkOffset = BubbleTextAlignment.offset(layout: layout, container: container)
+                nsView.bubbleAlignmentWidth = width
+            }
+        } else {
+            nsView.bubbleInkOffset = 0
+            nsView.bubbleAlignmentWidth = nil
+        }
         let used = layout.usedRect(for: container)
         let size = TranscriptTextMeasure.size(
             widestLine: Double(widestLine(layout, in: container)),
@@ -287,6 +298,18 @@ struct TranscriptTextView: NSViewRepresentable {
 
 /// The text view itself: hover, and the menu over a link.
 final class LinkTextView: NSTextView {
+    var bubbleAlignmentWidth: CGFloat?
+    var bubbleInkOffset: CGFloat = 0 {
+        didSet {
+            if oldValue != bubbleInkOffset { needsDisplay = true }
+        }
+    }
+
+    override var textContainerOrigin: NSPoint {
+        let origin = super.textContainerOrigin
+        return NSPoint(x: origin.x, y: origin.y + bubbleInkOffset)
+    }
+
     var actions = TranscriptLinkActions()
     var linkColor: NSColor = .linkColor
 

--- a/Sources/Bloom/Views/Transcript/UserTurnRowView.swift
+++ b/Sources/Bloom/Views/Transcript/UserTurnRowView.swift
@@ -114,13 +114,11 @@ struct UserTurnRowView: View {
             CappedWidth(width: maxWidth) {
                 bubble.padding(Self.padding)
             }
-            .background(Palette.accentFill, in: RoundedRectangle(cornerRadius: Self.corner))
+            .padding(.trailing, OutgoingBubbleShape.tailWidth)
+            .padding(.bottom, OutgoingBubbleShape.tailDrop)
+            .background(Palette.accentFill, in: OutgoingBubbleShape(cornerRadius: Self.corner))
             // No stroke around the fill. A border on a filled shape is a control's outline,
             // and the fill already separates the turn from the ground in both appearances.
-            //
-            // No tail either. The little pointer is iMessage's signature rather than a
-            // property of speech bubbles, and reproducing it would read as an imitation of
-            // another app instead of as this one's own decision.
             //
             // Everything inside is told it is sitting on the accent fill, which is the same
             // signal a selected sidebar row sends. `Chip`, `DiffStatLabel`, `RepoIcon` and now

--- a/Sources/Bloom/Views/Transcript/UserTurnRowView.swift
+++ b/Sources/Bloom/Views/Transcript/UserTurnRowView.swift
@@ -177,6 +177,7 @@ struct UserTurnRowView: View {
             // A prompt of nothing but attachments is a turn in its own right, and an empty `Text`
             // above the chips would put a blank line inside the bubble.
             if !text.isEmpty {
+                let font = Typo.body.resolvedNSFont(scale: fontScale, face: chatFont)
                 // Written text, not markdown. A question with a `*` in it is a question with a
                 // `*` in it, and two things only are lifted out of it: an address, found by
                 // `LinkScan`, and a file, found by `FileMention`. Both rules live in the core
@@ -187,10 +188,10 @@ struct UserTurnRowView: View {
                 // `TranscriptTextView` exists: a link inside a selectable `Text` is decoration.
                 // Measured on a real window, the cursor over one was an I-beam and a press routed
                 // nothing at all. See the note on that type.
-                TranscriptTextView(
+                    TranscriptTextView(
                     text: TranscriptLink.attributedString(
                         sent: text,
-                        font: Typo.body.resolvedNSFont(scale: fontScale, face: chatFont),
+                        font: font,
                         // White, the same ink a selected row uses on the same fill. Measured 5.2
                         // to 1 on Spatie Blue, which passes AA for body text in both appearances.
                         color: .alternateSelectedControlTextColor,
@@ -207,6 +208,7 @@ struct UserTurnRowView: View {
                     // muted slate that sits clearly on Spatie Blue and leaves white text alone.
                     // AppKit cannot read the `colorScheme` this bubble sets, so it is named.
                     selectionColor: Palette.bubbleTextSelection,
+                    alignsBubbleInk: true,
                     actions: linkActions.opening(file: open, hovering: { hovered = $0 })
                 )
                 .background { chipProbe }

--- a/Sources/Bloom/Views/Transcript/UserTurnRowView.swift
+++ b/Sources/Bloom/Views/Transcript/UserTurnRowView.swift
@@ -114,7 +114,6 @@ struct UserTurnRowView: View {
             CappedWidth(width: maxWidth) {
                 bubble.padding(Self.padding)
             }
-            .padding(.trailing, OutgoingBubbleShape.tailWidth)
             .padding(.bottom, OutgoingBubbleShape.tailDrop)
             .background(Palette.accentFill, in: OutgoingBubbleShape(cornerRadius: Self.corner))
             // No stroke around the fill. A border on a filled shape is a control's outline,

--- a/Sources/BloomCore/Agent/AgentQuestion.swift
+++ b/Sources/BloomCore/Agent/AgentQuestion.swift
@@ -39,21 +39,30 @@ public struct AgentQuestion: Sendable, Hashable, Identifiable {
         }
     }
 
-    /// The question itself, which is also the key an answer is filed under. The asker's words, and
-    /// the only handle the protocol gives an answer, so it is the identity too.
+    /// The asker's words. Claude also uses these as the answer key; Codex supplies a separate id.
     public var question: String
     /// The short chip the asker wanted beside it. Often empty.
     public var header: String
     public var multiSelect: Bool
     public var options: [Option]
+    /// Codex answers by a wire id; Claude answers by the question text.
+    public var answerID: String?
+    public var allowsOther: Bool
+    public var isSecret: Bool
 
-    public var id: String { question }
+    public var id: String { answerID ?? question }
 
-    public init(question: String, header: String = "", multiSelect: Bool = false, options: [Option] = []) {
+    public init(
+        question: String, header: String = "", multiSelect: Bool = false, options: [Option] = [],
+        answerID: String? = nil, allowsOther: Bool = true, isSecret: Bool = false
+    ) {
         self.question = question
         self.header = header
         self.multiSelect = multiSelect
         self.options = options
+        self.answerID = answerID
+        self.allowsOther = allowsOther
+        self.isSecret = isSecret
     }
 
     static func decode(_ json: JSONValue) -> AgentQuestion? {
@@ -63,7 +72,10 @@ public struct AgentQuestion: Sendable, Hashable, Identifiable {
             question: question,
             header: json["header"]?.stringValue ?? "",
             multiSelect: json["multiSelect"]?.boolValue ?? false,
-            options: (json["options"]?.arrayValue ?? []).compactMap(Option.decode)
+            options: (json["options"]?.arrayValue ?? []).compactMap(Option.decode),
+            answerID: json["bloomAnswerID"]?.stringValue,
+            allowsOther: json["bloomAllowsOther"]?.boolValue ?? true,
+            isSecret: json["isSecret"]?.boolValue ?? false
         )
     }
 }
@@ -73,7 +85,7 @@ public enum AgentQuestionnaire {
     /// The tool name, spelled once so the decoder and the view cannot disagree about it.
     public static let toolName = "AskUserQuestion"
 
-    /// What "Other" is called on every question, because the tool always allows one.
+    /// The custom-answer label on questions whose protocol allows one.
     ///
     /// The asker is told not to include an Other option of its own, on the promise that the host
     /// provides one. Bloom is the host, so Bloom provides it: without it a question whose options
@@ -124,7 +136,7 @@ public enum AgentQuestionnaire {
         guard !questions.isEmpty else { return false }
 
         return questions.allSatisfy { question in
-            let answer = answers[question.question] ?? ""
+            let answer = answers[question.id] ?? ""
             return !answer.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
     }

--- a/Sources/BloomCore/Agent/Codex/CodexPermission.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexPermission.swift
@@ -46,8 +46,11 @@ public enum CodexPermission {
     /// arrived a moment earlier: the request itself carries only an id, so the diff or the command
     /// is not in it. Without the item the question is still asked, just with less on it.
     public static func ask(for request: CodexApprovalRequest, item: CodexItem?) -> PermissionAsk {
-        let toolName = item.map(CodexTranslation.toolName(for:)) ?? fallbackToolName(request.kind)
-        let input = item.map(CodexTranslation.input(for:)) ?? request.params
+        let isQuestion = request.kind == .toolUserInput
+        let toolName = isQuestion ? AgentQuestionnaire.toolName
+            : item.map(CodexTranslation.toolName(for:)) ?? fallbackToolName(request.kind)
+        let input = isQuestion ? CodexQuestionnaire.input(for: request)
+            : item.map(CodexTranslation.input(for:)) ?? request.params
         let rule = rule(toolName: toolName, item: item, request: request)
 
         let ask = PermissionAsk(
@@ -71,6 +74,7 @@ public enum CodexPermission {
             // purpose: the flag is the one the prompt reads, and it must not depend on the rules
             // array happening to be empty.
             suppressesAlwaysAllow: rule == nil,
+            requiresUserInteraction: isQuestion,
             raw: Data()
         )
         // Rebuilt with its own bytes, because those bytes are what the database keeps and what a
@@ -203,9 +207,7 @@ public enum CodexPermission {
         switch decision {
         case .allow(.once): .accept
         case .allow(.session), .allow(.project): .acceptForSession
-        // Codex has no tool that asks a question, so nothing can produce one of these here. It is
-        // mapped to a plain accept rather than left to a `default`, so that adding a Codex tool
-        // that does ask one is a compile error in this file rather than a silently dropped reply.
+        // The runner sends the structured answer separately; this describes its approval outcome.
         case .answer: .accept
         case .deny(_, let endsTurn): endsTurn ? .cancel : .decline
         }

--- a/Sources/BloomCore/Agent/Codex/CodexQuestionnaire.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexQuestionnaire.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Adapts Codex's id-keyed question protocol to the shared question card. The original request
+/// remains authoritative when building a reply, so an edited input cannot answer unrelated ids.
+public enum CodexQuestionnaire {
+    public static func input(for request: CodexApprovalRequest) -> JSONValue {
+        let questions = (request.params["questions"]?.arrayValue ?? []).compactMap { value -> JSONValue? in
+            guard case .object(var question) = value,
+                  let id = question["id"]?.stringValue, !id.isEmpty else { return nil }
+            question["bloomAnswerID"] = .string(id)
+            let hasOptions = !(question["options"]?.arrayValue ?? []).isEmpty
+            question["bloomAllowsOther"] = .bool(!hasOptions || question["isOther"]?.boolValue == true)
+            return .object(question)
+        }
+        return .object(["questions": .array(questions)])
+    }
+
+    public static func result(input: JSONValue, request: CodexApprovalRequest) -> JSONValue {
+        var answers: [String: JSONValue] = [:]
+        for question in request.params["questions"]?.arrayValue ?? [] {
+            guard let id = question["id"]?.stringValue,
+                  let answer = input["answers"]?[id]?.stringValue,
+                  !answer.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
+            answers[id] = .object(["answers": .array([.string(answer)])])
+        }
+        return .object(["answers": .object(answers)])
+    }
+}

--- a/Sources/BloomCore/Agent/Codex/CodexRunner.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexRunner.swift
@@ -41,12 +41,12 @@ public actor CodexRunner: SessionRunner {
     /// backend, and `ModelIdentifier`'s head is the bug both were added for.
     private var wireModel: String { ModelIdentifier.resolve(session.model).model }
 
-    /// The items seen this turn, by id.
+    /// Items seen in each thread, keyed by thread and then item id.
     ///
     /// An approval request carries only an item id: the diff or the command is on the
     /// `item/started` that arrived a moment before it. Without this the question would have to be
     /// asked with nothing on it.
-    private var items: [String: CodexItem] = [:]
+    private var items: [String: [String: CodexItem]] = [:]
 
     /// Which server request each pending ask answers. Kept apart from the ask itself because the
     /// id is the server's own numbering and means nothing outside this connection, while the ask
@@ -257,8 +257,11 @@ public actor CodexRunner: SessionRunner {
     /// Answer one question, as a person. The turn resumes on the other side of this line.
     public func answer(requestID: String, decision: PermissionDecision) async {
         guard let ask = pending.take(requestID) else { return }
-        await write(answerTo: ask, decision: CodexPermission.decision(for: decision))
-        await deliverReason(of: decision)
+        let request = approvals[requestID]
+        let answerInput: JSONValue?
+        if case .answer(let input) = decision { answerInput = input } else { answerInput = nil }
+        await write(answerTo: ask, decision: CodexPermission.decision(for: decision), answerInput: answerInput)
+        await deliverReason(of: decision, request: request)
         await close(ask, as: decision.storedName, note: "")
 
         // Bloom's own bookkeeping, and it happens after the agent has been unblocked, so a
@@ -466,8 +469,52 @@ public actor CodexRunner: SessionRunner {
 
     // MARK: - Events
 
+    private var subagents = CodexSubagents()
+
+    public func subagentTranscript(for id: SubagentID) async -> SubagentTranscript? {
+        guard let child = subagents.threadID(for: id), let client,
+              let result = try? await client.send("thread/read", params: .object([
+                  "threadId": .string(child), "includeTurns": .bool(true),
+              ]), timeout: .seconds(10)),
+              result["thread"]?["id"]?.stringValue == child else { return nil }
+        return CodexSubagentTranscript.read(result["thread"] ?? .null, sessionID: session.id)
+    }
+
     private func handle(_ event: CodexEvent) async {
+        if let threadID {
+            for signal in subagents.receive(event, parentThreadID: threadID) {
+                sink.yield(.subagent(signal))
+            }
+            if let source = event.threadID, source != threadID {
+                // Child approvals still need an answer, but their prose, usage and completion
+                // belong to the child pane, never to the parent's transcript or turn handle.
+                if subagents.contains(threadID: source) {
+                    remember(event)
+                    if case .approval(let request) = event { await ask(request) }
+                }
+                return
+            }
+            switch event {
+            case .itemStarted(let item), .itemCompleted(let item):
+                if case .subAgentActivity(let activity) = item.item,
+                   activity.agentThreadID == threadID { return }
+            default:
+                break
+            }
+        }
         remember(event)
+
+        if case .unknown(let method, let raw) = event, method == "serverRequest/resolved",
+           let json = try? JSONDecoder().decode(JSONValue.self, from: raw),
+           let id = CodexRequestID(json["params"]?["requestId"]),
+           let threadID = json["params"]?["threadId"]?.stringValue {
+            let requestID = CodexPermission.requestID(id, threadID: threadID)
+            if let ask = pending.take(requestID) {
+                await close(ask, as: PermissionAskOutcome.resolved, note: "")
+                if pending.isEmpty, session.apply(.unblocked).moves { await save(session) }
+            }
+            return
+        }
 
         // A connection that closed because Bloom closed it is not news, and it must not be drawn
         // as an outage. `.closed` translates to an `.error`, which the window puts up as "The
@@ -490,9 +537,9 @@ public actor CodexRunner: SessionRunner {
     private func remember(_ event: CodexEvent) {
         switch event {
         case .itemStarted(let started), .itemCompleted(let started):
-            items[started.item.id] = started.item
-        case .turnCompleted:
-            items.removeAll()
+            items[started.threadID, default: [:]][started.item.id] = started.item
+        case .turnCompleted(let turn):
+            items.removeValue(forKey: turn.threadID)
         default:
             break
         }
@@ -535,7 +582,7 @@ public actor CodexRunner: SessionRunner {
     // MARK: - Asking
 
     private func ask(_ request: CodexApprovalRequest) async {
-        let ask = CodexPermission.ask(for: request, item: items[request.itemID])
+        let ask = CodexPermission.ask(for: request, item: items[request.threadID]?[request.itemID])
         pending.add(ask)
         approvals[ask.requestID] = request
 
@@ -561,6 +608,7 @@ public actor CodexRunner: SessionRunner {
 
         guard matched == nil, pending.contains(ask.requestID) else { return }
 
+        guard request.kind != .toolUserInput || request.params["isBlocking"]?.boolValue != false else { return }
         session.apply(.blocked)
         await save(session)
     }
@@ -606,16 +654,24 @@ public actor CodexRunner: SessionRunner {
     /// Failure here is deliberately quiet. The refusal has already landed and the turn is already
     /// unblocked; a steer that misses because the turn moved on must not turn an answered question
     /// into an error.
-    private func deliverReason(of decision: PermissionDecision) async {
+    private func deliverReason(of decision: PermissionDecision, request: CodexApprovalRequest?) async {
         guard case .deny(let message, let endsTurn) = decision, !endsTurn else { return }
         let text = message.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty, let client, let threadID, let turnID = handle.turnID else { return }
-        _ = try? await client.steerTurn(threadID: threadID, turnID: turnID, input: [.text(text)])
+        guard !text.isEmpty, let client, let request, !request.turnID.isEmpty else { return }
+        _ = try? await client.steerTurn(
+            threadID: request.threadID, turnID: request.turnID, input: [.text(text)]
+        )
     }
 
-    private func write(answerTo ask: PermissionAsk, decision: CodexApprovalDecision) async {
+    private func write(
+        answerTo ask: PermissionAsk, decision: CodexApprovalDecision, answerInput: JSONValue? = nil
+    ) async {
         if let request = approvals.removeValue(forKey: ask.requestID) {
-            await client?.answer(request, decision: decision)
+            if request.kind == .toolUserInput, let answerInput {
+                await client?.answer(request.id, with: CodexQuestionnaire.result(input: answerInput, request: request))
+            } else {
+                await client?.answer(request, decision: decision)
+            }
         }
 
         guard pending.isEmpty else { return }

--- a/Sources/BloomCore/Agent/Codex/CodexSubagentTranscript.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexSubagentTranscript.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Reads a child's thread without resuming it or starting a paid turn, using the existing
+/// transcript translator and renderer. This result is presentation only and is never stored.
+public enum CodexSubagentTranscript {
+    public static func read(_ thread: JSONValue, sessionID: SessionID) -> SubagentTranscript {
+        var translation = CodexTranslation()
+        var lines: [Data] = []
+        let threadID = thread["id"]?.stringValue ?? ""
+        for turn in thread["turns"]?.arrayValue ?? [] {
+            for raw in turn["items"]?.arrayValue ?? [] {
+                guard let item = CodexItem.decode(raw) else { continue }
+                if case .userMessage(let message) = item {
+                    lines.append(CodexRunner.userPayload(message.text))
+                    continue
+                }
+                let event = CodexItemEvent(
+                    item: item, threadID: threadID, turnID: turn["id"]?.stringValue ?? "", raw: Data()
+                )
+                var events = translation.translate(.itemStarted(event))
+                if CodexTranslation.status(of: item) != .inProgress {
+                    events += translation.translate(.itemCompleted(event))
+                }
+                lines.append(contentsOf: events.filter(\.isTranscriptRow).map(\.raw))
+            }
+        }
+        return SubagentTranscript.live(streamLines: lines, sessionID: sessionID)
+    }
+}

--- a/Sources/BloomCore/Agent/Codex/CodexSubagents.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexSubagents.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// One app-server connection carries the parent and its children. Child completions must never
+/// finish the parent's turn, and only children announced by this family may be read in its UI.
+public struct CodexSubagents: Sendable {
+    private var children: [String: CodexSubAgentActivity] = [:]
+    private var seenActivities: Set<String> = []
+
+    public init() {}
+
+    public func contains(threadID: String) -> Bool { children[threadID] != nil }
+
+    public func threadID(for id: SubagentID) -> String? {
+        children.keys.first { Self.id(for: $0) == id }
+    }
+
+    public static func id(for threadID: String) -> SubagentID { SubagentID("codex:\(threadID)") }
+
+    public mutating func receive(_ event: CodexEvent, parentThreadID: String) -> [SubagentSignal] {
+        guard let source = event.threadID,
+              source == parentThreadID || contains(threadID: source) else { return [] }
+        switch event {
+        case .itemStarted(let item), .itemCompleted(let item):
+            guard case .subAgentActivity(let activity) = item.item,
+                  !activity.agentThreadID.isEmpty, activity.agentThreadID != parentThreadID,
+                  seenActivities.insert(activity.id).inserted else { return [] }
+            var signals: [SubagentSignal] = []
+            if children[activity.agentThreadID] == nil {
+                children[activity.agentThreadID] = activity
+                signals.append(.started(start(activity)))
+            }
+            if activity.kind == "completed" || activity.kind == "interrupted" {
+                signals.append(.reported(SubagentReport(
+                    id: Self.id(for: activity.agentThreadID), status: activity.kind, summary: ""
+                )))
+            }
+            return signals
+        case .turnStarted(let turn):
+            guard let child = children[turn.threadID] else { return [] }
+            return [.started(start(child, resumesExisting: true))]
+        case .turnCompleted(let turn):
+            guard contains(threadID: turn.threadID) else { return [] }
+            return [.reported(SubagentReport(
+                id: Self.id(for: turn.threadID), status: turn.status.rawValue,
+                summary: turn.errorMessage ?? ""
+            ))]
+        default:
+            return []
+        }
+    }
+
+    private func start(_ child: CodexSubAgentActivity, resumesExisting: Bool = false) -> SubagentStart {
+        SubagentStart(
+            id: Self.id(for: child.agentThreadID), toolUseID: child.id,
+            description: child.agentPath.split(separator: "/").last.map(String.init) ?? "Codex subagent",
+            type: "Codex", isBackgrounded: true,
+            resumesExisting: resumesExisting
+        )
+    }
+}

--- a/Sources/BloomCore/Agent/PermissionGrant.swift
+++ b/Sources/BloomCore/Agent/PermissionGrant.swift
@@ -172,10 +172,12 @@ public enum PermissionAskOutcome {
     public static let abandoned = "abandoned"
     /// Written when a stored project grant answered it without troubling anybody.
     public static let auto = "allow-project-auto"
+    /// The server closed or timed out a question before the person submitted an answer.
+    public static let resolved = "resolved-by-agent"
 
     /// Whether this outcome means nobody ever actually answered.
     public static func wentUnanswered(_ decision: String) -> Bool {
-        [quit, stopped, abandoned].contains(decision)
+        [quit, stopped, abandoned, resolved].contains(decision)
     }
 
     /// What a row says about an ask that was never answered. No buttons, and no suggestion that
@@ -185,6 +187,7 @@ public enum PermissionAskOutcome {
         case quit: "Bloom closed this session before the question was answered."
         case stopped: "The turn was stopped before this was answered."
         case abandoned: "Bloom was not running when this was asked, so it went unanswered."
+        case resolved: "The agent closed this question before it was answered."
         default: ""
         }
     }

--- a/Sources/BloomCore/Presentation/OnboardingFlow.swift
+++ b/Sources/BloomCore/Presentation/OnboardingFlow.swift
@@ -107,10 +107,9 @@ public enum OnboardingStep: String, Sendable, Hashable, CaseIterable, Identifiab
 ///
 /// Two interesting rules. `firstStep` is where it opens: a first run gets the greeting, because
 /// that is the whole reason the greeting exists and a warm second is what somebody who has just
-/// double clicked a fresh app is owed. Every other way this window opens is somebody who has been
-/// here before, so the Help menu and a later broken launch open on the checks; greeting them again
-/// would be the app not remembering them. Back is still offered from there, so the greeting is
-/// never a screen that has been taken away.
+/// double clicked a fresh app is owed. The Help menu deliberately replays that first-run sequence.
+/// A later broken launch opens on the checks instead. Back is still offered from there, so the
+/// greeting is never a screen that has been taken away.
 ///
 /// `steps` is which screens exist for this window at all, and it is a list rather than a constant
 /// because the command line offer is only worth a screen when it has something to offer. Every

--- a/Sources/BloomCore/Support/Maker.swift
+++ b/Sources/BloomCore/Support/Maker.swift
@@ -33,6 +33,8 @@ public struct MakerProduct: Equatable, Sendable {
 public enum AppSite {
     public static let host = "runbloom.app"
     public static let url = URL(string: "https://runbloom.app")!
+    /// The public documentation was retired. Help opens the maintained support page instead.
+    public static let helpURL = url.appendingPathComponent("support")
 }
 
 /// Who made this app, and what else they make. The About window renders this; it decides none of it.

--- a/Sources/BloomCore/Transcript/ChatClearCommand.swift
+++ b/Sources/BloomCore/Transcript/ChatClearCommand.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// A host command, never a prompt sent to a paid agent. Arguments and sentences mentioning the
+/// command stay ordinary text; both a typed command and the completed slash chip end up here.
+public enum ChatClearCommand {
+    public static func matches(_ text: String) -> Bool {
+        text.trimmingCharacters(in: .whitespacesAndNewlines) == "/clear"
+    }
+}

--- a/Sources/BloomCore/Transcript/SlashCommandIndex.swift
+++ b/Sources/BloomCore/Transcript/SlashCommandIndex.swift
@@ -75,6 +75,12 @@ public enum SlashCommandIndex {
     /// and that a Bloom session can actually carry out. Adding to it is a decision, not a sweep.
     public static let builtIns: [SlashCommand] = [
         SlashCommand(
+            name: "clear",
+            detail: "Start a fresh chat here, keeping the previous conversation",
+            kind: .command,
+            scope: .builtIn
+        ),
+        SlashCommand(
             name: "code-review",
             detail: "Review the current diff, or a pull request, branch or path",
             kind: .command,

--- a/Sources/BloomCore/Transcript/Subagent.swift
+++ b/Sources/BloomCore/Transcript/Subagent.swift
@@ -121,6 +121,8 @@ public struct SubagentStart: Sendable, Hashable {
     /// The whole prompt the subagent was given. Not drawn in the row, which has 260 points, but
     /// it is the first thing the output pane shows and it is the only account of what was asked.
     public let prompt: String
+    /// A confirmed new turn on an existing Codex child thread, not a replayed spawn event.
+    public let resumesExisting: Bool
 
     public init(
         id: SubagentID,
@@ -130,7 +132,8 @@ public struct SubagentStart: Sendable, Hashable {
         isBackgrounded: Bool = false,
         spawnDepth: Int = 1,
         taskType: String = "",
-        prompt: String = ""
+        prompt: String = "",
+        resumesExisting: Bool = false
     ) {
         self.id = id
         self.toolUseID = toolUseID
@@ -140,6 +143,7 @@ public struct SubagentStart: Sendable, Hashable {
         self.spawnDepth = spawnDepth
         self.taskType = taskType
         self.prompt = prompt
+        self.resumesExisting = resumesExisting
     }
 }
 

--- a/Sources/BloomCore/Transcript/SubagentLifecycle.swift
+++ b/Sources/BloomCore/Transcript/SubagentLifecycle.swift
@@ -37,6 +37,8 @@ public enum SubagentState: String, Sendable, Hashable, CaseIterable, Codable {
 public enum SubagentLifecycleEvent: Sendable, Hashable {
     /// `system/task_started` arrived for this subagent.
     case spawned
+    /// A backend explicitly started another turn on this same child thread.
+    case resumed
     /// A status word off `system/task_updated`'s patch or `system/task_notification`, exactly as
     /// the CLI spelled it. Reading it is `SubagentState.init(reported:)`'s job, and a word nobody
     /// recognises is refused rather than guessed at.
@@ -102,6 +104,8 @@ extension SubagentState {
         case .spawned:
             guard self == .running else { return .refused }
             return .unchanged
+        case .resumed:
+            return self == .running ? .unchanged : .moves(to: .running)
 
         case .reported(let status):
             guard let reported = SubagentState(reported: status) else { return .refused }

--- a/Sources/BloomCore/Transcript/SubagentRoster.swift
+++ b/Sources/BloomCore/Transcript/SubagentRoster.swift
@@ -114,6 +114,10 @@ public struct Subagent: Sendable, Hashable, Identifiable {
 
     fileprivate mutating func move(to state: SubagentState, at now: Date) {
         self.state = state
+        if state == .running {
+            finishedAt = nil
+            return
+        }
         // Only the first ending is timed. Two lines report one ending and the second must not
         // restart the hold, which would be a row that stayed twice as long as any other.
         if finishedAt == nil { finishedAt = now }
@@ -244,7 +248,7 @@ public struct SubagentRoster: Sendable, Hashable {
                 if !start.toolUseID.isEmpty { byToolUse[start.toolUseID] = start.id }
                 return
             }
-            apply(.spawned, at: index, now: now)
+            apply(start.resumesExisting ? .resumed : .spawned, at: index, now: now)
 
         case .progressed(let progress):
             guard let id = byToolUse[progress.parentToolUseID],

--- a/Sources/BloomCore/Transcript/TranscriptTextMeasure.swift
+++ b/Sources/BloomCore/Transcript/TranscriptTextMeasure.swift
@@ -49,6 +49,14 @@ import Foundation
 /// So the fallback is the room the run was offered, and a hair's width when it was offered none.
 /// Nothing here can report a width the layout system did not first name.
 public enum TranscriptTextMeasure {
+    /// Centres visible letters rather than the font's asymmetric ascent and descent allowances.
+    /// Invalid or overflowing ink stays untouched, so this cannot introduce glyph clipping.
+    public static func bubbleTextOffset(height: Double, inkTop: Double, inkBottom: Double) -> Double {
+        guard height.isFinite, inkTop.isFinite, inkBottom.isFinite,
+              inkTop >= 0, inkBottom > inkTop, inkBottom <= height else { return 0 }
+        return (height - inkBottom - inkTop) / 2
+    }
+
     /// What "no width was proposed" is laid out at.
     ///
     /// Wide enough that nothing a transcript ever holds wraps inside it, which is what an ideal

--- a/Tests/BloomCoreTests/ChatClearCommandTests.swift
+++ b/Tests/BloomCoreTests/ChatClearCommandTests.swift
@@ -1,0 +1,17 @@
+import Testing
+@testable import BloomCore
+
+@Suite struct ChatClearCommandTests {
+    @Test func acceptsTheTypedCommandAndCompletedChip() {
+        #expect(ChatClearCommand.matches("/clear"))
+        #expect(ChatClearCommand.matches("/clear "))
+        #expect(ChatClearCommand.matches(" \n/clear\n"))
+        #expect(SlashCommandIndex.builtIns.contains { $0.name == "clear" })
+    }
+
+    @Test func neverClearsForOrdinaryProseOrArguments() {
+        for text in ["", "/clearance", "/clear everything", "Please add /clear", "`/clear`", "/CLEAR"] {
+            #expect(!ChatClearCommand.matches(text))
+        }
+    }
+}

--- a/Tests/BloomCoreTests/CodexQuestionnaireTests.swift
+++ b/Tests/BloomCoreTests/CodexQuestionnaireTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+@Suite struct CodexQuestionnaireTests {
+    private func request() -> CodexApprovalRequest {
+        CodexApprovalRequest(
+            id: .number(42), kind: .toolUserInput, threadID: "thread", turnID: "turn", itemID: "item",
+            params: .object(["questions": .array([
+                .object([
+                    "id": .string("scope"), "header": .string("Scope"), "question": .string("Which one?"),
+                    "options": .array([.object(["label": .string("All"), "description": .string("All screens")])]),
+                ]),
+                .object([
+                    "id": .string("theme"), "header": .string("Theme"), "question": .string("Which one?"),
+                    "isOther": .bool(true),
+                    "options": .array([.object(["label": .string("Both"), "description": .string("Both themes")])]),
+                ]),
+                .object(["id": .string("secret"), "question": .string("A private answer?"), "isSecret": .bool(true)]),
+            ])])
+        )
+    }
+
+    @Test func usesTheSharedQuestionCardWithoutGrantingPermissions() throws {
+        let ask = CodexPermission.ask(for: request(), item: nil)
+        #expect(ask.isQuestion)
+        #expect(ask.requiresUserInteraction)
+        #expect(ask.suppressesAlwaysAllow)
+        #expect(ask.suggestions.isEmpty)
+        let restored = try #require(PermissionAsk.decode(payload: ask.raw))
+        #expect(restored.input == ask.input)
+        #expect(restored.isQuestion)
+        let questions = AgentQuestionnaire.questions(in: restored.input)
+        #expect(questions.map(\.id) == ["scope", "theme", "secret"])
+        #expect(questions.map(\.allowsOther) == [false, true, true])
+        #expect(questions.last?.isSecret == true)
+    }
+
+    @Test func duplicateWordingKeepsSeparateAnswersAndProducesTheCodexWireShape() {
+        let input = CodexQuestionnaire.input(for: request())
+        let questions = AgentQuestionnaire.questions(in: input)
+        var draft = AgentQuestionDraft()
+        draft.toggle("All", on: questions[0])
+        draft.toggle("Both", on: questions[1])
+        draft.other["secret"] = "private"
+        let answers = draft.answers(to: questions)
+        #expect(AgentQuestionnaire.isComplete(questions, answers: answers))
+        let answered = AgentQuestionnaire.answered(input, answers: answers)
+        let result = CodexQuestionnaire.result(input: answered, request: request())
+        #expect(result["answers"]?["scope"]?["answers"] == .array([.string("All")]))
+        #expect(result["answers"]?["theme"]?["answers"] == .array([.string("Both")]))
+        #expect(result["answers"]?["secret"]?["answers"] == .array([.string("private")]))
+    }
+
+    @Test func ignoresUnknownAndBlankAnswers() {
+        let result = CodexQuestionnaire.result(
+            input: .object(["answers": .object(["scope": .string("  "), "unrelated": .string("injected")])]),
+            request: request()
+        )
+        #expect(result == .object(["answers": .object([:])]))
+        #expect(CodexApprovalDecision.decline.result(for: .toolUserInput) == .object(["answers": .object([:])]))
+    }
+}

--- a/Tests/BloomCoreTests/CodexRunnerTests.swift
+++ b/Tests/BloomCoreTests/CodexRunnerTests.swift
@@ -101,6 +101,29 @@ private func eventually(
         #expect(stored?.state == .running)
     }
 
+    @Test func childOutputAndCompletionNeverEnterOrFinishTheParentChat() async throws {
+        let store = try makeTestStore("codex-child-isolation")
+        let (session, _) = try await makeCodexSession(store)
+        let box = scriptedBox()
+        let runner = makeRunner(store: store, session: session, box: box)
+        try await runner.send("work with a child")
+        box.process.emit(#"{"method":"item/completed","params":{"threadId":"01a02144-3b7e-7233-97f2-73ebd5105085","turnId":"parent-turn","item":{"id":"root-self","type":"subAgentActivity","agentThreadId":"01a02144-3b7e-7233-97f2-73ebd5105085","agentPath":"/root","kind":"interacted"}}}"#)
+        box.process.emit(#"{"method":"item/completed","params":{"threadId":"child","turnId":"child-turn","item":{"id":"child-text","type":"agentMessage","text":"Child-only output"}}}"#)
+        box.process.emit(#"{"method":"turn/completed","params":{"threadId":"child","turn":{"id":"child-turn","status":"completed","items":[]}}}"#)
+        box.process.emit(#"{"method":"item/completed","params":{"threadId":"01a02144-3b7e-7233-97f2-73ebd5105085","turnId":"parent-turn","item":{"id":"parent-text","type":"agentMessage","text":"Parent still working"}}}"#)
+        await eventually("parent output after child completion") {
+            (try? await store.messages(sessionID: session.id).contains { $0.kind == .assistantText }) == true
+        }
+        let rows = try await store.messages(sessionID: session.id)
+        #expect(rows.filter { $0.kind == .assistantText }.count == 1)
+        #expect(!rows.contains { $0.kind == .result })
+        #expect(!rows.contains { String(decoding: $0.payload, as: UTF8.self).contains("root-self") })
+        #expect(!rows.contains { String(decoding: $0.payload, as: UTF8.self).contains("Child-only output") })
+        let current = try await store.session(id: session.id)
+        #expect(current?.state == .running)
+        await runner.shutdown()
+    }
+
     @Test func startsTheStoredCodexExecutable() async throws {
         let store = try makeTestStore("codex-runner-executable")
         let (session, _) = try await makeCodexSession(store)
@@ -114,6 +137,59 @@ private func eventually(
         try await runner.send("hello")
 
         #expect(box.process.launch.executable == "/tmp/tools/codex")
+    }
+
+    @Test func childApprovalsCannotBorrowParentMetadataOrSendReasonsToTheParent() async throws {
+        let store = try makeTestStore("codex-child-approval")
+        let (session, repoID) = try await makeCodexSession(store)
+        try await store.upsert(PermissionGrant(repoID: repoID, toolName: "Bash", ruleContent: "echo parent"))
+        let box = scriptedBox()
+        box.reply(to: "turn/steer", with: .object([:]))
+        let runner = makeRunner(store: store, session: session, box: box)
+        try await runner.send("review")
+        box.process.emit(#"{"method":"item/completed","params":{"threadId":"01a02144-3b7e-7233-97f2-73ebd5105085","turnId":"parent-turn","item":{"id":"spawn","type":"subAgentActivity","agentThreadId":"child","agentPath":"/root/review","kind":"started"}}}"#)
+        box.process.emit(#"{"method":"item/started","params":{"threadId":"01a02144-3b7e-7233-97f2-73ebd5105085","turnId":"parent-turn","item":{"id":"shared","type":"commandExecution","command":"echo parent","status":"inProgress"}}}"#)
+        box.process.emit(#"{"method":"item/started","params":{"threadId":"child","turnId":"child-turn","item":{"id":"shared","type":"commandExecution","command":"echo child","status":"inProgress"}}}"#)
+        box.process.emit(#"{"id":55,"method":"item/commandExecution/requestApproval","params":{"threadId":"child","turnId":"child-turn","itemId":"shared"}}"#)
+        await eventually("child permission to remain pending") {
+            ((try? await store.pendingPermissionAsks(sessionID: session.id)) ?? []).count == 1
+        }
+        let asks = try await store.pendingPermissionAsks(sessionID: session.id)
+        let ask = try #require(asks.first).ask
+        #expect(ask.input["command"]?.stringValue == "echo child")
+        await runner.answer(requestID: ask.requestID, decision: .deny(message: "Use a read-only check", endsTurn: false))
+        let steer = try #require(box.process.sentFrame { $0["method"]?.stringValue == "turn/steer" })
+        #expect(steer["params"]?["threadId"]?.stringValue == "child")
+        #expect(steer["params"]?["expectedTurnId"]?.stringValue == "child-turn")
+        await runner.shutdown()
+    }
+
+    @Test func aQuestionAnswerUsesTheCodexWireShapeAndResolvedQuestionsDisappear() async throws {
+        let store = try makeTestStore("codex-question-answer")
+        let (session, _) = try await makeCodexSession(store)
+        let box = scriptedBox()
+        let runner = makeRunner(store: store, session: session, box: box)
+        try await runner.send("ask me")
+        box.process.emit(#"{"id":71,"method":"item/tool/requestUserInput","params":{"threadId":"01a02144-3b7e-7233-97f2-73ebd5105085","turnId":"parent-turn","itemId":"question","isBlocking":false,"questions":[{"id":"scope","header":"Scope","question":"Which scope?","options":[{"label":"All","description":"Everything"}]}]}}"#)
+        await eventually("question card") {
+            ((try? await store.pendingPermissionAsks(sessionID: session.id)) ?? []).count == 1
+        }
+        let asks = try await store.pendingPermissionAsks(sessionID: session.id)
+        let ask = try #require(asks.first).ask
+        #expect(ask.toolName == AgentQuestionnaire.toolName)
+        let answered = AgentQuestionnaire.answered(ask.input, answers: ["scope": "All"])
+        await runner.answer(requestID: ask.requestID, decision: .answer(input: answered))
+        let reply = try #require(box.process.sentFrame { $0["id"]?.intValue == 71 && $0["result"] != nil })
+        #expect(reply["result"]?["answers"]?["scope"]?["answers"]?[0]?.stringValue == "All")
+        box.process.emit(#"{"id":72,"method":"item/tool/requestUserInput","params":{"threadId":"01a02144-3b7e-7233-97f2-73ebd5105085","turnId":"parent-turn","itemId":"question-2","questions":[{"id":"note","header":"Note","question":"Anything else?"}]}}"#)
+        box.process.emit(#"{"method":"serverRequest/resolved","params":{"threadId":"01a02144-3b7e-7233-97f2-73ebd5105085","requestId":72}}"#)
+        box.process.emit(#"{"method":"item/completed","params":{"threadId":"01a02144-3b7e-7233-97f2-73ebd5105085","turnId":"parent-turn","item":{"id":"sentinel","type":"agentMessage","text":"Question resolved"}}}"#)
+        await eventually("resolution processed before following prose") {
+            (try? await store.messages(sessionID: session.id).contains { $0.kind == .assistantText }) == true
+        }
+        let pending = try await store.pendingPermissionAsks(sessionID: session.id)
+        #expect(pending.isEmpty)
+        await runner.shutdown()
     }
 
     /// A chat that has spoken before resumes rather than starting a second conversation.

--- a/Tests/BloomCoreTests/CodexSubagentsTests.swift
+++ b/Tests/BloomCoreTests/CodexSubagentsTests.swift
@@ -1,0 +1,65 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+@Suite struct CodexSubagentsTests {
+    @Test func aChildSnapshotUsesTheSharedTranscriptWithoutInventingToolCompletion() throws {
+        let thread = try JSONDecoder().decode(JSONValue.self, from: Data(#"""
+        {"id":"child","turns":[{"id":"turn","items":[
+          {"type":"userMessage","id":"brief","content":[{"type":"text","text":"Review this change"}]},
+          {"type":"agentMessage","id":"answer","text":"I am checking the tests"},
+          {"type":"commandExecution","id":"shell","command":"swift test","status":"inProgress"}
+        ]}]}
+        """#.utf8))
+        let transcript = CodexSubagentTranscript.read(thread, sessionID: SessionID("parent"))
+        #expect(transcript.prompt == "Review this change")
+        #expect(transcript.messages.contains { $0.kind == .assistantText })
+        #expect(!transcript.messages.contains { $0.kind == .toolResult })
+    }
+
+    private func activity(_ id: String, child: String = "child", kind: String = "started") -> CodexEvent {
+        .itemCompleted(CodexItemEvent(
+            item: .subAgentActivity(CodexSubAgentActivity(
+                id: id, agentPath: "/root/component_audit", agentThreadID: child, kind: kind
+            )), threadID: "parent", turnID: "parent-turn", raw: Data()
+        ))
+    }
+
+    @Test func aChildUsesTheSharedRosterAndCanResumeWithoutDuplicatingItsRow() throws {
+        var tracker = CodexSubagents()
+        var roster = SubagentRoster()
+        for signal in tracker.receive(activity("spawn"), parentThreadID: "parent") { roster.apply(signal) }
+        #expect(roster.isWorking)
+        let duplicate = tracker.receive(activity("spawn"), parentThreadID: "parent")
+        #expect(duplicate.isEmpty)
+        for signal in tracker.receive(activity("done", kind: "completed"), parentThreadID: "parent") {
+            roster.apply(signal)
+        }
+        #expect(!roster.isWorking)
+        let turn = CodexTurn(id: "next", threadID: "child", status: .inProgress)
+        for signal in tracker.receive(.turnStarted(turn), parentThreadID: "parent") { roster.apply(signal) }
+        #expect(roster.isWorking)
+        let child = try #require(roster[CodexSubagents.id(for: "child")])
+        #expect(child.description == "component_audit")
+        #expect(child.finishedAt == nil)
+    }
+
+    @Test func neverCreatesAChildForRootAndNeverTrustsAnUnrelatedThread() {
+        var tracker = CodexSubagents()
+        let root = tracker.receive(activity("root", child: "parent", kind: "interacted"), parentThreadID: "parent")
+        #expect(root.isEmpty)
+        #expect(tracker.threadID(for: CodexSubagents.id(for: "unrelated")) == nil)
+        let other = tracker.receive(.turnStarted(CodexTurn(id: "x", threadID: "other", status: .inProgress)), parentThreadID: "parent")
+        #expect(other.isEmpty)
+    }
+
+    @Test func aParentFinishingDoesNotFinishItsChild() {
+        var tracker = CodexSubagents()
+        var roster = SubagentRoster()
+        for signal in tracker.receive(activity("spawn"), parentThreadID: "parent") { roster.apply(signal) }
+        let ended = tracker.receive(.turnCompleted(CodexTurn(id: "parent-turn", threadID: "parent", status: .completed)), parentThreadID: "parent")
+        for signal in ended { roster.apply(signal) }
+        #expect(roster.isWorking)
+        #expect(ended.isEmpty)
+    }
+}

--- a/Tests/BloomCoreTests/MakerTests.swift
+++ b/Tests/BloomCoreTests/MakerTests.swift
@@ -7,6 +7,11 @@ import Testing
 /// should be a deliberate change to what the app says about its makers, not a drive-by.
 @Suite("Maker")
 struct MakerTests {
+    @Test("Help links to support, not the retired documentation")
+    func helpDestination() {
+        #expect(AppSite.helpURL.absoluteString == "https://runbloom.app/support")
+    }
+
     @Test("The email's products, in the email's order")
     func productsMatchTheEmail() {
         #expect(Maker.products.map(\.name) == ["Flare", "Mailcoach", "There There"])

--- a/Tests/BloomCoreTests/TranscriptTextMeasureTests.swift
+++ b/Tests/BloomCoreTests/TranscriptTextMeasureTests.swift
@@ -4,6 +4,19 @@ import Foundation
 
 @Suite("How a run of transcript prose says how big it is")
 struct TranscriptTextMeasureTests {
+    @Test("bubble alignment balances actual ink on both single and multiple lines")
+    func bubbleAlignment() {
+        for (height, top, bottom) in [(17.0, 4.0, 16.0), (61.0, 4.0, 60.0), (17.0, 3.0, 14.0)] {
+            let offset = TranscriptTextMeasure.bubbleTextOffset(height: height, inkTop: top, inkBottom: bottom)
+            #expect(top + offset == height - bottom - offset)
+            #expect(top + offset >= 0 && bottom + offset <= height)
+        }
+        #expect(TranscriptTextMeasure.bubbleTextOffset(height: 0, inkTop: 0, inkBottom: 0) == 0)
+        #expect(TranscriptTextMeasure.bubbleTextOffset(height: .infinity, inkTop: 4, inkBottom: 16) == 0)
+        #expect(TranscriptTextMeasure.bubbleTextOffset(height: 17, inkTop: -1, inkBottom: 16) == 0)
+        #expect(TranscriptTextMeasure.bubbleTextOffset(height: 17, inkTop: 1, inkBottom: 18) == 0)
+    }
+
     // MARK: What a run is laid out at
 
     /// The measurement that started this: at a container of 456, a wrapped paragraph's widest line

--- a/Tools/house-rules.sh
+++ b/Tools/house-rules.sh
@@ -287,6 +287,7 @@ echo "==> an id has a type"
 # wrapper at every parse site and would buy nothing, because there is no second
 # kind of thread id to confuse one with.
 id_type_allowed_files=(
+  'Sources/BloomCore/Agent/AgentQuestion.swift' # Codex's opaque question answer id, not a Bloom row
   'Sources/BloomCore/Agent/AgentEvent.swift'   # Claude Code's stream-json, as measured
   'Sources/BloomCore/Agent/Codex/CodexEvent.swift'   # the Codex app-server protocol
   'Sources/BloomCore/Agent/Codex/CodexClient.swift'  # the same protocol's request envelopes


### PR DESCRIPTION
## Summary

- Give Codex subagents the shared sidebar roster and live output pane. Keep child output and turn completions out of the parent transcript, and keep activity visible while children work.
- Render Codex structured questions using Bloom's question cards, preserving answer IDs, custom answers and secret fields. Handle server-resolved requests without leaving stale cards.
- Add `/clear` to start a fresh chat while retaining the previous conversation and selected model controls.
- Point Help at the current support page and make Welcome to Bloom restart the wizard.
- Match the title bar to inactive tabs and optically centre message text using actual glyph bounds, including single-line bubbles and custom font settings.
- Give empty-state actions compact, neutral native buttons and sent/queued messages a shared curved tail with reserved layout space.

## Review and verification

- App builds with `swift build --jobs 4`.
- House rules, SwiftLint and whitespace checks pass.
- 95 focused regression tests passed before the final review additions; additional runner tests cover child approval isolation, answer wire format, and request resolution.
- Correctness and security review found and fixed child approval metadata collisions, denial routing and resumed-child output refresh.
- Native desktop interactions were not performed against the owner's running apps. The welcome restart probe is included, but its isolated local launch encountered a macOS beta startup failure before reaching the probe; it is not claimed as a passing visual test.

This does not rewrite older saved transcripts that already contain mixed parent/child output, and it does not claim a measured FPS increase.
