### PR TITLE
Fix repeated permission prompts after approving a plan

### DIFF
--- a/Sources/Bloom/Design/PlanApprovalSnapshotGallery.swift
+++ b/Sources/Bloom/Design/PlanApprovalSnapshotGallery.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+import BloomCore
+
+struct PlanApprovalSnapshotGallery: View {
+    private func card(mode: PermissionMode, decision: String? = nil) -> some View {
+        PermissionAskRowView(
+            ask: PermissionAsk(
+                requestID: "plan-\(mode.rawValue)", toolName: "ExitPlanMode",
+                input: .object(["plan": .string("Create two files, then update the first.")]),
+                requiresUserInteraction: true, implementationMode: mode
+            ),
+            decision: decision, note: "", projectName: "Bloom"
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.gutter) {
+            card(mode: .acceptEdits)
+            card(mode: .auto)
+            card(mode: .bypassPermissions)
+            card(mode: .acceptEdits, decision: "approve-plan-acceptEdits")
+            card(mode: .acceptEdits).frame(width: 350)
+        }
+        .padding(20)
+        .background(Palette.windowBackground)
+    }
+}

--- a/Sources/Bloom/Design/Snapshot.swift
+++ b/Sources/Bloom/Design/Snapshot.swift
@@ -923,6 +923,7 @@ enum Snapshot {
             ("home", AnyView(HomeView().frame(width: 900, height: 620)), CGSize(width: 900, height: 620)),
             ("components", AnyView(ComponentGallery().frame(width: 640, height: 700)), CGSize(width: 640, height: 700)),
             ("permission", AnyView(PermissionSnapshotGallery().frame(width: 720, height: 1560)), CGSize(width: 720, height: 1560)),
+            ("plan-approval", AnyView(PlanApprovalSnapshotGallery()), CGSize(width: 720, height: 1100)),
             ("tool-rows", AnyView(ToolRowSnapshotGallery().frame(width: 800, height: 1_020)), CGSize(width: 800, height: 1_020)),
             // Offscreen rather than through a window: no `CheckRunRow` holds a representable, so
             // `ImageRenderer` draws the real column here.

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -550,6 +550,7 @@ final class TranscriptModel {
         model: String? = nil,
         effort: String? = nil,
         permissionMode: PermissionMode? = nil,
+        implementationMode: PermissionMode? = nil,
         agentKind: AgentKind? = nil
     ) async {
         guard let store else { return }
@@ -559,6 +560,7 @@ final class TranscriptModel {
             model: model,
             effort: effort,
             permissionMode: permissionMode,
+            implementationMode: implementationMode,
             agentKind: agentKind
         )
         await refreshSession()
@@ -1593,6 +1595,12 @@ final class TranscriptModel {
     /// buttons stop being pressable the moment one of them is, and a slow store cannot leave two
     /// answers on their way to the same question.
     func answer(requestID: String, decision: PermissionDecision) async {
+        if case .approvePlan = decision {
+            // Saving the implementation mode can fail. Keep the card answerable until the
+            // runner confirms it, rather than showing a settled plan above a blocked agent.
+            await runner?.answer(requestID: requestID, decision: decision)
+            return
+        }
         settle(PermissionResolution(requestID: requestID, decision: decision.storedName))
         refreshAwaitingPermission()
         await runner?.answer(requestID: requestID, decision: decision)

--- a/Sources/Bloom/Views/Center/Composer/ComposerSessionEditor.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerSessionEditor.swift
@@ -13,7 +13,7 @@ struct ComposerSessionEditor {
     /// the session list is kept in step with edits made here.
     var model: WorkspaceModel?
 
-    func apply(_ change: (inout Session) -> Void) {
+    func apply(implementationMode: PermissionMode? = nil, _ change: (inout Session) -> Void) {
         var session = transcript.session
         change(&session)
         session.updatedAt = Date.now
@@ -31,6 +31,7 @@ struct ComposerSessionEditor {
                 model: session.model,
                 effort: session.effort,
                 permissionMode: session.permissionMode,
+                implementationMode: implementationMode,
                 agentKind: session.agentKind
             )
         }

--- a/Sources/Bloom/Views/Center/Composer/ComposerView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerView.swift
@@ -697,7 +697,7 @@ struct ComposerView: View {
             // the chat has said anything, so there is no transcript in the old backend's
             // vocabulary and no thread on its server to strand. A chat that has spoken forks
             // instead, which is `BackendChange` and is the footer's problem rather than this one.
-            sessionEditor.apply {
+            sessionEditor.apply(implementationMode: appDefaults.permissionMode) {
                 $0.model = resolved.model
                 $0.effort = resolved.effort
                 $0.agentKind = resolved.backend

--- a/Sources/Bloom/Views/Transcript/PermissionAskRowView.swift
+++ b/Sources/Bloom/Views/Transcript/PermissionAskRowView.swift
@@ -84,7 +84,13 @@ struct PermissionAskRowView: View {
             header
             command
             if isOpen {
-                if isWritingReason { reasonBox } else { actions }
+                if isWritingReason {
+                    reasonBox
+                } else if ask.isPlanApproval {
+                    planActions
+                } else {
+                    actions
+                }
             } else {
                 outcome
             }
@@ -168,7 +174,13 @@ struct PermissionAskRowView: View {
     /// see `TranscriptLayout.codeLeading`. It costs nothing here, because nothing is capped.
     @ViewBuilder
     private var command: some View {
-        if !ask.subject.isEmpty {
+        if ask.isPlanApproval, isOpen, let plan = ask.input["plan"]?.stringValue, !plan.isEmpty {
+            Text(plan)
+                .font(Typo.label)
+                .foregroundStyle(Palette.textPrimary)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+        } else if !ask.subject.isEmpty {
             HStack(alignment: .top, spacing: TranscriptLayout.glyphGap) {
                 Text(ask.subject)
                     .font(ask.subjectIsCode ? Typo.codeSmall : Typo.label)
@@ -297,6 +309,45 @@ struct PermissionAskRowView: View {
         }
     }
 
+    private var planActions: some View {
+        let mode = PlanApproval.implementationMode(ask.implementationMode ?? .acceptEdits)
+        return VStack(alignment: .leading, spacing: Metrics.spacing) {
+            Text("Implementation permissions: \(mode.label)")
+                .font(Typo.labelEmphasis)
+                .foregroundStyle(Palette.textPrimary)
+            Text(mode.summary(on: .claudeCode))
+                .font(Typo.caption)
+                .foregroundStyle(Palette.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: Metrics.spacing) { planButtons(mode: mode) }
+                VStack(alignment: .leading, spacing: Metrics.spacing) { planButtons(mode: mode) }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func planButtons(mode: PermissionMode) -> some View {
+        Button("Approve and implement") { onAnswer(.approvePlan(mode: mode)) }
+            .buttonStyle(.borderedProminent)
+            .tint(Palette.controlAccent)
+            .keyboardShortcut(.return, modifiers: .command)
+        Menu("Other permissions") {
+            ForEach(PlanApproval.modes.filter { $0 != mode }, id: \.self) { alternative in
+                Button("Approve with \(alternative.label)") { onAnswer(.approvePlan(mode: alternative)) }
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        Button("Keep planning") {
+            onAnswer(.deny(message: PlanApproval.keepPlanningMessage, endsTurn: false))
+        }
+        .buttonStyle(.bordered)
+        Button("Give feedback…") { isWritingReason = true }
+            .buttonStyle(.borderless)
+    }
+
     /// The rule, in the CLI's spelling, and what each button would do with it. Printed rather than
     /// hidden behind a hover, because a scope nobody read is a scope nobody chose.
     private var scopeLine: some View {
@@ -377,6 +428,7 @@ struct PermissionAskRowView: View {
     // MARK: Copy
 
     private var title: String {
+        if ask.isPlanApproval { return isOpen ? "Ready to implement the plan" : "Plan review" }
         let verb = ask.toolName == "Bash" ? "run a command" : "use \(ask.label)"
         return isOpen ? "The agent is asking to \(verb)" : "The agent asked to \(verb)"
     }
@@ -384,6 +436,9 @@ struct PermissionAskRowView: View {
     /// Follows `SetupDiagnosis`: a real sentence when there is one, and nothing rather than
     /// filler when there is not.
     private func outcomeText(_ decision: String) -> String {
+        if let mode = PlanApproval.approvedMode(storedDecision: decision) {
+            return "Plan approved. Implementation permissions: \(mode.label)."
+        }
         // A rule answered it. Naming the rule is what makes the grant reviewable: a call that ran
         // because of a decision made days ago must not look like a call that simply ran.
         if !note.isEmpty { return note }

--- a/Sources/BloomCore/Agent/AgentRunner.swift
+++ b/Sources/BloomCore/Agent/AgentRunner.swift
@@ -232,6 +232,9 @@ public actor AgentRunner {
             "--include-partial-messages",
             "--verbose",
             "--permission-mode", session.permissionMode.cliValue,
+            // Makes Bypass selectable on plan approval without enabling it during planning.
+            // Without this flag the CLI silently ignores a later setMode to bypassPermissions.
+            "--allow-dangerously-skip-permissions",
             // Always on, and this is the argument for it. Without it the CLI answers permission
             // questions on the user's behalf and the answer is no, which is every `permission-rule`
             // refusal in every transcript. With it the CLI stops deciding and asks.
@@ -496,6 +499,13 @@ public actor AgentRunner {
     /// Persist one event, apply whatever it says about the session, then hand it to the UI.
     /// Internal rather than private so tests can exercise persistence without a process.
     func ingest(_ event: AgentEvent) async {
+        var event = event
+        if case .permissionAsk(let ask) = event, ask.isPlanApproval {
+            let mode = (try? await store.planImplementationMode(
+                sessionID: session.id, hasWorktree: session.workspaceID != nil
+            )) ?? .acceptEdits
+            event = .permissionAsk(PlanApproval.preparing(ask, mode: mode))
+        }
         // A result for a turn Bloom never asked for closes nothing, and it is dropped here rather
         // than further down because every reader of a result treats one as a turn boundary: the
         // footer, the token counts, `SessionLifecycle`, and the drain that starts the next queued
@@ -746,6 +756,23 @@ public actor AgentRunner {
     /// unblocks a turn already in flight. The two share only the pipe.
     public func answer(requestID: String, decision: PermissionDecision) async {
         guard let ask = pending.take(requestID) else { return }
+
+        if case .approvePlan(let mode) = decision {
+            guard ask.isPlanApproval, PlanApproval.modes.contains(mode) else {
+                pending.add(ask)
+                return
+            }
+            // Save before unblocking: the permissionDecided event reloads the composer, and a
+            // resumed process must start in the mode the person just approved.
+            do {
+                try await store.updateSessionPreferences(id: session.id, permissionMode: mode)
+                session.permissionMode = mode
+            } catch {
+                pending.add(ask)
+                await report("could not save implementation permissions", error)
+                return
+            }
+        }
 
         await write(answerTo: ask, decision: decision)
         await close(ask, as: decision.storedName, note: "")

--- a/Sources/BloomCore/Agent/Codex/CodexPermission.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexPermission.swift
@@ -209,6 +209,8 @@ public enum CodexPermission {
         case .allow(.session), .allow(.project): .acceptForSession
         // The runner sends the structured answer separately; this describes its approval outcome.
         case .answer: .accept
+        // A Claude plan approval has no corresponding Codex request.
+        case .approvePlan: .decline
         case .deny(_, let endsTurn): endsTurn ? .cancel : .decline
         }
     }

--- a/Sources/BloomCore/Agent/PermissionAsk.swift
+++ b/Sources/BloomCore/Agent/PermissionAsk.swift
@@ -164,6 +164,8 @@ public struct PermissionAsk: Sendable, Hashable, Identifiable {
     /// A safety check somewhere in the reason says at least one part needs a person. False is the
     /// alarming value: it means manual approval is required.
     public var classifierApprovable: Bool?
+    /// Bloom's implementation choice, attached before this plan approval reaches the transcript.
+    public var implementationMode: PermissionMode?
     /// The whole line, so nothing is lost and a pending ask can be rebuilt from the database.
     public var raw: Data
 
@@ -183,6 +185,7 @@ public struct PermissionAsk: Sendable, Hashable, Identifiable {
         suppressesAlwaysAllow: Bool = false,
         requiresUserInteraction: Bool = false,
         classifierApprovable: Bool? = nil,
+        implementationMode: PermissionMode? = nil,
         raw: Data = Data()
     ) {
         self.requestID = requestID
@@ -198,6 +201,7 @@ public struct PermissionAsk: Sendable, Hashable, Identifiable {
         self.suppressesAlwaysAllow = suppressesAlwaysAllow
         self.requiresUserInteraction = requiresUserInteraction
         self.classifierApprovable = classifierApprovable
+        self.implementationMode = implementationMode
         self.raw = raw
     }
 
@@ -246,6 +250,8 @@ public struct PermissionAsk: Sendable, Hashable, Identifiable {
     /// `AgentQuestionnaire` and `AgentQuestionCard`.
     public var isQuestion: Bool { AgentQuestionnaire.isQuestion(toolName: toolName) }
 
+    public var isPlanApproval: Bool { toolName == "ExitPlanMode" }
+
     /// Whether a scope wider than this one call can honestly be offered.
     ///
     /// Three of the four ways it can be false are the CLI's own judgement rather than Bloom's
@@ -259,7 +265,7 @@ public struct PermissionAsk: Sendable, Hashable, Identifiable {
     /// second lock on a door that is already shut; it is here because the cost of that flag ever
     /// being absent is silent, and this makes it a state that cannot be reached instead.
     public var canWiden: Bool {
-        !isQuestion && !rules.isEmpty && !suppressesAlwaysAllow && !requiresUserInteraction
+        !isQuestion && !isPlanApproval && !rules.isEmpty && !suppressesAlwaysAllow && !requiresUserInteraction
     }
 
     /// The one thing worth putting beside the tool name in a collapsed row: the command for a
@@ -319,6 +325,7 @@ public struct PermissionAsk: Sendable, Hashable, Identifiable {
             suppressesAlwaysAllow: request["suppress_always_allow_rule"]?.boolValue ?? false,
             requiresUserInteraction: request["requires_user_interaction"]?.boolValue ?? false,
             classifierApprovable: request["classifier_approvable"]?.boolValue,
+            implementationMode: json["bloom_implementation_mode"]?.stringValue.flatMap(PermissionMode.init(rawValue:)),
             raw: raw
         )
     }
@@ -379,6 +386,8 @@ public enum PermissionDecision: Sendable, Hashable {
     /// which it is dealing with. Only `AskUserQuestion` produces one, and it is always `once`:
     /// there is no rule that could make the next question not need answering.
     case answer(input: JSONValue)
+    /// One plan approval, with an explicit implementation mode. Never a remembered tool rule.
+    case approvePlan(mode: PermissionMode)
     /// Refuse, in the user's own words, and optionally end the turn there.
     case deny(message: String, endsTurn: Bool)
 
@@ -404,7 +413,7 @@ public enum PermissionDecision: Sendable, Hashable {
     /// allow: the tool runs, with the reply in its input.
     public var isAllow: Bool {
         switch self {
-        case .allow, .answer: true
+        case .allow, .answer, .approvePlan: true
         case .deny: false
         }
     }
@@ -416,6 +425,7 @@ public enum PermissionDecision: Sendable, Hashable {
         case .allow(.session): "allowed for the session"
         case .allow(.project): "always allowed"
         case .answer: "answered"
+        case .approvePlan: "approved for implementation"
         case .deny: "denied"
         }
     }
@@ -426,6 +436,7 @@ public enum PermissionDecision: Sendable, Hashable {
         switch self {
         case .allow(let scope): "allow-\(scope.rawValue)"
         case .answer: "answered"
+        case .approvePlan(let mode): "approve-plan-\(mode.rawValue)"
         case .deny(_, let endsTurn): endsTurn ? "deny-stop" : "deny"
         }
     }
@@ -445,6 +456,19 @@ public enum PermissionAnswer {
         var response: [String: JSONValue] = [:]
 
         switch decision {
+        case .approvePlan(let mode):
+            guard ask.isPlanApproval, PlanApproval.modes.contains(mode) else {
+                throw PlanApprovalError.invalidDecision
+            }
+            response["behavior"] = .string("allow")
+            response["updatedInput"] = ask.input
+            response["updatedPermissions"] = .array([.object([
+                "type": .string("setMode"),
+                "mode": .string(mode.cliValue),
+                "destination": .string("session"),
+            ])])
+            response["decision"] = .string("user_temporary")
+
         case .answer(let input):
             // The one case that edits the input, and it edits it by adding the reply the tool
             // asked for. Nothing is remembered: a question answered once says nothing about the

--- a/Sources/BloomCore/Agent/PlanApproval.swift
+++ b/Sources/BloomCore/Agent/PlanApproval.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Approving a plan also chooses how implementation runs. A bare allow leaves a CLI launched
+/// in plan mode falling back to `default`, which asks again for every file edit.
+public enum PlanApproval {
+    public static let modes: [PermissionMode] = [.acceptEdits, .auto, .bypassPermissions]
+
+    public static func implementationMode(_ mode: PermissionMode) -> PermissionMode {
+        switch mode {
+        case .autoReview: .auto
+        case .plan: .acceptEdits
+        case .acceptEdits, .auto, .bypassPermissions: mode
+        }
+    }
+
+    public static func modeKey(sessionID: SessionID) -> String {
+        "session.\(sessionID).implementationPermissionMode"
+    }
+
+    /// Stored on the question so recycling a transcript cell cannot reset the offered mode,
+    /// and a reloaded transcript shows the same choice the person was asked to approve.
+    public static func preparing(_ ask: PermissionAsk, mode: PermissionMode) -> PermissionAsk {
+        guard ask.isPlanApproval else { return ask }
+        var prepared = ask
+        let mode = implementationMode(mode)
+        prepared.implementationMode = mode
+        if case .object(var json) = JSONValue.parse(String(decoding: ask.raw, as: UTF8.self)) {
+            json["bloom_implementation_mode"] = .string(mode.rawValue)
+            if let data = try? JSONEncoder().encode(JSONValue.object(json)) { prepared.raw = data }
+        }
+        return prepared
+    }
+
+    public static func approvedMode(storedDecision: String) -> PermissionMode? {
+        let prefix = "approve-plan-"
+        guard storedDecision.hasPrefix(prefix),
+              let mode = PermissionMode(rawValue: String(storedDecision.dropFirst(prefix.count))),
+              modes.contains(mode) else { return nil }
+        return mode
+    }
+
+    public static let keepPlanningMessage =
+        "The plan is not approved yet. Stay in plan mode and ask what should change before implementing."
+}
+
+enum PlanApprovalError: Error {
+    case invalidDecision
+}

--- a/Sources/BloomCore/Persistence/Store.swift
+++ b/Sources/BloomCore/Persistence/Store.swift
@@ -1837,6 +1837,7 @@ public actor Store {
     /// before the agent answered takes resume with it.
     @discardableResult
     public func upsert(_ session: Session) throws -> Session {
+        try rememberImplementationMode(for: session)
         try db.run(
             """
             INSERT INTO sessions (
@@ -1923,12 +1924,22 @@ public actor Store {
         model: String? = nil,
         effort: String? = nil,
         permissionMode: PermissionMode? = nil,
+        implementationMode: PermissionMode? = nil,
         /// Only ever set on a chat that has not spoken yet. Changing the backend of a chat that
         /// already has a message strands its transcript half in one vocabulary and half in the
         /// other, and its thread id on a server that knows nothing about the new one, so the
         /// picker forks a new chat instead. See docs/CODEX.md.
         agentKind: AgentKind? = nil
     ) throws {
+        // First-open defaults replace a placeholder session. Its fallback mode is not a user
+        // choice, so the composer supplies the configured implementation mode when opening Plan.
+        if permissionMode == .plan, let implementationMode {
+            try setSetting(PlanApproval.modeKey(sessionID: id), PlanApproval.implementationMode(implementationMode).rawValue)
+        }
+        if let permissionMode, var session = try session(id: id) {
+            session.permissionMode = permissionMode
+            try rememberImplementationMode(for: session)
+        }
         try db.run(
             """
             UPDATE sessions SET
@@ -3042,6 +3053,34 @@ public actor Store {
     }
 
     // MARK: - Settings
+
+    /// Planning temporarily replaces the mode in the session row. Keep the implementation
+    /// choice separately so starting in Plan and entering Plan through the composer agree.
+    private func rememberImplementationMode(for session: Session) throws {
+        let key = PlanApproval.modeKey(sessionID: session.id)
+        let remembered = try setting(key)
+        let mode: PermissionMode
+        if session.permissionMode != .plan {
+            mode = PlanApproval.implementationMode(session.permissionMode)
+        } else {
+            guard remembered == nil else { return }
+            mode = try planImplementationMode(sessionID: session.id, hasWorktree: session.workspaceID != nil)
+        }
+        if remembered != mode.rawValue { try setSetting(key, mode.rawValue) }
+    }
+
+    public func planImplementationMode(sessionID: SessionID, hasWorktree: Bool) throws -> PermissionMode {
+        if let session = try session(id: sessionID), session.permissionMode != .plan {
+            return PlanApproval.implementationMode(session.permissionMode)
+        }
+        if let raw = try setting(PlanApproval.modeKey(sessionID: sessionID)),
+           let mode = PermissionMode(rawValue: raw) {
+            return PlanApproval.implementationMode(mode)
+        }
+        guard hasWorktree else { return AskConversation.permissionMode }
+        let configured = try setting(AppDefaults.Key.permissionMode).flatMap(PermissionMode.init(rawValue:))
+        return PlanApproval.implementationMode(configured ?? AppDefaults.fallbackPermissionMode)
+    }
 
     public func setting(_ key: String) throws -> String? {
         try db.query("SELECT value FROM settings WHERE key = ?", [.text(key)]).first?.string("value")

--- a/Tests/BloomCoreTests/AgentRunnerTests.swift
+++ b/Tests/BloomCoreTests/AgentRunnerTests.swift
@@ -166,6 +166,7 @@ struct AgentRunnerArgvTests {
             "--include-partial-messages",
             "--verbose",
             "--permission-mode", "acceptEdits",
+            "--allow-dangerously-skip-permissions",
             "--permission-prompt-tool", "stdio",
             "--model", "opus",
             "--effort", "high",
@@ -362,7 +363,7 @@ struct AgentRunnerArgvTests {
             isFastMode: true,
             outputStyle: "Concise"
         )
-        let valueless: Set<String> = ["--verbose", "--include-partial-messages"]
+        let valueless: Set<String> = ["--verbose", "--include-partial-messages", "--allow-dangerously-skip-permissions"]
 
         for (index, item) in argv.enumerated() where item.hasPrefix("--") && !valueless.contains(item) {
             #expect(argv.indices.contains(index + 1), "\(item) has nothing after it")
@@ -1044,6 +1045,81 @@ struct AgentRunnerPermissionTests {
     }
 
     // MARK: Answering
+
+    @Test("plan approval changes the running and persisted mode and survives a new runner", arguments: PlanApproval.modes)
+    func approvingPlan(mode: PermissionMode) async throws {
+        let store = try makeTestStore("plan-runner")
+        let session = try await makeSession(store, permissionMode: .plan)
+        let (runner, process) = try await running(store, session: session)
+        await runner.ingest(.permissionAsk(try PlanApprovalTests.ask()))
+
+        await runner.answer(requestID: "plan-1", decision: .approvePlan(mode: mode))
+        // A double click cannot send a second answer or change the approved mode.
+        await runner.answer(requestID: "plan-1", decision: .approvePlan(mode: .bypassPermissions))
+
+        let sent = answers(on: process)
+        #expect(sent.count == 1)
+        let answer = try #require(sent.first)
+        #expect(answer["response"]?["response"]?["updatedPermissions"]?[0]?["mode"]?.stringValue == mode.cliValue)
+        #expect(await runner.currentSession.permissionMode == mode)
+        #expect(await runner.currentSession.state == .running)
+        #expect(await runner.pendingAsks.isEmpty)
+        let stored = try #require(await store.session(id: session.id))
+        #expect(stored.permissionMode == mode)
+        #expect(try await store.permissionAskDecisions(sessionID: session.id)["plan-1"] == "approve-plan-\(mode.rawValue)")
+        let repo = try await repoID(of: session, in: store)
+        #expect(try await store.permissionGrants(repoID: repo).isEmpty)
+
+        let recorder = ProcessRecorder()
+        let resumed = AgentRunner(workspacePath: "/tmp/w", session: stored, store: store, makeProcess: recorder.factory)
+        try await resumed.send("continue")
+        let arguments = try #require(recorder.last).launch.arguments
+        let modeIndex = try #require(arguments.firstIndex(of: "--permission-mode"))
+        #expect(arguments[modeIndex + 1] == mode.cliValue)
+        await runner.cancel()
+        await resumed.cancel()
+    }
+
+    @Test("the plan card offers the remembered implementation mode after storing the question")
+    func planOffer() async throws {
+        let store = try makeTestStore("plan-offer")
+        let session = try await makeSession(store, permissionMode: .acceptEdits)
+        try await store.updateSessionPreferences(id: session.id, permissionMode: .plan)
+        let planned = try #require(await store.session(id: session.id))
+        let (runner, _) = try await running(store, session: planned)
+        await runner.ingest(.permissionAsk(try PlanApprovalTests.ask()))
+        let rows = try await store.messages(sessionID: session.id)
+        let row = try #require(rows.last { $0.kind == .permissionAsk })
+        #expect(PermissionAsk.decode(payload: row.payload)?.implementationMode == .acceptEdits)
+        #expect(await runner.pendingAsks.first?.implementationMode == .acceptEdits)
+        await runner.cancel()
+    }
+
+    @Test("rejecting a plan leaves planning permissions intact")
+    func rejectingPlan() async throws {
+        let store = try makeTestStore("plan-reject")
+        let session = try await makeSession(store, permissionMode: .plan)
+        let (runner, process) = try await running(store, session: session)
+        await runner.ingest(.permissionAsk(try PlanApprovalTests.ask()))
+        await runner.answer(requestID: "plan-1", decision: .deny(message: PlanApproval.keepPlanningMessage, endsTurn: false))
+        #expect(await runner.currentSession.permissionMode == .plan)
+        #expect(try await store.session(id: session.id)?.permissionMode == .plan)
+        #expect(answers(on: process).first?["response"]?["response"]?["updatedPermissions"] == nil)
+        await runner.cancel()
+    }
+
+    @Test("a plan approval decision cannot answer an ordinary permission request")
+    func invalidPlanApproval() async throws {
+        let store = try makeTestStore("plan-invalid")
+        let session = try await makeSession(store)
+        let (runner, process) = try await running(store, session: session)
+        await runner.ingest(.permissionAsk(ask()))
+        await runner.answer(requestID: "req-1", decision: .approvePlan(mode: .bypassPermissions))
+        #expect(answers(on: process).isEmpty)
+        #expect(await runner.pendingAsks.count == 1)
+        #expect(await runner.currentSession.permissionMode == .acceptEdits)
+        await runner.cancel()
+    }
 
     @Test("allowing writes an answer the CLI can act on and lets the turn run again")
     func allowing() async throws {

--- a/Tests/BloomCoreTests/PlanApprovalTests.swift
+++ b/Tests/BloomCoreTests/PlanApprovalTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Plan approval", .scratchDirectory)
+struct PlanApprovalTests {
+    static let askLine = #"{"type":"control_request","request_id":"plan-1","request":{"subtype":"can_use_tool","tool_name":"ExitPlanMode","tool_use_id":"plan-tool-1","input":{"plan":"Create two files, then edit the first."},"requires_user_interaction":true}}"#
+
+    static func ask() throws -> PermissionAsk {
+        try #require(PermissionAsk.decode(payload: Data(askLine.utf8)))
+    }
+
+    @Test("approving sends only the selected mode, scoped to this session", arguments: PlanApproval.modes)
+    func approvalWire(mode: PermissionMode) throws {
+        let ask = try Self.ask()
+        let line = try PermissionAnswer.encode(ask: ask, decision: .approvePlan(mode: mode))
+        let envelope = try #require(JSONValue.parse(line))
+        let response = try #require(envelope["response"]?["response"])
+        #expect(envelope["response"]?["request_id"]?.stringValue == ask.requestID)
+        #expect(response["behavior"]?.stringValue == "allow")
+        #expect(response["updatedInput"] == ask.input)
+        #expect(response["updatedPermissions"] == .array([.object([
+            "type": .string("setMode"), "mode": .string(mode.cliValue), "destination": .string("session"),
+        ])]))
+        #expect(PlanApproval.approvedMode(storedDecision: PermissionDecision.approvePlan(mode: mode).storedName) == mode)
+    }
+
+    @Test("plan decisions cannot grant permissions on an unrelated tool or keep implementation in Plan")
+    func invalidDecisions() throws {
+        var ordinary = try Self.ask()
+        ordinary.toolName = "Write"
+        #expect(throws: PlanApprovalError.self) {
+            try PermissionAnswer.encode(ask: ordinary, decision: .approvePlan(mode: .bypassPermissions))
+        }
+        let plan = try Self.ask()
+        for mode in [PermissionMode.plan, .autoReview] {
+            #expect(throws: PlanApprovalError.self) {
+                try PermissionAnswer.encode(ask: plan, decision: .approvePlan(mode: mode))
+            }
+        }
+    }
+
+    @Test("the offered mode survives transcript persistence without changing the tool input")
+    func persistedOffer() throws {
+        let ask = try Self.ask()
+        let prepared = PlanApproval.preparing(ask, mode: .bypassPermissions)
+        let restored = try #require(PermissionAsk.decode(payload: prepared.raw))
+        #expect(restored.implementationMode == .bypassPermissions)
+        #expect(restored.input == ask.input)
+        #expect(restored.requestID == ask.requestID)
+    }
+
+    @Test("a plan can never be approved by an always-allow tool rule")
+    func requiresPlanReview() throws {
+        var ask = try Self.ask()
+        ask.requiresUserInteraction = false
+        ask.suggestions = [PermissionSuggestion(
+            type: "addRules", behavior: "allow", rules: [PermissionRule(toolName: "ExitPlanMode")]
+        )]
+        #expect(!ask.canWiden)
+    }
+
+    @Test("keeping planning sends no permission updates")
+    func keepPlanning() throws {
+        let line = try PermissionAnswer.encode(
+            ask: Self.ask(), decision: .deny(message: PlanApproval.keepPlanningMessage, endsTurn: false)
+        )
+        let response = try #require(JSONValue.parse(line)?["response"]?["response"])
+        #expect(response["behavior"]?.stringValue == "deny")
+        #expect(response["updatedPermissions"] == nil)
+        #expect(response["interrupt"] == .bool(false))
+    }
+
+    private func session(in store: Store, mode: PermissionMode) async throws -> Session {
+        let repo = try await store.upsert(Repo(name: "r", path: "/tmp/plan-repo"))
+        let workspace = try await store.upsert(Workspace(
+            repoID: repo.id, name: "w", branch: "b", path: "/tmp/plan-workspace", baseBranch: "main"
+        ))
+        return try await store.upsert(Session(workspaceID: workspace.id, permissionMode: mode))
+    }
+
+    @Test("starting in Plan remembers the configured implementation mode")
+    func startsInPlan() async throws {
+        let store = try makeTestStore("plan-default")
+        try await store.setSetting(AppDefaults.Key.permissionMode, PermissionMode.acceptEdits.rawValue)
+        let session = try await session(in: store, mode: .plan)
+        try await store.setSetting(AppDefaults.Key.permissionMode, PermissionMode.bypassPermissions.rawValue)
+        #expect(try await store.planImplementationMode(sessionID: session.id, hasWorktree: true) == .acceptEdits)
+        #expect(try await store.session(id: session.id)?.permissionMode == .plan)
+    }
+
+    @Test("entering Plan retains the last session choice through both preference write paths")
+    func remembersSessionChoice() async throws {
+        let store = try makeTestStore("plan-remember")
+        let session = try await session(in: store, mode: .auto)
+        try await store.updateSessionPreferences(id: session.id, permissionMode: .plan)
+        #expect(try await store.planImplementationMode(sessionID: session.id, hasWorktree: true) == .auto)
+        try await store.update(sessionID: session.id) { $0.permissionMode = .acceptEdits }
+        try await store.update(sessionID: session.id) { $0.permissionMode = .plan }
+        #expect(try await store.planImplementationMode(sessionID: session.id, hasWorktree: true) == .acceptEdits)
+    }
+
+    @Test("first-open Plan defaults replace a new chat's placeholder bypass mode")
+    func firstOpenDefaults() async throws {
+        let store = try makeTestStore("plan-first-open")
+        let session = try await session(in: store, mode: AppDefaults.fallbackPermissionMode)
+        try await store.updateSessionPreferences(
+            id: session.id, permissionMode: .plan, implementationMode: .acceptEdits
+        )
+        #expect(try await store.planImplementationMode(sessionID: session.id, hasWorktree: true) == .acceptEdits)
+        #expect(try await store.session(id: session.id)?.permissionMode == .plan)
+    }
+
+    @Test("a legacy session remembers its mode when entering Plan for the first time")
+    func legacySession() async throws {
+        let store = try makeTestStore("plan-legacy")
+        let session = try await session(in: store, mode: .acceptEdits)
+        try await store.setSetting(PlanApproval.modeKey(sessionID: session.id), nil)
+        try await store.updateSessionPreferences(id: session.id, permissionMode: .plan)
+        #expect(try await store.planImplementationMode(sessionID: session.id, hasWorktree: true) == .acceptEdits)
+    }
+
+    @Test("a chat without a worktree never inherits the app's bypass default")
+    func noWorktree() async throws {
+        let store = try makeTestStore("plan-no-worktree")
+        let session = try await store.upsert(Session(workspaceID: nil, permissionMode: .plan))
+        #expect(try await store.planImplementationMode(sessionID: session.id, hasWorktree: false) == .auto)
+    }
+}


### PR DESCRIPTION
Approving a plan now applies the selected implementation permissions instead of falling back to repeated prompts for file edits. The approval card shows the plan and permission mode, and offers implementation or continued planning. The chosen mode survives resumed sessions and respects the configured defaults for new chats.

Adds regression coverage for approval, rejection, persistence, and first-open defaults. Verified all three implementation modes against the installed CLI, plus focused tests, a warnings-as-errors app build, both linters, and light/dark layout snapshots.
