### PR TITLE
Give the tab activity indicator more breathing room

### DIFF
--- a/Sources/Bloom/Views/Tabs/TabItemView.swift
+++ b/Sources/Bloom/Views/Tabs/TabItemView.swift
@@ -115,6 +115,7 @@ struct TabItemView: View {
         HStack(spacing: Metrics.spacingSmall) {
             if isRunning {
                 ActivityDot(isActive: true)
+                    .padding(.trailing, Metrics.spacingSmall)
                     .accessibilityLabel("Running")
             }
 


### PR DESCRIPTION
Increase the gap between the blue activity dot and the chat icon from 4 to 8 points. Verified with `swift build --product Bloom`.