### PR TITLE
Fix explicit chat scrolling and offer optional workspace setup

### DIFF
--- a/Sources/Bloom/Design/Snapshot.swift
+++ b/Sources/Bloom/Design/Snapshot.swift
@@ -884,6 +884,7 @@ enum Snapshot {
         let board = QuotaBoard.make(from: await AgentQuotaSources.readAll())
 
         let scenes: [(String, AnyView, CGSize)] = [
+            ("workspace-setup", AnyView(WorkspaceSetupOptionGallery()), CGSize(width: 760, height: 200)),
             ("sidebar", AnyView(SidebarView().frame(width: 260, height: 620)), CGSize(width: 260, height: 620)),
             ("home", AnyView(HomeView().frame(width: 900, height: 620)), CGSize(width: 900, height: 620)),
             ("components", AnyView(ComponentGallery().frame(width: 640, height: 700)), CGSize(width: 640, height: 700)),

--- a/Sources/Bloom/Design/WorkspaceSetupOptionGallery.swift
+++ b/Sources/Bloom/Design/WorkspaceSetupOptionGallery.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+/// The actual create-window control in both states, without a project or a running agent.
+struct WorkspaceSetupOptionGallery: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.gutter) {
+            WorkspaceSetupOption(isEnabled: .constant(true))
+            WorkspaceSetupOption(isEnabled: .constant(false))
+        }
+        .padding(Metrics.gutter)
+        .frame(width: 760)
+        .background(Palette.surface)
+    }
+}

--- a/Sources/Bloom/State/AppModel+Workspaces.swift
+++ b/Sources/Bloom/State/AppModel+Workspaces.swift
@@ -45,12 +45,14 @@ extension AppModel {
         branch: String? = nil,
         controls: ComposerControls? = nil,
         staged: StagedAttachments? = nil,
-        checkout: WorkspaceCheckout? = nil
+        checkout: WorkspaceCheckout? = nil,
+        runSetupScript: Bool = true
     ) async -> Workspace? {
         do {
             return try await startWorkspace(
                 in: repo, prompt: prompt, baseBranch: baseBranch, opensWith: opensWith,
-                branch: branch, controls: controls, staged: staged, checkout: checkout
+                branch: branch, controls: controls, staged: staged, checkout: checkout,
+                runSetupScript: runSetupScript
             )
         } catch {
             // Diagnosed rather than reported. `error.readableMessage` on a `ShellError` is the git
@@ -96,7 +98,8 @@ extension AppModel {
         checkout: WorkspaceCheckout? = nil,
         /// A thread on the chosen backend for the new chat to pick up. Only `carryOn` passes one.
         /// See `WorkspaceStartRequest.resuming`.
-        resuming: String? = nil
+        resuming: String? = nil,
+        runSetupScript: Bool = true
     ) async throws -> Workspace {
         guard let manager else { throw AppNotReady.stillStartingUp }
         isCreatingWorkspace = true
@@ -242,7 +245,7 @@ extension AppModel {
             // The app runs setup itself, through `WorkspaceModel`, so the output streams into the
             // transcript, a failure raises the one sentence every route says about a failed setup,
             // and an archive can cancel it. See `adopt`.
-            runsSetup: false
+            setupPolicy: runSetupScript ? .deferred : .skip
         )
 
         // Nil declines, and the workspace keeps the title git would have given it. The closure is
@@ -293,8 +296,8 @@ extension AppModel {
             prompt, staged: stagedPaths, arrived: arrived, isChatWorkspace: opensWith == .chat
         )
 
-        // Setup runs whether or not there is an agent turn to follow it. Only the turn is skipped
-        // for a terminal workspace.
+        // The persisted setup state carries the creation choice. The opening prompt still goes
+        // through the same queue when setup is skipped, including in a chat workspace.
         await model(for: started.workspace).startSetupThenSend(prompt: opening, repo: repo)
         return started.workspace
     }

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -988,7 +988,7 @@ final class WorkspaceModel {
             SettingsLoader.load(repo: repoPath)
         }.value
 
-        if settings.setupScript != nil {
+        if workspace.setupState == .pending, settings.setupScript != nil {
             let succeeded = await stream(setupIn: repo, through: manager)
 
             // Archiving or quitting cancels this task. Starting an agent in a worktree that is on

--- a/Sources/Bloom/Views/CreateWorkspace/CreateWorkspaceView.swift
+++ b/Sources/Bloom/Views/CreateWorkspace/CreateWorkspaceView.swift
@@ -71,6 +71,7 @@ struct CreateWorkspaceView: View {
     /// Whether this project runs anything after the worktree is cut, so the footer can say so.
     /// Read with the branches, from the same settings the rest of this window is built from.
     @State private var hasSetupScript = false
+    @State private var runSetupScript = true
     @State private var isLoading = false
 
     /// Whether a model will be asked to name this workspace, which decides what the window may
@@ -185,7 +186,7 @@ struct CreateWorkspaceView: View {
             prompt: task,
             hasCheckout: checkout != nil,
             isChatWorkspace: mode.runsAnAgent,
-            isBusy: app.isCreatingWorkspace
+            isBusy: app.isCreatingWorkspace || isLoading
         )
     }
 
@@ -204,9 +205,7 @@ struct CreateWorkspaceView: View {
     /// where the project has one. No worktree jargon, because a person who knows the word does not
     /// need the sentence and a person who does not is not helped by it.
     private var consequence: some View {
-        Text(hasSetupScript
-            ? "Creates a separate copy of the project on this Mac, on its own branch, and runs this project's setup script in it."
-            : "Creates a separate copy of the project on this Mac, on its own branch.")
+        Text("Creates a separate copy of the project on this Mac, on its own branch.")
             .font(Typo.caption)
             .foregroundStyle(Palette.textTertiary)
             .fixedSize(horizontal: false, vertical: true)
@@ -226,6 +225,12 @@ struct CreateWorkspaceView: View {
                     .padding(Metrics.gutter)
             } else {
                 composer
+                if hasSetupScript {
+                    WorkspaceSetupOption(isEnabled: $runSetupScript)
+                        .disabled(isLoading)
+                        .padding(.horizontal, Metrics.gutter)
+                        .padding(.bottom, Metrics.spacingWide)
+                }
                 consequence
             }
         }
@@ -893,6 +898,8 @@ struct CreateWorkspaceView: View {
         // so it goes with the project. Left standing, it would name a folder in a repository the
         // window is no longer looking at.
         heldProblem = nil
+        runSetupScript = true
+        hasSetupScript = false
 
         // Whichever box the remembered mode has put on screen. The window no longer always opens
         // on the writing box, so focusing it unconditionally would put the caret in a view that
@@ -1124,6 +1131,7 @@ struct CreateWorkspaceView: View {
         let base = baseBranch.isEmpty ? repo.defaultBranch : baseBranch
         let source = checkout
         let chosenControls = controls
+        let shouldRunSetup = runSetupScript
 
         // A file can be moved or deleted between being attached and Create being pressed, and
         // naming a path that is not there only teaches the agent that Bloom lies about paths.
@@ -1158,7 +1166,8 @@ struct CreateWorkspaceView: View {
                 opensWith: chosen,
                 controls: chosenControls,
                 staged: staged,
-                checkout: source
+                checkout: source,
+                runSetupScript: shouldRunSetup
             )
             // Whatever survived is in the worktree now, and whatever did not was never going to be.
             AttachmentStaging.discard(draftID: handedOver)

--- a/Sources/Bloom/Views/CreateWorkspace/WorkspaceSetupOption.swift
+++ b/Sources/Bloom/Views/CreateWorkspace/WorkspaceSetupOption.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// A per-workspace choice, kept outside the composer controls that configure the agent.
+struct WorkspaceSetupOption: View {
+    @Binding var isEnabled: Bool
+
+    var body: some View {
+        Toggle(isOn: $isEnabled) {
+            VStack(alignment: .leading, spacing: Metrics.spacingTight) {
+                Text("Run setup script")
+                    .font(Typo.bodyEmphasis)
+                    .foregroundStyle(Palette.textPrimary)
+                Text("Use this project's setup script to prepare the new workspace.")
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .toggleStyle(.checkbox)
+        .tint(Palette.controlAccent)
+        .accessibilityHint("Turn off to skip setup for this workspace only.")
+        .padding(Metrics.inset)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Palette.surfaceSunken, in: RoundedRectangle(cornerRadius: Metrics.corner))
+    }
+}

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -56,6 +56,9 @@ struct TranscriptListView: View {
         let remembered = memory?.remembered(session: transcript.session.id)
         _expanded = State(initialValue: remembered?.expanded ?? [])
         _unfolded = State(initialValue: remembered?.unfolded ?? [])
+        _liveEndRequest = State(initialValue: TranscriptLiveEndRequest(
+            handled: remembered?.liveEndRequest ?? 0
+        ))
         let rows = transcript.rows
         _drawn = State(initialValue: Drawn(
             session: transcript.session.id,
@@ -187,6 +190,7 @@ struct TranscriptListView: View {
     /// The travel the jump pill makes. See `TranscriptLiveEndScroller`, which carries the frame
     /// timings that put an AppKit level scroll there in place of a `withAnimation`.
     @State private var scroller = TranscriptLiveEndScroller()
+    @State private var liveEndRequest = TranscriptLiveEndRequest()
     /// What keeps the view with the newest row while a turn runs. See `TranscriptLiveEndFollower`.
     /// Nothing in this body reads it, on purpose: it writes no SwiftUI state, so following a turn
     /// costs no pass over this list.
@@ -913,6 +917,7 @@ struct TranscriptListView: View {
                 // And a view that goes on dragging somebody somewhere after they have grabbed it
                 // is the worst thing in this file.
                 scroller.stop()
+                follower.seekLiveEnd(false)
             }
         )
         .overlay(alignment: .top) {
@@ -937,6 +942,8 @@ struct TranscriptListView: View {
         .onAppear { isVisible.value = true }
         .onDisappear {
             remember()
+            scroller.stop()
+            follower.stop()
             isVisible.value = false
             isGrowing.value = false
         }
@@ -991,8 +998,8 @@ struct TranscriptListView: View {
         // Asked for by the jump pill, and by every button that composes a turn: see
         // `TranscriptModel.submit`, which bumps this so that what somebody just asked for is the
         // thing they are looking at.
-        .onChange(of: transcript.liveEndRequests) { _, _ in
-            goToLiveEnd()
+        .onChange(of: transcript.liveEndRequests, initial: true) { _, _ in
+            honourLiveEndRequest()
         }
         .onChange(of: transcript.session.id) { _, _ in
             // The session being left is written down here, from its own measurements: `writingTo`
@@ -1012,6 +1019,7 @@ struct TranscriptListView: View {
             )
             // The folds of the session being arrived at, which are its own and are usually none.
             let remembered = memory?.remembered(session: transcript.session.id)
+            liveEndRequest = TranscriptLiveEndRequest(handled: remembered?.liveEndRequest ?? 0)
             expanded = remembered?.expanded ?? []
             unfolded = remembered?.unfolded ?? []
             // From nothing rather than extended: the rows below this pane have been replaced
@@ -1105,6 +1113,7 @@ struct TranscriptListView: View {
             // 163ms to 169ms main thread block on every return.
             guard resumed != transcript.session.id else {
                 arrivalSession = transcript.session.id
+                honourLiveEndRequest()
                 scheduleHistoryPreparation()
                 SwitchTrace.mark("transcript.window", workspace: transcript.workspace?.id)
                 SwitchTrace.markOnScreen("transcript.window", workspace: transcript.workspace?.id)
@@ -1141,6 +1150,7 @@ struct TranscriptListView: View {
             // The session has finished arriving, so from here on a row that turns up is a row the
             // reader is watching turn up. The history that just landed is not one of them.
             arrivalSession = transcript.session.id
+            honourLiveEndRequest()
             scheduleHistoryPreparation()
             SwitchTrace.mark("transcript.history", workspace: transcript.workspace?.id)
             SwitchTrace.markOnScreen("transcript.history", workspace: transcript.workspace?.id)
@@ -1198,6 +1208,7 @@ struct TranscriptListView: View {
         if let place = controller.topmostPlace { topPlace.value = place }
         updatePinnedQuestion()
         atLiveEnd.value = table.isAtEnd || controller.holdsEnd || follower.isFollowing
+            || follower.isSeekingLiveEnd
 
         var measured = TranscriptGeometry(
             paneHeight: TranscriptGeometry.height(table.viewportHeight),
@@ -1319,7 +1330,17 @@ struct TranscriptListView: View {
     /// has not been laid out at all. Each of those leaves a scroll that was correct when it was
     /// issued a few hundred points short, and short of the end is exactly the state the reader
     /// pressed the pill to get out of. `goToEnd` is a standing instruction rather than a movement.
+    private func honourLiveEndRequest() {
+        guard liveEndRequest.consume(
+            transcript.liveEndRequests, isReady: arrivalSession == transcript.session.id
+        ) else { return }
+        opening = .liveEnd
+        goToLiveEnd()
+    }
+
     private func goToLiveEnd() {
+        scroller.stop()
+        follower.seekLiveEnd(true)
         // The live end has to be IN the window before anything can travel to it, and a reader far
         // enough from the end to press this is often reading a window that does not hold it.
         if drawn.session == transcript.session.id,
@@ -1333,6 +1354,7 @@ struct TranscriptListView: View {
             // have landed.
             scroller.stop()
             controller.goToEnd()
+            follower.seekLiveEnd(false)
             return
         }
 
@@ -1341,15 +1363,20 @@ struct TranscriptListView: View {
         ) {
         case .jump:
             controller.goToEnd()
+            follower.seekLiveEnd(false)
         case .glide(let seconds):
             // Let go of the end first, or the instruction and the travel are two things moving the
             // same clip view. AppKit rather than `withAnimation`: `TranscriptLiveEndScroller`
             // carries the frame timings that settled that.
             controller.releaseEnd()
             guard scroller.glide(
-                seconds: seconds, completion: { [controller] in controller.goToEnd() }
+                seconds: seconds, completion: { [controller, follower] in
+                    controller.goToEnd()
+                    follower.seekLiveEnd(false)
+                }
             ) else {
                 controller.goToEnd()
+                follower.seekLiveEnd(false)
                 return
             }
         }
@@ -1532,7 +1559,8 @@ struct TranscriptListView: View {
                 // Idle preparation may have filled the whole table. Remember only the reader's
                 // neighbourhood so returning from another tab does not rebuild thousands of
                 // entries before the pane can appear.
-                drawn: rememberedWindow
+                drawn: rememberedWindow,
+                liveEndRequest: liveEndRequest.handled
             ),
             session: target.session
         )

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -1314,6 +1314,14 @@ struct TranscriptListView: View {
         controller.goToEnd()
     }
 
+    private func honourLiveEndRequest() {
+        guard liveEndRequest.consume(
+            transcript.liveEndRequests, isReady: arrivalSession == transcript.session.id
+        ) else { return }
+        opening = .liveEnd
+        goToLiveEnd()
+    }
+
     /// Takes the reader back to the newest row, which is what the jump pill asks for, and what
     /// every button that composes a turn asks for through `TranscriptModel.submit`.
     ///
@@ -1330,14 +1338,6 @@ struct TranscriptListView: View {
     /// has not been laid out at all. Each of those leaves a scroll that was correct when it was
     /// issued a few hundred points short, and short of the end is exactly the state the reader
     /// pressed the pill to get out of. `goToEnd` is a standing instruction rather than a movement.
-    private func honourLiveEndRequest() {
-        guard liveEndRequest.consume(
-            transcript.liveEndRequests, isReady: arrivalSession == transcript.session.id
-        ) else { return }
-        opening = .liveEnd
-        goToLiveEnd()
-    }
-
     private func goToLiveEnd() {
         scroller.stop()
         follower.seekLiveEnd(true)
@@ -1352,7 +1352,6 @@ struct TranscriptListView: View {
             // end of the content as it stands now is aimed at a row that is about to be somewhere
             // else entirely. The standing instruction is what makes the arrival stick once they
             // have landed.
-            scroller.stop()
             controller.goToEnd()
             follower.seekLiveEnd(false)
             return

--- a/Sources/Bloom/Views/Transcript/TranscriptLiveEndFollow.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptLiveEndFollow.swift
@@ -60,6 +60,19 @@ final class TranscriptLiveEndFollower {
     /// Whether the reader has hold of the view. Anything that is not an idle scroll phase.
     var isPaused = false { didSet { refresh() } }
 
+    /// An explicit glide owns the clip view until it lands. Streaming nudges must not start a
+    /// second display link, or reclaim the bottom before that glide has finished.
+    private(set) var isSeekingLiveEnd = false
+
+    func seekLiveEnd(_ seeking: Bool) {
+        isSeekingLiveEnd = seeking
+        if seeking {
+            dropLink()
+        } else {
+            refresh()
+        }
+    }
+
     /// Whether there is a travel to make at all, which is `TranscriptFollow.travels` and is about
     /// Reduce Motion. False leaves the transcript with the instant pin it has always had.
     var travels = true { didSet { refresh() } }
@@ -157,6 +170,7 @@ final class TranscriptLiveEndFollower {
         // Without the handback: a conversation the pane has left is owed nothing, and naming an
         // edge on the way out would land on whichever session arrives next.
         dropLink()
+        isSeekingLiveEnd = false
     }
 
     /// Forgets the height it had measured, without ending anything.
@@ -180,7 +194,7 @@ final class TranscriptLiveEndFollower {
     // MARK: - The link
 
     private var wants: Bool {
-        guard travels, isFrontmost, !isPaused, scrollView != nil else { return false }
+        guard travels, isFrontmost, !isPaused, !isSeekingLiveEnd, scrollView != nil else { return false }
         return isStreaming || CACurrentMediaTime() < deadline
     }
 

--- a/Sources/BloomCore/Transcript/TranscriptLiveEndRequest.swift
+++ b/Sources/BloomCore/Transcript/TranscriptLiveEndRequest.swift
@@ -1,0 +1,15 @@
+/// A pane acknowledges an explicit scroll only after its conversation has arrived. Requests
+/// sent while the pane is absent must survive rebuilding it and restoring its saved position.
+public struct TranscriptLiveEndRequest: Equatable, Sendable {
+    public private(set) var handled: Int
+
+    public init(handled: Int = 0) {
+        self.handled = handled
+    }
+
+    public mutating func consume(_ requested: Int, isReady: Bool) -> Bool {
+        guard isReady, requested > handled else { return false }
+        handled = requested
+        return true
+    }
+}

--- a/Sources/BloomCore/Transcript/TranscriptResume.swift
+++ b/Sources/BloomCore/Transcript/TranscriptResume.swift
@@ -104,6 +104,9 @@ public struct TranscriptPaneState: Equatable, Sendable {
     /// that holds different rows lands the reader somewhere else. See `TranscriptWindow`.
     public var drawn: TranscriptWindow
 
+    /// The last explicit scroll this pane honoured, not merely the last one the model sent.
+    public var liveEndRequest: Int
+
     public init(
         expanded: Set<Int>,
         unfolded: Set<Int> = [],
@@ -112,7 +115,8 @@ public struct TranscriptPaneState: Equatable, Sendable {
         anchorDelta: Double = 0,
         isAtLiveEnd: Bool,
         rowCount: Int,
-        drawn: TranscriptWindow = TranscriptWindow(start: 0, end: 0)
+        drawn: TranscriptWindow = TranscriptWindow(start: 0, end: 0),
+        liveEndRequest: Int = 0
     ) {
         self.expanded = expanded
         self.unfolded = unfolded
@@ -122,6 +126,7 @@ public struct TranscriptPaneState: Equatable, Sendable {
         self.isAtLiveEnd = isAtLiveEnd
         self.rowCount = rowCount
         self.drawn = drawn
+        self.liveEndRequest = liveEndRequest
     }
 }
 

--- a/Sources/BloomCore/Workspace/WorkspaceManager.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceManager.swift
@@ -166,7 +166,8 @@ public struct WorkspaceManager: Sendable {
         branch: String? = nil,
         baseBranch: String? = nil,
         origin: WorkspaceOrigin = .user,
-        checkout: WorkspaceCheckout? = nil
+        checkout: WorkspaceCheckout? = nil,
+        setupPolicy: WorkspaceSetupPolicy = .deferred
     ) async throws -> Workspace {
         // Everything below reads the repository and then acts on what it read, so two creates
         // running at once in one project decide on the same branch and the same directory and the
@@ -174,11 +175,13 @@ public struct WorkspaceManager: Sendable {
         // coalesced.
         try await WorktreeCutQueue.shared.cut(in: repo.path) {
             if let checkout {
-                return try await open(checkout, id: id, repo: repo, name: name, origin: origin)
+                return try await open(
+                    checkout, id: id, repo: repo, name: name, origin: origin, setupPolicy: setupPolicy
+                )
             }
             return try await cut(
                 id: id, repo: repo, prompt: prompt, name: name, branch: branch,
-                baseBranch: baseBranch, origin: origin
+                baseBranch: baseBranch, origin: origin, setupPolicy: setupPolicy
             )
         }
     }
@@ -192,7 +195,8 @@ public struct WorkspaceManager: Sendable {
         name: String?,
         branch: String?,
         baseBranch: String?,
-        origin: WorkspaceOrigin
+        origin: WorkspaceOrigin,
+        setupPolicy: WorkspaceSetupPolicy
     ) async throws -> Workspace {
         let settings = SettingsLoader.load(repo: repo.path)
         let base = baseBranch ?? repo.defaultBranch
@@ -231,7 +235,7 @@ public struct WorkspaceManager: Sendable {
             branch: finalBranch,
             path: worktreePath,
             baseBranch: base,
-            setupState: settings.setupScript == nil ? .skipped : .pending,
+            setupState: setupPolicy.initialState(script: settings.setupScript),
             sortOrder: try await store.nextWorkspaceSortOrder(repoID: repo.id),
             origin: origin
         )
@@ -259,7 +263,8 @@ public struct WorkspaceManager: Sendable {
         id: WorkspaceID,
         repo: Repo,
         name: String?,
-        origin: WorkspaceOrigin
+        origin: WorkspaceOrigin,
+        setupPolicy: WorkspaceSetupPolicy
     ) async throws -> Workspace {
         let settings = SettingsLoader.load(repo: repo.path)
         let existingBranches = Set(try await Git.branches(of: repo.path))
@@ -334,7 +339,7 @@ public struct WorkspaceManager: Sendable {
             branch: branch,
             path: worktreePath,
             baseBranch: checkout.baseBranch(default: repo.defaultBranch),
-            setupState: settings.setupScript == nil ? .skipped : .pending,
+            setupState: setupPolicy.initialState(script: settings.setupScript),
             sortOrder: try await store.nextWorkspaceSortOrder(repoID: repo.id),
             origin: origin,
             // Written now rather than waited for. A review workspace knows its pull request before

--- a/Sources/BloomCore/Workspace/WorkspaceSetupPolicy.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceSetupPolicy.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Setup at creation is either owned by the app, awaited by a headless caller, or declined.
+/// Skipping belongs to this request, never to the project's settings or a later manual run.
+public enum WorkspaceSetupPolicy: Sendable {
+    case deferred
+    case run
+    case skip
+
+    public func initialState(script: String?) -> SetupState {
+        guard self != .skip,
+              let script,
+              !script.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .skipped
+        }
+        return .pending
+    }
+}

--- a/Sources/BloomCore/Workspace/WorkspaceStart.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceStart.swift
@@ -63,14 +63,9 @@ public struct WorkspaceStartRequest: Sendable {
     /// could go wrong, an id the CLI cannot find, is the CLI's answer to give and not this
     /// layer's to guess at.
     public var resuming: String?
-    /// Whether `start` runs the setup script itself, and waits for it.
-    ///
-    /// False for the app, which runs it through `WorkspaceModel` so the output streams into the
-    /// transcript, a failure raises the one sentence every route says about a failed setup, and
-    /// the whole thing can be cancelled by an archive. True for a caller with no window to stream
-    /// into, which wants the worktree to have its dependencies installed by the time `start`
-    /// returns.
-    public var runsSetup: Bool
+    /// The app normally streams setup itself. A headless caller can await it here instead,
+    /// or the owner can skip it for this workspace without changing the project configuration.
+    public var setupPolicy: WorkspaceSetupPolicy
 
     public init(
         id: WorkspaceID = .new(),
@@ -84,7 +79,7 @@ public struct WorkspaceStartRequest: Sendable {
         controls: ComposerControls? = nil,
         opensSession: Bool = true,
         resuming: String? = nil,
-        runsSetup: Bool = false
+        setupPolicy: WorkspaceSetupPolicy = .deferred
     ) {
         self.id = id
         self.repo = repo
@@ -97,7 +92,7 @@ public struct WorkspaceStartRequest: Sendable {
         self.controls = controls
         self.opensSession = opensSession
         self.resuming = resuming
-        self.runsSetup = runsSetup
+        self.setupPolicy = setupPolicy
     }
 }
 
@@ -170,7 +165,7 @@ extension WorkspaceManager {
     ///   to decline. It is a closure because whether to name a workspace automatically depends on
     ///   a preference and on whether the CLI is installed, and on which codenames are already in
     ///   use, none of which this layer should be reaching for.
-    /// - Parameter setupOutput: each line the setup script writes, when `runsSetup` is true.
+    /// - Parameter setupOutput: each line the setup script writes, when `setupPolicy` is `.run`.
     public func start(
         _ request: WorkspaceStartRequest,
         namer: @Sendable () async -> String? = { nil },
@@ -190,7 +185,8 @@ extension WorkspaceManager {
             branch: request.branch,
             baseBranch: request.baseBranch,
             origin: request.origin,
-            checkout: request.checkout
+            checkout: request.checkout,
+            setupPolicy: request.setupPolicy
         )
 
         // Here rather than inside `createWorkspace`, for the reason that method's own comment
@@ -237,7 +233,7 @@ extension WorkspaceManager {
         }
 
         var setupSucceeded: Bool?
-        if request.runsSetup {
+        if request.setupPolicy == .run {
             // **`ensurePort`, which is the same door the app's own setup run goes through.**
             //
             // This used to call `PortAllocator.allocate(taken: [])` directly, which is the bug

--- a/Tests/BloomCoreTests/TranscriptLiveEndRequestTests.swift
+++ b/Tests/BloomCoreTests/TranscriptLiveEndRequestTests.swift
@@ -1,0 +1,41 @@
+import Testing
+@testable import BloomCore
+
+@Suite("Explicit transcript scrolling")
+struct TranscriptLiveEndRequestTests {
+    @Test func waitsForThePaneToArrive() {
+        var request = TranscriptLiveEndRequest()
+        let early = request.consume(1, isReady: false)
+        #expect(!early)
+        #expect(request.handled == 0)
+        let arrived = request.consume(1, isReady: true)
+        #expect(arrived)
+        #expect(request.handled == 1)
+    }
+
+    @Test func replaysRequestsSentWhileThePaneWasAbsentOnlyOnce() {
+        var request = TranscriptLiveEndRequest(handled: 2)
+        let returning = request.consume(4, isReady: true)
+        let repeated = request.consume(4, isReady: true)
+        #expect(returning)
+        #expect(!repeated)
+        #expect(request.handled == 4)
+    }
+
+    @Test func returningWithoutANewRequestPreservesTheReadersPlace() {
+        var request = TranscriptLiveEndRequest(handled: 2)
+        let returning = request.consume(2, isReady: true)
+        #expect(!returning)
+    }
+
+    @Test func eachPaneAcknowledgesRequestsIndependently() {
+        var first = TranscriptLiveEndRequest()
+        var second = TranscriptLiveEndRequest()
+        let visible = first.consume(1, isReady: true)
+        let hidden = second.consume(1, isReady: false)
+        let returning = second.consume(1, isReady: true)
+        #expect(visible)
+        #expect(!hidden)
+        #expect(returning)
+    }
+}

--- a/Tests/BloomCoreTests/WorkspaceSetupPolicyTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceSetupPolicyTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Workspace setup choice", .tags(.git), .scratchDirectory)
+struct WorkspaceSetupPolicyTests {
+    @Test("only a configured, requested script starts pending")
+    func initialStates() {
+        for policy in [WorkspaceSetupPolicy.deferred, .run, .skip] {
+            #expect(policy.initialState(script: nil) == .skipped)
+            #expect(policy.initialState(script: " \n ") == .skipped)
+            #expect(policy.initialState(script: "echo setup") == (policy == .skip ? .skipped : .pending))
+        }
+    }
+
+    @Test("skip applies to new and existing branches, with or without a chat",
+          arguments: [false, true], [false, true])
+    func skipsOnlyThisCreation(existingBranch: Bool, opensSession: Bool) async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        let store = try makeTestStore("skip-setup")
+        let manager = WorkspaceManager(store: store)
+        let registered = try await manager.addRepository(at: repo.path)
+        try repo.write(".conductor/settings.toml", """
+        files_to_copy = ["local.txt"]
+        [scripts]
+        setup = "echo installed > installed.txt"
+        """)
+        try repo.write("local.txt", "keep copied files")
+        if existingBranch {
+            try await Shell.check("git", ["branch", "existing"], cwd: repo.path)
+        }
+
+        let started = try await manager.start(WorkspaceStartRequest(
+            repo: registered, prompt: "Skip setup", origin: .user,
+            checkout: existingBranch ? .branch(ExistingBranch(name: "existing", isLocal: true)) : nil,
+            opensSession: opensSession, setupPolicy: .skip
+        ))
+
+        #expect(started.workspace.setupState == .skipped)
+        #expect(started.setupSucceeded == nil)
+        #expect((started.session != nil) == opensSession)
+        let stored = try #require(try await store.workspace(id: started.workspace.id))
+        #expect(stored.setupState == .skipped)
+        #expect(!FileManager.default.fileExists(atPath: started.workspace.path + "/installed.txt"))
+        #expect(FileManager.default.fileExists(atPath: started.workspace.path + "/local.txt"))
+        #expect(SettingsLoader.load(repo: repo.path).setupScript == "echo installed > installed.txt")
+
+        // The next ordinary create must not inherit this window's opt-out.
+        let next = try await manager.start(WorkspaceStartRequest(
+            repo: registered, prompt: "Normal setup", origin: .user
+        ))
+        #expect(next.workspace.setupState == .pending)
+
+        // Skipping automatic setup is not a permanent ban on running it explicitly.
+        let succeeded = await manager.runSetup(workspace: stored, repo: registered, port: 0) { _ in }
+        #expect(succeeded)
+        #expect(FileManager.default.fileExists(atPath: stored.path + "/installed.txt"))
+        let afterManualRun = try #require(try await store.workspace(id: stored.id))
+        #expect(afterManualRun.setupState == .succeeded)
+    }
+}

--- a/Tests/BloomCoreTests/WorkspaceStartTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceStartTests.swift
@@ -280,7 +280,7 @@ struct WorkspaceStartTests {
         let lines = LineCollector()
         let started = try await manager.start(
             WorkspaceStartRequest(
-                repo: registered, prompt: "Needs dependencies", origin: .user, runsSetup: true
+                repo: registered, prompt: "Needs dependencies", origin: .user, setupPolicy: .run
             ),
             setupOutput: { lines.append($0) }
         )
@@ -316,7 +316,7 @@ struct WorkspaceStartTests {
         let lines = LineCollector()
         let started = try await manager.start(
             WorkspaceStartRequest(
-                repo: registered, prompt: "Needs a port", origin: .user, runsSetup: true
+                repo: registered, prompt: "Needs a port", origin: .user, setupPolicy: .run
             ),
             setupOutput: { lines.append($0) }
         )
@@ -341,7 +341,7 @@ struct WorkspaceStartTests {
         """)
 
         let started = try await manager.start(WorkspaceStartRequest(
-            repo: registered, prompt: "Will not install", origin: .user, runsSetup: true
+            repo: registered, prompt: "Will not install", origin: .user, setupPolicy: .run
         ))
 
         #expect(started.setupSucceeded == false)


### PR DESCRIPTION
## Summary

- Honour explicit chat scroll requests from Fix merge conflicts and other prompt buttons, even when the chat pane is not ready yet.
- Hand scroll ownership cleanly between the explicit glide and streaming follower; preserve manual interruption.
- Add a native Run setup script checkbox to workspace creation, checked by default and shown when the project has a script.
- Scope skipping to this creation, including new branches and existing checkouts. Keep file copying, project settings, opening chat delivery and later manual setup available.
- Represent setup ownership as an explicit deferred/run/skip policy and persist the initial skipped state before the workspace reaches the UI.

The broader open-source audit recommendations remain separate follow-up work, not changes included in this PR.

## Verification

- App builds without warnings; both linters pass.
- 40 focused tests pass, including skip/default/manual-run cases across new/existing branches and with/without a chat.
- Actual checkbox component rendered and inspected in light and dark appearances.
- Explicit-scroll request tests and offscreen AppKit ownership-handoff probe pass.
- Review lanes: correctness and security. PHP, Laravel and React lanes do not apply to this Swift-only change.
