### PR TITLE
Let a project say where its browser pane opens

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ the file the value came from.
 
 The keys are `scripts.setup`, `scripts.archive`, `scripts.run` (a string, or a table of named
 scripts with a `command`), `scripts.run_mode`, `file_include_globs` (`[".env*"]` by default),
-`git.branch_prefix`, `git.branch_prefix_type`, `git.delete_branch_on_archive`, `models.default` and
-`models.claude.default_thinking_level`. A key ending in `_file` (`scripts.setup_file`,
+`git.branch_prefix`, `git.branch_prefix_type`, `git.delete_branch_on_archive`, `browser.url`,
+`models.default` and `models.claude.default_thinking_level`. A key ending in `_file` (`scripts.setup_file`,
 `scripts.archive_file`) names an executable file in the repository instead of an inline command.
 
 Every script Bloom runs is handed these variables on top of your own shell environment:
@@ -130,6 +130,7 @@ Every script Bloom runs is handed these variables on top of your own shell envir
 | `BLOOM_ROOT_PATH` | The main checkout |
 | `BLOOM_DEFAULT_BRANCH` | The repository's default branch |
 | `BLOOM_PORT` | The first of ten ports allocated to this workspace |
+| `BLOOM_URL_FILE` | A file to write the address a browser pane should open on. Git cannot see it |
 
 #### A database per worktree
 
@@ -183,6 +184,32 @@ mysql -u root -e "DROP DATABASE IF EXISTS \`$database\`"
 `$BLOOM_PORT` is the same number in both, and it is the same number after a restart, so the archive
 script can also bring down whatever the setup script started on it (`docker compose down -v`, or
 killing what is listening). It gets ten minutes to do so.
+
+#### Where a browser pane opens
+
+A browser pane opens on `http://localhost:$BLOOM_PORT`, which is right for a project whose dev
+server binds the port Bloom allocated and wrong for every project that does not. Two ways to say
+otherwise, and the first of them wins:
+
+```bash
+# .bloom/setup.sh, for an address only the script knows: a Herd or Valet site named after a slug it
+# just computed, a tunnel that printed its hostname, a sign-in link carrying a fresh token.
+site="$(printf '%s' "$BLOOM_PROJECT_NAME-$BLOOM_WORKSPACE_ID" | tr '_' '-' | cut -c1-30)"
+herd link "$site"
+herd secure "$site"
+echo "https://$site.test" > "$BLOOM_URL_FILE"
+```
+
+```toml
+# .bloom/settings.toml, for an address the whole project shares. The script variables above are
+# expanded, so one line covers every workspace.
+[browser]
+url = "http://localhost:$BLOOM_PORT/admin"
+```
+
+`$BLOOM_URL_FILE` is inside the worktree and covered by an ignore rule of Bloom's own, so it never
+reaches a commit. Write it whenever you like: it is read each time a pane is opened, so an archive
+script that tears the site down can empty it and a run script can rewrite it.
 
 ### The bridge
 

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -1073,6 +1073,40 @@ final class WorkspaceModel {
         return self.workspace.port
     }
 
+    /// Where a browser pane opened on this workspace should go.
+    ///
+    /// The port is allocated first because it is both the last-resort answer and a variable the
+    /// stated one may be written in terms of, and because a workspace nobody has opened a terminal
+    /// in yet holds no block at all. The decision itself is `WorkspaceBrowserURL`, which is where
+    /// the two ways a project can state an address, and the order between them, are written down.
+    ///
+    /// The settings are read again rather than taken from `settings`: this runs at the moment a
+    /// pane is opened, which is often the first thing that happens to a workspace, and an address
+    /// silently missing because the file had not been read yet is the sort of intermittent that
+    /// gets blamed on the script.
+    func browserAddress() async -> String {
+        let port = await ensurePort()
+        guard let repo, let store = app.store else {
+            return WorkspaceBrowserURL.resolve(
+                written: nil, stated: nil, environment: [:], port: port
+            )
+        }
+
+        let environment = WorkspaceManager(store: store).environment(
+            for: workspace, repo: repo, port: port
+        )
+        let worktree = workspace.path
+        let repoPath = repo.path
+        return await Task.detached(priority: .userInitiated) {
+            WorkspaceBrowserURL.read(
+                worktree: worktree,
+                settings: SettingsLoader.load(repo: repoPath),
+                environment: environment,
+                port: port
+            )
+        }.value
+    }
+
     /// One setup run: the state it resets, the output it streams, and what it leaves behind.
     ///
     /// Shared by the run a workspace opens with and by the re-run below, which differ only in what

--- a/Sources/Bloom/Views/Center/Panes/SessionTabsView.swift
+++ b/Sources/Bloom/Views/Center/Panes/SessionTabsView.swift
@@ -439,20 +439,12 @@ struct SessionTabsView: View {
 
     /// The `+` opens a browser on the workspace's own dev server, where a split opens one on
     /// nothing. That is not drift: this item is the one that means "look at what this workspace is
-    /// running", and it is the only route that has a port to hand.
+    /// running", and it is the only route that knows where that is.
     private func newBrowser() {
         Task {
-            await preparePort()
-            let address = model.port > 0 ? "http://localhost:\(model.port)" : ""
+            let address = await model.browserAddress()
             NewPane.open(.browser, in: model, url: address) { store.select($0, in: model) }
         }
-    }
-
-    /// The workspace's own port, which is what its setup and run scripts were told to bind and so
-    /// what its dev server is answering on. Allocation lives on the model, where concurrent
-    /// callers get one block. See `WorkspaceModel.ensurePort`.
-    private func preparePort() async {
-        await model.ensurePort()
     }
 
     // MARK: - Reordering

--- a/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
+++ b/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
@@ -921,12 +921,11 @@ struct BloomCommands: Commands {
     }
 
     /// A browser on the workspace's own dev server, which is what the `+` opens and what a split
-    /// does not: this is the route that has a port to hand. See `SessionTabsView.newBrowser`.
+    /// does not: this is the route that knows where that is. See `SessionTabsView.newBrowser`.
     private func openBrowserPane() {
         guard let workspace = model.selectedModel else { return }
         Task {
-            await workspace.ensurePort()
-            let address = workspace.port > 0 ? "http://localhost:\(workspace.port)" : ""
+            let address = await workspace.browserAddress()
             NewPane.open(.browser, in: workspace, url: address) {
                 WorkspaceTabsStore.shared.select($0, in: workspace)
             }

--- a/Sources/Bloom/Views/RepoSettings/RepoScriptsSection.swift
+++ b/Sources/Bloom/Views/RepoSettings/RepoScriptsSection.swift
@@ -49,6 +49,7 @@ struct RepoScriptsSection: View {
                     Text("Scripts run in the workspace folder without an interactive shell. Files use their shebang; inline commands use zsh.")
                     Text(Self.variables)
                         .font(Typo.codeTiny)
+                    Text(Self.urlFile)
                     Text(Self.alias)
                     Text(Self.rerun)
                 }
@@ -60,7 +61,15 @@ struct RepoScriptsSection: View {
 
     /// Named rather than described, because a script writer needs the exact spelling.
     private static let variables = "\(WorkspaceManager.environmentPrefix)_"
-        + "{WORKSPACE_NAME, WORKSPACE_ID, WORKSPACE_PATH, ROOT_PATH, DEFAULT_BRANCH, PORT, IS_LOCAL}"
+        + "{WORKSPACE_NAME, WORKSPACE_ID, WORKSPACE_PATH, PROJECT_NAME, ROOT_PATH, "
+        + "DEFAULT_BRANCH, PORT, IS_LOCAL, URL_FILE}"
+
+    /// The one variable a script writes to rather than reads. Said here rather than only in the
+    /// Workspaces pane, because the place somebody works out that they need it is while they are
+    /// looking at the script that would write it.
+    private static let urlFile = "Write an address to $"
+        + "\(WorkspaceManager.environmentPrefix)_URL_FILE and this workspace's browser panes open "
+        + "on it, for a site whose hostname only the setup script knows."
 
     /// Said once, quietly, and not given equal billing with the real names above it. A script
     /// written for Conductor keeps working; a script written today should not be written that way.

--- a/Sources/Bloom/Views/RepoSettings/RepoSettingsView.swift
+++ b/Sources/Bloom/Views/RepoSettings/RepoSettingsView.swift
@@ -87,6 +87,7 @@ struct RepoSettingsView: View {
                 case .workspaces:
                     Form {
                         branchSection
+                        browserSection
                         RepoFilesToCopySection(model: model)
                     }
                     .settingsForm()
@@ -455,6 +456,41 @@ struct RepoSettingsView: View {
             Text("Branches")
         }
     }
+
+    // MARK: - Browser
+
+    /// One field, because the interesting half of this setting is what a setup script writes, and
+    /// that has nowhere to be edited here: it belongs to a workspace rather than to the project.
+    /// What is stated here is the project's standing answer, and the footer is what tells somebody
+    /// reading this row why one of their workspaces opens somewhere else.
+    private var browserSection: some View {
+        Section {
+            SettingsRow("Address") {
+                TextField("", text: $model.draft.browserURL, prompt: Text(Self.browserPrompt))
+                    // See the branch prefix field: without this the form claims the row's value
+                    // column and the field ends up at the far edge of the window.
+                    .labelsHidden()
+                    .textFieldStyle(.roundedBorder)
+            }
+        } header: {
+            Text("Browser")
+        } footer: {
+            VStack(alignment: .leading, spacing: Metrics.spacingTight) {
+                Text(Self.browserFootnote)
+                SettingsDestinationLabel(model: model, key: .browserURL)
+            }
+            .font(Typo.caption)
+            .foregroundStyle(Palette.textSecondary)
+        }
+    }
+
+    private static let browserPrompt = "http://localhost:$\(WorkspaceManager.environmentPrefix)_PORT"
+
+    private static let browserFootnote = "Where a browser pane opens when you ask a workspace for "
+        + "one. Script variables are expanded, so a path or a hostname can be stated once for "
+        + "every workspace. A setup script that writes an address to "
+        + "$\(WorkspaceManager.environmentPrefix)_URL_FILE beats this, for the workspaces where "
+        + "only the script knows where the site ended up."
 
     // MARK: - Settings files
 

--- a/Sources/BloomCore/Persistence/Settings.swift
+++ b/Sources/BloomCore/Persistence/Settings.swift
@@ -29,6 +29,7 @@ public enum SettingsKey: String, Sendable, Hashable, CaseIterable {
     case deleteBranchOnArchive = "git.delete_branch_on_archive"
     case mergeInstructions = "instructions.merge"
     case conflictInstructions = "instructions.fix_conflicts"
+    case browserURL = "browser.url"
 
     /// The key path as components, for the document editor.
     public var path: [String] { rawValue.components(separatedBy: ".") }
@@ -81,6 +82,12 @@ public struct RepoSettings: Sendable, Hashable {
     /// `.bloom/merge-instructions.md` beat these.
     public var mergeInstructions: String?
     public var conflictInstructions: String?
+    /// What a browser pane opens on, before expansion, or nil for the port Bloom allocated.
+    ///
+    /// Stated with the variables a script is handed, so one line covers every workspace:
+    /// `http://localhost:$BLOOM_PORT/admin`. A workspace whose setup script wrote an address of
+    /// its own beats this. See `WorkspaceBrowserURL`, which holds both and the order between them.
+    public var browserURL: String?
     /// Set by a file inside the repository. Ranks ABOVE the app-level defaults, because pinning
     /// a model in a project's own settings is a deliberate statement about that project.
     public var defaultModel: String?
@@ -305,6 +312,10 @@ public enum SettingsLoader {
         if let text = toml["instructions.fix_conflicts"]?.stringValue {
             settings.conflictInstructions = text.isEmpty ? nil : text
             note(.conflictInstructions)
+        }
+        if let url = toml["browser.url"]?.stringValue {
+            settings.browserURL = url.isEmpty ? nil : url
+            note(.browserURL)
         }
         if let model = toml["models.default"]?.stringValue {
             settings.defaultModel = model

--- a/Sources/BloomCore/Persistence/SettingsWriter.swift
+++ b/Sources/BloomCore/Persistence/SettingsWriter.swift
@@ -12,6 +12,7 @@ public enum SettingsEdit: Sendable, Hashable {
     case deleteBranchOnArchive(Bool)
     case mergeInstructions(String?)
     case conflictInstructions(String?)
+    case browserURL(String?)
 
     public var key: SettingsKey {
         switch self {
@@ -24,6 +25,7 @@ public enum SettingsEdit: Sendable, Hashable {
         case .deleteBranchOnArchive: .deleteBranchOnArchive
         case .mergeInstructions: .mergeInstructions
         case .conflictInstructions: .conflictInstructions
+        case .browserURL: .browserURL
         }
     }
 }
@@ -345,6 +347,8 @@ public enum SettingsWriter {
             document.set(.string(mode), at: SettingsKey.runMode.path)
         case .branchPrefix(let prefix):
             set(prefix, at: SettingsKey.branchPrefix.path, in: &document, overriding: overriding)
+        case .browserURL(let url):
+            set(url, at: SettingsKey.browserURL.path, in: &document, overriding: overriding)
         case .deleteBranchOnArchive(let flag):
             document.set(.boolean(flag), at: SettingsKey.deleteBranchOnArchive.path)
         case .filesToCopy(let globs):

--- a/Sources/BloomCore/Workspace/RepoSettingsDraft.swift
+++ b/Sources/BloomCore/Workspace/RepoSettingsDraft.swift
@@ -43,6 +43,9 @@ public struct RepoSettingsDraft: Sendable, Hashable {
     /// most projects, which is the answer that sends a turn with nothing attached to it.
     public var mergeInstructions = ""
     public var conflictInstructions = ""
+    /// What a browser pane opens on, as typed, with the variables left unexpanded. Empty for the
+    /// port Bloom allocated, which is what most projects want.
+    public var browserURL = ""
 
     public init() {}
 
@@ -58,6 +61,7 @@ public struct RepoSettingsDraft: Sendable, Hashable {
         deleteBranchOnArchive = settings.deleteBranchOnArchive
         mergeInstructions = settings.mergeInstructions ?? ""
         conflictInstructions = settings.conflictInstructions ?? ""
+        browserURL = settings.browserURL ?? ""
     }
 
     /// The patterns, one per line. A blank line is not a pattern, and an empty field means "copy
@@ -141,6 +145,10 @@ public struct RepoSettingsDraft: Sendable, Hashable {
         let conflicts = conflictInstructions.trimmed
         if conflicts != (settings.conflictInstructions ?? "").trimmed {
             edits.append(.conflictInstructions(conflicts))
+        }
+        let url = browserURL.trimmed
+        if url != (settings.browserURL ?? "") {
+            edits.append(.browserURL(url))
         }
         return edits
     }

--- a/Sources/BloomCore/Workspace/WorkspaceBrowserURL.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceBrowserURL.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// The address a browser pane opens on when a workspace is asked for one, and the two ways a
+/// project can say what that address is.
+///
+/// `http://localhost:$BLOOM_PORT` was the only answer there was, and it is the right answer only
+/// for a project whose dev server is the thing listening on that port. A Herd or Valet site
+/// answers on `https://<site>.test` and on nothing else, a compose stack publishes whatever its
+/// file says, and a project whose front door is `/admin` or a signed sign-in link wants a path as
+/// well as a host. In all three the `+` opened a browser on a socket nothing was listening to.
+///
+/// There are two sources because there are two different questions. `browser.url` in the settings
+/// file is what a project states once for every workspace, and it is expanded with the same
+/// variables the scripts are handed, so `http://localhost:$BLOOM_PORT/admin` is a line somebody
+/// can commit. The file at `$BLOOM_URL_FILE` is for an address only the setup script can know: a
+/// site named after a slug it computed, a tunnel that printed its hostname, a sign-in link
+/// carrying a token minted while the database was being seeded. The file wins, because it is
+/// written by the thing that has just run.
+///
+/// Nothing here checks an address beyond it being one non-empty line. A typo that reaches the
+/// address bar says where it came from; one quietly swapped for `localhost` looks like Bloom
+/// ignoring the file the script just wrote.
+public enum WorkspaceBrowserURL {
+    /// Where a script writes the address, relative to the worktree.
+    ///
+    /// Inside `WorktreeScratch.generated`, so git cannot see it. The address is a fact about one
+    /// worktree on one machine, and a `.test` hostname arriving in somebody's pull request is
+    /// exactly the noise that folder exists to stop.
+    public static let file = "\(WorktreeScratch.generated)/url"
+
+    /// The absolute path handed to every script as `$BLOOM_URL_FILE`.
+    public static func path(inWorktree worktree: String) -> String {
+        (worktree as NSString).appendingPathComponent(file)
+    }
+
+    /// The address to open, from whichever source states one.
+    ///
+    /// Empty when nothing does and no port has been allocated either, which is what a browser
+    /// pane reads as "open on nothing" and is what it did before any of this existed.
+    ///
+    /// - Parameter written: the contents of the file the scripts write, or nil when there is none.
+    /// - Parameter stated: `browser.url` as the settings file states it, before expansion.
+    /// - Parameter environment: the variables scripts are handed, which is what `stated` expands
+    ///   against.
+    /// - Parameter port: the workspace's own port, or 0 while it holds none.
+    /// - Returns: an address with a scheme, or an empty string.
+    public static func resolve(
+        written: String?, stated: String?, environment: [String: String], port: Int
+    ) -> String {
+        if let address = address(written) { return address }
+        if let address = address(stated.map { expand($0, with: environment) }) { return address }
+        return port > 0 ? "http://localhost:\(port)" : ""
+    }
+
+    /// The same answer, having read the file the scripts write.
+    ///
+    /// - Parameter worktree: the workspace's own folder.
+    /// - Parameter settings: the project's settings, for `browser.url`.
+    /// - Parameter environment: the variables scripts are handed.
+    /// - Parameter port: the workspace's own port, or 0 while it holds none.
+    /// - Returns: an address with a scheme, or an empty string.
+    public static func read(
+        worktree: String, settings: RepoSettings, environment: [String: String], port: Int
+    ) -> String {
+        let written = try? String(contentsOfFile: path(inWorktree: worktree), encoding: .utf8)
+        return resolve(
+            written: written, stated: settings.browserURL, environment: environment, port: port
+        )
+    }
+
+    /// One line, trimmed, carrying a scheme. Nil for anything that states nothing.
+    ///
+    /// The first non-empty line rather than the whole file, because `echo` is how a script writes
+    /// this and a trailing newline is what `echo` leaves. A missing scheme is filled in rather
+    /// than refused: `myapp.test` is what a person writes when the point they are making is the
+    /// hostname, and `http://` in front of it is what every address bar does with it anyway.
+    static func address(_ raw: String?) -> String? {
+        guard let line = raw?
+            .components(separatedBy: .newlines)
+            .lazy
+            .map({ $0.trimmingCharacters(in: .whitespaces) })
+            .first(where: { !$0.isEmpty })
+        else { return nil }
+        return line.contains("://") ? line : "http://" + line
+    }
+
+    /// `$NAME` and `${NAME}` replaced from the table the scripts are handed.
+    ///
+    /// A name nothing sets is left exactly as it was typed rather than blanked. `$BLOOM_PROT` is
+    /// a typo, and an address bar showing it is a person's answer in one glance; the same typo
+    /// blanked produces `http://localhost:` and a question about Bloom.
+    static func expand(_ template: String, with environment: [String: String]) -> String {
+        var result = ""
+        var rest = Substring(template)
+
+        while let dollar = rest.firstIndex(of: "$") {
+            result += rest[rest.startIndex..<dollar]
+
+            var cursor = rest.index(after: dollar)
+            let braced = cursor < rest.endIndex && rest[cursor] == "{"
+            if braced { cursor = rest.index(after: cursor) }
+
+            var name = ""
+            while cursor < rest.endIndex, isNameCharacter(rest[cursor]) {
+                name.append(rest[cursor])
+                cursor = rest.index(after: cursor)
+            }
+
+            let closed = !braced || (cursor < rest.endIndex && rest[cursor] == "}")
+            if braced, closed { cursor = rest.index(after: cursor) }
+
+            if !name.isEmpty, closed, let value = environment[name] {
+                result += value
+            } else {
+                result += rest[dollar..<cursor]
+            }
+            rest = rest[cursor...]
+        }
+
+        return result + rest
+    }
+
+    private static func isNameCharacter(_ character: Character) -> Bool {
+        character == "_" || (character.isASCII && (character.isLetter || character.isNumber))
+    }
+}

--- a/Sources/BloomCore/Workspace/WorkspaceManager.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceManager.swift
@@ -417,7 +417,18 @@ public struct WorkspaceManager: Sendable {
     /// One function for all three, so the three cannot drift into binding different names. The
     /// deprecated prefix carries exactly the same values as the real one, so a script written
     /// either way sees the same workspace.
+    ///
+    /// `URL_FILE` is the one an author writes to rather than reads: the address a browser pane
+    /// should open this workspace on, for the projects where that is not the port. See
+    /// `WorkspaceBrowserURL`.
     public func environment(for workspace: Workspace, repo: Repo, port: Int) -> [String: String] {
+        // The one place `$BLOOM_URL_FILE` is handed out, and therefore the place its folder has to
+        // be made to exist: a script told to write to a path whose directory is missing fails with
+        // a redirection error, in the middle of setup, over a folder that is Bloom's business
+        // rather than theirs. Cheap and idempotent, which is what lets it sit on a path a terminal
+        // pane also goes through. See `WorktreeScratch.shield`.
+        WorktreeScratch.shield(WorktreeScratch.generated, in: workspace.path)
+
         let pairs: [(String, String)] = [
             ("IS_LOCAL", "1"),
             ("WORKSPACE_NAME", workspace.branch.replacingOccurrences(of: "/", with: "-")),
@@ -427,6 +438,7 @@ public struct WorkspaceManager: Sendable {
             ("ROOT_PATH", repo.path),
             ("DEFAULT_BRANCH", repo.defaultBranch),
             ("PORT", String(port)),
+            ("URL_FILE", WorkspaceBrowserURL.path(inWorktree: workspace.path)),
         ]
 
         var env: [String: String] = [:]

--- a/Sources/BloomCore/Workspace/WorktreeScratch.swift
+++ b/Sources/BloomCore/Workspace/WorktreeScratch.swift
@@ -62,6 +62,10 @@ public enum WorktreeScratch {
         let ignore = (full as NSString).appendingPathComponent(".gitignore")
         let manager = FileManager.default
         guard !manager.fileExists(atPath: ignore) else { return }
+        // A worktree that is not there gets no scratch folder. Creating the intermediate
+        // directories would otherwise rebuild the skeleton of a worktree somebody has already
+        // removed, which is a folder git knows nothing about standing where a workspace was.
+        guard manager.fileExists(atPath: worktree) else { return }
         // `.bloom` itself is created as a side effect and deliberately left bare. Its own
         // `.gitignore` is a file the team commits, and writing one here would put a file in the
         // user's pull request that they did not ask for, which is the bug this type exists to

--- a/Tests/BloomCoreTests/SettingsWriterTests.swift
+++ b/Tests/BloomCoreTests/SettingsWriterTests.swift
@@ -215,6 +215,7 @@ struct SettingsWriterTests {
                 .branchPrefix("freek"),
                 .deleteBranchOnArchive(true),
                 .runMode("concurrent"),
+                .browserURL("http://localhost:$BLOOM_PORT/admin"),
             ],
             repo: repo,
             settings: settings
@@ -229,6 +230,7 @@ struct SettingsWriterTests {
         #expect(settings.branchPrefix == "freek")
         #expect(settings.deleteBranchOnArchive)
         #expect(settings.runMode == "concurrent")
+        #expect(settings.browserURL == "http://localhost:$BLOOM_PORT/admin")
     }
 
     @Test("clearing a value removes the key rather than writing an empty one")

--- a/Tests/BloomCoreTests/WorkspaceBrowserURLTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceBrowserURLTests.swift
@@ -1,0 +1,147 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+/// What a browser pane opens on, and the order the two sources are asked in.
+@Suite("Workspace browser URL", .scratchDirectory)
+struct WorkspaceBrowserURLTests {
+    private let environment = [
+        "BLOOM_PORT": "3100",
+        "BLOOM_PROJECT_NAME": "shop",
+        "BLOOM_WORKSPACE_NAME": "feature-checkout",
+    ]
+
+    // MARK: - Which source answers
+
+    @Test("the port is the answer when nothing states an address")
+    func portIsTheFallback() {
+        let address = WorkspaceBrowserURL.resolve(
+            written: nil, stated: nil, environment: environment, port: 3100
+        )
+        #expect(address == "http://localhost:3100")
+    }
+
+    @Test("a workspace holding no port opens on nothing, as it did before any of this")
+    func noPortIsEmpty() {
+        let address = WorkspaceBrowserURL.resolve(
+            written: nil, stated: nil, environment: [:], port: 0
+        )
+        #expect(address.isEmpty)
+    }
+
+    @Test("the settings file beats the port")
+    func statedBeatsThePort() {
+        let address = WorkspaceBrowserURL.resolve(
+            written: nil, stated: "http://localhost:$BLOOM_PORT/admin",
+            environment: environment, port: 3100
+        )
+        #expect(address == "http://localhost:3100/admin")
+    }
+
+    @Test("what the script wrote beats the settings file")
+    func writtenBeatsStated() {
+        let address = WorkspaceBrowserURL.resolve(
+            written: "https://shop-a1b2c3d4.test\n", stated: "http://localhost:$BLOOM_PORT",
+            environment: environment, port: 3100
+        )
+        #expect(address == "https://shop-a1b2c3d4.test")
+    }
+
+    /// A script that ran, decided it had nothing to say and truncated the file is a script saying
+    /// nothing, not a script saying "open on the empty string".
+    @Test("an empty file falls through to the settings file")
+    func emptyWrittenFallsThrough() {
+        let address = WorkspaceBrowserURL.resolve(
+            written: "\n  \n", stated: "https://stated.test", environment: environment, port: 3100
+        )
+        #expect(address == "https://stated.test")
+    }
+
+    // MARK: - What counts as an address
+
+    @Test("the first line is the address, whatever follows it")
+    func firstLineWins() {
+        let address = WorkspaceBrowserURL.resolve(
+            written: "https://shop.test/login\nnot this\n", stated: nil,
+            environment: environment, port: 3100
+        )
+        #expect(address == "https://shop.test/login")
+    }
+
+    @Test("a missing scheme is filled in rather than refused")
+    func schemeIsFilledIn() {
+        let written = WorkspaceBrowserURL.resolve(
+            written: "shop.test", stated: nil, environment: environment, port: 0
+        )
+        #expect(written == "http://shop.test")
+
+        let stated = WorkspaceBrowserURL.resolve(
+            written: nil, stated: "localhost:$BLOOM_PORT", environment: environment, port: 3100
+        )
+        #expect(stated == "http://localhost:3100")
+    }
+
+    // MARK: - Expansion
+
+    @Test("both spellings of a variable expand")
+    func bothSpellingsExpand() {
+        let expanded = WorkspaceBrowserURL.expand(
+            "https://${BLOOM_PROJECT_NAME}-$BLOOM_WORKSPACE_NAME.test:$BLOOM_PORT/",
+            with: environment
+        )
+        #expect(expanded == "https://shop-feature-checkout.test:3100/")
+    }
+
+    /// Blanking it would produce `http://localhost:` and a question about Bloom. Left alone it
+    /// produces an address bar with the typo in it.
+    @Test("a name nothing sets is left as it was typed")
+    func unknownNamesSurvive() {
+        #expect(
+            WorkspaceBrowserURL.expand("http://localhost:$BLOOM_PROT", with: environment)
+                == "http://localhost:$BLOOM_PROT"
+        )
+        #expect(
+            WorkspaceBrowserURL.expand("http://localhost:${BLOOM_PORT", with: environment)
+                == "http://localhost:${BLOOM_PORT"
+        )
+        #expect(WorkspaceBrowserURL.expand("cost: $5", with: environment) == "cost: $5")
+        #expect(WorkspaceBrowserURL.expand("trailing $", with: environment) == "trailing $")
+    }
+
+    // MARK: - The file on disk
+
+    @Test("the file the scripts write is read from the worktree's scratch folder")
+    func readsTheFile() throws {
+        let worktree = TestScratch.unique("bloom-browser-url")
+        let path = WorkspaceBrowserURL.path(inWorktree: worktree)
+        try FileManager.default.createDirectory(
+            atPath: (path as NSString).deletingLastPathComponent, withIntermediateDirectories: true
+        )
+        try "https://written.test\n".write(toFile: path, atomically: true, encoding: .utf8)
+
+        var settings = RepoSettings()
+        settings.browserURL = "https://stated.test"
+        let address = WorkspaceBrowserURL.read(
+            worktree: worktree, settings: settings, environment: environment, port: 3100
+        )
+        #expect(address == "https://written.test")
+    }
+
+    @Test("a worktree with no such file uses the settings file")
+    func missingFileFallsThrough() {
+        var settings = RepoSettings()
+        settings.browserURL = "http://localhost:$BLOOM_PORT/admin"
+        let address = WorkspaceBrowserURL.read(
+            worktree: TestScratch.unique("bloom-browser-url-empty"),
+            settings: settings, environment: environment, port: 3100
+        )
+        #expect(address == "http://localhost:3100/admin")
+    }
+
+    /// The address is a fact about one machine, and one arriving in somebody's pull request is
+    /// what `WorktreeScratch` exists to stop.
+    @Test("the file git cannot see is where the address goes")
+    func theFileIsShielded() {
+        #expect(WorktreeScratch.isShielded(WorkspaceBrowserURL.file))
+    }
+}

--- a/Tests/BloomCoreTests/WorkspaceManagerTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceManagerTests.swift
@@ -220,6 +220,47 @@ struct WorkspaceManagerTests {
         #expect(try await store.workspace(id: workspace.id)?.setupState == .succeeded)
     }
 
+    /// The whole route, because the parts of it that can break are all outside the pure decision:
+    /// a variable the script cannot see, and a folder it cannot write into. See
+    /// `WorkspaceBrowserURL`.
+    @Test("a setup script can say where this workspace's browser panes open", .tags(.subprocess))
+    func setupScriptStatesTheBrowserAddress() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+
+        try repo.write(".conductor/settings.toml", """
+        [scripts]
+        setup = '''
+        echo "https://$BLOOM_PROJECT_NAME.test" > "$BLOOM_URL_FILE"
+        '''
+        """)
+
+        let store = try makeTestStore("wm")
+        let manager = WorkspaceManager(store: store)
+        let registered = try await manager.addRepository(at: repo.path)
+        let workspace = try await manager.createWorkspace(repo: registered, prompt: "Say where")
+
+        let succeeded = await manager.runSetup(
+            workspace: workspace, repo: registered, port: 3_100
+        ) { _ in }
+        #expect(succeeded)
+
+        let environment = manager.environment(for: workspace, repo: registered, port: 3_100)
+        let address = WorkspaceBrowserURL.read(
+            worktree: workspace.path,
+            settings: SettingsLoader.load(repo: repo.path),
+            environment: environment,
+            port: 3_100
+        )
+        #expect(address == "https://\(WorkspaceManager.projectName(for: registered)).test")
+
+        // Written into the worktree and invisible to git, which is the half a pull request would
+        // otherwise carry. See `WorktreeScratch`.
+        let worktree = TempRepo(existing: workspace.path)
+        #expect(worktree.exists(WorkspaceBrowserURL.file))
+        #expect(environment["CONDUCTOR_URL_FILE"] == environment["BLOOM_URL_FILE"])
+    }
+
     @Test("records a failing setup script rather than pretending it worked", .tags(.subprocess))
     func recordsFailingSetup() async throws {
         let repo = try await TempRepo()


### PR DESCRIPTION
## What does this do?

A browser pane opens on `http://localhost:$BLOOM_PORT`, which is the right answer only when the dev server is what is listening on that port. A Herd or Valet site answers on `https://<site>.test` and nowhere else, and a project whose front door is `/admin` or a sign-in link wants a path too. Two ways to say otherwise, first one wins:

- `$BLOOM_URL_FILE`, a new script variable naming a file in the worktree. A setup script echoes an address into it, for the addresses only the script knows: a site named after a slug it computed, a tunnel that printed its hostname, a login link carrying a token minted during seeding. Read each time a pane is opened, so a run or archive script can rewrite or empty it.
- `browser.url` in `.bloom/settings.toml`, expanded with the same variables the scripts get, so `http://localhost:$BLOOM_PORT/admin` covers every workspace. Editable in the project's settings, Workspaces pane.
- Neither: `http://localhost:$BLOOM_PORT`, exactly as before.

## What files does it touch?

`WorkspaceBrowserURL` in the core is the whole decision, with the file path, the resolution order and the variable expansion. `WorkspaceManager.environment` gains `URL_FILE`; `Settings`/`SettingsWriter`/`RepoSettingsDraft` gain `browser.url`; `WorkspaceModel.browserAddress` is what the two call sites that built the address by hand now ask (`SessionTabsView.newBrowser`, `BloomCommands.openBrowserPane`).

## Anything to be aware of?

`environment(for:repo:port:)` now shields `.bloom/scratch` before handing out `$BLOOM_URL_FILE`, so a script writing there does not fail on a missing directory. That means every workspace that opens a terminal gets the folder and its `.gitignore`, where before it arrived with the first pull request instructions. `WorktreeScratch.shield` also refuses a worktree that is not there, so nothing rebuilds the skeleton of a removed one.

Nothing validates the address beyond it being one non-empty line, and a missing scheme is filled in with `http://`. A typo that reaches the address bar says where it came from; one quietly swapped for `localhost` looks like Bloom ignoring the file.

## Testing

`WorkspaceBrowserURLTests` covers the order, the expansion and the file; `WorkspaceManagerTests` runs a real setup script that writes `$BLOOM_URL_FILE` and reads the address back. The app target and the suite could not be built on the machine this was written on, which has no Xcode, so CI is the first green.