### PR TITLE
Reduce delays when opening diff comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,6 +261,9 @@ jobs:
       - name: Check welcome navigation and window sizing
         run: ./Tools/welcome-layout-probe.sh
 
+      - name: Check diff scrolling and comment focus
+        run: ./Tools/review-run-probe.sh
+
       # Everything below only happens on a manual run.
       #
       # Assembles Bloom.app: the icon, the App Intents metadata, the embedded

--- a/Sources/Bloom/BloomLauncher.swift
+++ b/Sources/Bloom/BloomLauncher.swift
@@ -9,6 +9,7 @@ enum BloomLauncher {
         #if DEBUG
         if FlareProbe.isRequested { await FlareProbe.runAndExit() }
         if WelcomeLayoutProbe.isRequested { WelcomeLayoutProbe.runAndExit() }
+        if ReviewRunProbe.isRequested { ReviewRunProbe.runAndExit() }
         #endif
         BloomApp.main()
     }

--- a/Sources/Bloom/Design/ReviewRunProbe.swift
+++ b/Sources/Bloom/Design/ReviewRunProbe.swift
@@ -1,0 +1,150 @@
+import AppKit
+import BloomCore
+import Observation
+import SwiftUI
+
+#if DEBUG
+/// Checks the real diff controls in an invisible window without opening the app or its database.
+@MainActor
+enum ReviewRunProbe {
+    static var isRequested: Bool { CommandLine.arguments.contains("--review-run-probe") }
+
+    static func runAndExit() -> Never {
+        guard Bundle.main.bundleIdentifier == "be.spatie.bloom.review-probe" else { exit(1) }
+        NSApplication.shared.setActivationPolicy(.prohibited)
+        Task { await run() }
+        RunLoop.main.run()
+        exit(1)
+    }
+
+    private static func run() async {
+        var failures: [String] = []
+        var checks = 0
+        func check(_ condition: Bool, _ message: String) {
+            checks += 1
+            if !condition { failures.append(message) }
+        }
+
+        for numbers in [DiffGutter.Numbers.both, .old, .new] {
+            let fixture = ReviewRunFixture()
+            let host = NSHostingView(rootView: ReviewRunFixtureView(fixture: fixture, numbers: numbers))
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 760, height: 600),
+                styleMask: [.borderless], backing: .buffered, defer: false
+            )
+            window.contentView = host
+            await settle(window)
+            guard let scroll = scrollView(in: host) else {
+                check(false, "diff has no scroll view")
+                continue
+            }
+
+            for line in [1, 200, 380, 10] {
+                scroll.contentView.scroll(to: NSPoint(x: 0, y: CGFloat(line - 1) * CodeMetrics.rowHeight))
+                scroll.reflectScrolledClipView(scroll.contentView)
+                await settle(window)
+                hoverViews(in: host).first?.onChange?(line - 1)
+                await settle(window)
+                save(host, name: "\(numbers)-\(line)")
+                let height = scroll.documentView?.bounds.height ?? 0
+                check(abs(height - CodeMetrics.rowHeight * 400) < 1,
+                      "diff changed height while scrolling")
+            }
+            fixture.commentLine = 10
+            fixture.text = "Review text survives scrolling"
+            await settle(window)
+            save(host, name: "\(numbers)-editor")
+            check(textView(in: host)?.string == fixture.text, "comment text was not drawn")
+            check(window.firstResponder === textView(in: host), "comment did not receive focus")
+            scroll.contentView.scroll(to: NSPoint(x: 0, y: CodeMetrics.rowHeight * 350))
+            scroll.reflectScrolledClipView(scroll.contentView)
+            await settle(window)
+            scroll.contentView.scroll(to: NSPoint(x: 0, y: CodeMetrics.rowHeight * 9))
+            scroll.reflectScrolledClipView(scroll.contentView)
+            await settle(window)
+            check(textView(in: host)?.string == fixture.text, "comment text was lost after scrolling away")
+            check(!window.isVisible && !window.isKeyWindow, "probe showed or activated its window")
+            window.contentView = nil
+        }
+        let result: JSONValue = .object([
+            "checks": .integer(checks), "passed": .bool(failures.isEmpty), "failures": .strings(failures),
+        ])
+        if let data = try? JSONEncoder().encode(result) { FileHandle.standardOutput.write(data) }
+        exit(failures.isEmpty ? 0 : 1)
+    }
+
+    private static func settle(_ window: NSWindow) async {
+        for _ in 0..<3 {
+            window.contentView?.layoutSubtreeIfNeeded()
+            try? await Task.sleep(for: .milliseconds(30))
+        }
+    }
+
+    private static func scrollView(in view: NSView) -> NSScrollView? {
+        if let scroll = view as? NSScrollView { return scroll }
+        return view.subviews.lazy.compactMap { scrollView(in: $0) }.first
+    }
+
+    private static func save(_ host: NSView, name: String) {
+        guard let directory = ProbeHarness.value(for: "--review-run-probe"),
+              let bitmap = host.bitmapImageRepForCachingDisplay(in: host.bounds) else { return }
+        host.cacheDisplay(in: host.bounds, to: bitmap)
+        guard let data = bitmap.representation(using: .png, properties: [:]) else { return }
+        try? data.write(to: URL(fileURLWithPath: directory).appendingPathComponent(name + ".png"))
+    }
+
+    private static func textView(in view: NSView) -> ComposerTextView? {
+        if let text = view as? ComposerTextView { return text }
+        return view.subviews.lazy.compactMap { textView(in: $0) }.first
+    }
+
+    private static func hoverViews(in view: NSView) -> [DiffRowHover.RowHoverView] {
+        if let hover = view as? DiffRowHover.RowHoverView { return [hover] }
+        return view.subviews.flatMap { hoverViews(in: $0) }
+    }
+
+}
+
+@MainActor
+@Observable
+private final class ReviewRunFixture {
+    var commentLine: Int?
+    var text = ""
+}
+
+private struct ReviewRunFixtureView: View {
+    let fixture: ReviewRunFixture
+    var numbers: DiffGutter.Numbers
+
+    private var ranges: [Range<Int>] {
+        guard let line = fixture.commentLine else { return [1..<401] }
+        return [1..<(line + 1), (line + 1)..<401].filter { !$0.isEmpty }
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(ranges, id: \.lowerBound) { range in
+                    DiffRunView(
+                        lines: range.map { line in
+                            DiffRunLine(line: DiffLine(
+                                kind: numbers == .old ? .deletion : .addition,
+                                text: "let value\(line) = input", oldNumber: line, newNumber: line, index: line
+                            ))
+                        },
+                        language: .swift, numbers: numbers, width: 760,
+                        onComment: { fixture.commentLine = $0.line },
+                        onDragComment: { _, _ in }, onEndCommentDrag: {}, onEdit: { _ in }
+                    ).equatable()
+                    if fixture.commentLine == range.upperBound - 1 {
+                        ReviewCommentEditorView(
+                            text: Binding(get: { fixture.text }, set: { fixture.text = $0 }), width: 760,
+                            onCommit: { fixture.commentLine = nil }, onCancel: { fixture.commentLine = nil }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Sources/Bloom/Views/Inspector/DiffRunView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffRunView.swift
@@ -93,7 +93,9 @@ struct DiffRunView: View, Equatable {
 
     var body: some View {
         ZStack(alignment: .topLeading) {
-            VStack(spacing: 0) {
+            // A comment splits this run, so eagerly rebuilding up to 400 rows of controls stalls
+            // the main thread. Keep the selectable text whole and realise only nearby controls.
+            LazyVStack(spacing: 0) {
                 ForEach(rows) { row in
                     chrome(row)
                 }

--- a/Tools/review-run-probe.sh
+++ b/Tools/review-run-probe.sh
@@ -1,0 +1,42 @@
+#!/bin/zsh
+# Runs the diff comment regression in an invisible, isolated bundle after swift build.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+bin_dir="$(swift build --show-bin-path)"
+probe_root="$(mktemp -d "${TMPDIR:-/tmp}/bloom-review-probe.XXXXXX")"
+probe_app="$probe_root/Bloom Review Probe.app"
+framework="$(find .build/artifacts -path '*Sparkle.xcframework/macos*/Sparkle.framework' -type d | head -1)"
+[[ -n "$framework" ]]
+mkdir -p "$probe_app/Contents/MacOS" "$probe_app/Contents/Frameworks"
+cp "$bin_dir/Bloom" "$probe_app/Contents/MacOS/Bloom"
+cp Resources/Info.plist "$probe_app/Contents/Info.plist"
+ditto Resources "$probe_app/Contents/Resources"
+ditto "$framework" "$probe_app/Contents/Frameworks/Sparkle.framework"
+/usr/libexec/PlistBuddy -c 'Set :CFBundleIdentifier be.spatie.bloom.review-probe' "$probe_app/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c 'Set :CFBundleName Bloom Review Probe' "$probe_app/Contents/Info.plist"
+install_name_tool -add_rpath '@executable_path/../Frameworks' "$probe_app/Contents/MacOS/Bloom"
+codesign --force --deep --sign - "$probe_app" >/dev/null 2>&1
+
+# Refuse a release or stale binary, which would ignore the flag and start the application.
+python3 - "$probe_app/Contents/MacOS/Bloom" "$probe_root" <<'PY'
+import json
+import pathlib
+import subprocess
+import sys
+
+binary, root = sys.argv[1:]
+if b'--review-run-probe' not in pathlib.Path(binary).read_bytes():
+    raise SystemExit('Build the debug app with swift build before running this probe.')
+subprocess.run(
+    ['open', '-g', '-n', '-W', '-a', str(pathlib.Path(binary).parents[2]),
+     '--stdout', f'{root}/result.json', '--stderr', f'{root}/probe.log',
+     '--args', '--review-run-probe', root],
+    timeout=45, check=True,
+)
+report = pathlib.Path(root, 'result.json').read_text()
+print(report)
+if not json.loads(report)['passed']:
+    raise SystemExit(f'Probe failed; evidence: {root}')
+print(f'Probe evidence: {root}')
+PY


### PR DESCRIPTION
Render diff-row controls lazily so opening a review comment does not rebuild hundreds of offscreen controls. The selectable code text stays intact. An isolated 400-line benchmark dropped from 296ms to 41ms.

Adds an offscreen app probe for scrolling, comment focus and draft retention, run in CI. This addresses a measured bottleneck present in both 1.4.1 and 1.5.0; it does not establish a regression specific to 1.5.0.
