### PR TITLE
Document Homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ your hometown, mentioning what you are building with it. You'll find our address
 
 Bloom needs macOS 26 or later.
 
+Install the Apple Silicon release with [Homebrew](https://github.com/spatie/homebrew-bloom):
+
+```bash
+brew install --cask spatie/bloom/spatie-bloom
+```
+
+The cask is named `spatie-bloom` because Homebrew's `bloom` cask is an unrelated file manager.
+
 Download the disk image from [runbloom.app/download](https://runbloom.app/download), or from the
 [releases page](https://github.com/spatie/bloom/releases), and drag Bloom into your Applications
 folder. Every release is signed, notarised and stapled, then published to a Sparkle appcast, so an


### PR DESCRIPTION
Add the install command for the new [spatie/homebrew-bloom](https://github.com/spatie/homebrew-bloom) tap. Explain the `spatie-bloom` cask name, which avoids a collision with an unrelated file manager.

The tap checks hourly for stable releases and verifies checksums. Its installation, signature verification, cask checks and updater tests pass.

Bloom's build and lint pass. Core CI fails in `AuditPersistenceTests` (also failing on main) and `RuntimeSafetyTests`; this PR only changes the README.

Closes #158.
