### PR TITLE
Anchor archive confirmations to their source controls

### DIFF
--- a/Sources/Bloom/Design/ConfirmationPopover.swift
+++ b/Sources/Bloom/Design/ConfirmationPopover.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Shared native popover content for the pull request strip's existing confirmations.
+/// Shared native popover content for confirmations attached to their initiating controls.
 struct ConfirmationPopover<Content: View>: View {
     let title: String
     let confirmLabel: String
@@ -39,6 +39,9 @@ struct ConfirmationPopover<Content: View>: View {
             }
             .padding(.top, 4)
         }
+        // A selected sidebar row inverts its ink. The popover has its own neutral surface.
+        .environment(\.backgroundProminence, .standard)
+        .foregroundStyle(.primary)
         .font(.body)
         .fixedSize(horizontal: false, vertical: true)
         .padding(20)

--- a/Sources/Bloom/Design/SidebarIndentGallery.swift
+++ b/Sources/Bloom/Design/SidebarIndentGallery.swift
@@ -141,7 +141,9 @@ struct SidebarIndentGallery: View {
             ),
             isRunning: false,
             renaming: $renaming,
-            onArchive: { _ in }
+            onArchive: { _ in },
+            archiveRequest: .constant(nil),
+            menuArchiveRequest: .constant(nil)
         )
         .padding(.leading, SidebarMetrics.rowIndent)
         .frame(height: 32)

--- a/Sources/Bloom/Design/WorkspaceMenuItems.swift
+++ b/Sources/Bloom/Design/WorkspaceMenuItems.swift
@@ -93,6 +93,8 @@ struct WorkspaceMenuItems: View {
 
     var workspace: Workspace
     var scope: Scope = .row
+    /// A visible source can keep the safety question attached to its own control.
+    var onArchive: (() -> Void)?
     /// Raised to the list, which owns the one rename field that can be open at a time.
     var onRename: (WorkspaceID) -> Void
 
@@ -126,7 +128,11 @@ struct WorkspaceMenuItems: View {
         // The sidebar row's own hover archive button DOES ask every time, and that is not a
         // disagreement with this. See `SidebarWorkspaceRow.confirmRowArchive`.
         Button("Archive", role: .destructive) {
-            Task { await app.archive(workspace) }
+            if let onArchive {
+                onArchive()
+            } else {
+                Task { await app.archive(workspace) }
+            }
         }
     }
 

--- a/Sources/Bloom/Views/Archive/ArchiveConfirmationPopover.swift
+++ b/Sources/Bloom/Views/Archive/ArchiveConfirmationPopover.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import BloomCore
+
+struct ArchiveConfirmationPopover: View {
+    let request: ArchiveRequest
+    var canConfirm = true
+    let onConfirm: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        ConfirmationPopover(
+            title: "Archive this workspace?",
+            confirmLabel: request.confirmLabel,
+            tint: tint,
+            canConfirm: canConfirm,
+            onConfirm: onConfirm,
+            onCancel: onCancel,
+            width: 380
+        ) {
+            ViewThatFits(in: .vertical) {
+                Text(request.message).fixedSize(horizontal: false, vertical: true)
+                ScrollView {
+                    Text(request.message).frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .scrollBounceBehavior(.basedOnSize)
+            }
+            .frame(maxHeight: 440)
+        }
+    }
+
+    private var tint: Color {
+        if request.isDestructive { return Palette.negative }
+        return request.hazards.isPullRequestMerged ? Palette.mergedFill : Palette.controlAccent
+    }
+}
+
+extension View {
+    /// Attach this to the initiating control, which stays in the hierarchy until dismissal.
+    func archiveConfirmation(
+        _ request: Binding<ArchiveRequest?>,
+        arrowEdge: Edge = .top,
+        canConfirm: Bool = true,
+        onConfirm: @escaping (ArchiveRequest) -> Void
+    ) -> some View {
+        popover(item: request, arrowEdge: arrowEdge) { value in
+            ArchiveConfirmationPopover(
+                request: value,
+                canConfirm: canConfirm,
+                onConfirm: {
+                    request.wrappedValue = nil
+                    onConfirm(value)
+                },
+                onCancel: { request.wrappedValue = nil }
+            )
+        }
+    }
+}

--- a/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
@@ -400,26 +400,11 @@ struct PullRequestSummary: View {
 
     private var archiveControl: some View {
         Button("Archive", systemImage: "archivebox", action: onArchive)
-            .popover(item: $archiveRequest, arrowEdge: .top) { request in
-                ConfirmationPopover(
-                    title: "Archive this workspace?",
-                    confirmLabel: request.confirmLabel,
-                    tint: request.isDestructive ? Palette.negative : Palette.mergedFill,
-                    canConfirm: branchActions.isAllowed && !isWorking,
-                    onConfirm: { onConfirmArchive(request) },
-                    onCancel: dismissConfirmation,
-                    width: 380
-                ) {
-                    ViewThatFits(in: .vertical) {
-                        Text(request.message).fixedSize(horizontal: false, vertical: true)
-                        ScrollView {
-                            Text(request.message).frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                        .scrollBounceBehavior(.basedOnSize)
-                    }
-                    .frame(maxHeight: 440)
-                }
-            }
+            .archiveConfirmation(
+                $archiveRequest,
+                canConfirm: branchActions.isAllowed && !isWorking,
+                onConfirm: onConfirmArchive
+            )
             .buttonStyle(.borderedProminent)
             .buttonBorderShape(.roundedRectangle(radius: Metrics.corner))
             .tint(status.tone.fill)

--- a/Sources/Bloom/Views/Sidebar/SidebarView.swift
+++ b/Sources/Bloom/Views/Sidebar/SidebarView.swift
@@ -47,6 +47,7 @@ struct SidebarView: View {
     /// What the list itself thinks is selected. See the `onChange` pair below for why this is not
     /// bound straight to the model.
     @State private var listSelection: SidebarSelection?
+    @State private var archivePresentation = SidebarArchivePresentation()
 
     /// The grouped, filtered, sorted list the rows are drawn from.
     ///
@@ -326,7 +327,11 @@ struct SidebarView: View {
         // second, and the cost that argument is about is not here.
         .onChange(of: app.pendingWorkspaces) { _, _ in regroup() }
         // Rescoped, so widening the filter is not forty rows fading in at once. See `RowArrival`.
-        .onChange(of: filter) { _, _ in regroup(rescoped: true) }
+        .onChange(of: filter) { _, _ in
+            archivePresentation.cancel()
+            regroup(rescoped: true)
+        }
+        .onDisappear { archivePresentation.cancel() }
         // NOT rescoped, unlike the filter above, and the difference is what the two switches do.
         // A filter is a question you ask of rows that were always there. This one inserts project
         // headers at several depths at once, and a row that is arriving has no old position to
@@ -347,7 +352,11 @@ struct SidebarView: View {
         .onDeleteCommand {
             guard let id = app.selection.workspaceID,
                   let workspace = app.workspaces.first(where: { $0.id == id }) else { return }
-            Task { await app.archive(workspace) }
+            guard paneRows.contains(where: { row in
+                if case .workspace(let shown, _) = row { return shown.id == workspace.id }
+                return false
+            }) else { return }
+            archiveFromKeyboard(workspace)
         }
         // Rename from the menu bar, which reaches the field this list owns. A workspace this pane
         // is not drawing is ignored, so Home and the sidebar can both listen to one post.
@@ -564,6 +573,17 @@ struct SidebarView: View {
         app.selection = listSelection
     }
 
+    private func archiveFromKeyboard(_ workspace: Workspace) {
+        WorkspaceHoverCardPresenter.shared.pointerExited(.workspaceRow(workspace.id))
+        let generation = archivePresentation.begin(workspaceID: workspace.id, source: .row)
+        Task {
+            defer { archivePresentation.finish(generation: generation) }
+            await app.archive(workspace) { request in
+                archivePresentation.present(request, generation: generation)
+            }
+        }
+    }
+
     /// One workspace in the pane, with the fill and the ink the top level rows also take.
     private func workspaceRow(_ workspace: Workspace, projectName: String) -> some View {
         let target = SidebarSelection.workspace(workspace.id)
@@ -571,7 +591,8 @@ struct SidebarView: View {
             workspace: workspace,
             arrival: arrival,
             projectName: projectName,
-            renaming: $renaming
+            renaming: $renaming,
+            archivePresentation: $archivePresentation
         )
         .tag(target)
         // The same fill the three top level rows take. A row of one kind selecting in one blue and

--- a/Sources/Bloom/Views/Sidebar/SidebarWorkspaceRow.swift
+++ b/Sources/Bloom/Views/Sidebar/SidebarWorkspaceRow.swift
@@ -22,12 +22,19 @@ struct SidebarWorkspaceRow: View {
     /// See `body`, and `RepoHeaderRow.name` for why this is words rather than an outline level.
     var projectName: String
     @Binding var renaming: WorkspaceID?
+    @Binding var archivePresentation: SidebarArchivePresentation
 
     @Environment(AppModel.self) private var app
 
     /// Where this row is on screen, for the card that opens beside it. Held rather than reported:
     /// see `HoverCardAnchor`.
     @State private var anchor = HoverCardAnchor()
+    private typealias ArchiveSource = SidebarArchivePresentation.Source
+
+    private var isArchiveActive: Bool {
+        archivePresentation.workspaceID == workspace.id
+            && (archivePresentation.request != nil || archivePresentation.isRequesting)
+    }
 
     var body: some View {
         WorkspaceRow(
@@ -35,7 +42,12 @@ struct SidebarWorkspaceRow: View {
             isRunning: app.isRunning(workspace),
             isAwaitingPermission: app.isAwaitingPermission(workspace),
             renaming: $renaming,
-            onArchive: confirmRowArchive
+            onArchive: confirmRowArchive,
+            onMenuArchive: { archive(from: .menu) },
+            isArchiveActive: isArchiveActive,
+            archiveRequest: archiveBinding(for: .button),
+            menuArchiveRequest: archiveBinding(for: .menu),
+            onConfirmArchive: confirmArchive
         )
         // Innermost, on the drawing alone. Everything below this line is what the list is told
         // about the row, and a workspace that is fading in is still selectable, draggable and
@@ -81,7 +93,9 @@ struct SidebarWorkspaceRow: View {
         }
         // A row that leaves the pane while its card is up: archived from the menu bar, filtered
         // out, or its project folded. The pointer never leaves, so no exit ever arrives.
+        .onAppear { archivePresentation.rowAppeared(workspace.id) }
         .onDisappear {
+            archivePresentation.rowDisappeared(workspace.id, isArchiving: app.isArchiving(workspace.id))
             WorkspaceHoverCardPresenter.shared.pointerExited(.workspaceRow(workspace.id))
         }
         // Every item in it is `WorkspaceMenuItems`, which Home's rows draw from as well. It used
@@ -90,7 +104,12 @@ struct SidebarWorkspaceRow: View {
         //
         // The row's own hover ellipsis draws the same view, so a press and a right click on one
         // row cannot come up with different menus. See `WorkspaceRow.moreMenu`.
-        .contextMenu { WorkspaceMenuItems(workspace: workspace) { renaming = $0 } }
+        .contextMenu {
+            WorkspaceMenuItems(workspace: workspace, onArchive: { archive(from: .row) }) {
+                renaming = $0
+            }
+        }
+        .archiveConfirmation(archiveBinding(for: .row), arrowEdge: .leading, onConfirm: confirmArchive)
     }
 
     /// What the row's archive button does instead of archiving.
@@ -111,7 +130,47 @@ struct SidebarWorkspaceRow: View {
     /// is now said as an argument, and the one dialog that appears is the one that knows what is
     /// at stake. See `AppModel.archive(_:deleteBranch:alwaysConfirm:)`.
     private func confirmRowArchive(_ workspace: Workspace) {
-        Task { await app.archive(workspace, alwaysConfirm: true) }
+        archive(from: .button, alwaysConfirm: true)
+    }
+
+    private func archiveBinding(for source: ArchiveSource) -> Binding<ArchiveRequest?> {
+        Binding(
+            get: {
+                guard archivePresentation.workspaceID == workspace.id,
+                      archivePresentation.source == source else { return nil }
+                return archivePresentation.request
+            },
+            set: { request in
+                guard request == nil, archivePresentation.workspaceID == workspace.id,
+                      archivePresentation.source == source else { return }
+                archivePresentation.dismissRequest()
+            }
+        )
+    }
+
+    private func archive(from source: ArchiveSource, alwaysConfirm: Bool = false) {
+        let generation = beginArchive(from: source)
+        Task {
+            defer { archivePresentation.finish(generation: generation) }
+            await app.archive(workspace, alwaysConfirm: alwaysConfirm) { request in
+                archivePresentation.present(request, generation: generation)
+            }
+        }
+    }
+
+    private func confirmArchive(_ request: ArchiveRequest) {
+        let generation = beginArchive(from: archivePresentation.source)
+        Task {
+            defer { archivePresentation.finish(generation: generation) }
+            await app.confirmArchive(request) { fresh in
+                archivePresentation.present(fresh, generation: generation)
+            }
+        }
+    }
+
+    private func beginArchive(from source: ArchiveSource) -> UUID {
+        WorkspaceHoverCardPresenter.shared.pointerExited(.workspaceRow(workspace.id))
+        return archivePresentation.begin(workspaceID: workspace.id, source: source)
     }
 
     /// What the card says, built at the moment it opens rather than on every redraw.
@@ -125,7 +184,7 @@ struct SidebarWorkspaceRow: View {
     /// card over the window showing the name being replaced is a card about a fact that is in the
     /// middle of changing.
     private func hoverCard() -> WorkspaceHoverCard? {
-        guard renaming != workspace.id else { return nil }
+        guard renaming != workspace.id, !isArchiveActive else { return nil }
         return WorkspaceHoverCard.make(
             workspace: workspace,
             isRunning: app.isRunning(workspace),

--- a/Sources/Bloom/Views/Sidebar/WorkspaceRow.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspaceRow.swift
@@ -44,6 +44,11 @@ struct WorkspaceRow: View {
     /// Raised to `SidebarWorkspaceRow`, which owns both the confirmation and the call into the
     /// model, so this button and the row's context menu cannot end up on different paths.
     var onArchive: (Workspace) -> Void
+    var onMenuArchive: (() -> Void)?
+    var isArchiveActive = false
+    @Binding var archiveRequest: ArchiveRequest?
+    @Binding var menuArchiveRequest: ArchiveRequest?
+    var onConfirmArchive: (ArchiveRequest) -> Void = { _ in }
 
     @Environment(AppModel.self) private var app
 
@@ -226,7 +231,7 @@ struct WorkspaceRow: View {
 
     /// Whether the two hover controls are being shown. Never while renaming: the field owns the
     /// whole row, and controls drawn over its trailing edge would sit on the text being typed.
-    private var controlsShown: Bool { isHovered && !isRenaming }
+    private var controlsShown: Bool { (isHovered || isArchiveActive) && !isRenaming }
 
     /// The width the controls cover when they are shown: the two buttons, side by side.
     private static let controlsWidth = SidebarMetrics.rowButton * 2
@@ -338,7 +343,7 @@ struct WorkspaceRow: View {
     /// `SidebarWorkspaceRow.confirmRowArchive`.
     private var moreMenu: some View {
         Menu {
-            WorkspaceMenuItems(workspace: workspace) { renaming = $0 }
+            WorkspaceMenuItems(workspace: workspace, onArchive: onMenuArchive) { renaming = $0 }
         } label: {
             // Still the CIRCLED ellipsis, which is not what the colour complaint looked like it
             // was asking for. A bare `ellipsis` was the obvious partner for `archivebox`, on the
@@ -377,6 +382,7 @@ struct WorkspaceRow: View {
         .fixedSize()
         .foregroundStyle(isEmphasized ? Palette.textInverted : Palette.textSecondary)
         .help("More for this workspace")
+        .archiveConfirmation($menuArchiveRequest, arrowEdge: .leading, onConfirm: onConfirmArchive)
     }
 
     private var archiveButton: some View {
@@ -398,6 +404,7 @@ struct WorkspaceRow: View {
         // way, and `ComposerStopButton`, which spelled the keys out in words.
         .help("Archive workspace (⌘⌫)")
         .accessibilityLabel("Archive \(workspace.name)")
+        .archiveConfirmation($archiveRequest, arrowEdge: .leading, onConfirm: onConfirmArchive)
     }
 
     // MARK: - Renaming

--- a/Sources/BloomCore/Presentation/SidebarArchivePresentation.swift
+++ b/Sources/BloomCore/Presentation/SidebarArchivePresentation.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Owned by the sidebar so an optimistic archive can remove and restore its source row.
+public struct SidebarArchivePresentation: Sendable {
+    public enum Source: Sendable { case button, menu, row }
+
+    public private(set) var workspaceID: WorkspaceID?
+    public private(set) var source = Source.row
+    public private(set) var request: ArchiveRequest?
+    public private(set) var isRequesting = false
+    private var generation = UUID()
+    private var isVisible = false
+    private var isReturningAfterArchive = false
+
+    public init() {}
+
+    public mutating func begin(workspaceID: WorkspaceID, source: Source) -> UUID {
+        generation = UUID()
+        self.workspaceID = workspaceID
+        self.source = source
+        request = nil
+        isRequesting = true
+        isVisible = true
+        isReturningAfterArchive = false
+        return generation
+    }
+
+    public mutating func present(_ request: ArchiveRequest, generation: UUID) {
+        guard self.generation == generation, workspaceID == request.workspace.id,
+              isVisible || isReturningAfterArchive else { return }
+        self.request = request
+    }
+
+    public mutating func finish(generation: UUID) {
+        guard self.generation == generation else { return }
+        isRequesting = false
+    }
+
+    public mutating func rowAppeared(_ id: WorkspaceID) {
+        guard workspaceID == id else { return }
+        isVisible = true
+        isReturningAfterArchive = false
+    }
+
+    public mutating func rowDisappeared(_ id: WorkspaceID, isArchiving: Bool) {
+        guard workspaceID == id else { return }
+        isVisible = false
+        isReturningAfterArchive = isArchiving
+        if !isArchiving { cancel() }
+    }
+
+    /// A second dismissal from SwiftUI must not cancel the archive the confirm button just began.
+    public mutating func dismissRequest() {
+        guard request != nil else { return }
+        cancel()
+    }
+
+    public mutating func cancel() {
+        generation = UUID()
+        request = nil
+        isRequesting = false
+        isReturningAfterArchive = false
+    }
+}

--- a/Tests/BloomCoreTests/SidebarArchivePresentationTests.swift
+++ b/Tests/BloomCoreTests/SidebarArchivePresentationTests.swift
@@ -1,0 +1,105 @@
+import Testing
+@testable import BloomCore
+
+@Suite("Sidebar archive presentation")
+struct SidebarArchivePresentationTests {
+    @Test("a repeat safety question survives the archive removing and restoring its row")
+    func optimisticRemoval() {
+        var presentation = SidebarArchivePresentation()
+        let request = request()
+        let generation = presentation.begin(workspaceID: request.workspace.id, source: .menu)
+
+        presentation.rowDisappeared(request.workspace.id, isArchiving: true)
+        presentation.present(request, generation: generation)
+        presentation.finish(generation: generation)
+        presentation.rowAppeared(request.workspace.id)
+
+        #expect(presentation.request?.id == request.id)
+        #expect(presentation.source == .menu)
+        #expect(!presentation.isRequesting)
+    }
+
+    @Test("filtering or collapsing the source row discards a delayed safety question")
+    func voluntaryRemoval() {
+        var presentation = SidebarArchivePresentation()
+        let request = request()
+        let generation = presentation.begin(workspaceID: request.workspace.id, source: .button)
+
+        presentation.rowDisappeared(request.workspace.id, isArchiving: false)
+        presentation.rowAppeared(request.workspace.id)
+        presentation.present(request, generation: generation)
+
+        #expect(presentation.request == nil)
+        #expect(!presentation.isRequesting)
+    }
+
+    @Test("leaving the sidebar cancels even a question waiting for an archived row to return")
+    func leavingSidebar() {
+        var presentation = SidebarArchivePresentation()
+        let request = request()
+        let generation = presentation.begin(workspaceID: request.workspace.id, source: .row)
+
+        presentation.rowDisappeared(request.workspace.id, isArchiving: true)
+        presentation.cancel()
+        presentation.present(request, generation: generation)
+        presentation.rowAppeared(request.workspace.id)
+
+        #expect(presentation.request == nil)
+    }
+
+    @Test("the newest archive action owns its source and pending report")
+    func supersededAction() {
+        var presentation = SidebarArchivePresentation()
+        let first = request()
+        let second = request()
+        let oldGeneration = presentation.begin(workspaceID: first.workspace.id, source: .button)
+        let generation = presentation.begin(workspaceID: second.workspace.id, source: .row)
+
+        presentation.present(first, generation: oldGeneration)
+        presentation.finish(generation: oldGeneration)
+        #expect(presentation.request == nil)
+        #expect(presentation.isRequesting)
+
+        presentation.present(second, generation: generation)
+        #expect(presentation.request?.id == second.id)
+        #expect(presentation.source == .row)
+    }
+
+    @Test("a second dismissal does not cancel the action started by confirming")
+    func duplicateDismissal() {
+        var presentation = SidebarArchivePresentation()
+        let request = request()
+        let initial = presentation.begin(workspaceID: request.workspace.id, source: .button)
+        presentation.present(request, generation: initial)
+        presentation.dismissRequest()
+
+        let confirmed = presentation.begin(workspaceID: request.workspace.id, source: .button)
+        presentation.dismissRequest()
+        presentation.present(request, generation: confirmed)
+
+        #expect(presentation.request?.id == request.id)
+        #expect(presentation.isRequesting)
+    }
+
+    @Test("another row leaving the list cannot cancel this workspace's confirmation")
+    func unrelatedRow() {
+        var presentation = SidebarArchivePresentation()
+        let request = request()
+        let generation = presentation.begin(workspaceID: request.workspace.id, source: .button)
+
+        presentation.rowDisappeared(.new(), isArchiving: false)
+        presentation.present(request, generation: generation)
+
+        #expect(presentation.request?.workspace.id == request.workspace.id)
+    }
+
+    private func request() -> ArchiveRequest {
+        ArchiveRequest(
+            workspace: Workspace(
+                repoID: .new(), name: "Archive example", branch: "example",
+                path: "/tmp/archive-example", baseBranch: "main"
+            ),
+            report: WorkspaceSafetyReport()
+        )
+    }
+}


### PR DESCRIPTION
Show archive confirmations in native popovers anchored to the sidebar action or top-right Archive button. Share the confirmation view, keep hover controls visible while asking, and preserve safety warnings when an archive removes and restores its row.

The app builds with warnings treated as errors; both linters and 59 targeted tests pass.
