### PR TITLE
Fix action grouping and duplicate branch tooltip

### DIFF
--- a/Sources/Bloom/Views/Inspector/PullRequestCreator.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestCreator.swift
@@ -49,14 +49,6 @@ struct PullRequestCreator: View {
     var continued: ContinuedBranch?
     var action: () -> Void
 
-    /// Whether the pointer is on the branch name, which is the only time anything asks whether it
-    /// fits. See `TruncationProbe`: the answer costs a second text layout, so it is not one this
-    /// strip pays for at rest.
-    @State private var isHoveringBranch = false
-    /// Whether the name is actually being cut off. False until the probe above says otherwise, so
-    /// a branch that fits never grows a tooltip repeating what is already on screen.
-    @State private var isBranchTruncated = false
-
     /// Whether Bloom itself can talk to GitHub. It has no bearing on the button, which goes to the
     /// agent, and every bearing on whether this strip can be trusted when it says there is no pull
     /// request: signed out, Bloom simply never found out.
@@ -75,28 +67,13 @@ struct PullRequestCreator: View {
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: Metrics.spacingHair) {
-                // Head truncation, and it stays: a branch is `murze/add-personal-notifications`
-                // and the half that says which branch it is is the last half. What head
-                // truncation costs is that the name is then unreachable, and that is what the two
-                // modifiers under it buy back.
+                // Keep the readable end of a long branch. The band's custom hover card shows
+                // the full name, so a system tooltip here would duplicate it.
                 Text(branch)
                     .font(Typo.title)
                     .foregroundStyle(Palette.textPrimary)
                     .lineLimit(1)
                     .truncationMode(.head)
-                    .reportsTruncation(
-                        of: branch,
-                        font: Typo.title,
-                        isActive: isHoveringBranch,
-                        into: $isBranchTruncated
-                    )
-                    .onHover { isHoveringBranch = $0 }
-                    // Only when it is cut off. It used to be `.help(branch)` unconditionally,
-                    // which is a tooltip that spends a second and a half of the reader's time
-                    // repeating a string they can already see, and a tooltip that is usually
-                    // noise is a tooltip nobody waits for. Now it appears exactly when it is the
-                    // only way to read the name.
-                    .help(isBranchTruncated ? branch : "")
                     .accessibilityLabel("Branch \(branch)")
 
                 if github.isUsable {

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -518,10 +518,10 @@ struct TranscriptListView: View {
         // and the `onChange` at the foot of `body`, which is the pass.
         let folds = Self.foldsForThisPass(rows: rows, stored: self.folds, drawn: drawnRange)
         let lastVisibleSeq = drawnRows.last(where: { !TranscriptNoise.isHidden($0) })?.seq
-        // The turn the loop below is inside, so a fold's own line is emitted once, and the first
-        // row of that turn's working which is NOT hidden. Every row before it is skipped.
+        // The group the loop is inside, so its line is emitted once, and the indices of its
+        // completed rows. Pending rows can sit between hidden ones.
         var foldSeq: Int?
-        var shownFrom = 0
+        var hiddenIndices: Set<Int> = []
 
         var out: [TranscriptTableEntry] = []
         // A workspace's setup script, its worktree events and its opening prompt. All three are
@@ -571,22 +571,14 @@ struct TranscriptListView: View {
                     foldSeq = work.firstSeq
                     // What the fold would hide if the reader had not opened it, which is what the
                     // line has to say either way, and whether it has anything to say at all.
-                    let would = TranscriptFold.hides(work, revealed: revealed, drawn: drawnRange)
-                    let hidden = unfolded.contains(work.firstSeq) ? 0 : would
-                    shownFrom = if hidden == 0 {
-                        work.span.lowerBound
-                    } else if hidden < work.rows.count {
-                        work.rows[hidden].index
-                    } else {
-                        // The whole working is behind the line, so the next thing drawn is the
-                        // turn's answer, which is past the span.
-                        work.span.upperBound
-                    }
+                    let would = TranscriptFold.hiddenIndices(work, revealed: revealed, drawn: drawnRange)
+                    hiddenIndices = unfolded.contains(work.firstSeq) ? [] : would
+                    let isFolded = !hiddenIndices.isEmpty
                     out.append(foldEntry(
                         firstSeq: work.firstSeq,
-                        hiding: hidden > 0 ? would : work.rows.count,
-                        showsMore: hidden > 0 && would < work.rows.count,
-                        isFolded: hidden > 0,
+                        hiding: isFolded ? would.count : work.rows.count,
+                        showsMore: isFolded && would.count < work.rows.count,
+                        isFolded: isFolded,
                         // A subagent's line is drawn where its rows are, under the call that
                         // started it. See `TranscriptFold`, which is where the grouping is.
                         isNested: work.isNested,
@@ -594,13 +586,15 @@ struct TranscriptListView: View {
                         // when it is pressed is worse than no control. Its entry stays in the list
                         // all the same, drawing nothing, because an entry that came and went in
                         // the middle of the list is the `.rebuilt` this is all arranged to avoid.
-                        shows: would > 0,
+                        shows: !would.isEmpty,
                         session: sessionID
                     ))
                 }
-                // Everything before the first row that stays is the fold, and the rows that draw
-                // nothing between them go with it.
-                if index < shownFrom { continue }
+                // Skip completed actions individually so a pending command stays visible even
+                // when later commands have finished. Empty stream rows need no table entry either.
+                if !hiddenIndices.isEmpty,
+                   hiddenIndices.contains(index)
+                    || TranscriptRowInk.drawsNothing(kind: row.kind, payload: row.payload) { continue }
             }
             guard !TranscriptNoise.isHidden(row) else { continue }
             let isExpanded = expanded.contains(row.seq)

--- a/Sources/BloomCore/Transcript/TranscriptFold.swift
+++ b/Sources/BloomCore/Transcript/TranscriptFold.swift
@@ -47,12 +47,12 @@ import Foundation
 /// # What is never hidden
 ///
 /// Four things remain visible. Permanent outcomes split consecutive activity into a new fold;
-/// temporary or reader-selected rows cap the current fold without rearranging it.
+/// running actions stay outside their group, and reader-selected rows cap what it hides.
 ///
 /// 1. **A row whose result has not come back.** What such a row says can still change, and a fold
 ///    that had to reveal a row it had hidden is a transcript rearranging itself under somebody who
 ///    is reading it. A tool call with no result yet, and a permission question nobody has answered
-///    yet, are the same fact here.
+///    yet, are the same fact here. Completed actions after them can still join the fold.
 /// 2. **The agent stopping, and a row carrying content of its own.** An `error` row is the agent
 ///    exiting in a way it did not choose, and inline media is deliberate content wearing an
 ///    activity row's clothes. Both remain visible and divide the ordinary activity before and
@@ -80,8 +80,8 @@ import Foundation
 ///    only find a row the table is DRAWING, so a search hit or an unread mark inside a fold is not
 ///    a row somewhere off screen, it is a scroll that lands nowhere at all.
 ///
-/// **Every one of them is a stopping point rather than a refusal**, and that is the property the
-/// rest of this file is arranged around: what a fold hides only ever grows.
+/// Settling an action only adds it to the hidden rows. It never reveals completed work that
+/// was already folded, and the group keeps its identity while results arrive out of order.
 public enum TranscriptFold {
     /// The fewest rows worth hiding.
     ///
@@ -143,9 +143,9 @@ public enum TranscriptFold {
     /// different ids, which is exactly `.rebuilt`.
     ///
     /// - Parameter drawn: the window of rows the list is handing to the table. A fresh fold whose
-    ///   working runs past it cannot be adopted, and this is not a detail: `hides` refuses to fold
-    ///   a working the window stops inside, so adopting one would UNFOLD the turn for a pass. The
-    ///   window grows on the same event, one pass behind, exactly as these do.
+    ///   working runs past it cannot be adopted: `hiddenIndices` refuses to fold a working the
+    ///   window stops inside, so adopting one would UNFOLD the turn for a pass. The window grows
+    ///   on the same event, one pass behind, exactly as these do.
     public static func mayAdopt(_ fresh: Folds, over stale: Folds, drawn: Range<Int>) -> Bool {
         // A turn's first fold appearing is an insertion in the middle of the list, which is the
         // one shape `Folds` documents as a reload. It is left to the pass that already handles it.
@@ -161,38 +161,26 @@ public enum TranscriptFold {
     /// that leaves none. Rows are only ever appended, so a working that exposes a higher sequence
     /// number than it did is a working that has gained an exposed row.
     private static func lastExposedSeq(_ work: Work) -> Int {
-        guard work.ready < work.rows.count, let last = work.rows.last else { return .min }
+        guard let last = work.rows.last(where: { !work.ready.contains($0.index) }) else { return .min }
         return last.seq
     }
 
-    /// How many rows at the front of this turn's work are hidden right now, or nought for a fold
-    /// that is not folded.
+    /// The indices of completed activity rows hidden by a collapsed group.
     ///
-    /// **A prefix that only grows, which is the whole of why nothing unfolds under a reader.**
-    /// Every term moves in one direction only: results arrive and never un-arrive, questions get
-    /// answered and never unanswered, rows are appended and never removed, and `revealed` only ever
-    /// gains a row that is already on screen. So the answer for a given turn never goes down.
+    /// Results can arrive out of order. Keep pending actions visible without letting them hold
+    /// later completed actions outside the fold. The group still starts at its first activity
+    /// row, so settling a pending action changes the count without moving the disclosure.
     ///
-    /// `revealed` is every sequence number something has asked to be visible: the tool results the
-    /// reader has opened, and the row this session was opened on. `drawn` is the window of rows the
-    /// list is handing to the table, because a fold has to be able to draw what it leaves.
-    public static func hides(_ work: Work, revealed: Set<Int>, drawn: Range<Int>) -> Int {
-        // Settled work can all move into the fold. Its newest row remains visible as the fold's
-        // label, so this compacts the transcript without taking the current activity away.
-        var count = min(work.ready, work.rows.count)
-        // Cut short at the first row somebody is reading or being taken to, rather than refusing to
-        // fold at all: refusing would unfold a turn that had already folded.
+    /// A row the reader opened or navigated to still caps the fold, preserving the context they
+    /// are reading. A window that ends inside the group cannot fold it yet.
+    public static func hiddenIndices(_ work: Work, revealed: Set<Int>, drawn: Range<Int>) -> Set<Int> {
+        guard work.span.upperBound <= drawn.upperBound else { return [] }
+        var hidden = work.ready
         if !revealed.isEmpty,
-           let stop = work.rows.prefix(count).firstIndex(where: { revealed.contains($0.seq) }) {
-            count = stop
+           let stop = work.rows.first(where: { revealed.contains($0.seq) }) {
+            hidden = hidden.filter { $0 < stop.index }
         }
-        guard count >= leastHidden else { return 0 }
-        // A window that stops inside the working cannot fold it: the rows it would leave are rows
-        // the table is not drawing, and the line would stand over nothing. Only the window's END is
-        // asked about, because its start only ever moves down and what is hidden is an absolute
-        // range of rows rather than one measured from the window.
-        guard work.span.upperBound <= drawn.upperBound else { return 0 }
-        return count
+        return hidden.count >= leastHidden ? hidden : []
     }
 
     /// One row, in the only terms the fold cares about.
@@ -269,8 +257,8 @@ public enum TranscriptFold {
 
     /// One row of a turn's working: where it is, and what it is called.
     ///
-    /// The index answers "is this row hidden", which is a comparison against the first row that
-    /// stays. The seq answers "is this the row somebody asked to see", which arrives as a set of
+    /// The index answers "is this row hidden", through membership in the set of hidden indices.
+    /// The seq answers "is this the row somebody asked to see", which arrives as a set of
     /// sequence numbers from the view. Both are needed and neither can be derived from the other.
     public struct Row: Equatable, Sendable {
         public var index: Int
@@ -309,13 +297,9 @@ public enum TranscriptFold {
         public var span: Range<Int>
         /// Every row of the working that draws something, in order.
         public var rows: [Row]
-        /// How many rows from the front may be hidden.
-        ///
-        /// A prefix rather than a count, because a gap in the middle would let a row that is still
-        /// waiting be hidden behind one that has landed. Permanent visible rows are not part of
-        /// this work segment. It stops at the first row that has not settled, and it never goes
-        /// backwards, which is what makes the fold monotone.
-        public var ready: Int
+        /// Indices into the session's rows of every settled action in this group.
+        /// Pending actions are gaps in this set, so they cannot block later completed work.
+        public var ready: Set<Int>
         /// Whether the turn has said its answer, so nothing of the working need stay on screen.
         public var hasAnswer: Bool
         /// Whether this is a subagent's own work, so the line that stands for it is drawn indented
@@ -332,7 +316,7 @@ public enum TranscriptFold {
         public var firstSeq: Int { rows.first?.seq ?? 0 }
 
         public init(
-            span: Range<Int>, rows: [Row], ready: Int, hasAnswer: Bool, isNested: Bool = false
+            span: Range<Int>, rows: [Row], ready: Set<Int>, hasAnswer: Bool, isNested: Bool = false
         ) {
             self.span = span
             self.rows = rows
@@ -368,7 +352,7 @@ public enum TranscriptFold {
         /// Where the next scan starts, which is just past the last row that ENDED a turn.
         ///
         /// Only a user's message and a turn's result row settle everything above them. A turn that
-        /// is still running has a working whose answer is provisional and whose settled prefix is
+        /// is still running has a working whose answer is provisional and whose set of settled rows is
         /// about to grow, so it is rescanned in full every time a row lands. A turn is a few
         /// hundred rows at worst and the facts are read off the row rather than out of its payload.
         public var resumeIndex: Int
@@ -442,15 +426,10 @@ public enum TranscriptFold {
                 guard segment.count >= leastWork,
                       let first = segment.first,
                       let last = segment.last else { return }
-                var ready = 0
-                while ready < segment.count,
-                      segment[segment.index(segment.startIndex, offsetBy: ready)].ready {
-                    ready += 1
-                }
                 found.append(Work(
                     span: first.row.index..<(last.row.index + 1),
                     rows: segment.map(\.row),
-                    ready: ready,
+                    ready: Set(segment.lazy.filter(\.ready).map { $0.row.index }),
                     hasAnswer: hasAnswer,
                     // Every item in the buffer shares one parent, because a change of it is what
                     // closed the group, so the first answers for the segment.

--- a/Tests/BloomCoreTests/TranscriptFoldAdoptionTests.swift
+++ b/Tests/BloomCoreTests/TranscriptFoldAdoptionTests.swift
@@ -11,7 +11,7 @@ struct TranscriptFoldAdoptionTests {
     ) -> TranscriptFold.Work {
         let list = (0..<rows).map { TranscriptFold.Row(index: $0, seq: firstSeq + $0) }
         return TranscriptFold.Work(
-            span: 0..<(upperBound ?? rows), rows: list, ready: ready, hasAnswer: false
+            span: 0..<(upperBound ?? rows), rows: list, ready: Set(0..<ready), hasAnswer: false
         )
     }
 
@@ -26,6 +26,24 @@ struct TranscriptFoldAdoptionTests {
         let fresh = Self.folds([Self.work(firstSeq: 10, rows: 4, ready: 4)])
 
         #expect(TranscriptFold.mayAdopt(fresh, over: stale, drawn: 0..<40))
+    }
+
+    @Test func adoptsCompletedActionsAfterARunningCommand() {
+        var old = Self.work(firstSeq: 10, rows: 5, ready: 0)
+        old.ready = [1, 2, 3]
+        var new = old
+        new.ready.insert(4)
+
+        #expect(TranscriptFold.mayAdopt(Self.folds([new]), over: Self.folds([old]), drawn: 0..<40))
+    }
+
+    @Test func refusesANewRunningActionAfterCompletedActions() {
+        var old = Self.work(firstSeq: 10, rows: 4, ready: 0)
+        old.ready = [1, 2, 3]
+        var new = Self.work(firstSeq: 10, rows: 5, ready: 0)
+        new.ready = old.ready
+
+        #expect(!TranscriptFold.mayAdopt(Self.folds([new]), over: Self.folds([old]), drawn: 0..<40))
     }
 
     /// The batched case, and the reason the deferral exists: a result and the next call arrive
@@ -56,7 +74,7 @@ struct TranscriptFoldAdoptionTests {
         #expect(!TranscriptFold.mayAdopt(fresh, over: stale, drawn: 0..<40))
     }
 
-    /// **`hides` refuses to fold a working the drawn window stops inside**, so adopting one whose
+    /// **`hiddenIndices` refuses to fold a working the drawn window stops inside**, so adopting one whose
     /// rows the table is not all holding would unfold the turn for a pass, which is the opposite
     /// of the complaint. The window grows on the same event and one pass behind, exactly as the
     /// runs do.

--- a/Tests/BloomCoreTests/TranscriptFoldErrorTests.swift
+++ b/Tests/BloomCoreTests/TranscriptFoldErrorTests.swift
@@ -41,7 +41,7 @@ struct FoldingAnErroredActionTests {
     private let everything = 0..<1_000
 
     private func hides(_ work: TranscriptFold.Work, revealed: Set<Int> = []) -> Int {
-        TranscriptFold.hides(work, revealed: revealed, drawn: everything)
+        TranscriptFold.hiddenIndices(work, revealed: revealed, drawn: everything).count
     }
 
     private func only(_ facts: [TranscriptFold.Fact]) throws -> TranscriptFold.Work {

--- a/Tests/BloomCoreTests/TranscriptFoldNestingTests.swift
+++ b/Tests/BloomCoreTests/TranscriptFoldNestingTests.swift
@@ -48,7 +48,7 @@ struct FoldingASubagentsRowsTests {
     private let everything = 0..<1_000
 
     private func hides(_ work: TranscriptFold.Work) -> Int {
-        TranscriptFold.hides(work, revealed: [], drawn: everything)
+        TranscriptFold.hiddenIndices(work, revealed: [], drawn: everything).count
     }
 
     // MARK: The run that was drawn in full

--- a/Tests/BloomCoreTests/TranscriptFoldTests.swift
+++ b/Tests/BloomCoreTests/TranscriptFoldTests.swift
@@ -59,7 +59,7 @@ struct TranscriptFoldTests {
     private let everything = 0..<1_000
 
     private func hides(_ work: TranscriptFold.Work, revealed: Set<Int> = []) -> Int {
-        TranscriptFold.hides(work, revealed: revealed, drawn: everything)
+        TranscriptFold.hiddenIndices(work, revealed: revealed, drawn: everything).count
     }
 
     private func only(_ facts: [TranscriptFold.Fact]) throws -> TranscriptFold.Work {
@@ -191,18 +191,44 @@ struct TranscriptFoldTests {
 
         let partly = [user(0)] + (1..<7).map { tool($0, settled: $0 < 5) }
         let work = try only(partly)
-        #expect(work.ready == 4)
+        #expect(work.ready == Set(1..<5))
         #expect(hides(work) == 4)
     }
 
-    /// The prefix stops at the first row still waiting, so a later result cannot reach over one
-    /// that has not come back.
-    @Test("a settled row behind an unsettled one is still not hidden")
-    func thePrefixHasNoGaps() throws {
+    @Test("completed actions fold around a running command")
+    func completedActionsSkipPendingRows() throws {
         let facts = [user(0), tool(1), tool(2), tool(3, settled: false), tool(4), tool(5), tool(6)]
         let work = try only(facts)
-        #expect(work.ready == 2)
-        #expect(hides(work) == 0)
+        #expect(TranscriptFold.hiddenIndices(work, revealed: [], drawn: everything) == [1, 2, 4, 5, 6])
+    }
+
+    @Test("a running first action does not block later completed commands")
+    func runningFirstAction() throws {
+        let facts = [user(10), tool(20, settled: false), quiet(30), tool(40), tool(50), tool(60)]
+        let work = try only(facts)
+        // Folding uses array indices, while disclosure identity and reveals use sequence numbers.
+        #expect(work.firstSeq == 20)
+        #expect(TranscriptFold.hiddenIndices(work, revealed: [], drawn: everything) == [3, 4, 5])
+        #expect(TranscriptFold.hiddenIndices(work, revealed: [50], drawn: everything).isEmpty)
+    }
+
+    @Test("out of order results grow the same fold without revealing completed actions")
+    func resultsArriveOutOfOrder() throws {
+        var facts = [user(0)] + (1...8).map { tool($0, settled: false) }
+        var folds = TranscriptFold.folds(in: facts)
+        var previous: Set<Int> = []
+        for seq in [2, 4, 6, 8, 3, 7, 5, 1] {
+            facts[seq].settled = true
+            folds = TranscriptFold.folds(in: facts, extending: folds)
+            let work = try #require(folds.all.first)
+            let hidden = TranscriptFold.hiddenIndices(work, revealed: [], drawn: everything)
+            #expect(folds.all.count == 1)
+            #expect(work.firstSeq == 1)
+            #expect(previous.isSubset(of: hidden))
+            #expect(hidden.allSatisfy { facts[$0].settled })
+            previous = hidden
+        }
+        #expect(previous == Set(1...8))
     }
 
     /// **Rule 2.** An error row is the agent exiting in a way it did not choose, which is the one
@@ -219,7 +245,8 @@ struct TranscriptFoldTests {
     @Test("a question nobody has answered is never hidden")
     func anUndecidedAskIsNeverHidden() throws {
         let waiting = [user(0), tool(1), tool(2), tool(3), tool(4), ask(5, decided: false), tool(6)]
-        #expect(hides(try only(waiting)) == 4)
+        let hidden = TranscriptFold.hiddenIndices(try only(waiting), revealed: [], drawn: everything)
+        #expect(hidden == [1, 2, 3, 4, 6])
         // Answered, it is history and folds away with everything else through the newest row.
         let decided = [user(0), tool(1), tool(2), tool(3), tool(4), ask(5), tool(6)]
         #expect(hides(try only(decided)) == 6)
@@ -255,7 +282,7 @@ struct TranscriptFoldTests {
     func aFailureIsSettled() throws {
         let facts = [user(0)] + (1..<7).map { tool($0, failed: $0 == 6, settled: $0 != 6) }
         let work = try only(facts)
-        #expect(work.ready == 6)
+        #expect(work.ready == Set(1..<7))
         #expect(hides(work) == 6)
     }
 
@@ -266,8 +293,8 @@ struct TranscriptFoldTests {
     @Test("a working that runs past the drawn window does not fold")
     func aWorkingOutsideTheWindowDoesNotFold() throws {
         let work = try only([user(0)] + (1..<7).map { tool($0) })
-        #expect(TranscriptFold.hides(work, revealed: [], drawn: 0..<7) == 6)
-        #expect(TranscriptFold.hides(work, revealed: [], drawn: 0..<6) == 0)
+        #expect(TranscriptFold.hiddenIndices(work, revealed: [], drawn: 0..<7).count == 6)
+        #expect(TranscriptFold.hiddenIndices(work, revealed: [], drawn: 0..<6).count == 0)
     }
 
     /// Only the window's end is asked about. Its start moves down as a reader scrolls back, and
@@ -276,8 +303,8 @@ struct TranscriptFoldTests {
     @Test("the window's start does not move what is hidden")
     func growingUpwardsTakesNothingOut() throws {
         let work = try only([user(0)] + (1..<7).map { tool($0) })
-        #expect(TranscriptFold.hides(work, revealed: [], drawn: 4..<20) == 6)
-        #expect(TranscriptFold.hides(work, revealed: [], drawn: 0..<20) == 6)
+        #expect(TranscriptFold.hiddenIndices(work, revealed: [], drawn: 4..<20).count == 6)
+        #expect(TranscriptFold.hiddenIndices(work, revealed: [], drawn: 0..<20).count == 6)
     }
 
     // MARK: Nothing unfolds
@@ -342,13 +369,13 @@ struct TranscriptFoldTests {
         let laterLive = TranscriptFold.Work(
             span: 20..<24,
             rows: (20..<24).map { TranscriptFold.Row(index: $0, seq: $0) },
-            ready: 4,
+            ready: Set(20..<24),
             hasAnswer: false
         )
         let historical = TranscriptFold.Work(
             span: 10..<14,
             rows: (10..<14).map { TranscriptFold.Row(index: $0, seq: $0) },
-            ready: 4,
+            ready: Set(10..<14),
             hasAnswer: true
         )
         let folds = TranscriptFold.Folds(


### PR DESCRIPTION
Completed actions now fold into the actions group even when earlier commands are still running, while running commands and unanswered permission requests stay visible. Removes the native branch-name tooltip so only the custom hover card appears.

Verified with 82 focused tests, an app build, and both lint checks.
