### PR TITLE
Harden conversation persistence and workspace boundaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,9 @@ jobs:
           done
 
       # The rules that are ours rather than the language's. See the script.
+      - name: Check licence packaging
+        run: zsh Tools/release/tests/licences.sh
+
       - name: Check the house rules
         run: ./Tools/house-rules.sh
 

--- a/README.md
+++ b/README.md
@@ -58,12 +58,17 @@ You need Xcode 26, or a Swift 6.2 toolchain.
 ```bash
 git clone https://github.com/spatie/bloom.git
 cd bloom
-make app
+./Tools/dev-build.sh --no-launch
 ```
 
-`make` on its own lists every target. `make app` assembles a debug `Bloom.app` into SwiftPM's build
-directory, which is what you want while changing things, and `make run` builds a release copy and
-launches it.
+This installs `~/Applications/Bloom Dev.app` with a separate database, preferences and URL scheme.
+Open that copy when you want to try your changes. It does not replace the released application or
+use its data. See [the architecture guide](docs/ARCHITECTURE.md) before contributing.
+The dev script builds a committed revision, so commit your changes locally before rebuilding it.
+
+`make` on its own lists every target. `make build` compiles without installing or launching.
+`make app` and `make run` retain the production bundle identity, so use the isolated dev build for
+day-to-day development.
 
 There is no `.xcodeproj`, on purpose. Open `Package.swift` in Xcode and you get the targets, the
 schemes, the debugger and the previews; `CLAUDE.md` has the section explaining what a checked-in

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -284,40 +284,20 @@ The feed URL is `<BLOOM_PUBLIC_BASE_URL>/appcast.xml`, and it is computed from
 the same variables the upload uses rather than written down twice, so the
 address the app polls cannot drift from the address the feed is written to.
 
-## What has never run
+## Verified release path
 
-The workflow itself has run, and worked: v0.0.1-test and then 0.1.0 through
-0.6.0 each went through it, so importing the .p12, notarising the zip with an
-App Store Connect API key, stapling, the uploads and the appcast are all things
-that have happened for real. This section used to say the opposite, from before
-the first release, and was left saying it for six of them.
+The complete zip and disk-image pipeline has shipped. Release v1.2.0, build 1208,
+completed in [workflow run 34130547271](https://github.com/spatie/bloom/actions/runs/34130547271):
+signing, notarisation, stapling, uploads and appcast publication all passed.
+The public download redirected to its disk image and the website changelog was published.
 
-What has not run is the disk image half, added after 0.6.0:
+That is evidence for the pipeline, not a substitute for checking the next release. After every
+release, verify the workflow, both public artefacts, the appcast version and the website download
+redirect. Publish the matching notes on `runbloom.app/changelog` as well as on GitHub.
 
-- notarising a .dmg with the API key, and stapling the ticket to it
-- `spctl --assess --type open` against a notarised image
-- uploading a .dmg to the bucket, and the `bloom:diskImage` element reaching
-  the website through the appcast
-- `brew install --cask google-chrome`, which is only reached if a runner image
-  stops shipping Chrome
-
-There is no notarisation credential on any machine here, only the Developer ID
-certificate, so none of that could be tried locally either. What was checked
-locally, against the file rather than against an exit status:
-
-- `Tools/dmg/build.sh` produces the image from an app that has already been
-  signed with the hardened runtime, and the app inside the mounted image still
-  passes `codesign --verify --strict --deep`, so the layout step preserves the
-  signature and would preserve a stapled ticket with it
-- the image itself takes a Developer ID signature and passes
-  `codesign --verify --strict`
-- `spctl --assess --type open --context context:primary-signature` on that
-  image is rejected for want of a ticket, which is the check doing its job and
-  the reason it is a hard failure in `package-app.sh`
-
-The zip path is unchanged, so what it does is what it did for 0.6.0.
-
-Expect the first release with an image to need a fix or two anyway.
+`Tools/package-licences.sh` includes Bloom and dependency notices inside the app before signing.
+It reads SwiftPM's pinned checkouts and fails if a notice is missing. The independent packaging
+test runs in CI. Changes to dependencies should include a review of their distribution notices.
 
 ## Testing the parts that need no secrets
 

--- a/Sources/Bloom/State/AskModel.swift
+++ b/Sources/Bloom/State/AskModel.swift
@@ -29,6 +29,7 @@ final class AskModel {
     /// not both create a chat. The store is an actor, so two callers really can both read "no
     /// session" before either writes one.
     private var isOpening = false
+    private var isStartingFresh = false
     /// Whether the permission mode has been settled since Bloom started.
     ///
     /// This model is built once and kept for the life of the window, so its first `open()` is the
@@ -53,7 +54,7 @@ final class AskModel {
     /// Reads the chat back, or makes it, and builds its transcript. Safe to call again: the second
     /// call finds the session and returns.
     func open() async {
-        guard !isOpening, let store = app.store else { return }
+        guard !isOpening, !isStartingFresh, let store = app.store else { return }
         isOpening = true
         defer { isOpening = false }
 
@@ -106,7 +107,10 @@ final class AskModel {
     /// old conversation is still in the database, with its cost and its permission history, and
     /// nothing that has been said is thrown away because somebody wanted a clean start.
     func startFresh(controls: ComposerControls? = nil, draft: String = "") async {
-        guard let store = app.store, let current = session else { return }
+        guard !isOpening, !isStartingFresh, let store = app.store, let current = session,
+              let directory else { return }
+        isStartingFresh = true
+        defer { isStartingFresh = false }
 
         let carriedControls: ComposerControls
         if let controls {
@@ -129,26 +133,22 @@ final class AskModel {
             )
         }
 
-        transcript?.teardown()
-        transcript = nil
-        session = nil
-        // One column. The runner owns the state, the counters and the agent session id on this
-        // row and may have written any of them since this copy was read.
-        _ = try? await store.update(sessionID: current.id) { $0.archivedAt = Date() }
-        app.bridge?.retire(sessionID: current.id)
-
-        var next = AskConversation.newSession()
-        next.model = carriedControls.model
-        next.effort = carriedControls.effort
-        next.agentKind = carriedControls.agentKind
-        next.permissionMode = carriedControls.permissionMode
-        if let made = try? await store.upsert(next) {
-            await carriedControls.store(sessionID: made.id, in: store)
-            if !draft.isEmpty {
-                try? await store.saveDraft(sessionID: made.id, body: draft)
-            }
+        do {
+            let made = try await store.replaceAskConversation(
+                id: current.id, controls: carriedControls, draft: draft
+            )
+            transcript?.teardown()
+            app.bridge?.retire(sessionID: current.id)
+            session = made
+            let model = TranscriptModel(askSession: made, directory: directory, app: app)
+            transcript = model
+            await model.load()
+        } catch {
+            app.alert = BloomAlert(
+                title: "Could not start a new conversation",
+                message: TranscriptStanding.complaint(about: error)
+            )
         }
-        await open()
     }
 
     /// Signals the agent, without waiting. `AppModel.shutdownEverything` calls this on every model

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -678,7 +678,8 @@ final class TranscriptModel {
     func drain() async {
         guard !isWorkspaceArchiving, !wasStoppedByHand, store != nil else { return }
         guard drainState.begin() else { return }
-        defer { finishDrain() }
+        var allowRepeat = true
+        defer { finishDrain(allowRepeat: allowRepeat) }
         await refreshQueue()
 
         // The list is taken once and walked, rather than the queue being re-asked for a front
@@ -702,17 +703,23 @@ final class TranscriptModel {
             // Retired before it is handed over, rather than after. The pending bubble and the real
             // one are two drawings of the same sentence, and a delivery that is still pending
             // while its turn is starting is drawn twice. `restoreDelivery` is the one path back.
-            guard await claimForDelivery(next) else { return }
+            guard await claimForDelivery(next) else {
+                allowRepeat = false
+                return
+            }
 
             // A turn that would not start stops the pass. Its delivery is back at the front of
             // the queue with an error row under it, and pushing the next one into an agent that
             // just refused would bury that.
-            guard await deliver(next) else { return }
+            guard await deliver(next) else {
+                allowRepeat = false
+                return
+            }
         }
     }
 
-    private func finishDrain() {
-        let again = drainState.finish()
+    private func finishDrain(allowRepeat: Bool) {
+        let again = drainState.finish(allowRepeat: allowRepeat)
         if again, !wasStoppedByHand, !isWorkspaceArchiving {
             Task { await drain() }
         }
@@ -893,7 +900,8 @@ final class TranscriptModel {
     private func sendSteered(_ delivery: Delivery) async {
         guard !isWorkspaceArchiving, !wasStoppedByHand, store != nil else { return }
         guard drainState.begin() else { return }
-        defer { finishDrain() }
+        var allowRepeat = true
+        defer { finishDrain(allowRepeat: allowRepeat) }
         // A turn was started while this one was dying, which takes the owner typing into the
         // composer inside that second: `submit` drains, and the drain does not know a Steer is
         // booked. Two sends into one runner is the one outcome to avoid, and the cost of avoiding
@@ -906,8 +914,11 @@ final class TranscriptModel {
         guard pendingDeliveries.contains(where: { $0.id == delivery.id }) else { return }
 
         sending = delivery
-        guard await claimForDelivery(delivery) else { return }
-        await deliver(delivery)
+        guard await claimForDelivery(delivery) else {
+            allowRepeat = false
+            return
+        }
+        allowRepeat = await deliver(delivery)
     }
 
     /// Closes the question when the message it is about is no longer waiting.

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -222,6 +222,7 @@ final class TranscriptModel {
     /// drain hanging off that result has to be able to tell the two endings apart. Cleared when a
     /// turn starts, so it never outlives the turn it describes.
     private var wasStoppedByHand = false
+    @ObservationIgnored private var drainState = DeliveryDrainState.idle
 
     /// The queued message a Steer has picked, waiting for the turn it stopped to finish dying.
     ///
@@ -560,7 +561,8 @@ final class TranscriptModel {
         let body = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !body.isEmpty, let store else { return }
 
-        draft = ""
+        let submittedDraft = draft.trimmingCharacters(in: .whitespacesAndNewlines) == body ? draft : nil
+        if submittedDraft != nil { draft = "" }
 
         // Built here rather than inside the enqueue, so the row that goes in the table and the
         // bubble that goes on screen are one object with one id. Drawn twice under two ids is the
@@ -590,16 +592,17 @@ final class TranscriptModel {
         // asks `TranscriptMotion` whether Reduce Motion is on and jumps instead when it is.
         jumpToLiveEnd()
 
-        try? await store.saveDraft(sessionID: session.id, body: "")
-
         do {
-            _ = try await store.enqueueDelivery(delivery)
+            _ = try await store.enqueueDelivery(delivery, clearingDraftMatching: submittedDraft)
         } catch {
             // The bubble was drawn on the promise that this would be queued. It was not, so the
             // promise is taken back rather than left on screen next to a message that is never
             // going anywhere.
-            sending = nil
+            if sending?.id == delivery.id { sending = nil }
             pendingDeliveries.removeAll { $0.id == delivery.id }
+            draft = PendingMessageReturn.draft(taking: [delivery], into: draft)
+            composerFocusRequests += 1
+            await saveDraft()
             Log.composer.error(
                 "the message could not be queued: \(error.readableMessage, privacy: .public)"
             )
@@ -673,7 +676,9 @@ final class TranscriptModel {
     /// for at that moment, and both are covered by the queue simply sitting there, visibly, until
     /// somebody says something.
     func drain() async {
-        guard !isWorkspaceArchiving, let store else { return }
+        guard !isWorkspaceArchiving, !wasStoppedByHand, store != nil else { return }
+        guard drainState.begin() else { return }
+        defer { finishDrain() }
         await refreshQueue()
 
         // The list is taken once and walked, rather than the queue being re-asked for a front
@@ -682,7 +687,8 @@ final class TranscriptModel {
         for next in Delivery.deliverable(
             from: pendingDeliveries, hold: deliveryHold, on: session.agentKind
         ) {
-            guard !isWorkspaceArchiving, deliveryHold.allowsDelivery(on: session.agentKind) else { return }
+            guard !isWorkspaceArchiving, !wasStoppedByHand,
+                  deliveryHold.allowsDelivery(on: session.agentKind) else { return }
             // Deleted, or steered out, since the list was taken.
             guard pendingDeliveries.contains(where: { $0.id == next.id }) else { continue }
 
@@ -696,13 +702,46 @@ final class TranscriptModel {
             // Retired before it is handed over, rather than after. The pending bubble and the real
             // one are two drawings of the same sentence, and a delivery that is still pending
             // while its turn is starting is drawn twice. `restoreDelivery` is the one path back.
-            try? await store.markDelivered(id: next.id)
-            await refreshQueue()
+            guard await claimForDelivery(next) else { return }
 
             // A turn that would not start stops the pass. Its delivery is back at the front of
             // the queue with an error row under it, and pushing the next one into an agent that
             // just refused would bury that.
             guard await deliver(next) else { return }
+        }
+    }
+
+    private func finishDrain() {
+        let again = drainState.finish()
+        if again, !wasStoppedByHand, !isWorkspaceArchiving {
+            Task { await drain() }
+        }
+    }
+
+    private func claimForDelivery(_ delivery: Delivery) async -> Bool {
+        guard let store else { return false }
+        do {
+            let claimed = try await store.markDelivered(id: delivery.id)
+            guard claimed else {
+                if sending?.id == delivery.id { sending = nil }
+                await refreshQueue()
+                return false
+            }
+            await refreshQueue()
+            if isWorkspaceArchiving || wasStoppedByHand {
+                try await store.restoreDelivery(id: delivery.id)
+                if sending?.id == delivery.id { sending = nil }
+                await refreshQueue()
+                return false
+            }
+            return true
+        } catch {
+            if sending?.id == delivery.id { sending = nil }
+            app.alert = BloomAlert(
+                title: "Could not send the message",
+                message: TranscriptStanding.complaint(about: error)
+            )
+            return false
         }
     }
 
@@ -852,7 +891,9 @@ final class TranscriptModel {
     /// retire-then-deliver order for the same reason, which is that a delivery still marked
     /// pending while its turn is starting is drawn twice.
     private func sendSteered(_ delivery: Delivery) async {
-        guard !isWorkspaceArchiving, let store else { return }
+        guard !isWorkspaceArchiving, !wasStoppedByHand, store != nil else { return }
+        guard drainState.begin() else { return }
+        defer { finishDrain() }
         // A turn was started while this one was dying, which takes the owner typing into the
         // composer inside that second: `submit` drains, and the drain does not know a Steer is
         // booked. Two sends into one runner is the one outcome to avoid, and the cost of avoiding
@@ -865,8 +906,7 @@ final class TranscriptModel {
         guard pendingDeliveries.contains(where: { $0.id == delivery.id }) else { return }
 
         sending = delivery
-        try? await store.markDelivered(id: delivery.id)
-        await refreshQueue()
+        guard await claimForDelivery(delivery) else { return }
         await deliver(delivery)
     }
 
@@ -1066,6 +1106,7 @@ final class TranscriptModel {
     /// turn still emits its own result, and that event is what writes the final state back into the
     /// session row. Tearing the pump down here used to strand the session until the next launch.
     func stop() {
+        steering = nil
         cancelTurn()
 
         // **And the queue comes back with it.** Not draining after a Stop was right about the
@@ -1377,6 +1418,7 @@ final class TranscriptModel {
             // queue was handed back to the composer on the frame the button was pressed.
             if let steered = steering {
                 steering = nil
+                wasStoppedByHand = false
                 await sendSteered(steered)
             } else if !wasStoppedByHand {
                 await drain()

--- a/Sources/BloomCore/Agent/Codex/CodexRunner.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexRunner.swift
@@ -818,7 +818,6 @@ public actor CodexRunner: SessionRunner {
     )
 }
 
-
 /// The live connection, where synchronous code can reach it. See `CodexRunner.terminateNow`.
 private final class LiveConnection: Sendable {
     private let client = Mutex<CodexClient?>(nil)

--- a/Sources/BloomCore/Agent/Codex/CodexRunner.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexRunner.swift
@@ -26,7 +26,6 @@ public actor CodexRunner: SessionRunner {
     private var pumpTask: Task<Void, Never>?
     private var translation: CodexTranslation
     private var threadID: String?
-    private var cancelled = false
 
     /// What this project has already approved. One type for both backends: see `SessionGrants`.
     private let grants: SessionGrants
@@ -135,11 +134,13 @@ public actor CodexRunner: SessionRunner {
     /// sentence. See `AgentKind.acceptsMidTurnMessage` for why a message reaches here mid turn at
     /// all, and `steer(_:threadID:turnID:on:)` for the fall back when the turn has just ended.
     public func send(_ text: String, recording: Data? = nil) async throws {
+        let generation = handle.generation
         await applyContextWindowChange()
+        try handle.check(generation)
         let client = try await connected()
+        try handle.check(generation)
         let threadID = try await openThread(on: client)
-
-        cancelled = false
+        try handle.check(generation)
         // One row, whichever it is, for the reason `AgentRunner.send` gives: the crew payload
         // already holds both renderings, and a user row beside it is the envelope back on screen.
         if let recording {
@@ -147,6 +148,7 @@ public actor CodexRunner: SessionRunner {
         } else {
             await persist(kind: .user, payload: Self.userPayload(text))
         }
+        try handle.check(generation)
 
         // Absorbed into the running turn, so there is no new turn id to hold and no state to
         // move: `turnStarted` is `unchanged` from `running` anyway. See `SessionLifecycle`.
@@ -159,6 +161,7 @@ public actor CodexRunner: SessionRunner {
            await steer(text, threadID: threadID, turnID: turnID, on: client) {
             return
         }
+        try handle.check(generation)
 
         let turn = try await client.startTurn(
             threadID: threadID,
@@ -169,7 +172,12 @@ public actor CodexRunner: SessionRunner {
             sandboxPolicy: Self.sandboxPolicy(for: session.permissionMode, writableRoot: workspacePath),
             approvalsReviewer: Self.approvalsReviewer(for: session.permissionMode)
         )
-        handle.begin(turnID: turn.id)
+        guard handle.begin(turnID: turn.id, generation: generation) else {
+            // Stop can arrive while turn/start is in flight, before there is an id to interrupt.
+            // Do not resurrect that turn when the reply finally supplies its id.
+            try? await client.interruptTurn(threadID: threadID, turnID: turn.id)
+            throw CancellationError()
+        }
 
         session.apply(.turnStarted)
         await save(session)
@@ -189,8 +197,8 @@ public actor CodexRunner: SessionRunner {
     /// the server is `terminateNow`, and the difference between the two is which of them a chat
     /// is expected to survive.
     public nonisolated func cancelNow() {
-        handle.markCancelled()
-        Task { await self.stopTurn() }
+        let generation = handle.markCancelled()
+        Task { await self.stopTurn(generation: generation) }
     }
 
     /// Stop, as the button means it: file the questions and then interrupt the turn.
@@ -205,8 +213,10 @@ public actor CodexRunner: SessionRunner {
     /// Answered before the interrupt rather than after, for the reason `AgentRunner.cancelNow`
     /// gives: an answer written after the thing that closes the turn is an answer the model never
     /// receives.
-    private func stopTurn() async {
+    private func stopTurn(generation: UInt64) async {
+        guard handle.generation == generation, handle.wasCancelled else { return }
         await filePendingAsks()
+        guard handle.generation == generation, handle.wasCancelled else { return }
         await interrupt()
     }
 
@@ -244,7 +254,6 @@ public actor CodexRunner: SessionRunner {
     }
 
     private func interrupt() async {
-        cancelled = true
         // Written here rather than left for the result to infer, which is what the `cancelled`
         // flag used to do at both of the sites below. `SessionLifecycle` refuses a stop on a
         // session with no turn open and ignores a result on one that has already been stopped, so
@@ -801,6 +810,7 @@ private final class TurnHandle: Sendable {
     private struct State {
         var current: String?
         var cancelled = false
+        var generation: UInt64 = 0
     }
 
     private let state = Mutex(State())
@@ -826,16 +836,29 @@ private final class TurnHandle: Sendable {
     }
 
     var wasCancelled: Bool { state.withLock(\.cancelled) }
+    var generation: UInt64 { state.withLock(\.generation) }
 
-    func begin(turnID: String) {
+    func check(_ generation: UInt64) throws {
+        guard state.withLock({ $0.generation == generation }) else { throw CancellationError() }
+        try Task.checkCancellation()
+    }
+
+    func begin(turnID: String, generation: UInt64) -> Bool {
         state.withLock { state in
+            guard state.generation == generation else { return false }
             state.current = turnID
             state.cancelled = false
+            return true
         }
     }
 
-    func markCancelled() {
-        state.withLock { $0.cancelled = true }
+    @discardableResult
+    func markCancelled() -> UInt64 {
+        state.withLock {
+            $0.generation &+= 1
+            $0.cancelled = true
+            return $0.generation
+        }
     }
 
     func end() {

--- a/Sources/BloomCore/Agent/Codex/CodexRunner.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexRunner.swift
@@ -135,6 +135,8 @@ public actor CodexRunner: SessionRunner {
     /// all, and `steer(_:threadID:turnID:on:)` for the fall back when the turn has just ended.
     public func send(_ text: String, recording: Data? = nil) async throws {
         let generation = handle.generation
+        let replacement = handle.prepareReplacement()
+        defer { handle.finishReplacement(replacement) }
         await applyContextWindowChange()
         try handle.check(generation)
         let client = try await connected()
@@ -197,8 +199,8 @@ public actor CodexRunner: SessionRunner {
     /// the server is `terminateNow`, and the difference between the two is which of them a chat
     /// is expected to survive.
     public nonisolated func cancelNow() {
-        let generation = handle.markCancelled()
-        Task { await self.stopTurn(generation: generation) }
+        let stopped = handle.markCancelled()
+        Task { await self.stopTurn(stopped) }
     }
 
     /// Stop, as the button means it: file the questions and then interrupt the turn.
@@ -213,11 +215,11 @@ public actor CodexRunner: SessionRunner {
     /// Answered before the interrupt rather than after, for the reason `AgentRunner.cancelNow`
     /// gives: an answer written after the thing that closes the turn is an answer the model never
     /// receives.
-    private func stopTurn(generation: UInt64) async {
-        guard handle.generation == generation, handle.wasCancelled else { return }
-        await filePendingAsks()
-        guard handle.generation == generation, handle.wasCancelled else { return }
-        await interrupt()
+    private func stopTurn(_ stopped: TurnHandle.Stopped) async {
+        if handle.generation == stopped.generation, handle.wasCancelled {
+            await filePendingAsks()
+        }
+        await interrupt(stopped)
     }
 
     /// Answers every question this turn can no longer answer, and files it as stopped.
@@ -253,14 +255,20 @@ public actor CodexRunner: SessionRunner {
         Task { await self.shutdown() }
     }
 
-    private func interrupt() async {
+    private func interrupt(_ stopped: TurnHandle.Stopped) async {
+        // Capture the stopped turn before persistence suspends. A new explicit send may install
+        // a different turn while the cancelled state is being saved; that turn is not this Stop's.
+        let target = stopped.turnID
+        let client = self.client
+        let threadID = self.threadID
         // Written here rather than left for the result to infer, which is what the `cancelled`
         // flag used to do at both of the sites below. `SessionLifecycle` refuses a stop on a
         // session with no turn open and ignores a result on one that has already been stopped, so
         // the two facts are stated once each instead of being recombined by a ternary twice.
-        if session.apply(.cancelled).moves { await save(session) }
-        guard let client, let threadID, let turnID = handle.turnID else { return }
-        try? await client.interruptTurn(threadID: threadID, turnID: turnID)
+        if handle.generation == stopped.generation, handle.wasCancelled,
+           session.apply(.cancelled).moves { await save(session) }
+        guard let client, let threadID, let target else { return }
+        try? await client.interruptTurn(threadID: threadID, turnID: target)
     }
 
     /// Answer one question, as a person. The turn resumes on the other side of this line.
@@ -511,6 +519,14 @@ public actor CodexRunner: SessionRunner {
                 break
             }
         }
+        let endingTurn: String? = switch event {
+        case .turnCompleted(let turn): turn.id
+        case .turnError(let failure) where !failure.willRetry: failure.turnID
+        default: nil
+        }
+        // Filter before forgetting item metadata too: an old completion must not erase the
+        // command or file details used to explain a question from the newer turn.
+        if let endingTurn, !handle.acceptsTerminal(turnID: endingTurn) { return }
         remember(event)
 
         if case .unknown(let method, let raw) = event, method == "serverRequest/resolved",
@@ -538,7 +554,7 @@ public actor CodexRunner: SessionRunner {
         }
 
         for translated in translation.translate(event) {
-            await emit(translated)
+            await emit(translated, endingTurn: endingTurn)
         }
     }
 
@@ -554,7 +570,7 @@ public actor CodexRunner: SessionRunner {
         }
     }
 
-    private func emit(_ event: AgentEvent) async {
+    private func emit(_ event: AgentEvent, endingTurn: String? = nil) async {
         if event.isTranscriptRow {
             await persist(
                 kind: event.kind,
@@ -562,6 +578,10 @@ public actor CodexRunner: SessionRunner {
                 refID: event.refID
             )
         }
+
+        // Persistence suspends too. A terminal row already written stays in the history, but a
+        // late event must not move the current lifecycle or announce completion to the window.
+        if let endingTurn, !handle.acceptsTerminal(turnID: endingTurn) { return }
 
         switch event {
         case .result(let result):
@@ -585,6 +605,7 @@ public actor CodexRunner: SessionRunner {
             break
         }
 
+        if let endingTurn, !handle.acceptsTerminal(turnID: endingTurn) { return }
         sink.yield(event)
     }
 
@@ -807,10 +828,16 @@ public actor CodexRunner: SessionRunner {
 /// `EventFanout` in `SessionRunner`: `@unchecked` is a promise the compiler cannot check, and
 /// the two fields below have to move together.
 private final class TurnHandle: Sendable {
+    struct Stopped: Sendable {
+        let generation: UInt64
+        let turnID: String?
+    }
+
     private struct State {
         var current: String?
         var cancelled = false
         var generation: UInt64 = 0
+        var replacement: UUID?
     }
 
     private let state = Mutex(State())
@@ -838,6 +865,30 @@ private final class TurnHandle: Sendable {
     var wasCancelled: Bool { state.withLock(\.cancelled) }
     var generation: UInt64 { state.withLock(\.generation) }
 
+    /// The old turn stops owning the busy state as soon as the owner asks for its replacement,
+    /// not only when the server eventually returns a new id.
+    func prepareReplacement() -> UUID? {
+        state.withLock {
+            guard $0.cancelled else { return nil }
+            let token = UUID()
+            $0.replacement = token
+            return token
+        }
+    }
+
+    func finishReplacement(_ token: UUID?) {
+        state.withLock {
+            if $0.replacement == token { $0.replacement = nil }
+        }
+    }
+
+    func acceptsTerminal(turnID: String) -> Bool {
+        state.withLock {
+            if $0.replacement != nil, $0.current == turnID { return false }
+            return $0.current == nil || $0.current == turnID
+        }
+    }
+
     func check(_ generation: UInt64) throws {
         guard state.withLock({ $0.generation == generation }) else { throw CancellationError() }
         try Task.checkCancellation()
@@ -848,16 +899,17 @@ private final class TurnHandle: Sendable {
             guard state.generation == generation else { return false }
             state.current = turnID
             state.cancelled = false
+            state.replacement = nil
             return true
         }
     }
 
     @discardableResult
-    func markCancelled() -> UInt64 {
+    func markCancelled() -> Stopped {
         state.withLock {
             $0.generation &+= 1
             $0.cancelled = true
-            return $0.generation
+            return Stopped(generation: $0.generation, turnID: $0.current)
         }
     }
 

--- a/Sources/BloomCore/Agent/Codex/CodexRunner.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexRunner.swift
@@ -59,7 +59,7 @@ public actor CodexRunner: SessionRunner {
     private let connection = LiveConnection()
 
     private let pending = PendingAsks()
-    private let handle = TurnHandle()
+    private let handle = CodexTurnHandle()
     private let sink = EventFanout<AgentEvent>()
 
     /// Whether this run has already been stopped because its transcript was deleted underneath
@@ -215,7 +215,7 @@ public actor CodexRunner: SessionRunner {
     /// Answered before the interrupt rather than after, for the reason `AgentRunner.cancelNow`
     /// gives: an answer written after the thing that closes the turn is an answer the model never
     /// receives.
-    private func stopTurn(_ stopped: TurnHandle.Stopped) async {
+    private func stopTurn(_ stopped: CodexTurnHandle.Stopped) async {
         if handle.generation == stopped.generation, handle.wasCancelled {
             await filePendingAsks()
         }
@@ -255,7 +255,7 @@ public actor CodexRunner: SessionRunner {
         Task { await self.shutdown() }
     }
 
-    private func interrupt(_ stopped: TurnHandle.Stopped) async {
+    private func interrupt(_ stopped: CodexTurnHandle.Stopped) async {
         // Capture the stopped turn before persistence suspends. A new explicit send may install
         // a different turn while the cancelled state is being saved; that turn is not this Stop's.
         let target = stopped.turnID
@@ -571,6 +571,7 @@ public actor CodexRunner: SessionRunner {
     }
 
     private func emit(_ event: AgentEvent, endingTurn: String? = nil) async {
+        let intent = handle.intent
         if event.isTranscriptRow {
             await persist(
                 kind: event.kind,
@@ -581,7 +582,7 @@ public actor CodexRunner: SessionRunner {
 
         // Persistence suspends too. A terminal row already written stays in the history, but a
         // late event must not move the current lifecycle or announce completion to the window.
-        if let endingTurn, !handle.acceptsTerminal(turnID: endingTurn) { return }
+        if let endingTurn, !handle.acceptsTerminal(turnID: endingTurn, intent: intent) { return }
 
         switch event {
         case .result(let result):
@@ -605,7 +606,7 @@ public actor CodexRunner: SessionRunner {
             break
         }
 
-        if let endingTurn, !handle.acceptsTerminal(turnID: endingTurn) { return }
+        if let endingTurn, !handle.acceptsTerminal(turnID: endingTurn, intent: intent) { return }
         sink.yield(event)
     }
 
@@ -817,106 +818,6 @@ public actor CodexRunner: SessionRunner {
     )
 }
 
-// MARK: - Turn handle
-
-/// What a turn is, from outside the actor.
-///
-/// Stop is pressed from synchronous main-actor code, and the actor at that moment is busy running
-/// the thing being stopped. The intent has to be recorded where it can be read without waiting.
-///
-/// `Mutex<State>` rather than `NSLock` plus `@unchecked Sendable`, for the reason given on
-/// `EventFanout` in `SessionRunner`: `@unchecked` is a promise the compiler cannot check, and
-/// the two fields below have to move together.
-private final class TurnHandle: Sendable {
-    struct Stopped: Sendable {
-        let generation: UInt64
-        let turnID: String?
-    }
-
-    private struct State {
-        var current: String?
-        var cancelled = false
-        var generation: UInt64 = 0
-        var replacement: UUID?
-    }
-
-    private let state = Mutex(State())
-
-    var turnID: String? { state.withLock(\.current) }
-
-    /// The turn a message may be **steered into**, which is one that is open and has not been
-    /// stopped.
-    ///
-    /// **A stopped turn keeps its id for a moment and is over all the same.** `end()` runs on the
-    /// `turn/completed` the interrupt produces, so between `cancelNow` and that notification
-    /// arriving `current` still names a turn nobody is running. Steering into it is the wrong call
-    /// whatever the server answers, and it cost the one thing Stop is for: the next message went
-    /// into the dead turn instead of starting a new one on the same connection, which is what
-    /// keeps the grants the person has already given. `CodexRunnerTests`
-    /// `stopInterruptsTheTurnAndLeavesTheServerRunning` is that bug written down, at one handshake
-    /// and two turns.
-    ///
-    /// Both fields under one lock, which is the whole reason this is a `Mutex<State>`: reading
-    /// them separately is two answers that can disagree about the same instant.
-    var steerableTurnID: String? {
-        state.withLock { $0.cancelled ? nil : $0.current }
-    }
-
-    var wasCancelled: Bool { state.withLock(\.cancelled) }
-    var generation: UInt64 { state.withLock(\.generation) }
-
-    /// The old turn stops owning the busy state as soon as the owner asks for its replacement,
-    /// not only when the server eventually returns a new id.
-    func prepareReplacement() -> UUID? {
-        state.withLock {
-            guard $0.cancelled else { return nil }
-            let token = UUID()
-            $0.replacement = token
-            return token
-        }
-    }
-
-    func finishReplacement(_ token: UUID?) {
-        state.withLock {
-            if $0.replacement == token { $0.replacement = nil }
-        }
-    }
-
-    func acceptsTerminal(turnID: String) -> Bool {
-        state.withLock {
-            if $0.replacement != nil, $0.current == turnID { return false }
-            return $0.current == nil || $0.current == turnID
-        }
-    }
-
-    func check(_ generation: UInt64) throws {
-        guard state.withLock({ $0.generation == generation }) else { throw CancellationError() }
-        try Task.checkCancellation()
-    }
-
-    func begin(turnID: String, generation: UInt64) -> Bool {
-        state.withLock { state in
-            guard state.generation == generation else { return false }
-            state.current = turnID
-            state.cancelled = false
-            state.replacement = nil
-            return true
-        }
-    }
-
-    @discardableResult
-    func markCancelled() -> Stopped {
-        state.withLock {
-            $0.generation &+= 1
-            $0.cancelled = true
-            return Stopped(generation: $0.generation, turnID: $0.current)
-        }
-    }
-
-    func end() {
-        state.withLock { $0.current = nil }
-    }
-}
 
 /// The live connection, where synchronous code can reach it. See `CodexRunner.terminateNow`.
 private final class LiveConnection: Sendable {

--- a/Sources/BloomCore/Agent/Codex/CodexTurnHandle.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexTurnHandle.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Synchronization
+
+/// What a turn is, from outside the actor.
+///
+/// Stop is pressed from synchronous main-actor code, and the actor at that moment is busy running
+/// the thing being stopped. The intent has to be recorded where it can be read without waiting.
+///
+/// `Mutex<State>` rather than `NSLock` plus `@unchecked Sendable`, for the reason given on
+/// `EventFanout` in `SessionRunner`: `@unchecked` is a promise the compiler cannot check, and
+/// the two fields below have to move together.
+final class CodexTurnHandle: Sendable {
+    struct Stopped: Sendable {
+        let generation: UInt64
+        let turnID: String?
+    }
+
+    private struct State {
+        var current: String?
+        var lastTurnID: String?
+        var cancelled = false
+        var generation: UInt64 = 0
+        var replacement: UUID?
+        var intent = UUID()
+    }
+
+    private let state = Mutex(State())
+
+    var turnID: String? { state.withLock(\.current) }
+
+    /// The turn a message may be **steered into**, which is one that is open and has not been
+    /// stopped.
+    ///
+    /// **A stopped turn keeps its id for a moment and is over all the same.** `end()` runs on the
+    /// `turn/completed` the interrupt produces, so between `cancelNow` and that notification
+    /// arriving `current` still names a turn nobody is running. Steering into it is the wrong call
+    /// whatever the server answers, and it cost the one thing Stop is for: the next message went
+    /// into the dead turn instead of starting a new one on the same connection, which is what
+    /// keeps the grants the person has already given. `CodexRunnerTests`
+    /// `stopInterruptsTheTurnAndLeavesTheServerRunning` is that bug written down, at one handshake
+    /// and two turns.
+    ///
+    /// Both fields under one lock, which is the whole reason this is a `Mutex<State>`: reading
+    /// them separately is two answers that can disagree about the same instant.
+    var steerableTurnID: String? {
+        state.withLock { $0.cancelled ? nil : $0.current }
+    }
+
+    var wasCancelled: Bool { state.withLock(\.cancelled) }
+    var generation: UInt64 { state.withLock(\.generation) }
+    var intent: UUID { state.withLock(\.intent) }
+
+    /// The old turn stops owning the busy state as soon as the owner asks for its replacement,
+    /// not only when the server eventually returns a new id.
+    func prepareReplacement() -> UUID? {
+        state.withLock {
+            guard $0.cancelled || $0.current == nil else { return nil }
+            let token = UUID()
+            $0.replacement = token
+            $0.intent = token
+            return token
+        }
+    }
+
+    func finishReplacement(_ token: UUID?) {
+        state.withLock {
+            if $0.replacement == token { $0.replacement = nil }
+        }
+    }
+
+    func acceptsTerminal(turnID: String, intent: UUID? = nil) -> Bool {
+        state.withLock {
+            if let intent, intent != $0.intent { return false }
+            if $0.replacement != nil, $0.lastTurnID == turnID { return false }
+            return $0.current == nil || $0.current == turnID
+        }
+    }
+
+    func check(_ generation: UInt64) throws {
+        guard state.withLock({ $0.generation == generation }) else { throw CancellationError() }
+        try Task.checkCancellation()
+    }
+
+    func begin(turnID: String, generation: UInt64) -> Bool {
+        state.withLock { state in
+            guard state.generation == generation else { return false }
+            state.current = turnID
+            state.lastTurnID = turnID
+            state.cancelled = false
+            state.replacement = nil
+            return true
+        }
+    }
+
+    @discardableResult
+    func markCancelled() -> Stopped {
+        state.withLock {
+            $0.generation &+= 1
+            $0.cancelled = true
+            return Stopped(generation: $0.generation, turnID: $0.current)
+        }
+    }
+
+    func end() {
+        state.withLock { $0.current = nil }
+    }
+}

--- a/Sources/BloomCore/Agent/ComposerControls.swift
+++ b/Sources/BloomCore/Agent/ComposerControls.swift
@@ -226,17 +226,15 @@ public struct ComposerControls: Equatable, Sendable {
     /// never asked and one that was asked and said no read back the same. `AgentRunner` and
     /// `CodexRunner` treat them the same too, which is what keeps the two ends from disagreeing.
     public func store(sessionID: SessionID, in store: Store) async {
-        try? await store.setSetting(
-            Self.fastModeKey(sessionID: sessionID), isFastMode ? "1" : nil
-        )
-        try? await store.setSetting(
-            Self.outputStyleKey(sessionID: sessionID),
-            OutputStyle.isDefault(outputStyle) ? nil : outputStyle
-        )
-        try? await store.setSetting(
-            Self.contextWindowKey(sessionID: sessionID),
-            CodexContextWindow.stored(codexContextWindow)
-        )
-        try? await store.setSetting(Self.defaultsAppliedKey(sessionID: sessionID), "1")
+        try? await store.saveComposerControls(self, sessionID: sessionID)
+    }
+
+    func settings(sessionID: SessionID) -> [(String, String?)] {
+        [
+            (Self.fastModeKey(sessionID: sessionID), isFastMode ? "1" : nil),
+            (Self.outputStyleKey(sessionID: sessionID), OutputStyle.isDefault(outputStyle) ? nil : outputStyle),
+            (Self.contextWindowKey(sessionID: sessionID), CodexContextWindow.stored(codexContextWindow)),
+            (Self.defaultsAppliedKey(sessionID: sessionID), "1"),
+        ]
     }
 }

--- a/Sources/BloomCore/Bridge/BridgeServer.swift
+++ b/Sources/BloomCore/Bridge/BridgeServer.swift
@@ -298,13 +298,16 @@ public final class BridgeServer: Sendable {
             connection.close()
             return
         }
-        guard let identity = await handshake(opening, on: connection) else {
+        guard let hello = await handshake(opening, on: connection) else {
             connection.close()
             return
         }
 
-        let dispatch = BridgeDispatch(store: store, identity: identity, toolbox: toolbox)
         while let line = await iterator.next() {
+            // A handshake does not grant authority for the lifetime of a socket. Rotation and
+            // retirement must also revoke clients that were already connected.
+            guard let identity = registry.identity(forToken: hello.token) else { break }
+            let dispatch = BridgeDispatch(store: store, identity: identity, toolbox: toolbox)
             if let reply = await dispatch.respond(to: line) {
                 connection.writeLine(reply)
             }
@@ -318,7 +321,7 @@ public final class BridgeServer: Sendable {
     /// running Bloom is told about the version rather than about an unknown token, which is what
     /// it would otherwise look like: the token really would be unknown, because it was minted by
     /// the other copy.
-    private func handshake(_ line: String, on connection: UnixSocketConnection) async -> BridgeIdentity? {
+    private func handshake(_ line: String, on connection: UnixSocketConnection) async -> BridgeHello? {
         guard let data = line.data(using: .utf8),
               let hello = try? JSONDecoder().decode(BridgeHello.self, from: data)
         else {
@@ -344,7 +347,7 @@ public final class BridgeServer: Sendable {
             note("bridge caller claimed role \(hello.role) and is \(identity.role.rawValue)")
         }
         connection.writeLine(encode(BridgeWelcome.accepting()))
-        return identity
+        return hello
     }
 
     private func refuse(_ problem: String, on connection: UnixSocketConnection) {

--- a/Sources/BloomCore/Persistence/SQLite.swift
+++ b/Sources/BloomCore/Persistence/SQLite.swift
@@ -14,7 +14,7 @@ enum SQLValue: Sendable, Equatable {
     var intValue: Int64? {
         switch self {
         case .int(let value): value
-        case .double(let value): Int64(value)
+        case .double(let value): Int64(exactly: value.rounded(.towardZero))
         case .text(let value): Int64(value)
         default: nil
         }
@@ -228,10 +228,17 @@ final class SQLiteDatabase: @unchecked Sendable {
             case .null: sqlite3_bind_null(statement, index)
             case .int(let v): sqlite3_bind_int64(statement, index, v)
             case .double(let v): sqlite3_bind_double(statement, index, v)
-            case .text(let v): sqlite3_bind_text(statement, index, v, -1, sqliteTransient)
-            case .blob(let v): v.withUnsafeBytes {
-                sqlite3_bind_blob(statement, index, $0.baseAddress, Int32(v.count), sqliteTransient)
+            case .text(let v): v.withCString {
+                sqlite3_bind_text64(statement, index, $0, UInt64(v.utf8.count), sqliteTransient, UInt8(SQLITE_UTF8))
             }
+            case .blob(let v):
+                if v.isEmpty {
+                    sqlite3_bind_zeroblob(statement, index, 0)
+                } else {
+                    v.withUnsafeBytes {
+                        sqlite3_bind_blob64(statement, index, $0.baseAddress, UInt64(v.count), sqliteTransient)
+                    }
+                }
             }
             guard status == SQLITE_OK else {
                 sqlite3_finalize(statement)
@@ -245,12 +252,16 @@ final class SQLiteDatabase: @unchecked Sendable {
         switch sqlite3_column_type(statement, index) {
         case SQLITE_INTEGER: .int(sqlite3_column_int64(statement, index))
         case SQLITE_FLOAT: .double(sqlite3_column_double(statement, index))
-        case SQLITE_TEXT: .text(String(cString: sqlite3_column_text(statement, index)))
+        case SQLITE_TEXT:
+            .text(String(decoding: UnsafeBufferPointer(
+                start: sqlite3_column_text(statement, index),
+                count: Int(sqlite3_column_bytes(statement, index))
+            ), as: UTF8.self))
         case SQLITE_BLOB:
             if let bytes = sqlite3_column_blob(statement, index) {
                 .blob(Data(bytes: bytes, count: Int(sqlite3_column_bytes(statement, index))))
             } else {
-                .null
+                .blob(Data())
             }
         default: .null
         }
@@ -311,8 +322,17 @@ final class SQLiteDatabase: @unchecked Sendable {
         }
     }
 
-    var userVersion: Int32 {
-        get { (try? query("PRAGMA user_version;").first?.int("user_version")).flatMap { $0 }.map(Int32.init) ?? 0 }
-        set { try? execute("PRAGMA user_version = \(newValue);") }
+    var changedRowCount: Int { Int(sqlite3_changes(handle)) }
+
+    func readUserVersion() throws -> Int32 {
+        guard let value = try query("PRAGMA user_version;").first?.int("user_version"),
+              let version = Int32(exactly: value) else {
+            throw SQLiteError(message: "Could not read the database schema version", sql: nil)
+        }
+        return version
+    }
+
+    func setUserVersion(_ version: Int32) throws {
+        try execute("PRAGMA user_version = \(version);")
     }
 }

--- a/Sources/BloomCore/Persistence/Store.swift
+++ b/Sources/BloomCore/Persistence/Store.swift
@@ -985,7 +985,10 @@ public actor Store {
             },
         ]
 
-        let current = Int(db.userVersion)
+        let current = Int(try db.readUserVersion())
+        guard current >= 0, current <= migrations.count else {
+            throw SQLiteError(message: "Unsupported database schema version \(current)", sql: nil)
+        }
 
         // Before the version is trusted, and whatever it says. See `repairSchema`: a database
         // stamped as fully migrated with a column missing is a real state that a real machine
@@ -1011,7 +1014,7 @@ public actor Store {
             for index in current..<migrations.count {
                 try migrations[index](db)
             }
-            db.userVersion = Int32(migrations.count)
+            try db.setUserVersion(Int32(migrations.count))
         }
     }
 
@@ -2478,6 +2481,19 @@ public actor Store {
 
     // MARK: - Deliveries
 
+    /// Queue acceptance and draft removal either both commit or neither does. A newer saved
+    /// draft belongs to the next message and must survive an earlier submission completing.
+    @discardableResult
+    public func enqueueDelivery(_ delivery: Delivery, clearingDraftMatching draft: String?) throws -> Delivery {
+        try db.transaction {
+            let queued = try enqueueDelivery(delivery)
+            if let draft, try self.draft(sessionID: delivery.targetSessionID) == draft {
+                try saveDraft(sessionID: delivery.targetSessionID, body: "")
+            }
+            return queued
+        }
+    }
+
     /// Everything asked for on this session that has not gone yet, oldest first.
     ///
     /// `created_at, rowid` and not `created_at` alone. The opening prompt and a sentence typed
@@ -2532,11 +2548,13 @@ public actor Store {
     /// `seq` is what the delivery became in the `messages` table where the caller knows it, which
     /// the owner's own path does not: the runner writes that row as part of starting the turn.
     /// See `Delivery.deliveredSeq`.
-    public func markDelivered(id: DeliveryID, seq: Int? = nil, at date: Date = Date()) throws {
+    @discardableResult
+    public func markDelivered(id: DeliveryID, seq: Int? = nil, at date: Date = Date()) throws -> Bool {
         try db.run(
-            "UPDATE deliveries SET delivered_at = ?, delivered_seq = ? WHERE id = ?",
+            "UPDATE deliveries SET delivered_at = ?, delivered_seq = ? WHERE id = ? AND delivered_at IS NULL",
             [.double(date.timeIntervalSince1970), seq.map { .int(Int64($0)) } ?? .null, .text(id)]
         )
+        return db.changedRowCount == 1
     }
 
     /// Takes one back out of the queue, because whoever asked for it changed their mind.
@@ -2555,12 +2573,8 @@ public actor Store {
     /// in the gap, because there is no gap.
     @discardableResult
     public func cancelDelivery(id: DeliveryID) throws -> Bool {
-        let pending = try db.query(
-            "SELECT id FROM deliveries WHERE id = ? AND delivered_at IS NULL", [.text(id)]
-        )
-        guard !pending.isEmpty else { return false }
         try db.run("DELETE FROM deliveries WHERE id = ? AND delivered_at IS NULL", [.text(id)])
-        return true
+        return db.changedRowCount == 1
     }
 
     /// Puts one back in the queue after a send that never started a turn.
@@ -2924,6 +2938,39 @@ public actor Store {
 
     public func setting(_ key: String) throws -> String? {
         try db.query("SELECT value FROM settings WHERE key = ?", [.text(key)]).first?.string("value")
+    }
+
+    public func saveComposerControls(_ controls: ComposerControls, sessionID: SessionID) throws {
+        try db.transaction {
+            for (key, value) in controls.settings(sessionID: sessionID) {
+                try setSetting(key, value)
+            }
+        }
+    }
+
+    /// Archive and replacement are one commit. A failed insert, preference or draft write must
+    /// leave the original conversation reachable, and a second caller must not replace it twice.
+    public func replaceAskConversation(
+        id: SessionID, controls: ComposerControls, draft: String = ""
+    ) throws -> Session {
+        try db.transaction {
+            guard let current = try session(id: id), current.workspaceID == nil,
+                  current.archivedAt == nil else {
+                throw SQLiteError(message: "This conversation is no longer current.", sql: nil)
+            }
+            var next = AskConversation.newSession()
+            next.model = controls.model
+            next.effort = controls.effort
+            next.agentKind = controls.agentKind
+            next.permissionMode = controls.permissionMode
+            try upsert(next)
+            for (key, value) in controls.settings(sessionID: next.id) {
+                try setSetting(key, value)
+            }
+            try saveDraft(sessionID: next.id, body: draft)
+            _ = try update(sessionID: id) { $0.archivedAt = Date() }
+            return next
+        }
     }
 
     public func setSetting(_ key: String, _ value: String?) throws {

--- a/Sources/BloomCore/System/ContainedPath.swift
+++ b/Sources/BloomCore/System/ContainedPath.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Filesystem containment, not just a lexical prefix: a symlink must not widen a worktree's access.
+public enum ContainedPath {
+    public static func resolve(_ url: URL, inside root: URL) -> URL? {
+        let base = root.standardizedFileURL.resolvingSymlinksInPath()
+        let candidate = url.standardizedFileURL.resolvingSymlinksInPath()
+        let prefix = base.path.hasSuffix("/") ? base.path : base.path + "/"
+        return candidate.path.hasPrefix(prefix) ? candidate : nil
+    }
+
+    static func relative(_ path: String, inside root: String, forWriting: Bool = false) -> URL? {
+        guard !path.isEmpty, !(path as NSString).isAbsolutePath,
+              !path.split(separator: "/").contains("..") else { return nil }
+        let base = URL(filePath: root, directoryHint: .isDirectory).resolvingSymlinksInPath()
+        if forWriting {
+            // Refuse even an in-root destination symlink. Copying must never overwrite a second
+            // path the branch author chose in place of the configured destination.
+            var component = base
+            for part in path.split(separator: "/") {
+                component.append(path: String(part))
+                if (try? FileManager.default.destinationOfSymbolicLink(atPath: component.path)) != nil {
+                    return nil
+                }
+            }
+        }
+        return resolve(base.appending(path: path), inside: base)
+    }
+}

--- a/Sources/BloomCore/System/LocalPage.swift
+++ b/Sources/BloomCore/System/LocalPage.swift
@@ -82,11 +82,8 @@ public enum LocalPage {
         else { return nil }
 
         // The separator goes on before the comparison, so a worktree at `/w/bloom` cannot claim
-        // the file at `/w/bloom-old/index.html`. Standardised on both sides so that a `..` in the
-        // middle of the address is resolved before it is compared rather than after it is loaded.
-        let base = URL(filePath: root, directoryHint: .isDirectory).standardizedFileURL.path
-        let prefix = base.hasSuffix("/") ? base : base + "/"
-        guard url.standardizedFileURL.path.hasPrefix(prefix) else { return nil }
-        return url
+        // the file at `/w/bloom-old/index.html`. Canonical paths also keep a symlink inside the
+        // worktree from granting browser access to a page outside it.
+        return ContainedPath.resolve(url, inside: URL(filePath: root, directoryHint: .isDirectory))
     }
 }

--- a/Sources/BloomCore/Transcript/DeliveryDrainState.swift
+++ b/Sources/BloomCore/Transcript/DeliveryDrainState.swift
@@ -1,0 +1,21 @@
+/// Coalesces requests made while a delivery awaits its runner, without allowing two senders.
+public enum DeliveryDrainState: Sendable {
+    case idle
+    case active
+    case requested
+
+    public mutating func begin() -> Bool {
+        guard case .idle = self else {
+            self = .requested
+            return false
+        }
+        self = .active
+        return true
+    }
+
+    public mutating func finish() -> Bool {
+        let again = self == .requested
+        self = .idle
+        return again
+    }
+}

--- a/Sources/BloomCore/Transcript/DeliveryDrainState.swift
+++ b/Sources/BloomCore/Transcript/DeliveryDrainState.swift
@@ -13,8 +13,8 @@ public enum DeliveryDrainState: Sendable {
         return true
     }
 
-    public mutating func finish() -> Bool {
-        let again = self == .requested
+    public mutating func finish(allowRepeat: Bool = true) -> Bool {
+        let again = self == .requested && allowRepeat
         self = .idle
         return again
     }

--- a/Sources/BloomCore/Workspace/FilesToCopyPlan.swift
+++ b/Sources/BloomCore/Workspace/FilesToCopyPlan.swift
@@ -7,9 +7,8 @@ import Foundation
 /// shows up much later as a workspace that will not boot. Resolving it while the pattern is being
 /// typed turns the field into something that can be checked.
 ///
-/// Deliberately a mirror of `WorkspaceManager.copyFiles` rather than a better matcher. A preview
-/// that resolved more cleverly than the copier would be a lie in the opposite direction, so
-/// `filesToCopyMatchesTheCopier` in the test suite pins the two together against the real thing.
+/// The copier consumes this same plan, so preview and execution share matching and source-path
+/// containment. The copier additionally checks destination paths before writing.
 public struct FilesToCopyPlan: Sendable, Hashable {
     public struct Match: Sendable, Hashable, Identifiable {
         /// Relative to the repository root, which is how the pattern is written.
@@ -77,9 +76,20 @@ public enum FilesToCopyResolver {
 
             let directory = (trimmed as NSString).deletingLastPathComponent
             let filePattern = (trimmed as NSString).lastPathComponent
-            let searchDirectory = directory.isEmpty
-                ? repo
-                : (repo as NSString).appendingPathComponent(directory)
+            guard !(trimmed as NSString).isAbsolutePath,
+                  !trimmed.split(separator: "/").contains("..") else {
+                plan.unmatchedPatterns.append(trimmed)
+                continue
+            }
+            let searchDirectory: String
+            if directory.isEmpty || directory == "." {
+                searchDirectory = repo
+            } else if let contained = ContainedPath.relative(directory, inside: repo) {
+                searchDirectory = contained.path
+            } else {
+                plan.unmatchedPatterns.append(trimmed)
+                continue
+            }
 
             guard let entries = try? manager.contentsOfDirectory(atPath: searchDirectory) else {
                 plan.unmatchedPatterns.append(trimmed)
@@ -89,7 +99,7 @@ public enum FilesToCopyResolver {
             var matchedAnything = false
             for entry in entries where matches(entry, pattern: filePattern) {
                 let relative = directory.isEmpty ? entry : "\(directory)/\(entry)"
-                let absolute = (searchDirectory as NSString).appendingPathComponent(entry)
+                guard let absolute = ContainedPath.relative(relative, inside: repo)?.path else { continue }
 
                 var entryIsDirectory: ObjCBool = false
                 guard manager.fileExists(atPath: absolute, isDirectory: &entryIsDirectory) else { continue }

--- a/Sources/BloomCore/Workspace/WorkspaceManager.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceManager.swift
@@ -355,46 +355,15 @@ public struct WorkspaceManager: Sendable {
     /// Copies glob patterns like `.env*` from the main checkout into a fresh worktree.
     func copyFiles(_ patterns: [String], from source: String, to destination: String) throws {
         let manager = FileManager.default
-        for pattern in patterns {
-            let directory = (pattern as NSString).deletingLastPathComponent
-            let filePattern = (pattern as NSString).lastPathComponent
-            let searchDirectory = directory.isEmpty
-                ? source
-                : (source as NSString).appendingPathComponent(directory)
-
-            guard let entries = try? manager.contentsOfDirectory(atPath: searchDirectory) else { continue }
-
-            for entry in entries where matches(entry, pattern: filePattern) {
-                let from = (searchDirectory as NSString).appendingPathComponent(entry)
-                let relative = directory.isEmpty ? entry : "\(directory)/\(entry)"
-                let to = (destination as NSString).appendingPathComponent(relative)
-
-                var isDirectory: ObjCBool = false
-                guard manager.fileExists(atPath: from, isDirectory: &isDirectory), !isDirectory.boolValue else {
-                    continue
-                }
-                if manager.fileExists(atPath: to) { continue }
-
-                try? manager.createDirectory(
-                    atPath: (to as NSString).deletingLastPathComponent,
-                    withIntermediateDirectories: true
-                )
-                try? manager.copyItem(atPath: from, toPath: to)
-            }
+        let plan = FilesToCopyResolver.resolve(patterns: patterns, in: source, limit: .max)
+        for match in plan.matches where !match.isDirectory {
+            guard let from = ContainedPath.relative(match.path, inside: source),
+                  let to = ContainedPath.relative(match.path, inside: destination, forWriting: true)
+            else { continue }
+            if manager.fileExists(atPath: to.path) { continue }
+            try manager.createDirectory(at: to.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try manager.copyItem(at: from, to: to)
         }
-    }
-
-    /// What a `files_to_copy` pattern matches, asked of the one place that answers it.
-    ///
-    /// These three lines were here as well as in `FilesToCopyResolver`, whose doc calls itself a
-    /// deliberate mirror of this method. A mirror is the right shape for the walk, because the
-    /// preview runs on every keystroke and must not write anything, and it is the wrong shape for
-    /// the predicate: two `fnmatch` calls that have to agree about what `.env*` means are two
-    /// places a wildcard rule can be changed in. The behavioural test still runs the real copier
-    /// against a real folder and compares what landed with what the preview named, so the walk is
-    /// pinned the way it was; this half no longer needs pinning because there is only one of it.
-    func matches(_ name: String, pattern: String) -> Bool {
-        FilesToCopyResolver.matches(name, pattern: pattern)
     }
 
     // MARK: - Scripts

--- a/Tests/BloomCoreTests/AuditPersistenceTests.swift
+++ b/Tests/BloomCoreTests/AuditPersistenceTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite(.scratchDirectory)
+struct AuditPersistenceTests {
+    @Test func sqlitePreservesNulTextAndEmptyBlobs() throws {
+        let db = try SQLiteDatabase(path: ":memory:")
+        let text = "before\0after 🌱"
+        let row = try #require(db.query("SELECT ? AS text, ? AS blob, ? AS missing", [
+            .text(text), .blob(Data()), .null,
+        ]).first)
+        #expect(row.string("text") == text)
+        #expect(row.data("blob") == Data())
+        #expect(row.data("missing") == nil)
+    }
+
+    @Test(arguments: [Double.nan, Double.infinity, -Double.infinity, Double(Int64.max)])
+    func unrepresentableIntegersDoNotTrap(_ value: Double) {
+        #expect(SQLValue.double(value).intValue == nil)
+        #expect(SQLValue.double(-1.9).intValue == -1)
+    }
+
+    @Test(arguments: [Int32(-1), Int32.max])
+    func unsupportedSchemaIsNotRepaired(_ version: Int32) throws {
+        let path = TestScratch.unique("schema.sqlite")
+        let raw = try SQLiteDatabase(path: path)
+        try raw.setUserVersion(version)
+        #expect(throws: SQLiteError.self) { try Store(path: path) }
+        #expect(try raw.readUserVersion() == version)
+        #expect(try raw.query("SELECT name FROM sqlite_master WHERE type = 'table'").isEmpty)
+    }
+
+    @Test func aDeliveryHasOnlyOneClaimantAndDiscardWinsBeforeClaim() async throws {
+        let store = try makeTestStore("claim")
+        let session = try await store.upsert(AskConversation.newSession())
+        let delivery = try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "hello"))
+        async let first = store.markDelivered(id: delivery.id)
+        async let second = store.markDelivered(id: delivery.id)
+        let results = try await [first, second]
+        #expect(results.filter { $0 }.count == 1)
+        let cancelledAfter = try await store.cancelDelivery(id: delivery.id)
+        #expect(!cancelledAfter)
+        let other = try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "discard"))
+        let cancelled = try await store.cancelDelivery(id: other.id)
+        let claimed = try await store.markDelivered(id: other.id)
+        #expect(cancelled)
+        #expect(!claimed)
+    }
+
+    @Test func failedClaimLeavesTheMessagePending() async throws {
+        let store = try makeTestStore("failed-claim")
+        let session = try await store.upsert(AskConversation.newSession())
+        let delivery = try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "hello"))
+        let raw = try SQLiteDatabase(path: store.path)
+        try raw.execute("CREATE TRIGGER refuse_claim BEFORE UPDATE ON deliveries BEGIN SELECT RAISE(ABORT, 'disk full'); END")
+        await #expect(throws: SQLiteError.self) { try await store.markDelivered(id: delivery.id) }
+        #expect(try await store.pendingDeliveries(sessionID: session.id).map(\.id) == [delivery.id])
+    }
+
+    @Test(arguments: ["INSERT ON deliveries", "DELETE ON drafts"])
+    func enqueueAndDraftClearRollBackTogether(_ write: String) async throws {
+        let store = try makeTestStore("enqueue-rollback")
+        let session = try await store.upsert(AskConversation.newSession())
+        try await store.saveDraft(sessionID: session.id, body: "my draft")
+        let raw = try SQLiteDatabase(path: store.path)
+        try raw.execute("CREATE TRIGGER refuse_write BEFORE \(write) BEGIN SELECT RAISE(ABORT, 'disk full'); END")
+        let delivery = Delivery(targetSessionID: session.id, body: "my draft")
+        await #expect(throws: SQLiteError.self) {
+            try await store.enqueueDelivery(delivery, clearingDraftMatching: "my draft")
+        }
+        #expect(try await store.draft(sessionID: session.id) == "my draft")
+        #expect(try await store.pendingDeliveries(sessionID: session.id).isEmpty)
+    }
+
+    @Test func enqueueNeverClearsANewerOrUnrelatedDraft() async throws {
+        let store = try makeTestStore("enqueue-draft")
+        let session = try await store.upsert(AskConversation.newSession())
+        try await store.saveDraft(sessionID: session.id, body: "newer")
+        try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "old"), clearingDraftMatching: "old")
+        #expect(try await store.draft(sessionID: session.id) == "newer")
+        try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "merge"), clearingDraftMatching: nil)
+        #expect(try await store.draft(sessionID: session.id) == "newer")
+        try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "newer"), clearingDraftMatching: "newer")
+        #expect(try await store.draft(sessionID: session.id).isEmpty)
+    }
+
+    @Test(arguments: ["INSERT ON sessions", "INSERT ON settings", "INSERT ON drafts", "UPDATE ON sessions"])
+    func freshConversationRollsBackEveryWrite(_ write: String) async throws {
+        let store = try makeTestStore("ask-rollback")
+        let session = try await store.upsert(AskConversation.newSession())
+        try await store.saveDraft(sessionID: session.id, body: "original")
+        let raw = try SQLiteDatabase(path: store.path)
+        try raw.execute("CREATE TRIGGER refuse_write BEFORE \(write) BEGIN SELECT RAISE(ABORT, 'disk full'); END")
+        await #expect(throws: SQLiteError.self) {
+            try await store.replaceAskConversation(id: session.id, controls: ComposerControls(isFastMode: true), draft: "carried")
+        }
+        #expect(try await store.sessionsWithoutWorkspace().map(\.id) == [session.id])
+        #expect(try await store.draft(sessionID: session.id) == "original")
+        #expect(try raw.query("SELECT * FROM sessions").count == 1)
+        #expect(try raw.query("SELECT * FROM settings WHERE key LIKE 'session.%'").isEmpty)
+    }
+
+    @Test func freshConversationCommitsOnceWithControlsAndDraft() async throws {
+        let store = try makeTestStore("ask-replace")
+        let session = try await store.upsert(AskConversation.newSession())
+        let controls = ComposerControls(isFastMode: true)
+        let next = try await store.replaceAskConversation(id: session.id, controls: controls, draft: "carried")
+        #expect(try await store.session(id: session.id)?.archivedAt != nil)
+        #expect(try await store.sessionsWithoutWorkspace().map(\.id) == [next.id])
+        #expect(try await store.draft(sessionID: next.id) == "carried")
+        #expect(try await store.setting(ComposerControls.fastModeKey(sessionID: next.id)) == "1")
+        await #expect(throws: SQLiteError.self) {
+            try await store.replaceAskConversation(id: session.id, controls: controls)
+        }
+    }
+
+    @Test func overlappingDrainsCoalesceUntilTheOwnerFinishes() {
+        var state = DeliveryDrainState.idle
+        let first = state.begin()
+        let second = state.begin()
+        let third = state.begin()
+        let again = state.finish()
+        let next = state.begin()
+        let finished = state.finish()
+        #expect(first && !second && !third && again && next && !finished)
+    }
+}

--- a/Tests/BloomCoreTests/AuditPersistenceTests.swift
+++ b/Tests/BloomCoreTests/AuditPersistenceTests.swift
@@ -125,4 +125,13 @@ struct AuditPersistenceTests {
         let finished = state.finish()
         #expect(first && !second && !third && again && next && !finished)
     }
+
+    @Test func aFailedDrainDoesNotAutomaticallyRetryCoalescedSubmissions() {
+        var state = DeliveryDrainState.idle
+        let first = state.begin()
+        let overlapping = state.begin()
+        let repeatAfterFailure = state.finish(allowRepeat: false)
+        let explicitRetry = state.begin()
+        #expect(first && !overlapping && !repeatAfterFailure && explicitRetry)
+    }
 }

--- a/Tests/BloomCoreTests/BridgeServerTests.swift
+++ b/Tests/BloomCoreTests/BridgeServerTests.swift
@@ -11,6 +11,26 @@ import Testing
 /// config file can say whether the flags are right. That is `LiveBridgeTests`.
 @Suite("BridgeServer", .tags(.subprocess, .persistence), .scratchDirectory)
 struct BridgeServerTests {
+    @Test(arguments: [false, true])
+    func revocationClosesAlreadyAuthenticatedClients(owner: Bool) async throws {
+        let (server, sessionToken, _, session) = try await makeBridge()
+        defer { server.stop() }
+        let token = owner ? "test-owner-token" : sessionToken
+        if owner { server.registry.admit(ownerToken: token) }
+        var caller = try Caller(socketPath: server.socketPath)
+        let welcome = try await caller.hello(BridgeHello(token: token, role: owner ? "owner" : "parent", shim: "test"))
+        #expect(welcome.accepted)
+        _ = try await caller.call(#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#)
+        if owner {
+            server.registry.admit(ownerToken: "replacement-owner-token")
+        } else {
+            server.retire(sessionID: session.id)
+        }
+        caller.connection.writeLine(#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#)
+        let reply = await caller.iterator.next()
+        #expect(reply == nil)
+    }
+
     /// A store holding one project, one workspace and one chat, and a server listening for it.
     private func makeBridge(
         origin: WorkspaceOrigin = .user

--- a/Tests/BloomCoreTests/CodexRunnerTests.swift
+++ b/Tests/BloomCoreTests/CodexRunnerTests.swift
@@ -59,8 +59,8 @@ private let turnStartReply = JSONValue.object([
     ]),
 ])
 
-private func scriptedBox() -> ProcessBox {
-    let box = ProcessBox()
+private func scriptedBox(onWrite: @escaping @Sendable (String) -> Void = { _ in }) -> ProcessBox {
+    let box = ProcessBox(onWrite: onWrite)
     box.reply(to: "thread/start", with: threadStartReply)
     box.reply(to: "thread/resume", with: threadStartReply)
     box.reply(to: "turn/start", with: turnStartReply)
@@ -136,14 +136,19 @@ private func eventually(
         await runner.shutdown()
     }
 
-    @Test(arguments: ["initialize", "thread/start", "turn/start"])
+    @Test(.timeLimit(.minutes(1)), arguments: ["initialize", "thread/start", "turn/start"])
     func stopWhileStartingCannotBeLost(_ delayed: String) async throws {
         let store = try makeTestStore("codex-start-stop")
         let (session, _) = try await makeCodexSession(store)
-        let box = scriptedBox()
+        // Buffer the request itself: a polling deadline can expire before the send task is
+        // scheduled when the full suite is running thousands of tests concurrently.
+        let (requests, requestSink) = AsyncStream<String>.makeStream()
+        defer { requestSink.finish() }
+        let box = scriptedBox { requestSink.yield($0) }
         box.ignore(delayed)
         let runner = makeRunner(store: store, session: session, box: box)
         let sending = Task {
+            defer { requestSink.finish() }
             do {
                 try await runner.send("do not run after Stop")
                 Issue.record("a cancelled send returned success")
@@ -153,10 +158,8 @@ private func eventually(
                 Issue.record("unexpected send error: \(error)")
             }
         }
-        await eventually("delayed request", within: 20) {
-            box.processes.first?.sentMethods.contains(delayed) == true
-        }
-        let request = try #require(box.process.sentFrame { $0["method"]?.stringValue == delayed })
+        let frame = await requests.first { JSONValue.parse($0)?["method"]?.stringValue == delayed }
+        let request = try #require(frame.flatMap(JSONValue.parse))
         let id = try #require(request["id"])
         runner.cancelNow()
         let reply: JSONValue = switch delayed {

--- a/Tests/BloomCoreTests/CodexRunnerTests.swift
+++ b/Tests/BloomCoreTests/CodexRunnerTests.swift
@@ -84,6 +84,49 @@ private func eventually(
 // MARK: - Tests
 
 @Suite(.scratchDirectory) struct CodexRunnerTests {
+    @Test(arguments: ["initialize", "thread/start", "turn/start"])
+    func stopWhileStartingCannotBeLost(_ delayed: String) async throws {
+        let store = try makeTestStore("codex-start-stop")
+        let (session, _) = try await makeCodexSession(store)
+        let box = scriptedBox()
+        box.ignore(delayed)
+        let runner = makeRunner(store: store, session: session, box: box)
+        let sending = Task {
+            do {
+                try await runner.send("do not run after Stop")
+                Issue.record("a cancelled send returned success")
+            } catch is CancellationError {
+                // Expected: the suspended send cannot cross the cancellation boundary.
+            } catch {
+                Issue.record("unexpected send error: \(error)")
+            }
+        }
+        await eventually("delayed request") {
+            box.processes.first?.sentMethods.contains(delayed) == true
+        }
+        let request = try #require(box.process.sentFrame { $0["method"]?.stringValue == delayed })
+        let id = try #require(request["id"])
+        runner.cancelNow()
+        let reply: JSONValue = switch delayed {
+        case "thread/start": threadStartReply
+        case "turn/start": turnStartReply
+        default: .object([:])
+        }
+        box.process.reply(to: delayed, with: reply)
+        box.process.emit("{\"id\":\(id.compactJSON),\"result\":\(reply.compactJSON)}")
+        await sending.value
+
+        if delayed == "turn/start" {
+            #expect(box.process.sentMethods.contains("turn/interrupt"))
+        } else {
+            #expect(!box.process.sentMethods.contains("turn/start"))
+        }
+        #expect(try await store.session(id: session.id)?.state != .running)
+        try await runner.send("this new turn is intentional")
+        #expect(try await store.session(id: session.id)?.state == .running)
+        await runner.shutdown()
+    }
+
     @Test func startsAThreadOnTheFirstTurnAndStoresItsID() async throws {
         let store = try makeTestStore("codex-runner-start")
         let (session, _) = try await makeCodexSession(store)
@@ -724,7 +767,7 @@ private func eventually(
         let session = try await store.upsert(Session(workspaceID: workspace.id, agentKind: .codex))
 
         let raw = try SQLiteDatabase(path: path)
-        raw.userVersion = 0
+        try raw.setUserVersion(0)
 
         let reopened = try Store(path: path)
         let sessions = try await reopened.sessions(workspaceID: workspace.id)

--- a/Tests/BloomCoreTests/CodexRunnerTests.swift
+++ b/Tests/BloomCoreTests/CodexRunnerTests.swift
@@ -84,6 +84,58 @@ private func eventually(
 // MARK: - Tests
 
 @Suite(.scratchDirectory) struct CodexRunnerTests {
+    @Test(arguments: [false, true])
+    func lateStoppedCompletionCannotEndTheNextIntentionalTurn(delayStart: Bool) async throws {
+        let store = try makeTestStore("codex-late-stop")
+        let (session, _) = try await makeCodexSession(store)
+        let box = scriptedBox()
+        let runner = makeRunner(store: store, session: session, box: box)
+        try await runner.send("first turn")
+        runner.cancelNow()
+        box.reply(to: "turn/start", with: .object([
+            "turn": .object(["id": .string("new-turn"), "status": .string("inProgress"), "items": .array([])]),
+        ]))
+        if delayStart { box.ignore("turn/start") }
+        let nextSend = Task { try await runner.send("new intentional turn") }
+        await eventually("second turn start", within: 20) {
+            box.process.sentMethods.filter { $0 == "turn/start" }.count == 2
+        }
+        if !delayStart { try await nextSend.value }
+        box.process.emit(#"{"method":"item/started","params":{"threadId":"01a02144-3b7e-7233-97f2-73ebd5105085","turnId":"new-turn","item":{"id":"new-command","type":"commandExecution","command":"echo new","status":"inProgress"}}}"#)
+        box.process.emit(#"{"method":"turn/completed","params":{"threadId":"01a02144-3b7e-7233-97f2-73ebd5105085","turn":{"id":"01a02144-3bab-7fe3-a92c-6eec594d84fd","status":"interrupted","items":[]}}}"#)
+        box.process.emit(#"{"method":"item/completed","params":{"threadId":"01a02144-3b7e-7233-97f2-73ebd5105085","turnId":"new-turn","item":{"id":"new-text","type":"agentMessage","text":"still working"}}}"#)
+        await eventually("new output after stale completion", within: 20) {
+            (try? await store.messages(sessionID: session.id).contains { $0.kind == .assistantText }) == true
+        }
+        // A result delivered while turn/start is pending would clear TranscriptModel's busy
+        // state. No result row is produced for this superseded completion either.
+        #expect(try await store.messages(sessionID: session.id).filter { $0.kind == .result }.isEmpty)
+        if delayStart {
+            let starts = box.process.stdin.compactMap(JSONValue.parse).filter { $0["method"]?.stringValue == "turn/start" }
+            let request = try #require(starts.last)
+            let id = try #require(request["id"])
+            box.process.emit("{\"id\":\(id.compactJSON),\"result\":{\"turn\":{\"id\":\"new-turn\",\"status\":\"inProgress\",\"items\":[]}}}")
+            try await nextSend.value
+        }
+        #expect(try await store.session(id: session.id)?.state == .running)
+        let interrupted = box.process.stdin.compactMap(JSONValue.parse).filter { $0["method"]?.stringValue == "turn/interrupt" }
+        #expect(!interrupted.contains { $0["params"]?["turnId"]?.stringValue == "new-turn" })
+        #expect(interrupted.contains { $0["params"]?["turnId"]?.stringValue == "01a02144-3bab-7fe3-a92c-6eec594d84fd" })
+        box.process.emit(#"{"id":99,"method":"item/commandExecution/requestApproval","params":{"threadId":"01a02144-3b7e-7233-97f2-73ebd5105085","turnId":"new-turn","itemId":"new-command"}}"#)
+        await eventually("new command approval after stale completion", within: 20) {
+            ((try? await store.pendingPermissionAsks(sessionID: session.id)) ?? []).count == 1
+        }
+        let asks = try await store.pendingPermissionAsks(sessionID: session.id)
+        #expect(asks.first?.ask.input["command"]?.stringValue == "echo new")
+        runner.cancelNow()
+        await eventually("new turn still interruptible", within: 20) {
+            box.process.stdin.compactMap(JSONValue.parse).contains {
+                $0["method"]?.stringValue == "turn/interrupt" && $0["params"]?["turnId"]?.stringValue == "new-turn"
+            }
+        }
+        await runner.shutdown()
+    }
+
     @Test(arguments: ["initialize", "thread/start", "turn/start"])
     func stopWhileStartingCannotBeLost(_ delayed: String) async throws {
         let store = try makeTestStore("codex-start-stop")
@@ -101,7 +153,7 @@ private func eventually(
                 Issue.record("unexpected send error: \(error)")
             }
         }
-        await eventually("delayed request") {
+        await eventually("delayed request", within: 20) {
             box.processes.first?.sentMethods.contains(delayed) == true
         }
         let request = try #require(box.process.sentFrame { $0["method"]?.stringValue == delayed })

--- a/Tests/BloomCoreTests/CodexTestSupport.swift
+++ b/Tests/BloomCoreTests/CodexTestSupport.swift
@@ -41,7 +41,7 @@ final class ScriptedCodexProcess: AgentProcessing, @unchecked Sendable {
     // MARK: Scripting
 
     func reply(to method: String, with result: JSONValue) {
-        lock.lock(); replies[method] = result; lock.unlock()
+        lock.lock(); replies[method] = result; ignored.remove(method); lock.unlock()
     }
 
     func fail(_ method: String, code: Int, message: String) {

--- a/Tests/BloomCoreTests/CodexTestSupport.swift
+++ b/Tests/BloomCoreTests/CodexTestSupport.swift
@@ -12,6 +12,7 @@ import Foundation
 /// it.
 final class ScriptedCodexProcess: AgentProcessing, @unchecked Sendable {
     let launch: AgentLaunch
+    private let onWrite: @Sendable (String) -> Void
 
     private let lock = NSLock()
     private var written: [String] = []
@@ -26,8 +27,9 @@ final class ScriptedCodexProcess: AgentProcessing, @unchecked Sendable {
     let lines: AsyncThrowingStream<String, Error>
     let errorLines: AsyncStream<String>
 
-    init(launch: AgentLaunch) {
+    init(launch: AgentLaunch, onWrite: @escaping @Sendable (String) -> Void = { _ in }) {
         self.launch = launch
+        self.onWrite = onWrite
 
         var out: AsyncThrowingStream<String, Error>.Continuation!
         lines = AsyncThrowingStream(bufferingPolicy: .unbounded) { out = $0 }
@@ -97,6 +99,7 @@ final class ScriptedCodexProcess: AgentProcessing, @unchecked Sendable {
         let refusals = failures
         let silent = ignored
         lock.unlock()
+        onWrite(text)
 
         guard let json = JSONValue.parse(text),
               let method = json["method"]?.stringValue,
@@ -131,6 +134,7 @@ final class ScriptedCodexProcess: AgentProcessing, @unchecked Sendable {
 /// Holds the script, because the process itself does not exist until `start()` launches it and a
 /// test has to be able to say what the server will answer before that.
 final class ProcessBox: @unchecked Sendable {
+    private let onWrite: @Sendable (String) -> Void
     private let lock = NSLock()
     private var made: ScriptedCodexProcess?
     /// Every process this box has handed out, in order. A reconnect is a second one, and asking
@@ -139,6 +143,10 @@ final class ProcessBox: @unchecked Sendable {
     private var replies: [String: JSONValue] = [:]
     private var failures: [String: (code: Int, message: String)] = [:]
     private var ignored: [String] = []
+
+    init(onWrite: @escaping @Sendable (String) -> Void = { _ in }) {
+        self.onWrite = onWrite
+    }
 
     func ignore(_ method: String) {
         lock.lock(); ignored.append(method); let live = made; lock.unlock()
@@ -157,7 +165,7 @@ final class ProcessBox: @unchecked Sendable {
 
     var factory: @Sendable (AgentLaunch) -> any AgentProcessing {
         { launch in
-            let process = ScriptedCodexProcess(launch: launch)
+            let process = ScriptedCodexProcess(launch: launch, onWrite: self.onWrite)
             self.lock.lock()
             self.made = process
             self.started.append(process)

--- a/Tests/BloomCoreTests/CodexTurnHandleTests.swift
+++ b/Tests/BloomCoreTests/CodexTurnHandleTests.swift
@@ -1,0 +1,41 @@
+import Testing
+@testable import BloomCore
+
+struct CodexTurnHandleTests {
+    @Test func terminalOwnershipExpiresAcrossPersistenceSuspensions() {
+        let handle = CodexTurnHandle()
+        let began = handle.begin(turnID: "old", generation: handle.generation)
+        let oldIntent = handle.intent
+        handle.end()
+        let replacement = handle.prepareReplacement()
+        handle.finishReplacement(replacement)
+        #expect(began)
+        #expect(!handle.acceptsTerminal(turnID: "old", intent: oldIntent))
+    }
+
+    @Test func replacementSuppressesCompletionEvenAfterTheOldHandleEnded() {
+        let handle = CodexTurnHandle()
+        let began = handle.begin(turnID: "old", generation: handle.generation)
+        let stopped = handle.markCancelled()
+        handle.end()
+        let replacement = handle.prepareReplacement()
+        #expect(began)
+        #expect(stopped.turnID == "old")
+        #expect(!handle.acceptsTerminal(turnID: "old"))
+        let nextBegan = handle.begin(turnID: "new", generation: handle.generation)
+        handle.finishReplacement(replacement)
+        #expect(nextBegan)
+        #expect(!handle.acceptsTerminal(turnID: "old"))
+        #expect(handle.acceptsTerminal(turnID: "new"))
+    }
+
+    @Test func stopInvalidatesAnInFlightStartButNotTheNextIntentionalOne() {
+        let handle = CodexTurnHandle()
+        let beforeStop = handle.generation
+        handle.markCancelled()
+        let late = handle.begin(turnID: "late", generation: beforeStop)
+        let next = handle.begin(turnID: "new", generation: handle.generation)
+        #expect(!late && next)
+        #expect(handle.steerableTurnID == "new")
+    }
+}

--- a/Tests/BloomCoreTests/ContainedPathTests.swift
+++ b/Tests/BloomCoreTests/ContainedPathTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite(.scratchDirectory)
+struct ContainedPathTests {
+    @Test func previewAndCopyRefuseTraversalAndExternalSymlinks() throws {
+        let root = URL(filePath: TestScratch.unique("containment"), directoryHint: .isDirectory)
+        let source = root.appending(path: "source")
+        let destination = root.appending(path: "destination")
+        let outside = root.appending(path: "outside")
+        for directory in [source, destination, outside] {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+        try Data("secret".utf8).write(to: outside.appending(path: "secret.env"))
+        try Data("safe".utf8).write(to: source.appending(path: ".env"))
+        try FileManager.default.createSymbolicLink(at: source.appending(path: "escape"), withDestinationURL: outside)
+        try FileManager.default.createSymbolicLink(at: source.appending(path: "linked.env"), withDestinationURL: outside.appending(path: "secret.env"))
+        let patterns = ["../outside/*.env", "escape/*.env", "linked.env", "./.env"]
+        let plan = FilesToCopyResolver.resolve(patterns: patterns, in: source.path)
+        #expect(plan.matches.map(\.path) == ["./.env"])
+        let manager = WorkspaceManager(store: try makeTestStore("contained-copy"))
+        try manager.copyFiles(patterns, from: source.path, to: destination.path)
+        #expect(try String(contentsOf: destination.appending(path: ".env"), encoding: .utf8) == "safe")
+        #expect(!FileManager.default.fileExists(atPath: destination.appending(path: "escape").path))
+        #expect(!FileManager.default.fileExists(atPath: destination.appending(path: "linked.env").path))
+    }
+
+    @Test func branchControlledDestinationCannotRedirectCopiedSecrets() throws {
+        let root = URL(filePath: TestScratch.unique("destination"), directoryHint: .isDirectory)
+        let source = root.appending(path: "source")
+        let destination = root.appending(path: "destination")
+        let outside = root.appending(path: "outside")
+        for directory in [source.appending(path: "config"), destination, outside] {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+        try Data("secret".utf8).write(to: source.appending(path: "config/.env"))
+        try FileManager.default.createSymbolicLink(at: destination.appending(path: "config"), withDestinationURL: outside)
+        let manager = WorkspaceManager(store: try makeTestStore("destination-copy"))
+        try manager.copyFiles(["config/.env"], from: source.path, to: destination.path)
+        #expect(!FileManager.default.fileExists(atPath: outside.appending(path: ".env").path))
+    }
+
+    @Test func localPagesResolveInternalLinksButRefuseExternalOnes() throws {
+        let root = URL(filePath: TestScratch.unique("page-links"), directoryHint: .isDirectory)
+        let worktree = root.appending(path: "worktree")
+        try FileManager.default.createDirectory(at: worktree, withIntermediateDirectories: true)
+        let page = worktree.appending(path: "page.html")
+        try Data("page".utf8).write(to: page)
+        let external = root.appending(path: "private.html")
+        try Data("private".utf8).write(to: external)
+        let link = worktree.appending(path: "linked.html")
+        let escape = worktree.appending(path: "escape.html")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: page)
+        try FileManager.default.createSymbolicLink(at: escape, withDestinationURL: external)
+        #expect(LocalPage.fileURL(from: link.absoluteString, root: worktree.path) == page.resolvingSymlinksInPath())
+        #expect(LocalPage.fileURL(from: escape.absoluteString, root: worktree.path) == nil)
+    }
+}

--- a/Tests/BloomCoreTests/CrewDeliveryTests.swift
+++ b/Tests/BloomCoreTests/CrewDeliveryTests.swift
@@ -127,7 +127,7 @@ struct CrewDeliveryTests {
         )
 
         let raw = try SQLiteDatabase(path: path)
-        raw.userVersion = 0
+        try raw.setUserVersion(0)
 
         let reopened = try Store(path: path)
         let pending = try await reopened.pendingDeliveries(sessionID: member.id)

--- a/Tests/BloomCoreTests/MergedPullRequestTests.swift
+++ b/Tests/BloomCoreTests/MergedPullRequestTests.swift
@@ -208,7 +208,7 @@ struct MergedPullRequestTests {
         // `ALTER TABLE` has no `IF NOT EXISTS`, and this is the shape the store's own tests use to
         // reproduce an old schema: replaying the step must neither throw nor clear the column.
         let raw = try SQLiteDatabase(path: path)
-        raw.userVersion = 0
+        try raw.setUserVersion(0)
 
         let reopened = try Store(path: path)
         #expect(try await reopened.workspace(id: workspace.id)?.pullRequestNumber == 222)

--- a/Tests/BloomCoreTests/ProjectVisibilityTests.swift
+++ b/Tests/BloomCoreTests/ProjectVisibilityTests.swift
@@ -98,7 +98,7 @@ struct HiddenProjectStoreTests {
         _ = try await store.update(repoID: repo.id) { $0.hidden = true }
 
         let raw = try SQLiteDatabase(path: path)
-        raw.userVersion = 0
+        try raw.setUserVersion(0)
 
         let reopened = try Store(path: path)
         #expect(try await reopened.repo(id: repo.id)?.hidden == true)

--- a/Tests/BloomCoreTests/QuickPromptStoreTests.swift
+++ b/Tests/BloomCoreTests/QuickPromptStoreTests.swift
@@ -119,7 +119,7 @@ struct QuickPromptStoreTests {
         _ = try await store.update(quickPromptID: opted.id) { $0.sendsImmediately = true }
 
         let raw = try SQLiteDatabase(path: path)
-        raw.userVersion = 0
+        try raw.setUserVersion(0)
 
         let reopened = try Store(path: path)
         let plain = try #require(try await reopened.quickPrompt(id: old.id))

--- a/Tests/BloomCoreTests/RuntimeSafetyTests.swift
+++ b/Tests/BloomCoreTests/RuntimeSafetyTests.swift
@@ -565,7 +565,7 @@ struct StoreSequenceAllocationTests {
         // Rewind to the schema before the constraint existed and plant what it was added to catch.
         let db = try SQLiteDatabase(path: path)
         try db.execute("DROP INDEX IF EXISTS messages_session_seq;")
-        db.userVersion = 1
+        try db.setUserVersion(1)
         for (seq, body) in [(0, "a"), (1, "b"), (1, "c"), (2, "d")] {
             try db.run(
                 """

--- a/Tests/BloomCoreTests/SessionWithoutWorkspaceTests.swift
+++ b/Tests/BloomCoreTests/SessionWithoutWorkspaceTests.swift
@@ -117,7 +117,7 @@ struct SessionWithoutWorkspaceTests {
         // the very cascade this test exists to catch.
         try raw.execute("PRAGMA foreign_keys = OFF;")
         try raw.execute(Self.oldSessionsTable)
-        raw.userVersion = 0
+        try raw.setUserVersion(0)
         #expect(try isNullable(path) == false)
 
         let reopened = try Store(path: path)
@@ -141,7 +141,7 @@ struct SessionWithoutWorkspaceTests {
         _ = try await store.appendNext(sessionID: ask.id, kind: .user, payload: Data("hello".utf8))
 
         let raw = try SQLiteDatabase(path: path)
-        raw.userVersion = 0
+        try raw.setUserVersion(0)
 
         let reopened = try Store(path: path)
         #expect(try isNullable(path))

--- a/Tests/BloomCoreTests/StoreOceanTests.swift
+++ b/Tests/BloomCoreTests/StoreOceanTests.swift
@@ -97,7 +97,7 @@ struct StoreOceanTests {
         let pick = try #require(try await store.claimOcean(now: now))
 
         let raw = try SQLiteDatabase(path: path)
-        raw.userVersion = 0
+        try raw.setUserVersion(0)
 
         let reopened = try Store(path: path)
         #expect(try await reopened.oceans().count == 132)
@@ -124,7 +124,7 @@ struct StoreOceanTests {
             "INSERT INTO oceans (slug, name, latitude, longitude, used_at) VALUES (?, ?, ?, ?, ?)",
             [.text("borneo"), .text("Borneo"), .double(0.96), .double(114.55), .double(42)]
         )
-        raw.userVersion = 0
+        try raw.setUserVersion(0)
 
         let reopened = try Store(path: path)
         let oceans = try await reopened.oceans()

--- a/Tests/BloomCoreTests/WorkspaceManagerTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceManagerTests.swift
@@ -345,9 +345,8 @@ struct WorkspaceManagerTests {
         ("a.txt", "?.txt", true),
         ("ab.txt", "?.txt", false),
     ])
-    func matchesGlobs(name: String, pattern: String, expected: Bool) throws {
-        let manager = WorkspaceManager(store: try makeTestStore("wm"))
-        #expect(manager.matches(name, pattern: pattern) == expected)
+    func matchesGlobs(name: String, pattern: String, expected: Bool) {
+        #expect(FilesToCopyResolver.matches(name, pattern: pattern) == expected)
     }
     // MARK: - Opening a branch that already exists
 

--- a/Tests/BloomCoreTests/WorkspacePortTests.swift
+++ b/Tests/BloomCoreTests/WorkspacePortTests.swift
@@ -91,7 +91,7 @@ struct WorkspacePortTests {
         // `ALTER TABLE` has no `IF NOT EXISTS`, and this is the shape the store's own tests use
         // to reproduce an old schema: replaying the step must neither throw nor reset the column.
         let raw = try SQLiteDatabase(path: path)
-        raw.userVersion = 0
+        try raw.setUserVersion(0)
 
         let reopened = try Store(path: path)
         let stored = try #require(try await reopened.workspace(id: workspace.id))

--- a/Tests/BloomCoreTests/WorkspaceWriteIsolationTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceWriteIsolationTests.swift
@@ -172,7 +172,7 @@ struct WorkspaceWriteIsolationTests {
         try await store.update(workspaceID: workspace.id) { $0.colour = "D8608C" }
 
         let raw = try SQLiteDatabase(path: path)
-        raw.userVersion = 0
+        try raw.setUserVersion(0)
 
         let reopened = try Store(path: path)
         let stored = try #require(try await reopened.workspace(id: workspace.id))
@@ -253,7 +253,7 @@ struct WorkspaceWriteIsolationTests {
         ))
 
         let raw = try SQLiteDatabase(path: path)
-        raw.userVersion = 0
+        try raw.setUserVersion(0)
 
         let reopened = try Store(path: path)
         let storedParent = try #require(try await reopened.workspace(id: parent.id))

--- a/Tools/build.sh
+++ b/Tools/build.sh
@@ -170,6 +170,8 @@ embed_sparkle() {
 
 embed_sparkle
 
+zsh Tools/package-licences.sh "$APP" "$(dirname "$(dirname "$BIN_DIR")")/checkouts"
+
 # The accent Bloom hands to AppKit, checked against the one Bloom draws with itself.
 #
 # Resources/Assets.xcassets/AccentColor.colorset is a colour set and nothing more, and a colour set
@@ -322,8 +324,11 @@ emit_app_intents_metadata() {
   /usr/bin/python3 -c "import json,sys; json.dump(json.load(open(sys.argv[1]))['constValueProtocols'], open(sys.argv[2],'w'))" \
     "$protocols" "$protocolList"
 
+  # Match SwiftPM's package identity: BloomCore's typed ids belong to this package, so their
+  # App Intents conformances are not foreign conformances in this separate typecheck either.
   swiftc -typecheck -wmo \
     -module-name Bloom \
+    -package-name bloom \
     -swift-version 6 \
     -target "$triple" \
     -sdk "$sdk" \

--- a/Tools/house-rules.sh
+++ b/Tools/house-rules.sh
@@ -290,6 +290,7 @@ id_type_allowed_files=(
   'Sources/BloomCore/Agent/AgentQuestion.swift' # Codex's opaque question answer id, not a Bloom row
   'Sources/BloomCore/Agent/AgentEvent.swift'   # Claude Code's stream-json, as measured
   'Sources/BloomCore/Agent/Codex/CodexEvent.swift'   # the Codex app-server protocol
+  'Sources/BloomCore/Agent/Codex/CodexTurnHandle.swift' # turn ids assigned by that server
   'Sources/BloomCore/Agent/Codex/CodexClient.swift'  # the same protocol's request envelopes
   'Sources/BloomCore/Agent/AgentRetry.swift'   # the same stream-json, one line of it
 )

--- a/Tools/package-licences.sh
+++ b/Tools/package-licences.sh
@@ -1,0 +1,21 @@
+#!/bin/zsh
+# Copy notices from the exact dependency checkouts SwiftPM built, before signing the bundle.
+# Missing notices fail packaging rather than silently shipping an incomplete distribution.
+set -euo pipefail
+
+bundle="${1:?app bundle required}"
+checkouts="${2:?SwiftPM checkouts directory required}"
+source_root="$(cd "$(dirname "$0")/.." && pwd)"
+notices="$bundle/Contents/Resources/Licences"
+mkdir -p "$notices"
+
+copy_notice() {
+  [[ -s "$1" ]] || { echo "Missing licence notice: $1" >&2; return 1; }
+  cp "$1" "$notices/$2"
+}
+
+copy_notice "$source_root/LICENSE.md" Bloom.txt
+copy_notice "$checkouts/SwiftTerm/LICENSE" SwiftTerm.txt
+# Sparkle's notice includes its bundled third-party licences.
+copy_notice "$checkouts/Sparkle/LICENSE" Sparkle.txt
+copy_notice "$checkouts/swift-argument-parser/LICENSE.txt" SwiftArgumentParser.txt

--- a/Tools/release/tests/licences.sh
+++ b/Tools/release/tests/licences.sh
@@ -2,7 +2,7 @@
 # Packaging contract without a compiler, credentials or an installed application.
 set -euo pipefail
 cd "$(dirname "$0")/../../.."
-fixture="$(mktemp -d -t bloom-licence-test)"
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/bloom-licence-test.XXXXXX")"
 trap 'rm -rf "$fixture"' EXIT
 
 mkdir -p "$fixture/checkouts/SwiftTerm" "$fixture/checkouts/Sparkle" "$fixture/checkouts/swift-argument-parser"

--- a/Tools/release/tests/licences.sh
+++ b/Tools/release/tests/licences.sh
@@ -1,0 +1,20 @@
+#!/bin/zsh
+# Packaging contract without a compiler, credentials or an installed application.
+set -euo pipefail
+cd "$(dirname "$0")/../../.."
+fixture="$(mktemp -d -t bloom-licence-test)"
+trap 'rm -rf "$fixture"' EXIT
+
+mkdir -p "$fixture/checkouts/SwiftTerm" "$fixture/checkouts/Sparkle" "$fixture/checkouts/swift-argument-parser"
+cp LICENSE.md "$fixture/checkouts/SwiftTerm/LICENSE"
+cp LICENSE.md "$fixture/checkouts/Sparkle/LICENSE"
+cp LICENSE.md "$fixture/checkouts/swift-argument-parser/LICENSE.txt"
+zsh Tools/package-licences.sh "$fixture/Bloom.app" "$fixture/checkouts"
+for notice in Bloom SwiftTerm Sparkle SwiftArgumentParser; do
+  cmp LICENSE.md "$fixture/Bloom.app/Contents/Resources/Licences/$notice.txt"
+done
+if zsh Tools/package-licences.sh "$fixture/Incomplete.app" "$fixture/missing" >/dev/null 2>&1; then
+  echo "Packaging accepted missing dependency notices" >&2
+  exit 1
+fi
+echo "Licence packaging checks passed"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,73 @@
+# Architecture and contributor guide
+
+Bloom separates its tested behaviour from its window. Read `CLAUDE.md` for the enforced rules and
+`RELEASING.md` for distribution. Build an isolated dev copy; never test against the installed
+production app or its database.
+
+## Boundaries
+
+- `BloomCore` owns persistence, processes, agent protocols, workspace operations and pure
+  presentation decisions. It cannot import a UI framework.
+- `Bloom` owns SwiftUI and AppKit integration. Main-actor observable models coordinate the window;
+  views render state and forward intent rather than running shell commands.
+- `bloom-bridge` relays MCP requests to the running app. The registry establishes caller authority;
+  dispatch checks tool roles. Existing connections revalidate tokens for each request.
+
+Files are grouped by subject, not into generic helpers or services. Extract a component when it
+owns a coherent responsibility or removes repeated behaviour. Do not split a file merely to meet
+a line count, or expose private mutable state just to make an extension possible.
+
+## State and concurrency
+
+Lifecycle rules belong in value types with explicit events and outcomes. Existing examples are
+`SessionLifecycle`, `SetupState`, `SubagentState` and `DeliveryDrainState`.
+Use a state machine when transitions have rules, cancellation or asynchronous hand-offs. A single
+independent preference does not need a state machine simply because it is a boolean.
+
+An actor serialises synchronous work, not an entire operation containing `await`. Recheck state
+after suspension. The delivery drain has one owner and coalesces competing requests; SQLite
+conditionally claims each pending delivery. Codex startup uses a cancellation generation so Stop
+cannot be undone by a late connection or turn-start reply. Process factories make these races
+testable without running a paid agent.
+
+## Database structure
+
+`Store` is the single actor owning the SQLite connection. Foreign keys connect projects,
+workspaces, sessions, messages and deliveries. Ordered migrations and schema-repair checks are
+covered by tests. Unsupported schema versions are refused before repair, and migration stamps
+are throwing writes inside the migration transaction.
+
+Keep SQLite here rather than introducing SwiftData alongside it: the app already relies on
+explicit transactions, targeted updates, ordered transcript reads and migration compatibility.
+A second persistence stack would duplicate ownership without solving a demonstrated problem.
+
+`upsert` creates rows from newly constructed values. Existing rows use targeted updates inside
+the actor, so a slow UI edit cannot overwrite newer runner or filesystem state. Operations that
+must succeed together use one transaction: enqueue plus draft removal; fresh Ask conversation
+plus preferences, draft and archival. Failure must preserve the recoverable state.
+
+The SQLite wrapper binds and reads explicit byte lengths, preserving embedded NUL text and empty
+blobs. Numeric conversion checks representability instead of trapping on corrupt values.
+
+## Files and permissions
+
+The setup-copy preview and copier share one resolver. Relative traversal is rejected, source
+symlinks must stay inside the source root, and destination symlinks cannot redirect copied files.
+Local HTML page access uses the same canonical containment primitive.
+
+These checks constrain Bloom's own operations. They are not an operating-system sandbox against
+a hostile local process changing files concurrently. An authorised setup script or agent can still
+execute code with the access its selected mode grants. Review scope and permissions at boundaries;
+do not describe a worktree as isolation equivalent to a virtual machine.
+
+## Verification and review scope
+
+Run focused core tests, build the app, and run both `make lint` and `make swiftlint`. The full suite
+and warnings-as-errors app build run on the pull request. Fault-injection tests cover failed writes,
+and fake-process tests cover protocol timing. Licence packaging is tested separately.
+
+The September 2026 audit addressed concrete persistence, cancellation, duplicate-delivery,
+file-containment and token-revocation findings. It also removed the duplicate copy walker and
+centralised composer-setting persistence. This is not a claim that the entire application is free
+of defects or that every interface has been interactively reviewed. Keep adding a regression test
+for each reproducible defect, and profile before replacing a working native component.


### PR DESCRIPTION
## Summary

- Serialise overlapping delivery drains and atomically claim pending messages. Preserve drafts if enqueueing fails and clear matching drafts in the enqueue transaction.
- Replace Ask Bloom conversations, preferences and drafts atomically; keep the old conversation open on failure.
- Honour Stop while Codex is connecting or starting a turn, including a late turn/start reply.
- Revalidate bridge tokens on every request and share symlink-aware containment between local pages, setup-copy preview and copying.
- Preserve SQLite embedded-NUL text and empty blobs, safely convert numeric values, and reject unsupported schema versions before repair.
- Bundle pinned dependency licence notices, verify packaging in CI, and document architecture, development isolation and the verified release path.

## Verification

167 focused tests pass, including fault injection, cancellation timing, connected-client revocation and filesystem boundary regressions. App compilation and assembled bundle pass with no compiler warnings; both linters pass. Licence packaging fixture tests and bundle signature verification pass.

Correctness and security review lanes are running in report-only mode. PHP, Laravel and React lanes do not apply to this Swift/shell/documentation diff.

This PR follows the broader open-source-readiness audit. It does not claim a complete OS sandbox or a defect-free application.