### PR TITLE
Animate attachment pill close buttons on hover

### DIFF
--- a/Sources/Bloom/Views/Center/Composer/ComposerChipText.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerChipText.swift
@@ -494,15 +494,19 @@ final class AttachmentChipCell: NSTextAttachmentCell {
             width: side,
             height: side
         )
-        // The chip's own icon, unless the pointer is on it, in which case the slot is the close
-        // control instead. A symbol that would not load draws nothing rather than leaving the
-        // wrong glyph in the slot: `icon` already falls back to the file's icon where there is a
-        // file, and for a block of instructions there is no second answer to fall back to.
-        let mark = (isRemovable(from: controlView, at: characterIndex) ? close : nil) ?? icon
-        mark?.draw(
-            in: iconRect, from: .zero, operation: .sourceOver, fraction: 1,
+        // Crossfade inside the fixed icon slot so the name and hit target stay still.
+        let hoverFraction = (controlView as? ComposerTextView)?
+            .chipHoverFraction(at: characterIndex) ?? 0
+        icon?.draw(
+            in: iconRect, from: .zero, operation: .sourceOver, fraction: 1 - hoverFraction,
             respectFlipped: true, hints: nil
         )
+        if hoverFraction > 0 {
+            close?.draw(
+                in: iconRect, from: .zero, operation: .sourceOver, fraction: hoverFraction,
+                respectFlipped: true, hints: nil
+            )
+        }
 
         let name = NSAttributedString(string: label, attributes: nameAttributes)
         let height = name.size().height

--- a/Sources/Bloom/Views/Center/Composer/ComposerTextView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerTextView.swift
@@ -39,6 +39,13 @@ final class ComposerTextView: NSTextView, HoverQuickLookSource {
     fileprivate var hoveredChip: HoveredChip?
     fileprivate var hoverTask: Task<Void, Never>?
     fileprivate var hoverArea: NSTrackingArea?
+    private var chipHoverFractions: [HoveredChip: CGFloat] = [:]
+    private var chipHoverAnimation: Task<Void, Never>?
+
+    override func didChangeText() {
+        resetChipHover()
+        super.didChangeText()
+    }
 
     override func keyDown(with event: NSEvent) {
         if keyHandler?(event, selectedRange()) == true { return }
@@ -60,6 +67,7 @@ final class ComposerTextView: NSTextView, HoverQuickLookSource {
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         HoverQuickLookController.shared.update(self)
+        if window == nil { resetChipHover() }
         if window != nil { onWindowChange?() }
     }
 
@@ -317,14 +325,9 @@ extension ComposerTextView {
 
     private func hover(over chip: HoveredChip?) {
         guard chip != hoveredChip else { return }
-        let was = hoveredChip
         hoveredChip = chip
         hoverTask?.cancel()
-
-        // The close control lives in the chip's own icon slot, so crossing into or out of one is
-        // a redraw. The whole box rather than the two glyph rects: it is twelve lines at most, and
-        // this runs when the pointer crosses a chip's edge rather than while it moves along one.
-        if was?.index != chip?.index { needsDisplay = true }
+        animateChipHover()
 
         guard let chip else {
             hoverAttachment?(nil)
@@ -336,12 +339,71 @@ extension ComposerTextView {
             self.hoverAttachment?(chip.path)
         }
     }
+
+    private func resetChipHover() {
+        hoverTask?.cancel()
+        chipHoverAnimation?.cancel()
+        chipHoverAnimation = nil
+        chipHoverFractions.removeAll()
+        hoveredChip = nil
+        hoverAttachment?(nil)
+        needsDisplay = true
+    }
+
+    private func animateChipHover() {
+        chipHoverAnimation?.cancel()
+        if NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
+            chipHoverAnimation = nil
+            chipHoverFractions = hoveredChip.map { [$0: 1] } ?? [:]
+            needsDisplay = true
+            return
+        }
+
+        if let hoveredChip, chipHoverFractions[hoveredChip] == nil {
+            chipHoverFractions[hoveredChip] = 0
+        }
+        // Retarget from the currently drawn opacity, including chips still fading out.
+        let initial = chipHoverFractions
+        let target = hoveredChip
+        let clock = ContinuousClock()
+        let start = clock.now
+        chipHoverAnimation = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                let elapsed = min(1, (clock.now - start) / .milliseconds(180))
+                let eased = CGFloat(1 - pow(1 - elapsed, 3))
+                for (chip, fraction) in initial {
+                    let destination: CGFloat = chip == target ? 1 : 0
+                    self.chipHoverFractions[chip] = fraction + (destination - fraction) * eased
+                    if chip.index < (self.textStorage?.length ?? 0) {
+                        self.layoutManager?.invalidateDisplay(
+                            forCharacterRange: NSRange(location: chip.index, length: 1)
+                        )
+                    }
+                }
+                if elapsed == 1 {
+                    self.chipHoverFractions = target.map { [$0: 1] } ?? [:]
+                    self.chipHoverAnimation = nil
+                    return
+                }
+                try? await Task.sleep(for: .milliseconds(16))
+            }
+        }
+    }
+
+    func chipHoverFraction(at characterIndex: Int) -> CGFloat {
+        guard let storage = textStorage,
+              characterIndex >= 0, characterIndex < storage.length,
+              let path = ComposerChipText.subject(of: storage, at: characterIndex)?.path
+        else { return 0 }
+        return chipHoverFractions[HoveredChip(path: path, index: characterIndex)] ?? 0
+    }
 }
 
 /// A chip and where it is, which is what the pointer is on rather than just which file it names:
 /// the same screenshot can be in the sentence twice, and the close control belongs to the one
 /// under the pointer.
-struct HoveredChip: Equatable {
+struct HoveredChip: Hashable {
     var path: String
     /// The character the chip is, in the text view's own storage.
     var index: Int


### PR DESCRIPTION
Crossfade composer attachment icons into their close buttons over 180 ms, with smooth reversals and a fixed hit target. Respect Reduce Motion and clear hover state when the draft changes or the editor leaves its window.

Local build, house rules and SwiftLint pass.