### PR TITLE
Make opening existing branches easier to discover

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ The `.noindex` suffix keeps Spotlight out of them, which is what a dozen worktre
 need once each of them holds its own copy of `vendor` and `.build`. A workspace can also be started
 on an existing branch, or on a GitHub pull request, to review one rather than write one.
 
+To continue on an existing branch, open **New Workspace** (Cmd+N), choose the project, and click
+**Open existing branch…** beside the branch selector. Search for and select the branch, then
+create the workspace. Commits go onto that branch. Choose **Terminal** under **Start with** if
+you want to open it without starting an agent. The branch selector also offers this under its
+**Existing branch** tab.
+
+If the branch is already checked out in a Bloom workspace, selecting it opens that workspace.
+If another worktree holds it, Bloom shows its location so you can free the branch there first.
+
 **Panes.** A workspace holds tabs, and a tab can be split. A pane is a chat, a terminal standing in
 the worktree, or a browser, so the dev server the setup script started can be read beside the
 conversation that is changing it.

--- a/Sources/Bloom/Views/CreateWorkspace/CreateWorkspaceView.swift
+++ b/Sources/Bloom/Views/CreateWorkspace/CreateWorkspaceView.swift
@@ -389,10 +389,8 @@ struct CreateWorkspaceView: View {
     /// Where the work comes from: a new branch cut from a base, an open pull request, or a branch
     /// that already exists.
     ///
-    /// One control rather than three, and it stays where the base branch picker was, because the
-    /// three are answers to the same question and only ever one of them is in force. Visible
-    /// rather than filed under the overflow menu for the reason the base branch always was: it is
-    /// the setting here whose wrong value is expensive.
+    /// The current source and a direct action for opening an existing branch. The latter makes
+    /// that route visible without having to discover it inside the base branch picker.
     ///
     /// Everything it draws is `WorkspaceSourcePicker`, including the search field a `Menu` could
     /// not have held. What is left here is what the window owns: which project's lists these are,

--- a/Sources/Bloom/Views/Sidebar/WorkspaceSourcePicker.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspaceSourcePicker.swift
@@ -73,8 +73,32 @@ struct WorkspaceSourcePicker: View {
     }
 
     var body: some View {
+        HStack(spacing: Metrics.spacingSmall) {
+            sourceButton
+
+            if checkout == nil {
+                Button {
+                    present(.existingBranch)
+                } label: {
+                    ComposerControlLabel(
+                        systemImage: "arrow.triangle.branch",
+                        text: "Open existing branch…",
+                        tint: Palette.controlAccent
+                    )
+                }
+                .buttonStyle(.plain)
+                .fixedSize()
+                .help("Open a workspace on an existing branch or pull request")
+            }
+        }
+        .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+            panel
+        }
+    }
+
+    private var sourceButton: some View {
         Button {
-            isPresented = true
+            present(checkout == nil ? .newBranch : .existingBranch)
         } label: {
             ComposerControlLabel(
                 systemImage: glyph,
@@ -88,9 +112,14 @@ struct WorkspaceSourcePicker: View {
         .help("Open a pull request or a branch, or cut a new branch")
         .accessibilityLabel("Start from")
         .accessibilityValue(label)
-        .popover(isPresented: $isPresented, arrowEdge: .bottom) {
-            panel
-        }
+    }
+
+    /// Both entry points use the same picker, but the explicit branch action skips the new tab.
+    private func present(_ openingTab: WorkspaceSourceTab) {
+        query = ""
+        tab = openingTab
+        selected = offering.search(query: "").rows(in: tab).first
+        isPresented = true
     }
 
     private var panel: some View {
@@ -126,14 +155,6 @@ struct WorkspaceSourcePicker: View {
         }
         .frame(width: Self.width)
         .background { tabShortcuts }
-        // A fresh query every time it opens. The panel is a way of finding one thing, not a filter
-        // somebody set and left, and reopening it onto yesterday's word would hide the list that
-        // has since loaded behind it.
-        .onAppear {
-            query = ""
-            tab = checkout == nil ? .newBranch : .existingBranch
-            selected = offering.search(query: "").rows(in: tab).first
-        }
     }
 
     /// `PanelTabs` rather than a segmented picker, and its own note carries the three measurements


### PR DESCRIPTION
Add an “Open existing branch…” button to New Workspace that opens the existing branch search directly. Document how to open the actual branch and handle branches already checked out elsewhere.