### PR TITLE
Fix the welcome screen crash

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,6 +258,9 @@ jobs:
       - name: Build the app target
         run: swift build -Xswiftc -warnings-as-errors
 
+      - name: Check welcome navigation and window sizing
+        run: ./Tools/welcome-layout-probe.sh
+
       # Everything below only happens on a manual run.
       #
       # Assembles Bloom.app: the icon, the App Intents metadata, the embedded

--- a/Sources/Bloom/BloomLauncher.swift
+++ b/Sources/Bloom/BloomLauncher.swift
@@ -8,6 +8,7 @@ enum BloomLauncher {
     static func main() async {
         #if DEBUG
         if FlareProbe.isRequested { await FlareProbe.runAndExit() }
+        if WelcomeLayoutProbe.isRequested { WelcomeLayoutProbe.runAndExit() }
         #endif
         BloomApp.main()
     }

--- a/Sources/Bloom/Design/WelcomeLayoutProbe.swift
+++ b/Sources/Bloom/Design/WelcomeLayoutProbe.swift
@@ -1,0 +1,106 @@
+import AppKit
+import BloomCore
+import Observation
+import SwiftUI
+
+#if DEBUG
+/// Exercises welcome content changes without opening the app, a visible window or a database.
+@MainActor
+enum WelcomeLayoutProbe {
+    static var isRequested: Bool { CommandLine.arguments.contains("--welcome-layout-probe") }
+
+    static func runAndExit() -> Never {
+        guard Bundle.main.bundleIdentifier == "be.spatie.bloom.welcome-probe",
+              SetupRehearsal.report != nil else { exit(1) }
+        NSApplication.shared.setActivationPolicy(.prohibited)
+        Task { await run() }
+        RunLoop.main.run()
+        exit(1)
+    }
+
+    private static func run() async {
+        var failures: [String] = []
+        var checks = 0
+        func check(_ condition: Bool, _ message: String) {
+            checks += 1
+            if !condition { failures.append(message) }
+        }
+        for disableAnimations in [false, true] {
+            let fixture = WelcomeLayoutFixture()
+            let host = WelcomeHostingController(
+                rootView: WelcomeLayoutContent(fixture: fixture)
+                    .transaction { if disableAnimations { $0.disablesAnimations = true } },
+                contentWidth: WelcomeView.contentWidth
+            )
+            let window = NSWindow(
+                contentRect: NSRect(origin: .zero, size: host.fittingContentSize()),
+                styleMask: [.titled, .closable, .fullSizeContentView],
+                backing: .buffered, defer: false
+            )
+            window.isReleasedWhenClosed = false
+            window.titleVisibility = .hidden
+            window.titlebarAppearsTransparent = true
+            window.contentViewController = host
+            await settle(window)
+            let greetingHeight = window.frame.height
+
+            for visit in 0..<3 {
+                withAnimation(disableAnimations ? nil : Motion.pane) { fixture.showsChecks = true }
+                await settle(window)
+                check(window.frame.height > greetingHeight, "checks did not grow the window")
+                check(abs(host.view.bounds.height - host.fittingContentSize().height) < 1,
+                      "checks do not fit the window")
+                check(!window.isVisible && !window.isKeyWindow, "probe showed its window")
+                withAnimation(disableAnimations ? nil : Motion.pane) { fixture.showsChecks = false }
+                await settle(window)
+                check(abs(window.frame.height - greetingHeight) < 1,
+                      "visit \(visit), animations disabled \(disableAnimations): greeting \(greetingHeight), returned \(window.frame.height), ideal \(host.fittingContentSize().height)")
+            }
+            window.contentViewController = nil
+        }
+        let result: JSONValue = .object([
+            "checks": .integer(checks), "passed": .bool(failures.isEmpty),
+            "failures": .strings(failures),
+        ])
+        if let data = try? JSONEncoder().encode(result) { FileHandle.standardOutput.write(data) }
+        exit(failures.isEmpty ? 0 : 1)
+    }
+
+    private static func settle(_ window: NSWindow) async {
+        // Several turns let the crossfade, the staggered checks and the deferred resize finish.
+        for _ in 0..<12 {
+            window.layoutIfNeeded()
+            window.contentView?.layoutSubtreeIfNeeded()
+            window.contentView?.displayIfNeeded()
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+    }
+}
+
+@MainActor
+@Observable
+private final class WelcomeLayoutFixture {
+    var showsChecks = false
+    let inspection = SetupInspection(rehearsal: SetupRehearsal.report)
+    let registration = CommandLineRegistration(source: { nil })
+}
+
+private struct WelcomeLayoutContent: View {
+    let fixture: WelcomeLayoutFixture
+
+    var body: some View {
+        Group {
+            if fixture.showsChecks {
+                WelcomeView(inspection: fixture.inspection, registration: fixture.registration,
+                            start: .checks, onFinish: {})
+                    .transition(.opacity)
+            } else {
+                WelcomeGreeting(isFirstVisit: false, continueTitle: "See what Bloom needs",
+                                onContinue: { fixture.showsChecks = true })
+                    .transition(.opacity)
+            }
+        }
+        .frame(width: WelcomeView.contentWidth)
+    }
+}
+#endif

--- a/Sources/Bloom/Views/Chrome/Window/WelcomeHostingController.swift
+++ b/Sources/Bloom/Views/Chrome/Window/WelcomeHostingController.swift
@@ -10,23 +10,28 @@ import SwiftUI
 /// recurse. Measuring after layout keeps the content-sized window while making the resize a new
 /// main-actor turn rather than part of the pass that requested it.
 @MainActor
-final class WelcomeHostingController<Content: View>: NSHostingController<Content> {
+final class WelcomeHostingController: NSHostingController<AnyView> {
     private let contentWidth: CGFloat
     private var resizeIsScheduled = false
 
-    init(rootView: Content, contentWidth: CGFloat) {
+    init(rootView: some View, contentWidth: CGFloat) {
         self.contentWidth = contentWidth
-        super.init(rootView: rootView)
+        super.init(rootView: AnyView(rootView))
         sizingOptions = []
+        // AppKit's viewDidLayout callback crashed in Swift's generated actor check before it
+        // reached our code (#159). Observe SwiftUI's content instead, keeping native layout out
+        // of that callback and allowing shorter steps to shrink the window again.
+        self.rootView = AnyView(rootView
+            .fixedSize(horizontal: false, vertical: true)
+            // The origin changes when the title bar's safe area arrives after attachment.
+            // Watching size alone leaves the initial greeting shorter than a return visit.
+            .onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: { [weak self] _ in
+                self?.scheduleResize()
+            })
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("not decoded from a nib") }
-
-    override func viewDidLayout() {
-        super.viewDidLayout()
-        scheduleResize()
-    }
 
     /// The size used before the controller has joined a window. It is measured from the same root
     /// view that will be installed, so the first frame and every later frame share one rule.

--- a/Tests/BloomCoreTests/AuditPersistenceTests.swift
+++ b/Tests/BloomCoreTests/AuditPersistenceTests.swift
@@ -91,6 +91,7 @@ struct AuditPersistenceTests {
         let session = try await store.upsert(AskConversation.newSession())
         try await store.saveDraft(sessionID: session.id, body: "original")
         let raw = try SQLiteDatabase(path: store.path)
+        let settingsBefore = try raw.query("SELECT * FROM settings ORDER BY key").map(\.columns)
         try raw.execute("CREATE TRIGGER refuse_write BEFORE \(write) BEGIN SELECT RAISE(ABORT, 'disk full'); END")
         await #expect(throws: SQLiteError.self) {
             try await store.replaceAskConversation(id: session.id, controls: ComposerControls(isFastMode: true), draft: "carried")
@@ -98,7 +99,7 @@ struct AuditPersistenceTests {
         #expect(try await store.sessionsWithoutWorkspace().map(\.id) == [session.id])
         #expect(try await store.draft(sessionID: session.id) == "original")
         #expect(try raw.query("SELECT * FROM sessions").count == 1)
-        #expect(try raw.query("SELECT * FROM settings WHERE key LIKE 'session.%'").isEmpty)
+        #expect(try raw.query("SELECT * FROM settings ORDER BY key").map(\.columns) == settingsBefore)
     }
 
     @Test func freshConversationCommitsOnceWithControlsAndDraft() async throws {

--- a/Tools/welcome-layout-probe.sh
+++ b/Tools/welcome-layout-probe.sh
@@ -1,0 +1,43 @@
+#!/bin/zsh
+# Runs the welcome transition regression in an invisible, isolated bundle after swift build.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+bin_dir="$(swift build --show-bin-path)"
+probe_root="$(mktemp -d "${TMPDIR:-/tmp}/bloom-welcome-probe.XXXXXX")"
+probe_app="$probe_root/Bloom Welcome Probe.app"
+framework="$(find .build/artifacts -path '*Sparkle.xcframework/macos*/Sparkle.framework' -type d | head -1)"
+[[ -n "$framework" ]]
+mkdir -p "$probe_app/Contents/MacOS" "$probe_app/Contents/Frameworks"
+cp "$bin_dir/Bloom" "$probe_app/Contents/MacOS/Bloom"
+cp Resources/Info.plist "$probe_app/Contents/Info.plist"
+ditto Resources "$probe_app/Contents/Resources"
+ditto "$framework" "$probe_app/Contents/Frameworks/Sparkle.framework"
+/usr/libexec/PlistBuddy -c 'Set :CFBundleIdentifier be.spatie.bloom.welcome-probe' "$probe_app/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c 'Set :CFBundleName Bloom Welcome Probe' "$probe_app/Contents/Info.plist"
+install_name_tool -add_rpath '@executable_path/../Frameworks' "$probe_app/Contents/MacOS/Bloom"
+codesign --force --deep --sign - "$probe_app" >/dev/null 2>&1
+
+# Refuse a release or stale binary, which would ignore the flag and start the application.
+python3 - "$probe_app/Contents/MacOS/Bloom" "$probe_root" <<'PY'
+import json
+import pathlib
+import subprocess
+import sys
+
+binary, root = sys.argv[1:]
+if b'--welcome-layout-probe' not in pathlib.Path(binary).read_bytes():
+    raise SystemExit('Build the debug app with swift build before running this probe.')
+for scenario in ('all-clear', 'no-agent', 'signed-out-github'):
+    subprocess.run(
+        ['open', '-g', '-n', '-W', '-a', str(pathlib.Path(binary).parents[2]),
+         '--stdout', f'{root}/{scenario}.json', '--stderr', f'{root}/{scenario}.log',
+         '--args', '--welcome-layout-probe', '--setup-rehearsal', scenario],
+        timeout=45, check=True,
+    )
+    report = pathlib.Path(root, f'{scenario}.json').read_text()
+    print(f'{scenario}: {report}')
+    if not json.loads(report)['passed']:
+        raise SystemExit(f'{scenario} failed; evidence: {root}')
+print(f'Probe evidence: {root}')
+PY


### PR DESCRIPTION
Fix the crash when clicking “See what Bloom needs” by observing SwiftUI content geometry instead of overriding AppKit's layout callback. Keep deferred resizing and add an isolated transition and sizing regression check to CI.

Update the rollback assertion to preserve existing session settings, matching the permission persistence change on main.

Fixes #159.
