### PR TITLE
Let a workspace's own agent ask for its workspace to be archived

### DIFF
--- a/Sources/Bloom/State/AppModel+Archive.swift
+++ b/Sources/Bloom/State/AppModel+Archive.swift
@@ -200,6 +200,86 @@ extension AppModel {
         )
     }
 
+    /// Books an archive a workspace's own agent has asked for, to be run when its turn ends.
+    ///
+    /// Nothing at all happens here, and that is the point. The agent that called `workspace_archive`
+    /// is inside the worktree, and `performArchive` stops a workspace's agents before git touches
+    /// a file, so archiving now would kill the turn that is waiting for this answer and leave the
+    /// tool result going nowhere. See `WorkspaceArchiveTool` for the rest of that argument.
+    func bookArchiveForBridge(of workspace: Workspace, after sessionID: SessionID) -> WorkspaceArchiveOutcome {
+        bookArchive(of: workspace.id, after: sessionID)
+        Log.archive.info(
+            "\(workspace.name, privacy: .public) is booked to be archived when its agent's turn ends"
+        )
+        return .requested
+    }
+
+    /// Runs a booked archive, now that the turn that asked for it has ended.
+    ///
+    /// The safety check is asked again, from scratch and with nothing excused. The first ask
+    /// happened inside the tool call, minutes and a whole turn ago, and everything it looked at
+    /// can have moved since: a crew member the agent started can still be running, the owner can
+    /// have queued a message, and the agent's own last act can have been to leave the worktree
+    /// dirty. See `WorkspaceArchiveSafety`.
+    ///
+    /// A refusal goes to the owner rather than to the caller, because there is no caller left to
+    /// tell: the turn that asked has ended, and the tool told it in so many words that it would
+    /// not hear the answer. A notice rather than an alert, because this is news about something
+    /// the app did while nobody was watching and the workspace is still in the sidebar where they
+    /// can archive it by hand.
+    ///
+    /// `wasStopped` is the owner pressing Stop, and it drops the booking rather than deferring it
+    /// again. Somebody who has just stepped into a turn is not somebody whose worktree should
+    /// disappear a second later, and a request that survived being overruled would go off at the
+    /// end of whatever turn they typed next, which is further from the decision rather than nearer
+    /// to it. They are told, because a request that quietly evaporates is one they would go on
+    /// waiting for.
+    func archiveIfRequested(
+        _ workspace: Workspace, endedIn sessionID: SessionID, wasStopped: Bool = false
+    ) async {
+        guard takeArchiveBooking(of: workspace.id, endedIn: sessionID) else { return }
+        guard let store else { return }
+
+        if wasStopped {
+            Log.archive.notice(
+                "the booked archive of \(workspace.name, privacy: .public) was dropped: its turn was stopped by hand"
+            )
+            notice = BloomNotice(
+                message: "\(workspace.name) had asked to be archived when its agent finished. You "
+                    + "stopped that turn, so nothing was archived and the request is dropped."
+            )
+            return
+        }
+
+        if let objection = await WorkspaceArchiveSafety.objection(
+            to: workspace, excusing: nil, store: store
+        ) {
+            Log.archive.notice(
+                "the booked archive of \(workspace.name, privacy: .public) was refused: \(objection, privacy: .public)"
+            )
+            notice = BloomNotice(
+                message: "\(workspace.name) asked to be archived when its agent finished, and it "
+                    + "was not. \(objection)"
+            )
+            return
+        }
+
+        // `deleteBranch: false` and `allowsConfirmation: false` are the same two arguments the
+        // owner's own client is archived under, and they are what keeps this from ever being more
+        // destructive than the tool's description promised: the branch is kept whatever the
+        // project's settings say, and a workspace with something at stake is refused rather than
+        // put behind a dialog nobody is sitting in front of.
+        switch await archive(workspace, deleteBranch: false, allowsConfirmation: false) {
+        case .archived, .requested:
+            break
+        case .refused(let reason):
+            notice = BloomNotice(
+                message: "\(workspace.name) asked to be archived when its agent finished, and it "
+                    + "was not. \(reason)"
+            )
+        }
+    }
+
     /// GitHub's verdict on this workspace's branch, from whichever of the two places has already
     /// asked: the open workspace's own model, or the store every sidebar row reads.
     ///

--- a/Sources/Bloom/State/AppModel+WorkspaceBridge.swift
+++ b/Sources/Bloom/State/AppModel+WorkspaceBridge.swift
@@ -101,9 +101,9 @@ extension AppModel {
             BrowserScrollTool(browser),
             BrowserScreenshotTool(browser),
             BrowserTextTool(browser),
-            WorkspaceArchiveTool { [weak self] workspace in
+            WorkspaceArchiveTool { [weak self] order in
                 guard let self else { return .refused("Bloom is still starting up.") }
-                return await self.archiveWorkspaceForBridge(workspace)
+                return await self.archiveWorkspaceForBridge(order)
             },
             WorkspaceMergeTool { [weak self] workspace, pullRequest, method in
                 guard let self else {
@@ -138,11 +138,23 @@ extension AppModel {
 
     /// Uses the UI lifecycle so tabs, agents, terminals and selection cannot outlive the worktree.
     /// A refusal goes back to the caller instead of asking the user to approve a destructive retry.
-    private func archiveWorkspaceForBridge(_ workspace: Workspace) async -> WorkspaceArchiveOutcome {
-        guard let current = workspaces.first(where: { $0.id == workspace.id }) else {
+    ///
+    /// The owner's own client is acted on at once, because it is standing outside every turn. A
+    /// workspace's own agent is booked, because it is standing inside the worktree: see
+    /// `bookArchiveForBridge` and `WorkspaceArchiveTool`.
+    ///
+    /// `workspaces` rather than the row the tool read, in both arms. The list is this window's
+    /// own, so a workspace that has been archived by hand since the call came in is not in it, and
+    /// booking against a row nobody can act on any more would be a request that could only ever be
+    /// refused at the owner.
+    private func archiveWorkspaceForBridge(_ order: WorkspaceArchiveOrder) async -> WorkspaceArchiveOutcome {
+        guard let current = workspaces.first(where: { $0.id == order.workspace.id }) else {
             return .refused("This workspace is no longer active. Refresh workspace_list.")
         }
-        return await archive(current, deleteBranch: false, allowsConfirmation: false)
+        guard let sessionID = order.afterTurnOf else {
+            return await archive(current, deleteBranch: false, allowsConfirmation: false)
+        }
+        return bookArchiveForBridge(of: current, after: sessionID)
     }
 
     /// Confirms that the path the model named is a real image or movie inside its own worktree.

--- a/Sources/Bloom/State/AppModel.swift
+++ b/Sources/Bloom/State/AppModel.swift
@@ -270,6 +270,33 @@ final class AppModel {
 
     func isArchiving(_ id: WorkspaceID) -> Bool { archivingWorkspaceIDs.contains(id) }
 
+    /// Workspaces whose own agent has asked to be archived, and the chat whose turn has to end
+    /// before that can happen.
+    ///
+    /// The booking is here rather than on `WorkspaceModel` because the model is torn down by the
+    /// archive it is waiting for, and a request held on the thing it is about is a request that
+    /// dies half way through being carried out. It is a dictionary rather than a set because the
+    /// chat is the point: a workspace running a crew ends several turns and only one of them is
+    /// the turn that asked. See `AppModel.archiveIfRequested`.
+    ///
+    /// One booking per workspace. A second call from the same agent overwrites the first rather
+    /// than queueing behind it, because both name the same worktree and the later one is the one
+    /// with the fresher chat behind it.
+    private var archiveBookings: [WorkspaceID: SessionID] = [:]
+
+    /// Books a workspace to be archived once the asking chat's turn has ended.
+    func bookArchive(of id: WorkspaceID, after sessionID: SessionID) {
+        archiveBookings[id] = sessionID
+    }
+
+    /// Takes the booking back, if there is one and this is the chat it was waiting on. Answers
+    /// whether the caller now owns it, so a booking cannot be acted on twice.
+    func takeArchiveBooking(of id: WorkspaceID, endedIn sessionID: SessionID) -> Bool {
+        guard archiveBookings[id] == sessionID else { return false }
+        archiveBookings[id] = nil
+        return true
+    }
+
     /// Workspaces the owner has asked for whose worktree is still being cut.
     ///
     /// The mirror of `archivingWorkspaceIDs` above: that one takes a row away before the disk work
@@ -1209,6 +1236,10 @@ final class AppModel {
     func forgetWorkspace(_ id: WorkspaceID) {
         stopHidingFromSidebar(id)
         workspaceModels[id] = nil
+        // An archive that has happened cannot still be waiting to happen. Nothing books one twice
+        // today, but a booking outliving the worktree it names is a request that can only ever be
+        // refused, and it would be refused at the owner rather than at the agent that made it.
+        archiveBookings[id] = nil
         storedActivity.removeAll { $0.workspaceID == id }
         // The crew rows go for the same reason the activity rows above do: `ON DELETE CASCADE`
         // has taken this workspace's sessions with it, and rows read before that would keep

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -1434,6 +1434,14 @@ final class TranscriptModel {
             await reportToOrchestrator(
                 CrewMessage.failed(name: session.title, reason: failure.message)
             )
+            // An agent that died is an agent whose turn has ended, so a workspace it had asked to
+            // archive is due now. `notifyFinished` is not on this path and never was: it is about
+            // a result, and there is none. The recheck decides as it does everywhere else.
+            if let workspaceNow {
+                await app.archiveIfRequested(
+                    workspaceNow, endedIn: session.id, wasStopped: wasStoppedByHand
+                )
+            }
 
         case .result(let result):
             // A turn that recovered leaves its sentence on the row that closes it; one that failed
@@ -1819,6 +1827,25 @@ final class TranscriptModel {
 
         NotificationService.shared.turnFinished(
             workspace: workspaceNow, result: result, wasCancelled: session.state == .cancelled
+        )
+
+        // Last, and after the banner, because this is the one thing here that can take the
+        // workspace away: a notification about a turn that finished in a workspace is worth
+        // sending whether or not the worktree survives the next line.
+        //
+        // Before the drain rather than after it, which is the ordering that matters. `drain` runs
+        // once this returns and is guarded by `isWorkspaceArchiving`, so an archive that starts
+        // here cannot have a queued message sent into it; and a workspace that still has one
+        // queued is refused with the true reason rather than with "an agent is running" a
+        // fraction of a second later.
+        //
+        // `wasStoppedByHand` is read here rather than a few lines down for the reason the drain
+        // reads it: the owner stepped in, and a worktree removing itself out from under somebody
+        // who has just pressed Stop is the opposite of what Stop is for. It is still true at this
+        // line for a Steer, which is a stop made in order to say one particular thing, and that is
+        // right too. See `AppModel.archiveIfRequested`.
+        await app.archiveIfRequested(
+            workspaceNow, endedIn: session.id, wasStopped: wasStoppedByHand
         )
     }
 }

--- a/Sources/BloomCore/Bridge/BridgeToolApproval.swift
+++ b/Sources/BloomCore/Bridge/BridgeToolApproval.swift
@@ -24,9 +24,16 @@ import Foundation
 ///
 /// ## What is deliberately not on the list
 ///
-/// Anything that destroys work. When `workspace_archive` lands it removes a worktree and can
-/// remove a branch with it, and the whole reason Bloom asks before archiving by hand is that the
-/// answer is sometimes no. A tool that can lose work is a tool a person answers for.
+/// Anything that destroys work. `workspace_archive` removes a worktree, and the whole reason Bloom
+/// asks before archiving by hand is that the answer is sometimes no. A tool that can lose work is
+/// a tool a person answers for.
+///
+/// That holds for both of its roles, and the workspace agent's arm is the one worth stating,
+/// because everything else on this list argues from the hung turn an unanswered ask costs. It does
+/// not apply here. The agent's call is a request booked for the end of its own turn, so the ask
+/// lands while the agent is still running and the owner is the only one who can still say no; and
+/// an ask nobody answers leaves the workspace exactly as it was, which is the outcome the caller
+/// was told to expect anyway. See `WorkspaceArchiveTool`.
 ///
 /// `quick_prompt_delete` and `quick_prompt_update` are the two on the bridge today that this
 /// applies to. Neither touches a repository, but both act on a few lines the owner wrote by hand,

--- a/Sources/BloomCore/Bridge/WorkspaceArchiveSafety.swift
+++ b/Sources/BloomCore/Bridge/WorkspaceArchiveSafety.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Whether a workspace can be taken off disk right now, asked in the two places that have to agree.
+///
+/// The owner's own client asks once, and once is enough: it is standing outside every turn, so
+/// nothing it can see is about to change between the question and the archive. A workspace's own
+/// agent asks twice, and that is the whole reason this is a type rather than a paragraph inside
+/// `WorkspaceArchiveTool`. The first ask is made while the asking turn is still running, so the
+/// caller's own chat is excused; the second is made once that turn has ended, with nothing
+/// excused, and it is the one that decides. Written out twice it would be edited once, and the
+/// half nobody edited would be the half that runs after the agent has stopped watching.
+public enum WorkspaceArchiveSafety {
+    /// The sentence to refuse with, or nil when nothing objects.
+    ///
+    /// `excusing` is the chat that is doing the asking. Its own `running` is the call in flight
+    /// rather than work at risk, so it is not an objection. Everything else about it still is, and
+    /// its queue in particular: a message waiting to go is something the owner asked for, and
+    /// archiving over it would throw it away without ever having shown it to an agent.
+    public static func objection(
+        to workspace: Workspace,
+        excusing asking: SessionID?,
+        store: Store
+    ) async -> String? {
+        if workspace.setupState == .running {
+            return "Workspace setup is still running. Wait for it to finish before archiving."
+        }
+        do {
+            for session in try await store.sessions(workspaceID: workspace.id) {
+                if session.id != asking, session.state == .running || session.state == .waiting {
+                    return """
+                        An agent is running or awaiting an answer in this workspace. Finish or \
+                        stop it before archiving.
+                        """
+                }
+                if try await !store.pendingDeliveries(sessionID: session.id).isEmpty {
+                    return "This workspace has queued messages. Handle them before archiving."
+                }
+            }
+        } catch {
+            return "Bloom could not check this workspace's activity. Nothing was archived; try again shortly."
+        }
+        return nil
+    }
+}

--- a/Sources/BloomCore/Bridge/WorkspaceArchiveTool.swift
+++ b/Sources/BloomCore/Bridge/WorkspaceArchiveTool.swift
@@ -1,15 +1,74 @@
 import Foundation
 
-/// Returned only after the normal archive lifecycle has completed or refused the request.
+/// What became of an archive request.
+///
+/// `archived` is only returned after the normal archive lifecycle has completed. `requested` is
+/// the answer to a workspace's own agent and is deliberately a third case rather than a success
+/// with a hedge in its sentence: the caller is mid turn, nothing has been removed, and a model
+/// handed `archived` would go on to tell the owner that a worktree it is still standing in has
+/// gone.
 public enum WorkspaceArchiveOutcome: Sendable, Equatable {
     case archived
+    /// Booked, and it runs when the asking turn ends. See `WorkspaceArchiveOrder.afterTurnOf`.
+    case requested
     case refused(String)
 }
 
-public typealias WorkspaceArchiving = @Sendable (Workspace) async -> WorkspaceArchiveOutcome
+/// Who is asking, which is the whole of what the app needs to know to decide when to act.
+///
+/// The session rather than a flag, because the app has to wait for one particular turn to end and
+/// a workspace holds several chats at once. A boolean would have it archive on whichever chat
+/// happened to finish first, which in a workspace running a crew is not the one that asked.
+public struct WorkspaceArchiveOrder: Sendable, Hashable {
+    public let workspace: Workspace
+    /// The chat whose turn has to end before the worktree can go, or nil for the owner's own
+    /// client, which is sitting in no turn and can be acted on at once.
+    public let afterTurnOf: SessionID?
 
-/// The owner's explicit cleanup request. The app retains the branch and applies the same
-/// live-agent and filesystem checks as the Archive command, with no force option.
+    public init(workspace: Workspace, afterTurnOf: SessionID?) {
+        self.workspace = workspace
+        self.afterTurnOf = afterTurnOf
+    }
+}
+
+public typealias WorkspaceArchiving = @Sendable (WorkspaceArchiveOrder) async -> WorkspaceArchiveOutcome
+
+/// `workspace_archive`: clean a workspace up, keeping everything that exists nowhere else.
+///
+/// ## Who may call it, and why the two arms are shaped differently
+///
+/// `.owner` and `.parent`, exactly as `workspace_rename` is, and for the same reasons.
+///
+/// The owner's client names a workspace out loud, because it is sitting in none and nothing else
+/// says which. A parent names none and is refused if it tries: the token says which workspace is
+/// asking, so there is nothing to forge or mistype, and a call that named another workspace and
+/// quietly got this one would look like it worked. That is the whole of the isolation. A workspace
+/// agent cannot reach another workspace here because there is no argument through which it could.
+///
+/// Not `.child`. A child reports and that is all, here as everywhere. A child's workspace is one
+/// an agent asked for and nobody weighed, so it is the last worktree that should be removable by
+/// something nobody weighed either.
+///
+/// ## Why a workspace agent's call is a request rather than an archive
+///
+/// The agent is inside the worktree that would be removed. `git worktree remove --force`
+/// unlinking files under a running agent is how work gets corrupted rather than merely lost, which
+/// is why `AppModel.performArchive` stops the agents first, and stopping the agent that is waiting
+/// on this tool call means killing the turn that made it. So the call is booked and the tool says
+/// so: the safety check runs again once that turn has ended, with nothing excused, and the archive
+/// runs then. The answer says "requested" in those words because a model that reads it as done
+/// tells the owner something that has not happened yet, and because there is nothing left for it
+/// to say afterwards: whatever it was keeping back is keeping back for ever.
+///
+/// A refusal after the fact reaches the owner rather than the agent, because by then there is no
+/// agent to reach. See `AppModel.archiveIfRequested`.
+///
+/// ## Why it is not self-approved
+///
+/// It removes a worktree, and `BridgeToolApproval`'s own head names it as the example of what is
+/// deliberately off that list: a tool that can lose work is a tool a person answers for. Deferring
+/// the cleanup does not change that, and the ask lands in front of the owner while the agent is
+/// still running, which is the one moment they can still say no.
 public struct WorkspaceArchiveTool: BridgeToolHandling {
     private let archive: WorkspaceArchiving
 
@@ -17,32 +76,43 @@ public struct WorkspaceArchiveTool: BridgeToolHandling {
         self.archive = archive
     }
 
-    public let roles: Set<BridgeRole> = [.owner]
+    public let roles: Set<BridgeRole> = [.owner, .parent]
 
     public let tool = BridgeTool(
         name: "workspace_archive",
         description: """
-            Archive a workspace when the owner asks to clean it up. Pass its exact 'id' from \
-            workspace_list. This removes the worktree and closes its terminals and dev servers. \
-            Its branch, notes and chat history are kept, and the workspace moves to Archived.
+            Archive a workspace that is finished with. This removes the worktree and closes its \
+            terminals and dev servers. Its branch, notes and chat history are kept, and the \
+            workspace moves to Archived.
 
-            The normal archive script runs if the project has one. A running agent, uncommitted \
-            changes, local files that would be lost, or a failed safety check refuses the call. \
-            There is no force option. Explain a refusal to the owner and let them resolve it or \
-            archive manually in Bloom. Do not discard files just to make this tool succeed.
+            If you are working in a workspace, this archives yours and there is nothing to pass: \
+            do not name a workspace, it will be refused. You are still running, so the worktree \
+            cannot go yet. The call is a request: Bloom checks again once your turn has ended and \
+            archives then. Say everything you have to say in this same turn, because there will \
+            not be another one, and do not report the workspace as archived. Only ask when the \
+            work is done and the owner has said the workspace can go.
 
-            Only call after the owner has asked for the workspace to be archived. The result \
-            confirms completion, not a queued request. An already archived workspace is a no-op.
+            From a client of the owner's own, pass 'id' with the exact workspace id from \
+            workspace_list. Only call after the owner has asked for that workspace to be archived.
+
+            The normal archive script runs if the project has one. Another agent running, queued \
+            messages, uncommitted changes, local files that would be lost, or a failed safety \
+            check refuses the call. There is no force option and no way to delete the branch. \
+            Explain a refusal and let the owner resolve it or archive manually in Bloom. Do not \
+            discard files just to make this tool succeed. An already archived workspace is a no-op.
             """,
         inputSchema: .object([
             "type": .string("object"),
             "properties": .object([
                 "id": .object([
                     "type": .string("string"),
-                    "description": .string("The exact workspace id returned by workspace_list."),
+                    "description": .string(
+                        "The exact workspace id returned by workspace_list. Only from the owner's "
+                            + "own client. An agent working in a workspace archives its own and "
+                            + "must leave this out."
+                    ),
                 ]),
             ]),
-            "required": .array([.string("id")]),
             "additionalProperties": .bool(false),
         ])
     )
@@ -50,47 +120,95 @@ public struct WorkspaceArchiveTool: BridgeToolHandling {
     public func call(
         _ request: MCPRequest, as identity: BridgeIdentity, store: Store
     ) async -> BridgeToolResult {
-        guard identity.role == .owner else {
-            return .failure("Only the owner's connection can archive workspaces.")
-        }
-        guard case .object(let arguments)? = request.params,
-              Set(arguments.keys) == ["id"],
-              let rawID = request.stringParam("id")?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !rawID.isEmpty else {
-            return .failure("Pass only 'id', using the exact workspace id from workspace_list. There is no force option.")
-        }
         let workspace: Workspace
-        do {
-            guard let found = try await store.workspace(id: WorkspaceID(rawID)) else {
-                return .failure("No workspace has that id. Call workspace_list and use the id it reports.")
-            }
-            workspace = found
-        } catch {
-            return .failure("Bloom could not read this workspace. Nothing was archived; try again shortly.")
+        let asking: SessionID?
+        switch await find(request, as: identity, store: store) {
+        case .refused(let sentence): return .failure(sentence)
+        case .found(let found, let session): (workspace, asking) = (found, session)
         }
+
         if workspace.state == .archived {
             return BridgeToolResult(text: "'\(workspace.name)' is already archived. Nothing changed.")
         }
-        do {
-            if workspace.setupState == .running {
-                return .failure("Workspace setup is still running. Wait for it to finish before archiving.")
-            }
-            for session in try await store.sessions(workspaceID: workspace.id) {
-                if session.state == .running || session.state == .waiting {
-                    return .failure("An agent is running or awaiting an answer in this workspace. Finish or stop it before archiving.")
-                }
-                if try await !store.pendingDeliveries(sessionID: session.id).isEmpty {
-                    return .failure("This workspace has queued messages. Handle them before archiving.")
-                }
-            }
-        } catch {
-            return .failure("Bloom could not check this workspace's activity. Nothing was archived; try again shortly.")
+        if let objection = await WorkspaceArchiveSafety.objection(
+            to: workspace, excusing: asking, store: store
+        ) {
+            return .failure(objection)
         }
-        switch await archive(workspace) {
+
+        switch await archive(WorkspaceArchiveOrder(workspace: workspace, afterTurnOf: asking)) {
         case .archived:
             return BridgeToolResult(text: "Archived '\(workspace.name)'. Its branch, notes and chat history were kept.")
+        case .requested:
+            return BridgeToolResult(text: """
+                Archiving '\(workspace.name)' is requested, not done. Nothing has been removed and \
+                you are still in the worktree. Bloom checks again when this turn ends, and \
+                archives then if no agent is running here and nothing is queued; if it refuses, \
+                the workspace stays and the owner is told why. This is your last turn in this \
+                workspace, so finish what you were saying now, and do not report it as archived.
+                """)
         case .refused(let reason):
             return .failure("The archive request was refused. \(reason)")
+        }
+    }
+
+    /// Which workspace this call is about, and whose turn it is being made from.
+    private enum Subject {
+        /// The workspace, and the chat that must finish first when a workspace agent is asking.
+        case found(Workspace, SessionID?)
+        case refused(String)
+    }
+
+    /// Which workspace this call is about and whose turn it is being made from, or why there is
+    /// neither. The two arms are the two roles and they do not overlap.
+    private func find(
+        _ request: MCPRequest, as identity: BridgeIdentity, store: Store
+    ) async -> Subject {
+        // Enforced here as well as in the toolbox, because the toolbox's gate is what a
+        // `tools/call` goes through and a process speaking raw MCP at the socket with a child's
+        // token is not obliged to.
+        guard roles.contains(identity.role) else {
+            return .refused(
+                "Only the owner's own client, or the agent working in a workspace, can archive one."
+            )
+        }
+
+        var arguments: [String: JSONValue] = [:]
+        if case .object(let object)? = request.params { arguments = object }
+
+        guard identity.role == .owner else {
+            guard arguments.isEmpty else {
+                return .refused("""
+                    workspace_archive archives the workspace you are in, which is the only one you \
+                    may act in, so it takes no arguments. Ask again with none, and note that there \
+                    is no force option and no way to delete the branch.
+                    """)
+            }
+            guard let workspaceID = identity.workspaceID, let sessionID = identity.sessionID else {
+                return .refused(BridgeWorkspaceScope.refusal(tool: "workspace_archive", doing: "archives"))
+            }
+            do {
+                guard let own = try await store.workspace(id: workspaceID) else {
+                    return .refused("That workspace is no longer in Bloom, so there is nothing to archive.")
+                }
+                return .found(own, sessionID)
+            } catch {
+                return .refused("Bloom could not read this workspace. Nothing was archived; try again shortly.")
+            }
+        }
+
+        guard Set(arguments.keys) == ["id"],
+              let rawID = request.stringParam("id")?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawID.isEmpty else {
+            return .refused("Pass only 'id', using the exact workspace id from workspace_list. There is no force option.")
+        }
+        do {
+            guard let found = try await store.workspace(id: WorkspaceID(rawID)) else {
+                return .refused("No workspace has that id. Call workspace_list and use the id it reports.")
+            }
+            return .found(found, nil)
+        } catch {
+            return .refused("Bloom could not read this workspace. Nothing was archived; try again shortly.")
         }
     }
 }

--- a/Tests/BloomCoreTests/WorkspaceArchiveSafetyTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceArchiveSafetyTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// The check the tool makes while the asking turn is still running, and the one the app makes
+/// again once it has ended. Both go through here, so this is where the difference between them is
+/// written down: one excuses the chat that is asking, the other excuses nothing.
+struct WorkspaceArchiveSafetyTests {
+    @Test("a quiet workspace has nothing to object to")
+    func quiet() async throws {
+        let (store, workspace) = try await fixture()
+        try await store.upsert(Session(workspaceID: workspace.id, title: "Finished"))
+        #expect(await WorkspaceArchiveSafety.objection(to: workspace, excusing: nil, store: store) == nil)
+    }
+
+    @Test("the asking chat's own turn is the call in flight rather than work at risk")
+    func asksAreExcused() async throws {
+        let (store, workspace) = try await fixture()
+        var asking = Session(workspaceID: workspace.id, title: "Asking")
+        asking.state = .running
+        asking = try await store.upsert(asking)
+
+        // While it asks: nothing objects, because the only thing running is the turn making the
+        // call.
+        #expect(await WorkspaceArchiveSafety.objection(
+            to: workspace, excusing: asking.id, store: store
+        ) == nil)
+
+        // The recheck, made with nothing excused. A chat still marked running when the archive is
+        // due is a turn that never ended, and the worktree stays.
+        let objection = await WorkspaceArchiveSafety.objection(
+            to: workspace, excusing: nil, store: store
+        )
+        #expect(objection?.contains("An agent is running") == true)
+    }
+
+    @Test("another chat running or waiting objects even to the chat that is asking",
+          arguments: [SessionState.running, .waiting])
+    func anotherAgent(_ state: SessionState) async throws {
+        let (store, workspace) = try await fixture()
+        let asking = try await store.upsert(Session(workspaceID: workspace.id, title: "Asking"))
+        var other = Session(workspaceID: workspace.id, title: "Crew member")
+        other.state = state
+        try await store.upsert(other)
+        let objection = await WorkspaceArchiveSafety.objection(
+            to: workspace, excusing: asking.id, store: store
+        )
+        #expect(objection?.contains("An agent is running") == true)
+    }
+
+    @Test("a queued message is never excused, not even the asking chat's own")
+    func queuedMessages() async throws {
+        let (store, workspace) = try await fixture()
+        var asking = Session(workspaceID: workspace.id, title: "Asking")
+        asking.state = .running
+        asking = try await store.upsert(asking)
+        try await store.enqueueDelivery(Delivery(targetSessionID: asking.id, body: "One more thing"))
+        let objection = await WorkspaceArchiveSafety.objection(
+            to: workspace, excusing: asking.id, store: store
+        )
+        #expect(objection?.contains("queued messages") == true)
+    }
+
+    @Test("setup still running objects whoever is asking")
+    func setupRunning() async throws {
+        let (store, workspace) = try await fixture()
+        var preparing = workspace
+        preparing.setupState = .running
+        preparing = try await store.upsert(preparing)
+        let asking = try await store.upsert(Session(workspaceID: preparing.id, title: "Asking"))
+        let objection = await WorkspaceArchiveSafety.objection(
+            to: preparing, excusing: asking.id, store: store
+        )
+        #expect(objection?.contains("setup is still running") == true)
+    }
+
+    @Test("a chat busy in another workspace is not this workspace's problem")
+    func otherWorkspacesAreIgnored() async throws {
+        let (store, workspace) = try await fixture()
+        let elsewhere = try await store.upsert(Workspace(
+            repoID: workspace.repoID, name: "Elsewhere", branch: "elsewhere",
+            path: "/tmp/archive-safety-elsewhere", baseBranch: "main"
+        ))
+        var busy = Session(workspaceID: elsewhere.id, title: "Busy elsewhere")
+        busy.state = .running
+        try await store.upsert(busy)
+        #expect(await WorkspaceArchiveSafety.objection(to: workspace, excusing: nil, store: store) == nil)
+    }
+
+    private func fixture() async throws -> (Store, Workspace) {
+        let store = try makeTestStore("archive-safety")
+        let repo = try await store.upsert(Repo(name: "Archive safety", path: "/tmp/archive-safety"))
+        let workspace = try await store.upsert(Workspace(
+            repoID: repo.id, name: "Finished review", branch: "review",
+            path: "/tmp/archive-safety-review", baseBranch: "main"
+        ))
+        return (store, workspace)
+    }
+}

--- a/Tests/BloomCoreTests/WorkspaceArchiveToolTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceArchiveToolTests.swift
@@ -3,22 +3,29 @@ import Testing
 @testable import BloomCore
 
 struct WorkspaceArchiveToolTests {
-    @Test("archive is owner-only and is never self-approved")
+    @Test("archive is offered to the owner and to a workspace agent, and is never self-approved")
     func permissions() {
         let tool = WorkspaceArchiveTool { _ in .archived }
         let toolbox = BridgeToolbox(handlers: [tool])
         #expect(toolbox.handler(named: "workspace_archive", for: .owner) != nil)
-        #expect(toolbox.handler(named: "workspace_archive", for: .parent) == nil)
+        #expect(toolbox.handler(named: "workspace_archive", for: .parent) != nil)
+        // A child reports and nothing else, here as everywhere.
         #expect(toolbox.handler(named: "workspace_archive", for: .child) == nil)
+        #expect(toolbox.tools(for: .parent).map(\.name).contains("workspace_archive"))
+        #expect(!toolbox.tools(for: .child).map(\.name).contains("workspace_archive"))
+        // Removing a worktree stays a question a person answers, whichever role asks it.
         #expect(!BridgeToolApproval.selfApproved.contains("workspace_archive"))
+        #expect(!BridgeToolApproval.isSelfApproved(
+            toolName: "mcp__bloom-workspace-bridge__workspace_archive"
+        ))
     }
 
-    @Test("archive requires an exact id and never accepts force or branch deletion")
-    func arguments() async throws {
+    @Test("the owner needs an exact id and never gets force or branch deletion")
+    func ownerArguments() async throws {
         let (store, workspace) = try await fixture()
         let calls = ArchiveCalls()
-        let tool = WorkspaceArchiveTool { workspace in
-            await calls.record(workspace.id)
+        let tool = WorkspaceArchiveTool { order in
+            await calls.record(order)
             return .archived
         }
         for arguments: [String: JSONValue] in [
@@ -30,45 +37,158 @@ struct WorkspaceArchiveToolTests {
             let result = await tool.call(request(arguments), as: .owner, store: store)
             #expect(result.isError)
         }
-        #expect(await calls.ids.isEmpty)
+        #expect(await calls.orders.isEmpty)
     }
 
-    @Test("a direct call cannot bypass the role gate")
-    func directRoleGate() async throws {
+    @Test("a child cannot reach the handler even by speaking raw MCP at it")
+    func childRoleGate() async throws {
         let (store, workspace) = try await fixture()
         let tool = WorkspaceArchiveTool { _ in
-            Issue.record("unauthorised archive reached the app")
+            Issue.record("a child reached the archive lifecycle")
             return .archived
         }
-        let identity = BridgeIdentity(sessionID: SessionID("parent-session"), workspaceID: workspace.id, role: .parent)
-        let result = await tool.call(request(["id": .string(workspace.id.rawValue)]), as: identity, store: store)
+        let identity = BridgeIdentity(
+            sessionID: SessionID("child-session"), workspaceID: workspace.id, role: .child
+        )
+        let result = await tool.call(request([:]), as: identity, store: store)
         #expect(result.isError)
     }
 
-    @Test("already archived is an idempotent no-op")
+    // MARK: - A workspace agent archives its own workspace and no other
+
+    @Test("a workspace agent gets its own workspace from its token, whatever it asks for")
+    func workspaceIsolation() async throws {
+        let (store, mine) = try await fixture()
+        let theirs = try await second(in: store)
+        let calls = ArchiveCalls()
+        let tool = WorkspaceArchiveTool { order in
+            await calls.record(order)
+            return .requested
+        }
+        let identity = BridgeIdentity(
+            sessionID: SessionID("my-session"), workspaceID: mine.id, role: .parent
+        )
+
+        // Naming any workspace is refused rather than ignored, so a call that meant to reach
+        // another one cannot come back looking as though it worked.
+        for named in [theirs.id.rawValue, theirs.name, mine.id.rawValue] {
+            let result = await tool.call(request(["id": .string(named)]), as: identity, store: store)
+            #expect(result.isError)
+            #expect(result.text.contains("takes no arguments"))
+        }
+        #expect(await calls.orders.isEmpty)
+
+        let result = await tool.call(request([:]), as: identity, store: store)
+        #expect(!result.isError)
+        #expect(await calls.orders.map(\.workspace.id) == [mine.id])
+        #expect(try await store.workspace(id: theirs.id)?.state == .active)
+    }
+
+    @Test("a token naming a workspace that has gone is refused rather than guessed at")
+    func workspaceOnTheTokenHasGone() async throws {
+        let (store, _) = try await fixture()
+        let tool = WorkspaceArchiveTool { _ in
+            Issue.record("a caller with no live workspace reached the archive lifecycle")
+            return .archived
+        }
+        let identity = BridgeIdentity(
+            sessionID: SessionID("s"), workspaceID: WorkspaceID("gone"), role: .parent
+        )
+        let result = await tool.call(request([:]), as: identity, store: store)
+        #expect(result.isError)
+        #expect(result.text.contains("no longer in Bloom"))
+    }
+
+    // MARK: - Deferred cleanup
+
+    @Test("a workspace agent's call books cleanup for the end of its own turn")
+    func deferredCleanup() async throws {
+        let (store, workspace) = try await fixture()
+        var session = Session(workspaceID: workspace.id, title: "Doing the work")
+        session.state = .running
+        session = try await store.upsert(session)
+        let calls = ArchiveCalls()
+        let tool = WorkspaceArchiveTool { order in
+            await calls.record(order)
+            return .requested
+        }
+        let identity = BridgeIdentity(
+            sessionID: session.id, workspaceID: workspace.id, role: .parent
+        )
+        let result = await tool.call(request([:]), as: identity, store: store)
+
+        #expect(!result.isError)
+        // The chat rather than a flag: a workspace running a crew ends several turns and only one
+        // of them is the turn that asked.
+        #expect(await calls.orders.map(\.afterTurnOf) == [session.id])
+        // It must not read as done. The agent is still standing in the worktree.
+        #expect(result.text.contains("requested, not done"))
+        #expect(result.text.contains("Nothing has been removed"))
+        #expect(!result.text.contains("Archived '"))
+        #expect(try await store.workspace(id: workspace.id)?.state == .active)
+    }
+
+    @Test("the owner's own client is acted on at once, waiting for no turn")
+    func ownerIsNotDeferred() async throws {
+        let (store, workspace) = try await fixture()
+        let calls = ArchiveCalls()
+        let tool = WorkspaceArchiveTool { order in
+            await calls.record(order)
+            return .archived
+        }
+        let result = await tool.call(
+            request(["id": .string(workspace.id.rawValue)]), as: .owner, store: store
+        )
+        #expect(!result.isError)
+        #expect(await calls.orders.map(\.afterTurnOf) == [nil])
+        #expect(result.text.contains(workspace.name))
+        #expect(result.text.contains("branch, notes and chat history were kept"))
+    }
+
+    @Test("already archived is an idempotent no-op for both roles")
     func alreadyArchived() async throws {
         let (store, workspace) = try await fixture(state: .archived)
         let tool = WorkspaceArchiveTool { _ in
             Issue.record("an archived workspace reached the app again")
             return .archived
         }
-        let result = await tool.call(request(["id": .string(workspace.id.rawValue)]), as: .owner, store: store)
-        #expect(!result.isError)
-        #expect(result.text.contains("already archived"))
+        let identity = BridgeIdentity(
+            sessionID: SessionID("s"), workspaceID: workspace.id, role: .parent
+        )
+        for (request, identity) in [
+            (request(["id": .string(workspace.id.rawValue)]), BridgeIdentity.owner),
+            (request([:]), identity),
+        ] {
+            let result = await tool.call(request, as: identity, store: store)
+            #expect(!result.isError)
+            #expect(result.text.contains("already archived"))
+        }
     }
 
-    @Test("running and waiting sessions prevent archive", arguments: [SessionState.running, .waiting])
+    // MARK: - Safety
+
+    @Test("another agent running or waiting refuses the call", arguments: [SessionState.running, .waiting])
     func busySession(_ state: SessionState) async throws {
         let (store, workspace) = try await fixture()
-        var session = Session(workspaceID: workspace.id, title: "Busy")
-        session.state = state
-        try await store.upsert(session)
+        var busy = Session(workspaceID: workspace.id, title: "Busy")
+        busy.state = state
+        try await store.upsert(busy)
+        let asking = try await store.upsert(Session(workspaceID: workspace.id, title: "Asking"))
         let tool = WorkspaceArchiveTool { _ in
             Issue.record("a busy workspace reached the app")
             return .archived
         }
-        let result = await tool.call(request(["id": .string(workspace.id.rawValue)]), as: .owner, store: store)
-        #expect(result.isError)
+        let identity = BridgeIdentity(
+            sessionID: asking.id, workspaceID: workspace.id, role: .parent
+        )
+        for (request, identity) in [
+            (request(["id": .string(workspace.id.rawValue)]), BridgeIdentity.owner),
+            (request([:]), identity),
+        ] {
+            let result = await tool.call(request, as: identity, store: store)
+            #expect(result.isError)
+            #expect(result.text.contains("An agent is running"))
+        }
     }
 
     @Test("running setup and queued messages prevent archive", arguments: [true, false])
@@ -86,34 +206,42 @@ struct WorkspaceArchiveToolTests {
             Issue.record("pending work reached the archive lifecycle")
             return .archived
         }
-        let result = await tool.call(request(["id": .string(workspace.id.rawValue)]), as: .owner, store: store)
+        let result = await tool.call(
+            request(["id": .string(workspace.id.rawValue)]), as: .owner, store: store
+        )
         #expect(result.isError)
         #expect(try await store.workspace(id: workspace.id)?.state == .active)
+    }
+
+    @Test("a workspace agent's own queue refuses its own request")
+    func ownQueueRefuses() async throws {
+        let (store, workspace) = try await fixture()
+        var session = Session(workspaceID: workspace.id, title: "Asking")
+        session.state = .running
+        session = try await store.upsert(session)
+        try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "One more thing"))
+        let tool = WorkspaceArchiveTool { _ in
+            Issue.record("a queued message reached the archive lifecycle")
+            return .archived
+        }
+        let identity = BridgeIdentity(
+            sessionID: session.id, workspaceID: workspace.id, role: .parent
+        )
+        let result = await tool.call(request([:]), as: identity, store: store)
+        #expect(result.isError)
+        #expect(result.text.contains("queued messages"))
     }
 
     @Test("app safety and archive failures reach the caller without a success claim")
     func refusal() async throws {
         let (store, workspace) = try await fixture()
         let tool = WorkspaceArchiveTool { _ in .refused("There are uncommitted changes.") }
-        let result = await tool.call(request(["id": .string(workspace.id.rawValue)]), as: .owner, store: store)
+        let result = await tool.call(
+            request(["id": .string(workspace.id.rawValue)]), as: .owner, store: store
+        )
         #expect(result.isError)
         #expect(result.text.contains("uncommitted changes"))
         #expect(try await store.workspace(id: workspace.id)?.state == .active)
-    }
-
-    @Test("completion identifies the archived workspace and retained history")
-    func completion() async throws {
-        let (store, workspace) = try await fixture()
-        let calls = ArchiveCalls()
-        let tool = WorkspaceArchiveTool { workspace in
-            await calls.record(workspace.id)
-            return .archived
-        }
-        let result = await tool.call(request(["id": .string(workspace.id.rawValue)]), as: .owner, store: store)
-        #expect(!result.isError)
-        #expect(await calls.ids == [workspace.id])
-        #expect(result.text.contains(workspace.name))
-        #expect(result.text.contains("branch, notes and chat history were kept"))
     }
 
     private func request(_ arguments: [String: JSONValue]) -> MCPRequest {
@@ -129,9 +257,17 @@ struct WorkspaceArchiveToolTests {
         ))
         return (store, workspace)
     }
+
+    private func second(in store: Store) async throws -> Workspace {
+        let repo = try await store.upsert(Repo(name: "Other project", path: "/tmp/archive-tool-other"))
+        return try await store.upsert(Workspace(
+            repoID: repo.id, name: "Somebody else's work", branch: "theirs",
+            path: "/tmp/archive-tool-theirs", baseBranch: "main"
+        ))
+    }
 }
 
 private actor ArchiveCalls {
-    var ids: [WorkspaceID] = []
-    func record(_ id: WorkspaceID) { ids.append(id) }
+    var orders: [WorkspaceArchiveOrder] = []
+    func record(_ order: WorkspaceArchiveOrder) { orders.append(order) }
 }

--- a/docs/BRIDGE.md
+++ b/docs/BRIDGE.md
@@ -117,7 +117,7 @@ places: the listing, the dispatch and the gate.
 | `workspace_list` | Every workspace, its state, its worktree path, its chats and their cost, what an agent is stopped on, what is queued and why | | | ✓ |
 | `workspace_start` | Cut a worktree and put an agent in it with a task, on a new branch, existing branch or GitHub pull request | ✓ | | ✓ |
 | `workspace_rename` | Give a workspace the name the work in it turned out to be about. Its own, for a workspace agent; any of them, named out loud, for the owner | ✓ | | ✓ |
-| `workspace_archive` | Archive a workspace through normal safety checks, keeping its branch and history | | | ✓ |
+| `workspace_archive` | Archive a workspace through normal safety checks, keeping its branch and history. Its own, and only when the turn asking for it has ended, for a workspace agent; any of them, named out loud and at once, for the owner | ✓ | | ✓ |
 | `workspace_merge` | Ask a workspace's own agent to merge its pull request | | | ✓ |
 | `reveal` | Point Bloom's window at one workspace, or at Home narrowed by project, scope and search. Navigation and nothing else: it creates nothing and archives nothing | | | ✓ |
 | `pane_open` | Open a chat, a terminal or a browser in a new tab of the caller's own workspace | ✓ | | |
@@ -262,13 +262,30 @@ Nothing here opens or closes a tab except the tools whose whole subject that is.
 brings an existing tab forward and will not make one on the way, which is what keeps "go back to the
 terminal" from forking a second terminal.
 
-`workspace_archive` is owner-only and takes an exact workspace id from `workspace_list`.
-It runs the app's normal archive lifecycle, including the project archive script, and only answers
-success after completion. The worktree is removed; the branch, notes and chat history are kept.
-Running agents, uncommitted work, local files at risk and failed safety checks refuse the call.
-There is no force or branch-deletion argument. Already archived workspaces are a no-op.
-This tool is not self-approved: the caller's permission policy still applies. `reveal` can show
-candidates before the owner chooses which to archive.
+`workspace_archive` runs the app's normal archive lifecycle, including the project archive script.
+The worktree is removed; the branch, notes and chat history are kept. Running agents, queued
+messages, uncommitted work, local files at risk and failed safety checks refuse the call. There is
+no force or branch-deletion argument. Already archived workspaces are a no-op. This tool is not
+self-approved for either role: removing a worktree is a question a person answers, and `reveal` can
+show candidates before the owner chooses which to archive.
+
+**Its two arms are shaped like `workspace_rename`'s, and one of them answers differently.** The
+owner's own client takes an exact workspace id from `workspace_list`, is acted on at once, and only
+answers success after completion. A workspace's own agent takes no arguments at all and is refused
+if it passes any: the token says which workspace is asking, so there is nothing to name and nothing
+to forge, and that is the whole of the isolation between one workspace and the next.
+
+That agent's call is a **request rather than an archive**, and its answer says so in those words.
+The agent is standing in the worktree that would be removed, and `AppModel.performArchive` stops a
+workspace's agents before git touches a file, so archiving there and then would kill the turn that
+is waiting for the answer. Bloom books it instead and runs it when that turn ends, whether the turn
+ended with a result or with the agent dying. The safety check is then made again from scratch, with
+nothing excused: another agent still running in the workspace or a message still queued refuses it,
+and the refusal reaches the owner as a notice, because by then there is no agent left to tell. The
+first check, made during the call, excuses only the asking chat's own running turn, and never its
+queue. See `WorkspaceArchiveSafety`, which is the one place both checks are written.
+
+Not `.child`. A child reports and that is all, here as everywhere.
 
 Nothing a rename touches is on disk. `workspace_rename` writes one column of one row: the branch,
 the worktree, the pull request and the directory keep the names they have. That is worth saying out


### PR DESCRIPTION
`workspace_archive` was owner-only, so an agent that had finished its work had to stop and ask the owner to archive the worktree it was standing in. It now reaches `.parent` too, shaped like `workspace_rename`: the owner's client names a workspace out loud, a workspace agent names none and is refused if it tries. The token is the only thing that says which workspace is archived, so one workspace cannot reach another. Not `.child`.

A workspace agent's call is a request, not an archive. `performArchive` stops a workspace's agents before git touches a file, which would kill the turn waiting for the answer, so Bloom books it and runs it when that turn ends (result or agent death). The answer says "requested, not done" in those words. The owner pressing Stop drops the booking and says so.

The safety check runs twice through one place, `WorkspaceArchiveSafety`: during the call it excuses only the asking chat's own running turn and never its queue; at cleanup it excuses nothing, so another agent still running or a message still queued refuses it. A refusal after the fact reaches the owner as a notice, because by then there is no agent left to tell.

Unchanged: the owner connection's behaviour, the archive script, branch preservation, chat history, and `workspace_archive` staying off `BridgeToolApproval.selfApproved` for both roles.