### PR TITLE
Allow archiving workspaces with unrecognized folders

### DIFF
--- a/Sources/Bloom/State/AppModel+Archive.swift
+++ b/Sources/Bloom/State/AppModel+Archive.swift
@@ -354,6 +354,14 @@ extension AppModel {
             // One more workspace is archived now, so anything holding the old answer is wrong.
             invalidateArchived()
             await offerUndo(of: workspace, repo: repo, report: report)
+            if let path = report?.preservedFolderPath {
+                notice = BloomNotice(
+                    message: "\(workspace.name) was archived. Its folder at `\(path)` and its branch "
+                        + "were kept because Git no longer recognizes the folder as a worktree. "
+                        + "The archive script was skipped.",
+                    dismissal: .untilDismissed
+                )
+            }
             Log.archive.info("archived \(workspace.name, privacy: .public)")
             return .archived
         } catch let error as WorkspaceError {

--- a/Sources/BloomCore/Git/Git+Safety.swift
+++ b/Sources/BloomCore/Git/Git+Safety.swift
@@ -101,7 +101,7 @@ public struct WorkspaceSafetyReport: Sendable, Hashable {
 
     /// Archiving only updates the record when this folder is no longer a checkout.
     /// Its files, branch and Git metadata are kept, and the archive script is skipped.
-    public var preservedFolderPath: String? = nil
+    public var preservedFolderPath: String?
 
     public init(
         hasUncommittedChanges: Bool = false,

--- a/Sources/BloomCore/Git/Git+Safety.swift
+++ b/Sources/BloomCore/Git/Git+Safety.swift
@@ -99,6 +99,10 @@ public struct WorkspaceSafetyReport: Sendable, Hashable {
     /// throws away the per-worktree reflog that was the last thing holding them.
     public var detachedCommits: Int
 
+    /// Archiving only updates the record when this folder is no longer a checkout.
+    /// Its files, branch and Git metadata are kept, and the archive script is skipped.
+    public var preservedFolderPath: String? = nil
+
     public init(
         hasUncommittedChanges: Bool = false,
         untrackedFiles: [String] = [],

--- a/Sources/BloomCore/Git/Git+Worktrees.swift
+++ b/Sources/BloomCore/Git/Git+Worktrees.swift
@@ -30,12 +30,15 @@ extension Git {
     ///   shortcut worth taking anywhere: `worktree add -b` on a branch that does exist fails with
     ///   git's own words rather than doing something quiet and wrong, so a caller that gets this
     ///   backwards finds out immediately.
+    /// - Parameter previousPath: a stale worktree retained during archiving. Prune its
+    ///   registration before restoring its branch if it is the sole holder and unlocked.
     public static func addWorktree(
         repo: String,
         path: String,
         branch: String,
         base: String,
-        branchIsNew: Bool? = nil
+        branchIsNew: Bool? = nil,
+        replacingPrunableWorktreeAt previousPath: String? = nil
     ) async throws {
         try validate(branch: branch)
         try validate(ref: base, label: "base branch")
@@ -46,6 +49,18 @@ extension Git {
 
         let exists = if let branchIsNew { !branchIsNew } else { await branchExists(branch, in: repo) }
         if exists {
+            if let previousPath {
+                let holders = try await worktrees(of: repo).filter { $0.branch == branch }
+                // A retained, stale registration must not block restoration at a new path.
+                // Let Git prune obsolete registrations. This keeps their files and branches,
+                // respects locks, and leaves the restored branch free to be archived again.
+                if holders.count == 1, let holder = holders.first,
+                   URL(fileURLWithPath: holder.path).resolvingSymlinksInPath()
+                    == URL(fileURLWithPath: previousPath).resolvingSymlinksInPath(),
+                   holder.isPrunable, !holder.isLocked {
+                    try await check(["worktree", "prune"], in: repo)
+                }
+            }
             try await check(["worktree", "add", "--", path, branch], in: repo)
         } else {
             try await check(["worktree", "add", "-b", branch, "--", path, base], in: repo)

--- a/Sources/BloomCore/Workspace/ArchiveConfirmation.swift
+++ b/Sources/BloomCore/Workspace/ArchiveConfirmation.swift
@@ -148,8 +148,13 @@ public struct ArchiveRequest: Identifiable, Sendable {
     /// everywhere else in the app.
     public var message: String {
         var text = "\u{201C}\(workspace.name)\u{201D}\n\n"
-        text += "The worktree is deleted and the branch is "
-        text += hazards.isDeletingBranch ? "deleted too." : "kept."
+        if let path = report.preservedFolderPath {
+            text += "Git no longer recognizes this folder as a worktree. "
+            text += "The folder at \(path) and the branch are kept. The archive script is skipped."
+        } else {
+            text += "The worktree is deleted and the branch is "
+            text += hazards.isDeletingBranch ? "deleted too." : "kept."
+        }
         text += " The workspace moves to Archived."
 
         // Only where the stakes are already low. A merged pull request means the branch's code is

--- a/Sources/BloomCore/Workspace/ArchivedWorkspaceFootprint.swift
+++ b/Sources/BloomCore/Workspace/ArchivedWorkspaceFootprint.swift
@@ -4,8 +4,8 @@ import Foundation
 ///
 /// Archiving removes the worktree and, if the project asks for it, the branch. It removes nothing
 /// from the database at all: `Workspace.archive()` writes two columns and every row that ever
-/// hung off the workspace is still there. So an archived workspace costs no disk outside
-/// `bloom.sqlite` and, inside it, costs everything it ever did.
+/// hung off the workspace is still there. An unrecognized worktree folder is kept on disk when
+/// archiving. These measurements cover only the database contents, not that retained folder.
 ///
 /// **The bytes here are measured, not estimated, and they are deliberately an undercount.** The
 /// numbers come from `LENGTH()` over the columns that actually hold content, dominated by

--- a/Sources/BloomCore/Workspace/WorkspaceManager.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceManager.swift
@@ -516,12 +516,22 @@ public struct WorkspaceManager: Sendable {
     /// What archiving this workspace would throw away. Call it before `archive` to build a
     /// confirmation the user can actually judge.
     public func safetyReport(workspace: Workspace, repo: Repo) async throws -> WorkspaceSafetyReport {
-        try await Git.safetyReport(
+        if await preservesFolderWhenArchiving(workspace) {
+            var report = WorkspaceSafetyReport()
+            report.preservedFolderPath = workspace.path
+            return report
+        }
+        return try await Git.safetyReport(
             worktree: workspace.path,
             branch: workspace.branch,
             base: workspace.baseBranch,
             repo: repo.path
         )
+    }
+
+    private func preservesFolderWhenArchiving(_ workspace: Workspace) async -> Bool {
+        guard FileManager.default.fileExists(atPath: workspace.path) else { return false }
+        return !(await Git.isRepository(workspace.path))
     }
 
     // MARK: - Ports
@@ -640,6 +650,14 @@ public struct WorkspaceManager: Sendable {
                 throw WorkspaceError.unsafeToArchive(computed)
             }
             report = computed
+        }
+
+        // A deleted worktree can be recreated by a lingering process. Git cannot remove that
+        // folder safely, but it need not prevent archiving the record. Keep everything on disk,
+        // including the branch and stale worktree metadata, even when force was requested.
+        if report?.preservedFolderPath != nil {
+            try await store.update(workspaceID: workspace.id) { $0.archive() }
+            return
         }
 
         // A failing archive script means the workspace was not wound down: containers still

--- a/Sources/BloomCore/Workspace/WorkspaceRestore.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceRestore.swift
@@ -235,7 +235,8 @@ public extension WorkspaceManager {
         }
 
         try await Git.addWorktree(
-            repo: repo.path, path: path, branch: workspace.branch, base: base
+            repo: repo.path, path: path, branch: workspace.branch, base: base,
+            replacingPrunableWorktreeAt: workspace.path
         )
 
         let settings = SettingsLoader.load(repo: repo.path)

--- a/Sources/BloomCore/Workspace/WorkspaceRestore.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceRestore.swift
@@ -141,7 +141,8 @@ public struct RestoreOutcome: Sendable, Equatable {
 /// second copy to check out.
 public extension WorkspaceSafetyReport {
     var isRestorableFromBranch: Bool {
-        !hasUncommittedChanges
+        preservedFolderPath == nil
+            && !hasUncommittedChanges
             && untrackedFiles.isEmpty
             && modifiedIgnoredFiles.isEmpty
             && detachedCommits == 0

--- a/Sources/BloomCore/Workspace/WorkspaceTrouble.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceTrouble.swift
@@ -50,11 +50,8 @@ public enum WorkspaceTrouble: Sendable, Equatable {
     case worktreeBaseBranchGone(branch: String, workspace: String)
     /// Archiving cannot go on because the worktree it would remove is not there.
     case archiveWorktreeGone(workspace: String)
-    /// Archiving cannot go on because the folder is there and git does not own it any more.
-    ///
-    /// The one case that names a worktree's path, against the rule above, because it is the one
-    /// case whose remedy is the owner opening that folder: git will not release a worktree it
-    /// does not recognise, so nothing in Bloom can finish this until the directory is gone.
+    /// Git could not read the folder after an archive failed. Names the path so the owner can
+    /// find the files that were kept. An unrecognized folder normally archives without removal.
     case archiveWorktreeNotACheckout(workspace: String, path: String)
     /// Archiving stopped because the worktree holds work that is in no commit.
     case archiveWorktreeNotEmpty(workspace: String)
@@ -191,10 +188,8 @@ public enum WorkspaceTrouble: Sendable, Equatable {
                 a worktree any more, which is what a folder that was deleted and then recreated \
                 looks like.
 
-                A worktree git no longer recognises cannot be handed back, so archiving cannot \
-                finish while that folder is there.
-
-                Look at what is in it, delete it yourself, and archive again.
+                Its files have been kept. Try archiving again. Bloom keeps folders that git \
+                no longer recognizes as a worktree.
                 """
 
         case let .archiveWorktreeNotEmpty(workspace):

--- a/Tests/BloomCoreTests/ArchiveConfirmationTests.swift
+++ b/Tests/BloomCoreTests/ArchiveConfirmationTests.swift
@@ -43,6 +43,23 @@ struct ArchiveConfirmationTests {
         "public/hot",
     ]
 
+    @Test("an unrecognized folder confirmation explains what is kept")
+    func unrecognizedFolderIsKept() {
+        let workspace = makeWorkspace()
+        var report = WorkspaceSafetyReport()
+        report.preservedFolderPath = workspace.path
+        let request = ArchiveRequest(
+            workspace: workspace, report: report,
+            hazards: ArchiveHazards(isDeletingBranch: true)
+        )
+
+        #expect(request.confirmLabel == "Archive")
+        #expect(request.losses.isEmpty)
+        #expect(request.message.contains("The folder at \(workspace.path) and the branch are kept."))
+        #expect(request.message.contains("The archive script is skipped."))
+        #expect(!request.message.contains("is deleted"))
+    }
+
     @Test("nothing at stake and a merged pull request reads as routine")
     func cleanAndMergedIsRoutine() {
         let request = ArchiveRequest(

--- a/Tests/BloomCoreTests/WorkspaceArchiveTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceArchiveTests.swift
@@ -253,6 +253,42 @@ struct WorkspaceArchiveTests {
         let branchSHA = try await Shell.check("git", ["rev-parse", workspace.branch], cwd: repo.path)
         #expect(branchSHA.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == sha)
         #expect(!repo.exists("archive-script-ran"))
+
+        let restored = try await manager.restore(workspace: workspace, repo: registered)
+        defer { try? FileManager.default.removeItem(atPath: restored.workspace.path) }
+        #expect(restored.workspace.state == .active)
+        #expect(restored.workspace.path != workspace.path)
+        #expect(try await Git.headSHA(of: restored.workspace.path) == sha)
+        #expect(folder.read("notes.txt") == "only remaining copy\n")
+
+        // Later archives and restores must not remain blocked by the original registration.
+        try repo.write(".conductor/settings.toml", "")
+        try await manager.archive(workspace: restored.workspace, repo: registered, deleteBranch: false)
+        let restoredAgain = try await manager.restore(workspace: restored.workspace, repo: registered)
+        try await manager.archive(workspace: restoredAgain.workspace, repo: registered, deleteBranch: true, force: true)
+        #expect(!(await Git.branchExists(workspace.branch, in: repo.path)))
+        #expect(folder.read("notes.txt") == "only remaining copy\n")
+    }
+
+    @Test("restoring a retained folder cannot override another live checkout")
+    func retainedFolderDoesNotOverrideLiveCheckout() async throws {
+        let (repo, registered, manager, workspace) = try await makeWorkspace()
+        defer { repo.cleanUp() }
+        defer { try? FileManager.default.removeItem(atPath: workspace.path) }
+        try FileManager.default.removeItem(atPath: workspace.path)
+        try FileManager.default.createDirectory(atPath: workspace.path, withIntermediateDirectories: true)
+        try await manager.archive(workspace: workspace, repo: registered)
+
+        let livePath = workspace.path + "-live"
+        defer { try? FileManager.default.removeItem(atPath: livePath) }
+        try await Shell.check("git", ["worktree", "add", "--force", "--", livePath, workspace.branch], cwd: repo.path)
+        try TempRepo(existing: livePath).write("notes.txt", "live work\n")
+
+        await #expect(throws: ShellError.self) {
+            try await manager.restore(workspace: workspace, repo: registered)
+        }
+        #expect(TempRepo(existing: livePath).read("notes.txt") == "live work\n")
+        #expect(try await manager.store.workspace(id: workspace.id)?.state == .archived)
     }
 
     @Test("forcing over a dirty worktree destroys exactly what the report listed")

--- a/Tests/BloomCoreTests/WorkspaceArchiveTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceArchiveTests.swift
@@ -217,6 +217,44 @@ struct WorkspaceArchiveTests {
         #expect(await Git.branchExists(workspace.branch, in: repo.path))
     }
 
+    @Test("an unrecognized folder archives while preserving its files and branch",
+          arguments: [false, true], [false, true])
+    func archivesAnUnrecognizedFolder(force: Bool, prune: Bool) async throws {
+        let (repo, registered, manager, workspace) = try await makeWorkspace(settings: """
+        [git]
+        delete_branch_on_archive = true
+        [scripts]
+        archive = 'touch "$BLOOM_ROOT_PATH/archive-script-ran"; exit 9'
+        """)
+        defer { repo.cleanUp() }
+        defer { try? FileManager.default.removeItem(atPath: workspace.path) }
+
+        try TempRepo(existing: workspace.path).write("feature.txt", "committed work\n")
+        try await commit(in: workspace.path, message: "keep this branch")
+        let sha = try await Git.headSHA(of: workspace.path)
+        try FileManager.default.removeItem(atPath: workspace.path)
+        if prune {
+            try await Shell.check("git", ["worktree", "prune"], cwd: repo.path)
+        }
+        try FileManager.default.createDirectory(atPath: workspace.path, withIntermediateDirectories: true)
+        let folder = TempRepo(existing: workspace.path)
+        try folder.write("notes.txt", "only remaining copy\n")
+
+        let report = try await manager.safetyReport(workspace: workspace, repo: registered)
+        #expect(report.preservedFolderPath == workspace.path)
+        #expect(report.isSafeToDiscard)
+        #expect(!report.isRestorableFromBranch)
+
+        try await manager.archive(workspace: workspace, repo: registered, force: force)
+
+        #expect(try await manager.store.workspace(id: workspace.id)?.state == .archived)
+        #expect(folder.read("notes.txt") == "only remaining copy\n")
+        #expect(await Git.branchExists(workspace.branch, in: repo.path))
+        let branchSHA = try await Shell.check("git", ["rev-parse", workspace.branch], cwd: repo.path)
+        #expect(branchSHA.stdout.trimmingCharacters(in: .whitespacesAndNewlines) == sha)
+        #expect(!repo.exists("archive-script-ran"))
+    }
+
     @Test("forcing over a dirty worktree destroys exactly what the report listed")
     func forceDestroysOnlyWhatWasReported() async throws {
         let (repo, registered, manager, workspace) = try await makeWorkspace()

--- a/Tests/BloomCoreTests/WorkspaceTroubleTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceTroubleTests.swift
@@ -221,8 +221,7 @@ struct WorkspaceTroubleTests {
         #expect(!trouble.sentence.contains("status --porcelain"))
     }
 
-    /// The one sentence in the type that names a worktree path, because deleting that folder is
-    /// the only thing that unblocks the archive.
+    /// A failed archive names the folder that was kept without asking the owner to delete it.
     @Test("names the folder when git no longer knows it as a worktree")
     func archivingAFolderGitHasLostTrackOf() async throws {
         let repo = try await TempRepo(defaultBranch: "main")
@@ -238,7 +237,8 @@ struct WorkspaceTroubleTests {
             workspace: "Limits panel", path: worktree, baseBranch: "main"
         )
         #expect(trouble == .archiveWorktreeNotACheckout(workspace: "Limits panel", path: worktree))
-        #expect(trouble.sentence.contains("delete it yourself"))
+        #expect(trouble.sentence.contains("Its files have been kept"))
+        #expect(!trouble.sentence.contains("delete it yourself"))
         #expect(!trouble.sentence.contains("not a working tree"))
     }
 


### PR DESCRIPTION
Allow workspaces to archive when Git no longer recognizes their folder. Keep the folder and branch, skip the archive script, and explain what was preserved. Restore into a fresh folder and clean stale Git registrations so subsequent archives work too.

Includes regression coverage for stale and pruned registrations, repeated archive and restore cycles, and refusing to override another live checkout.
