### PR TITLE
Use native popovers for merge and archive confirmations

### DIFF
--- a/Sources/Bloom/Design/Confirmation.swift
+++ b/Sources/Bloom/Design/Confirmation.swift
@@ -3,44 +3,11 @@ import AppKit
 
 /// The dialog Bloom asks a yes-or-no question in, drawn by Bloom rather than by AppKit.
 ///
-/// **Why this exists.** Every confirmation in the app was a `.confirmationDialog`, which is a
-/// perfectly good control right up to the moment you need one thing out of it that it does not
-/// offer. Merging is that moment. It is the only confirmation in the app whose answer is not a
-/// loss, and a system dialog can draw its confirm button in exactly two ways: red, or grey.
-/// `a595dfb` measured every route to a third colour and found none. `.tint` is ignored on an
-/// alert button, and `.foregroundStyle` or `.buttonStyle` do not restyle it, they drop it from the
-/// dialog.
+/// Used for confirmations that block the window, such as discarding a queued message.
+/// The pull request strip uses `ConfirmationPopover` for its merge and archive confirmations.
 ///
-/// The trap in that measurement is why this is a component and not a repaint. In a system dialog
-/// the button's role is two switches wired together and the second one is the safety: the roles
-/// that draw grey are exactly the roles that hand the answer to the Return key. A scratch build
-/// with the role dropped merged a real pull request on one keystroke. The price of colour, in a
-/// system dialog, is the guard. Owning the dialog is what buys both, and owning it means owning
-/// the key handling, which is written out under `Keys` below.
-///
-/// **Why a component and not a bespoke merge dialog.** The app asks eleven of these questions and
-/// they have always looked alike. If merging alone became a hand-drawn panel the app would have
-/// two kinds of confirmation, and the difference between them would tell the reader nothing: they
-/// would differ by when they were written rather than by what they ask. So this is the shape all
-/// eleven are meant to end in.
-///
-/// Three are converted: merging, archiving and throwing a queued message away. The other eight
-/// are still `.confirmationDialog`, and the count is written here rather than left to be guessed
-/// because this paragraph said six and one for as long as it took four of them to be written.
-/// They are the revert in the file header bar and the one in the changed file list, the removal
-/// of a project asked from three places (one question, see `ProjectRemoval`), the discard in the
-/// file edit pane and the two in `RootView`.
-///
-/// **Why it looks like the system's.** The eight are still system dialogs and they are the
-/// baseline the reader has in their eye, so every number in `Layout` was read off a real
-/// `.confirmationDialog` in a window capture rather than chosen. The controls are the system's
-/// own `.bordered` buttons, so their plate, their corner radius, their pressed state and their
-/// inactive-window rendering are AppKit's and cannot drift away from the five. Measured against
-/// the system dialog on the same machine the reproduction is exact except for the buttons, which
-/// come out 28 points tall against the alert's 30: an alert button is not a size `controlSize`
-/// offers, `.large` is 28 and `.extraLarge` is 36, and 28 for both is worth more than 30 for one.
-/// The sheet is 260 by 180 where the system's is 260 by 188, and that difference is those two
-/// buttons.
+/// Native buttons preserve macOS control behaviour. The keyboard begins on Cancel, Escape
+/// dismisses, and no button is assigned the default action. See `Keys` below.
 struct ConfirmationSheet: View {
     let confirmation: Confirmation
     let onConfirm: () -> Void

--- a/Sources/Bloom/Design/ConfirmationPopover.swift
+++ b/Sources/Bloom/Design/ConfirmationPopover.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// Shared native popover content for the pull request strip's existing confirmations.
+struct ConfirmationPopover<Content: View>: View {
+    let title: String
+    let confirmLabel: String
+    let tint: Color
+    var canConfirm = true
+    let onConfirm: () -> Void
+    let onCancel: () -> Void
+    var width: CGFloat = 340
+    @ViewBuilder var content: () -> Content
+
+    @FocusState private var focus: Field?
+
+    private enum Field: Hashable { case cancel, confirm }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+
+            content()
+
+            HStack(spacing: 8) {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .buttonStyle(.bordered)
+                    .focused($focus, equals: .cancel)
+                    .keyboardShortcut(.cancelAction)
+                Button(confirmLabel) {
+                    guard canConfirm else { return }
+                    onConfirm()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(tint)
+                .focused($focus, equals: .confirm)
+                .disabled(!canConfirm)
+            }
+            .padding(.top, 4)
+        }
+        .font(.body)
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(20)
+        .frame(width: width)
+        // Colour is independent of the default action: Return must never confirm.
+        .defaultFocus($focus, .cancel)
+    }
+}

--- a/Sources/Bloom/State/AppModel+Archive.swift
+++ b/Sources/Bloom/State/AppModel+Archive.swift
@@ -118,7 +118,10 @@ extension AppModel {
     /// through `isPullRequestMerged`, so what is left to stop an archive is an agent mid turn and
     /// work that exists nowhere but that directory. Neither is weakened for it.
     func archive(
-        _ workspace: Workspace, deleteBranch: Bool? = nil, alwaysConfirm: Bool = false
+        _ workspace: Workspace,
+        deleteBranch: Bool? = nil,
+        alwaysConfirm: Bool = false,
+        presentConfirmation: ((ArchiveRequest) -> Void)? = nil
     ) async {
         guard let manager, let repo = repo(for: workspace) else {
             Log.archive.error(
@@ -153,13 +156,13 @@ extension AppModel {
                 path: workspace.path,
                 baseBranch: workspace.baseBranch
             )
-            pendingArchive = ArchiveRequest(
+            offerArchiveConfirmation(ArchiveRequest(
                 workspace: workspace,
                 report: WorkspaceSafetyReport(),
                 deleteBranch: deleteBranch,
                 problem: "Bloom could not check this workspace for unsaved work. \(trouble.sentence)",
                 hazards: hazards
-            )
+            ), present: presentConfirmation)
             return
         }
 
@@ -169,9 +172,9 @@ extension AppModel {
         )
 
         guard isSafe, !hazards.isAgentRunning, !alwaysConfirm else {
-            pendingArchive = ArchiveRequest(
+            offerArchiveConfirmation(ArchiveRequest(
                 workspace: workspace, report: report, deleteBranch: deleteBranch, hazards: hazards
-            )
+            ), present: presentConfirmation)
             return
         }
 
@@ -181,7 +184,8 @@ extension AppModel {
             deleteBranch: deleteBranch,
             force: false,
             report: report,
-            hazards: hazards
+            hazards: hazards,
+            presentConfirmation: presentConfirmation
         )
     }
 
@@ -209,8 +213,11 @@ extension AppModel {
     ///
     /// So nothing here may depend on state a dismissal can clear. The value the dialog was built
     /// from is the value it acts on.
-    func confirmArchive(_ request: ArchiveRequest) async {
-        pendingArchive = nil
+    func confirmArchive(
+        _ request: ArchiveRequest,
+        presentConfirmation: ((ArchiveRequest) -> Void)? = nil
+    ) async {
+        if pendingArchive?.id == request.id { pendingArchive = nil }
         guard let repo = repo(for: request.workspace) else {
             Log.archive.error(
                 "confirmed the archive of \(request.workspace.name, privacy: .public), but its project is gone"
@@ -225,12 +232,24 @@ extension AppModel {
             deleteBranch: request.deleteBranch,
             force: true,
             report: request.problem == nil ? request.report : nil,
-            hazards: request.hazards
+            hazards: request.hazards,
+            presentConfirmation: presentConfirmation
         )
     }
 
     func cancelPendingArchive() {
         pendingArchive = nil
+    }
+
+    /// Keep repeat safety questions on the surface that started the archive.
+    private func offerArchiveConfirmation(
+        _ request: ArchiveRequest, present: ((ArchiveRequest) -> Void)?
+    ) {
+        if let present {
+            present(request)
+        } else {
+            pendingArchive = request
+        }
     }
 
     private func performArchive(
@@ -239,7 +258,8 @@ extension AppModel {
         deleteBranch: Bool?,
         force: Bool,
         report: WorkspaceSafetyReport?,
-        hazards: ArchiveHazards
+        hazards: ArchiveHazards,
+        presentConfirmation: ((ArchiveRequest) -> Void)?
     ) async {
         guard let manager else {
             Log.archive.error(
@@ -327,9 +347,9 @@ extension AppModel {
                     "\(workspace.name, privacy: .public) changed between the check and the archive, so it is being asked about again"
                 )
                 // Only reachable when the worktree changed between the check and the archive.
-                pendingArchive = ArchiveRequest(
+                offerArchiveConfirmation(ArchiveRequest(
                     workspace: workspace, report: fresh, deleteBranch: deleteBranch, hazards: hazards
-                )
+                ), present: presentConfirmation)
             default:
                 Log.archive.error(
                     "could not archive \(workspace.name, privacy: .public): \(error.readableMessage, privacy: .public)"

--- a/Sources/Bloom/Views/Inspector/MergeConfirmationPopover.swift
+++ b/Sources/Bloom/Views/Inspector/MergeConfirmationPopover.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import BloomCore
+
+/// A confirmation attached to the merge control, keeping the chat and diff visible.
+struct MergeConfirmationPopover: View {
+    let pullRequest: PullRequest
+    let baseBranch: String
+    let localWork: LocalWork?
+    let method: GitHub.MergeMethod
+    let deletesBranch: Bool
+    let canMerge: Bool
+    let onConfirm: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        ConfirmationPopover(
+            title: pullRequest.mergeConfirmationTitle(base: baseBranch),
+            confirmLabel: method.label,
+            tint: Palette.positive,
+            canConfirm: canMerge,
+            onConfirm: onConfirm,
+            onCancel: onCancel
+        ) {
+            ForEach(pullRequest.mergeWarnings(base: baseBranch, local: localWork), id: \.self) { warning in
+                Text(warning)
+                    .foregroundStyle(Palette.negative)
+            }
+
+            Text(pullRequest.mergeConfirmationMessage)
+
+            if let deletion = pullRequest.mergeBranchDeletionMessage(deletesBranch: deletesBranch) {
+                Text(deletion)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}

--- a/Sources/Bloom/Views/Inspector/PullRequestBar.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestBar.swift
@@ -32,6 +32,8 @@ struct PullRequestBar: View {
     private static let pollInterval = Duration.seconds(20)
 
     @State private var isWorking = false
+    @State private var pendingArchive: ArchiveRequest?
+    @State private var isVisible = false
 
     /// Where an answer goes. Set here, drawn in the column: see the note on the type.
     private var report: PullRequestNotice? {
@@ -42,6 +44,12 @@ struct PullRequestBar: View {
     var body: some View {
         strip
             .task(id: model.workspace.id) { await poll() }
+            .onChange(of: model.workspace.id) { _, _ in pendingArchive = nil }
+            .onAppear { isVisible = true }
+            .onDisappear {
+                isVisible = false
+                pendingArchive = nil
+            }
     }
 
     private var strip: some View {
@@ -97,7 +105,9 @@ struct PullRequestBar: View {
                 onPush: push,
                 onFixConflicts: { fixConflicts(on: pullRequest) },
                 onContinue: { carryOn(after: pullRequest) },
-                onArchive: archive
+                onArchive: archive,
+                archiveRequest: $pendingArchive,
+                onConfirmArchive: confirmArchive
             )
         } else {
             PullRequestCreator(
@@ -262,14 +272,24 @@ struct PullRequestBar: View {
         }
     }
 
-    /// Archives, through the app's own path with every safety check intact.
-    ///
-    /// No confirmation is raised here. `AppModel.archive` decides for itself whether to ask, and
-    /// on a merged pull request it will not unless there is genuinely something to lose. Why this
-    /// button is allowed to be quiet while the sidebar's hover button never is, is written out at
-    /// `PullRequestSummary.archiveButton`.
+    /// The safety checks stay in AppModel; only their presentation belongs to this button.
     private func archive() {
-        Task { await app.archive(model.workspace) }
+        let workspace = model.workspace
+        Task {
+            await app.archive(workspace, presentConfirmation: presentArchive)
+        }
+    }
+
+    private func confirmArchive(_ request: ArchiveRequest) {
+        pendingArchive = nil
+        Task {
+            await app.confirmArchive(request, presentConfirmation: presentArchive)
+        }
+    }
+
+    private func presentArchive(_ request: ArchiveRequest) {
+        guard isVisible, app.selection.workspaceID == request.workspace.id else { return }
+        pendingArchive = request
     }
 
     /// Hands the merge to the agent, the same way Create pull request and Commit and push do.

--- a/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
@@ -48,6 +48,8 @@ struct PullRequestSummary: View {
     var onContinue: () -> Void
     /// Archives, through the app's ordinary archive with all its checks intact.
     var onArchive: () -> Void
+    @Binding var archiveRequest: ArchiveRequest?
+    var onConfirmArchive: (ArchiveRequest) -> Void
 
     /// Which method the user picked, held only for as long as the confirmation is up. Non-nil is
     /// what presents the dialog, so there is no way to reach `onMerge` without passing through it.
@@ -87,40 +89,19 @@ struct PullRequestSummary: View {
                 ShareLink(item: url) { Text("Share") }
             }
         }
-        // Attached to the merge button's own row, so the dialog animates out of the control that
-        // asked for it.
-        //
-        // Bloom's own confirmation and not `.confirmationDialog`, and the reasoning is written
-        // out on `ConfirmationSheet`. The short version is that this is the one confirmation in
-        // the app whose answer is not a loss, a system dialog can only draw its confirm button in
-        // red or grey, and the roles that draw it grey are the same roles that hand the merge to
-        // the Return key. `a595dfb` measured that and kept the red button rather than give up the
-        // guard. This keeps the guard and drops the red: Escape still cancels, Return still does
-        // nothing, and the button that lands the branch is finally the colour of landing it.
-        .confirmation($pendingMerge) { method in
-            Confirmation(
-                title: pullRequest.mergeConfirmationTitle(base: baseBranch),
-                // The two things that change the answer, and nothing else. The title above names
-                // the pull request and the button below names the method, so neither is repeated.
-                message: pullRequest.mergeConfirmation(
-                    base: baseBranch,
-                    deletesBranch: Self.deletesBranch,
-                    local: localWork
-                ),
-                confirmLabel: method.label,
-                // Escape lands here. See `ConfirmationSheet` for why no confirmation in this app
-                // gives its cancel button `.keyboardShortcut(.defaultAction)`.
-                cancelLabel: "Keep the pull request open",
-                tone: .completing
-            )
-        } onConfirm: { method in
-            onMerge(method)
-        }
         // The Workspace menu's copy of the merge, which had no item anywhere until now. It is
         // published from here because here is the only place that can raise the confirmation
         // above, so the menu item asks this view rather than growing a second path to a merge.
         // See `MergeAction`.
         .focusedSceneValue(\.mergeAction, mergeAction)
+        .onChange(of: canConfirmMerge) { _, available in
+            if !available { pendingMerge = nil }
+        }
+        .onChange(of: branchActions.isAllowed) { _, allowed in
+            if !allowed { dismissConfirmation() }
+        }
+        .onChange(of: worktree) { _, _ in dismissConfirmation() }
+        .onChange(of: pullRequest.url) { _, _ in dismissConfirmation() }
     }
 
     /// What the menu bar's Merge item says and does, or nil when this strip has nothing to land:
@@ -260,6 +241,26 @@ struct PullRequestSummary: View {
         // strip's own context menu only ever read.
         trailingControls
             .disabled(!branchActions.isAllowed)
+            .popover(isPresented: Binding(
+                get: { pendingMerge != nil },
+                set: { if !$0 { pendingMerge = nil } }
+            ), arrowEdge: .top) {
+                if let method = pendingMerge {
+                    MergeConfirmationPopover(
+                        pullRequest: pullRequest,
+                        baseBranch: baseBranch,
+                        localWork: localWork,
+                        method: method,
+                        deletesBranch: Self.deletesBranch,
+                        canMerge: canConfirmMerge,
+                        onConfirm: {
+                            pendingMerge = nil
+                            onMerge(method)
+                        },
+                        onCancel: { pendingMerge = nil }
+                    )
+                }
+            }
     }
 
     @ViewBuilder
@@ -399,6 +400,26 @@ struct PullRequestSummary: View {
 
     private var archiveControl: some View {
         Button("Archive", systemImage: "archivebox", action: onArchive)
+            .popover(item: $archiveRequest, arrowEdge: .top) { request in
+                ConfirmationPopover(
+                    title: "Archive this workspace?",
+                    confirmLabel: request.confirmLabel,
+                    tint: request.isDestructive ? Palette.negative : Palette.mergedFill,
+                    canConfirm: branchActions.isAllowed && !isWorking,
+                    onConfirm: { onConfirmArchive(request) },
+                    onCancel: dismissConfirmation,
+                    width: 380
+                ) {
+                    ViewThatFits(in: .vertical) {
+                        Text(request.message).fixedSize(horizontal: false, vertical: true)
+                        ScrollView {
+                            Text(request.message).frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .scrollBounceBehavior(.basedOnSize)
+                    }
+                    .frame(maxHeight: 440)
+                }
+            }
             .buttonStyle(.borderedProminent)
             .buttonBorderShape(.roundedRectangle(radius: Metrics.corner))
             .tint(status.tone.fill)
@@ -543,6 +564,15 @@ struct PullRequestSummary: View {
             choose: onChooseMergeMethod,
             merge: { propose(mergeMethod) }
         )
+    }
+
+    private func dismissConfirmation() {
+        pendingMerge = nil
+        archiveRequest = nil
+    }
+
+    private var canConfirmMerge: Bool {
+        pullRequest.isOpen && status.canMerge && branchActions.isAllowed && !isWorking
     }
 
     // MARK: - Text

--- a/Sources/BloomCore/GitHub/PullRequestStatus.swift
+++ b/Sources/BloomCore/GitHub/PullRequestStatus.swift
@@ -243,64 +243,45 @@ public extension PullRequest {
         )
     }
 
-    /// The title of the confirmation, which is the one line a user reliably reads.
-    ///
-    /// It says who does it, and that is the whole of the change from the version that read "Merge
-    /// #42 into main?". Bloom no longer runs `gh pr merge`: the request goes to this workspace's
-    /// agent as an ordinary turn, and a title that implies the app is about to do it is the one
-    /// line most likely to be believed.
     func mergeConfirmationTitle(base: String) -> String {
-        "Ask the agent to merge #\(number) into \(base)?"
+        "Merge #\(number) into \(base)?"
     }
 
-    /// What confirming does, said as consequences rather than as a question.
-    ///
-    /// Rewritten when the merge moved onto the agent, and the closing paragraph is the part that
-    /// changed meaning rather than wording. It used to end "Bloom cannot undo this", which was the
-    /// honest thing to say about an app that was about to call `gh pr merge` itself and had no
-    /// answer for what came back. Bloom does not call it any more. What the reader is agreeing to
-    /// is a message going into the chat, and the two facts that follow from that are worth more
-    /// than an undo warning: the commands happen in front of them, under whatever permission mode
-    /// they set, and a refusal from GitHub comes back as words instead of as a failed button.
-    ///
-    /// What did NOT change is the first paragraph. A squash merge still lands what GitHub has,
-    /// not what is on this disk, and moving the work to an agent does not put an uncommitted file
-    /// into the merge. The strip lets the button stay live over local work rather than disabling
-    /// it, so this is still where that trade is paid back.
-    ///
-    /// The two conditional paragraphs are not compression candidates. Each of them only appears
-    /// when it is the most important thing on screen.
-    func mergeConfirmation(
-        base: String,
-        deletesBranch: Bool,
-        local: LocalWork? = nil
-    ) -> String {
-        var paragraphs: [String] = []
-        // First, above the rest, because it is the one line here that says the merge will land
-        // something OTHER than what the reader is looking at.
+    var mergeConfirmationMessage: String {
+        "Your agent will merge this pull request in the chat, where you can follow its progress."
+    }
+
+    func mergeBranchDeletionMessage(deletesBranch: Bool) -> String? {
+        guard deletesBranch, !branch.isEmpty else { return nil }
+        return "After merging, \(branch) will be deleted on GitHub. Your local branch stays."
+    }
+
+    /// These warnings precede the explanation so a merge of older work or a failing check
+    /// cannot disappear into the secondary branch-deletion note.
+    func mergeWarnings(base: String, local: LocalWork? = nil) -> [String] {
+        var warnings: [String] = []
         if let local, local.isAhead {
-            paragraphs.append(
+            warnings.append(
                 "GitHub does not have everything in this worktree: "
                     + Self.localDetail(local)
                     + ". None of that is part of what is merged, and the agent is told to leave it"
                     + " alone rather than commit it first."
             )
         }
-        if checks == .failing || hasConflicts {
-            paragraphs.append(
-                checks == .failing ? checksSummary : "This branch conflicts with \(base)."
-            )
-        }
-        // An older gh does not report the head branch, and naming a branch we are guessing at
-        // would be worse than not naming one. The instructions this turn carries say the same
-        // thing: without a name, the branch on the server is left standing.
-        var closing = "This workspace's agent is asked to merge it, in the chat, so you see every "
-            + "command it runs and it can tell you if GitHub refuses."
-        if deletesBranch, !branch.isEmpty {
-            closing += " Once the merge lands it deletes \(branch) on GitHub, not here."
-        }
-        paragraphs.append(closing)
-        return paragraphs.joined(separator: "\n\n")
+        if checks == .failing { warnings.append(checksSummary) }
+        if hasConflicts { warnings.append("This branch conflicts with \(base).") }
+        return warnings
+    }
+
+    func mergeConfirmation(
+        base: String,
+        deletesBranch: Bool,
+        local: LocalWork? = nil
+    ) -> String {
+        (mergeWarnings(base: base, local: local)
+            + [mergeConfirmationMessage]
+            + [mergeBranchDeletionMessage(deletesBranch: deletesBranch)].compactMap { $0 })
+            .joined(separator: "\n\n")
     }
 
     /// The headline for an open, unblocked pull request.

--- a/Tests/BloomCoreTests/WorkspaceStatusTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceStatusTests.swift
@@ -268,8 +268,6 @@ struct WorkspaceStatusTests {
         ).branch.isEmpty)
     }
 
-    /// The title is the one line a reader reliably reads, so it is the line that has to say who
-    /// merges. Bloom does not: the request goes to the workspace's agent as an ordinary turn.
     @Test("the merge confirmation says who is going to do it")
     func mergeConfirmationNamesEverything() throws {
         let pullRequest = try decode(json(
@@ -278,7 +276,7 @@ struct WorkspaceStatusTests {
         ))
 
         #expect(pullRequest.mergeConfirmationTitle(base: "main")
-            == "Ask the agent to merge #42 into main?")
+            == "Merge #42 into main?")
 
         let text = pullRequest.mergeConfirmation(base: "main", deletesBranch: true)
         #expect(text.contains("feature/glyphs"))
@@ -294,17 +292,14 @@ struct WorkspaceStatusTests {
         #expect(!text.contains("Squash and merge"))
     }
 
-    /// One paragraph still, and both halves of what confirming actually does: a turn goes into the
-    /// chat, and the branch on the server goes after the merge lands.
-    @Test("a clean merge confirmation is one short paragraph")
+    @Test("a clean merge separates the explanation from the branch deletion note")
     func mergeConfirmationIsShort() throws {
-        let text = try decode(json(state: "OPEN")).mergeConfirmation(
-            base: "main", deletesBranch: true
-        )
-        #expect(text == "This workspace's agent is asked to merge it, in the chat, so you see "
-            + "every command it runs and it can tell you if GitHub refuses. Once the merge lands "
-            + "it deletes feature/glyphs on GitHub, not here.")
-        #expect(!text.contains("\n"))
+        let pullRequest = try decode(json(state: "OPEN"))
+        #expect(pullRequest.mergeWarnings(base: "main").isEmpty)
+        #expect(pullRequest.mergeConfirmationMessage
+            == "Your agent will merge this pull request in the chat, where you can follow its progress.")
+        #expect(pullRequest.mergeBranchDeletionMessage(deletesBranch: true)
+            == "After merging, feature/glyphs will be deleted on GitHub. Your local branch stays.")
     }
 
     @Test("a confirmation that does not delete the branch does not claim to")
@@ -312,8 +307,9 @@ struct WorkspaceStatusTests {
         let text = try decode(json(state: "OPEN")).mergeConfirmation(
             base: "main", deletesBranch: false
         )
-        #expect(!text.contains("is deleted on GitHub"))
-        #expect(text.contains("asked to merge it, in the chat"))
+        #expect(!text.contains("deleted on GitHub"))
+        #expect(text.contains("agent will merge this pull request in the chat"))
+        #expect(try decode(json(state: "OPEN")).mergeBranchDeletionMessage(deletesBranch: false) == nil)
     }
 
     /// `describesPullRequest` is what sends `summary` and `detail` off to a pull request for the


### PR DESCRIPTION
Replace the pull request bar's merge and archive confirmation dialogs with native popovers so the chat and diff stay visible. Add coloured confirm buttons, shorter merge copy, and scrollable archive warnings while preserving safety checks and cancellation behaviour.

Verified with a release build, 98 targeted tests, and both linters.
