### PR TITLE
Add project autocomplete and Ask Bloom tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ you want to open it without starting an agent. The branch selector also offers t
 If the branch is already checked out in a Bloom workspace, selecting it opens that workspace.
 If another worktree holds it, Bloom shows its location so you can free the branch there first.
 
+The project field suggests folders as you type, searching beside your existing projects or inside
+a typed path. Use the arrow keys and Return to choose a suggestion, or Tab to complete the first
+match. In Settings, General, choose where new projects are created and add other folders to search.
+
 **Panes.** A workspace holds tabs, and a tab can be split. A pane is a chat, a terminal standing in
 the worktree, or a browser, so the dev server the setup script started can be read beside the
 conversation that is changing it.
@@ -108,8 +112,11 @@ file. Choose **Review all files** to scroll through every file's changes togethe
 to **Selected file** to focus on one. When `gh` is installed it also carries the pull request: open
 it, watch its checks, merge it.
 
-**Ask Bloom.** A conversation that belongs to no workspace, for the questions that are about your
-projects rather than about one branch.
+**Ask Bloom.** Conversations that belong to no workspace, for questions about your projects.
+Start another conversation with the toolbar button or Cmd+T. The tab bar appears when a second
+conversation is open, and switching tabs keeps agents running. Closing a tab archives its chat.
+Choose the working directory for new conversations in Settings, General; existing chats retain
+their directory.
 
 **Quick prompts.** A library of prompts you reuse, available in any workspace.
 

--- a/Sources/Bloom/State/AskModel.swift
+++ b/Sources/Bloom/State/AskModel.swift
@@ -23,9 +23,13 @@ final class AskModel {
     init(app: AppModel) { self.app = app }
 
     func open() async {
-        guard !hasOpened, !isChanging, let store = app.store else { return }
+        guard !isChanging, let store = app.store else { return }
         isChanging = true
         defer { isChanging = false }
+        if hasOpened {
+            if transcript == nil, let selectedID { await select(selectedID) }
+            return
+        }
         do {
             sessions = try await store.sessionsWithoutWorkspace()
             if sessions.isEmpty {

--- a/Sources/Bloom/State/AskModel.swift
+++ b/Sources/Bloom/State/AskModel.swift
@@ -2,180 +2,172 @@ import Foundation
 import Observation
 import BloomCore
 
-/// The state behind Ask Bloom: one conversation, above every project.
-///
-/// It is `WorkspaceModel` with everything a worktree brings taken out. There is no diff, no
-/// terminal, no pull request, no setup script and no tab strip, because none of those is about a
-/// conversation. What is left is a session row, the transcript over it, and the directory the
-/// agent runs in.
-///
-/// **One chat rather than a list.** The design is one conversation that sits above every project,
-/// and a strip of tabs here would be a second answer to "which Ask Bloom am I in" for a room with
-/// one chair in it. Starting a new one archives the old, which is what `Session.archivedAt`
-/// already means and what leaves the transcript readable rather than deleted.
+/// Each open Ask tab owns a live transcript. Selection never tears down a running conversation.
 @MainActor
 @Observable
 final class AskModel {
-    /// The chat, once it has been read back or made. Nil for the moment between the pane opening
-    /// and the store answering, which is the only time this pane draws nothing.
-    private(set) var session: Session?
-    private(set) var transcript: TranscriptModel?
-    /// Set when the working directory could not be made, which is the one failure that stops this
-    /// pane rather than degrading it. See `directory`.
+    private(set) var sessions: [Session] = []
+    private(set) var selectedID: SessionID?
+    private(set) var transcripts: [SessionID: TranscriptModel] = [:]
     private(set) var trouble: String?
-
+    var closingID: SessionID?
     private unowned let app: AppModel
-    /// Whether `open()` is already running, so the pane's `.task` and a reselection of the row do
-    /// not both create a chat. The store is an actor, so two callers really can both read "no
-    /// session" before either writes one.
-    private var isOpening = false
-    private var isStartingFresh = false
-    /// Whether the permission mode has been settled since Bloom started.
-    ///
-    /// This model is built once and kept for the life of the window, so its first `open()` is the
-    /// launch boundary. See `AskConversation.modeOnOpening` for why there has to be one.
-    private var hasSettledMode = false
+    private var isChanging = false
+    private var hasOpened = false
+    private var settledModes: Set<SessionID> = []
+    private var loading: Set<SessionID> = []
 
-    init(app: AppModel) {
-        self.app = app
-    }
+    var transcript: TranscriptModel? { selectedID.flatMap { transcripts[$0] } }
+    var session: Session? { transcript?.session ?? sessions.first { $0.id == selectedID } }
 
-    /// The empty directory the agent runs in, made once.
-    ///
-    /// Read the argument on `AskConversation.directory`: this is a permission decision, and it is
-    /// the second of two. A chat started in the owner's home directory would treat every file in
-    /// it as inside the working directory, which is the one place any permission mode stops asking
-    /// about.
-    private var directory: String? {
-        guard let store = app.store else { return nil }
-        return AskConversation.prepareDirectory(besideDatabaseAt: store.path)
-    }
+    init(app: AppModel) { self.app = app }
 
-    /// Reads the chat back, or makes it, and builds its transcript. Safe to call again: the second
-    /// call finds the session and returns.
     func open() async {
-        guard !isOpening, !isStartingFresh, let store = app.store else { return }
-        isOpening = true
-        defer { isOpening = false }
-
-        guard let directory else {
-            trouble = "Bloom could not make the folder this conversation runs in, "
-                + "inside its own Application Support directory."
-            return
-        }
-        trouble = nil
-
-        // Oldest first, and the first is the one. More than one can only exist if somebody made a
-        // second by hand in the database; taking the oldest means the chat the owner has been
-        // using stays the chat the owner has been using.
-        let existing = (try? await store.sessionsWithoutWorkspace()) ?? []
-        var chat: Session
-        if let first = existing.first {
-            chat = first
-        } else if let made = try? await store.upsert(AskConversation.newSession()) {
-            chat = made
-        } else {
-            // The database refused the insert. Nothing is drawn rather than a pane pretending to
-            // be a conversation, and the next selection of the row tries again.
-            return
-        }
-
-        // Back to Ask on the first open of the launch, whatever the owner left it on. The picker
-        // still works and still lasts the rest of the launch; what expires is the presence that
-        // justified the choice, not the choice. See `AskConversation.modeOnOpening`.
-        if let mode = AskConversation.modeOnOpening(
-            stored: chat.permissionMode, isFirstOpenSinceLaunch: !hasSettledMode
-        ) {
-            // The one column, through the method that names it: the runner owns the state, the
-            // counters and the agent session id on this row and may have written any of them.
-            try? await store.updateSessionPreferences(id: chat.id, permissionMode: mode)
-            chat.permissionMode = mode
-        }
-        hasSettledMode = true
-
-        session = chat
-        if transcript?.session.id != chat.id {
-            let model = TranscriptModel(askSession: chat, directory: directory, app: app)
-            transcript = model
-            await model.load()
-        }
+        guard !hasOpened, !isChanging, let store = app.store else { return }
+        isChanging = true
+        defer { isChanging = false }
+        do {
+            sessions = try await store.sessionsWithoutWorkspace()
+            if sessions.isEmpty {
+                let directory = try await newDirectory()
+                sessions = [try await store.createAskConversation(directory: directory)]
+            }
+            let saved = try await store.setting(AskTabs.selectionKey)
+            hasOpened = true
+            if let id = AskTabs.selection(saved: saved, sessions: sessions) { await select(id) }
+        } catch { trouble = error.readableMessage }
     }
 
-    /// Puts this conversation away and opens an empty one.
-    ///
-    /// Archived rather than deleted, which is what the column already means everywhere else: the
-    /// old conversation is still in the database, with its cost and its permission history, and
-    /// nothing that has been said is thrown away because somebody wanted a clean start.
-    func startFresh(controls: ComposerControls? = nil, draft: String = "") async {
-        guard !isOpening, !isStartingFresh, let store = app.store, let current = session,
-              let directory else { return }
-        isStartingFresh = true
-        defer { isStartingFresh = false }
-
-        let carriedControls: ComposerControls
-        if let controls {
-            carriedControls = controls
-        } else {
-            let isFastMode = (try? await store.setting(
-                ComposerControls.fastModeKey(sessionID: current.id)
-            )) == "1"
-            let outputStyle = (try? await store.setting(
-                ComposerControls.outputStyleKey(sessionID: current.id)
-            )) ?? OutputStyle.defaultName
-            let contextWindow = CodexContextWindow.normalised(try? await store.setting(
-                ComposerControls.contextWindowKey(sessionID: current.id)
-            ))
-            carriedControls = ComposerControls(
-                session: current,
-                isFastMode: isFastMode,
-                outputStyle: outputStyle,
-                codexContextWindow: contextWindow
-            )
-        }
-
+    func select(_ id: SessionID) async {
+        guard let store = app.store, var chat = sessions.first(where: { $0.id == id }) else { return }
+        selectedID = id
+        trouble = nil
         do {
-            let made = try await store.replaceAskConversation(
-                id: current.id, controls: carriedControls, draft: draft
-            )
-            transcript?.teardown()
-            app.bridge?.retire(sessionID: current.id)
-            session = made
-            let model = TranscriptModel(askSession: made, directory: directory, app: app)
-            transcript = model
+            try await store.setSetting(AskTabs.selectionKey, id.rawValue)
+            if transcripts[id] != nil || loading.contains(id) { return }
+            loading.insert(id)
+            defer { loading.remove(id) }
+            // Old conversations predate directory preferences and retain their original cwd.
+            let saved = try await store.setting(AskTabs.directoryKey(id))
+            guard let directory = AskTabs.prepareDirectory(saved ?? "", databasePath: store.path) else {
+                throw AskDirectoryError.unavailable(saved ?? AskConversation.directory(besideDatabaseAt: store.path))
+            }
+            if let mode = AskConversation.modeOnOpening(
+                stored: chat.permissionMode, isFirstOpenSinceLaunch: !settledModes.contains(id)
+            ) {
+                try await store.updateSessionPreferences(id: id, permissionMode: mode)
+                chat.permissionMode = mode
+            }
+            settledModes.insert(id)
+            let model = TranscriptModel(askSession: chat, directory: directory, app: app)
+            transcripts[id] = model
             await model.load()
         } catch {
-            app.alert = BloomAlert(
-                title: "Could not start a new conversation",
-                message: TranscriptStanding.complaint(about: error)
-            )
+            if selectedID == id { trouble = error.readableMessage }
         }
     }
 
-    /// Signals the agent, without waiting. `AppModel.shutdownEverything` calls this on every model
-    /// first so the SIGTERM escalations all run at once rather than one after another.
-    ///
-    /// **This chat has to be in that sweep.** macOS reparents a child process to launchd rather
-    /// than killing it, so a conversation left out of the teardown would leave a `claude` running
-    /// against Bloom's own Application Support directory for the rest of the day, with nothing on
-    /// screen to say so.
-    func stopEverything() {
-        transcript?.terminateNow()
+    func newConversation() async {
+        guard !isChanging, let store = app.store else { return }
+        isChanging = true
+        defer { isChanging = false }
+        do {
+            if !hasOpened { sessions = try await store.sessionsWithoutWorkspace() }
+            let directory = try await newDirectory()
+            let made = try await store.createAskConversation(directory: directory)
+            sessions.append(made)
+            hasOpened = true
+            await select(made.id)
+        } catch { report(error, title: "Could not start a new conversation") }
     }
 
-    func shutdown() async {
-        await transcript?.shutdown()
+    /// Explicit fresh-start composer actions replace only their tab, carrying its directory.
+    func startFresh(controls: ComposerControls? = nil, draft: String = "") async {
+        guard !isChanging, let store = app.store, let current = session else { return }
+        isChanging = true
+        defer { isChanging = false }
+        do {
+            let carried: ComposerControls
+            if let controls {
+                carried = controls
+            } else {
+                let fast = (try await store.setting(ComposerControls.fastModeKey(sessionID: current.id))) == "1"
+                let style = (try await store.setting(ComposerControls.outputStyleKey(sessionID: current.id))) ?? ""
+                let window = CodexContextWindow.normalised(
+                    try await store.setting(ComposerControls.contextWindowKey(sessionID: current.id))
+                )
+                carried = ComposerControls(session: current, isFastMode: fast, outputStyle: style,
+                                           codexContextWindow: window)
+            }
+            let made = try await store.replaceAskConversation(id: current.id, controls: carried, draft: draft)
+            transcripts.removeValue(forKey: current.id)?.teardown()
+            app.bridge?.retire(sessionID: current.id)
+            if let index = sessions.firstIndex(where: { $0.id == current.id }) { sessions[index] = made }
+            settledModes.insert(made.id)
+            await select(made.id)
+        } catch { report(error, title: "Could not start a new conversation") }
     }
 
-    /// Whether the agent in this chat is mid turn, for the sidebar row's own mark.
-    ///
-    /// Read off the live transcript rather than out of `Store.sessionActivity`, and that is the
-    /// right source rather than a shortcut: that query joins the workspaces table to answer "which
-    /// worktrees have an agent in them", and this conversation is in none of them.
-    var isRunning: Bool {
-        transcript?.isRunning == true || transcript?.subagents.isWorking == true
+    func requestClose(_ id: SessionID) {
+        if isRunning(id) { closingID = id } else { Task { await close(id) } }
     }
 
-    var isAwaitingPermission: Bool {
-        transcript?.isAwaitingPermission ?? false
+    func close(_ id: SessionID) async {
+        guard !isChanging, sessions.count > 1, let store = app.store else { return }
+        isChanging = true
+        defer { isChanging = false }
+        do {
+            let next = try await store.closeAskConversation(id: id, selected: selectedID)
+            transcripts.removeValue(forKey: id)?.teardown()
+            app.bridge?.retire(sessionID: id)
+            sessions.removeAll { $0.id == id }
+            if let next { await select(next) }
+        } catch { report(error, title: "Could not close the conversation") }
+    }
+
+    func rename(_ id: SessionID, title: String) async {
+        guard let store = app.store else { return }
+        let title = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return }
+        do {
+            _ = try await store.update(sessionID: id) { $0.title = title }
+            if let index = sessions.firstIndex(where: { $0.id == id }) { sessions[index].title = title }
+            transcripts[id]?.session.title = title
+        } catch { report(error, title: "Could not rename the conversation") }
+    }
+
+    func title(for chat: Session) -> String { transcripts[chat.id]?.session.title ?? chat.title }
+
+    func isRunning(_ id: SessionID) -> Bool {
+        transcripts[id]?.isRunning == true || transcripts[id]?.subagents.isWorking == true
+    }
+
+    var isRunning: Bool { transcripts.keys.contains { isRunning($0) } }
+    var isAwaitingPermission: Bool { transcripts.values.contains { $0.isAwaitingPermission } }
+
+    func stopEverything() { for model in transcripts.values { model.terminateNow() } }
+    func shutdown() async { for model in transcripts.values { await model.shutdown() } }
+
+    private func newDirectory() async throws -> String {
+        guard let store = app.store else { throw AskDirectoryError.unavailable("") }
+        let preferences = await DirectoryPreferences.load(from: store)
+        guard let path = AskTabs.prepareDirectory(preferences.ask, databasePath: store.path) else {
+            throw AskDirectoryError.unavailable(preferences.ask)
+        }
+        return path
+    }
+
+    private func report(_ error: Error, title: String) {
+        app.alert = BloomAlert(title: title, message: error.readableMessage)
+    }
+}
+
+private enum AskDirectoryError: LocalizedError {
+    case unavailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable(let path): "The working directory could not be opened: \(path)"
+        }
     }
 }

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -77,9 +77,8 @@ final class TranscriptModel {
     /// unread mark, a notification that names a place. Each of them now says nothing rather than
     /// saying it about a workspace that was invented to keep the type non-optional.
     let workspace: Workspace?
-    /// Where this chat's agent runs. The worktree, when there is one, and Ask Bloom's own empty
-    /// directory when there is not. See `AskConversation.directory`, which argues at length why
-    /// that directory is empty rather than the owner's home.
+    /// Where this chat's agent runs: its worktree, or the directory retained by its Ask tab.
+    /// New Ask conversations use the folder chosen in Settings, with Bloom's own folder as fallback.
     let cwd: String
     private unowned let app: AppModel
 

--- a/Sources/Bloom/Views/Ask/AskTabStrip.swift
+++ b/Sources/Bloom/Views/Ask/AskTabStrip.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import BloomCore
+
+struct AskTabStrip: View {
+    @Environment(AppModel.self) private var app
+    @State private var renaming: SessionID?
+    @Namespace private var selection
+
+    var body: some View {
+        TabStrip(selection: app.ask.selectedID) {
+            EmptyView()
+        } tabs: {
+            HStack(spacing: 0) {
+                ForEach(app.ask.sessions) { chat in
+                    TabItemView(
+                        title: app.ask.title(for: chat), icon: .symbol(PaneGlyph.chat),
+                        isActive: app.ask.selectedID == chat.id,
+                        isRunning: app.ask.isRunning(chat.id),
+                        isAtPaneEdge: app.ask.sessions.first?.id == chat.id,
+                        isRenaming: renaming == chat.id,
+                        editableTitle: app.ask.title(for: chat), canClose: true,
+                        closeTitle: "Close conversation",
+                        onSelect: { Task { await app.ask.select(chat.id) } },
+                        onStartRename: { renaming = chat.id },
+                        onCommitRename: { title in
+                            renaming = nil
+                            Task { await app.ask.rename(chat.id, title: title) }
+                        },
+                        onCancelRename: { renaming = nil },
+                        onClose: { app.ask.requestClose(chat.id) },
+                        namespace: selection
+                    )
+                    .id(chat.id)
+                }
+            }
+        } append: {
+            Button { Task { await app.ask.newConversation() } } label: {
+                Image(systemName: "plus")
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, Metrics.inset)
+            .help("New Ask Bloom conversation")
+            .accessibilityLabel("New Ask Bloom conversation")
+        } trailing: {
+            EmptyView()
+        }
+    }
+}

--- a/Sources/Bloom/Views/Ask/AskView.swift
+++ b/Sources/Bloom/Views/Ask/AskView.swift
@@ -1,28 +1,9 @@
 import SwiftUI
 import BloomCore
 
-/// Ask Bloom: one conversation, filling the centre column, scoped to no workspace.
-///
-/// **No furniture that assumes a worktree.** There is no tab strip, because there is one chat; no
-/// inspector, because there is no diff; no terminal, because there is nowhere to run anything; and
-/// no pull request accessory in the title bar, because there is no branch. All of that falls out of
-/// `SidebarSelection.ask` having a nil `workspaceID` rather than being hidden here one control at a
-/// time.
-///
-/// **One thing the strip carried was not about a worktree, and this pane had lost it with the
-/// rest.** The rule under a tab strip is where the window says an agent is working, so a chat with
-/// no strip said nothing while its turn ran. It is on this pane's top edge now; see the overlay in
-/// `body`.
-///
-/// What it is is `ChatPaneView` with the workspace taken out, and it is a separate view rather than
-/// that one made optional: `ChatPaneView` measures its own room, remembers its scroll position in a
-/// workspace model and hangs a jump pill off a transcript that has a setup script above it. Two of
-/// those three have nothing to be about here.
+/// Ask conversations share the app's tab chrome, visible once a second conversation is open.
 struct AskView: View {
     @Environment(AppModel.self) private var app
-
-    @State private var isTranscriptScrolledUp = false
-    @State private var room = ComposerRoom()
 
     @AppStorage(ChatTextSize.defaultsKey) private var textSize = ChatTextSize.defaultChoice
     @AppStorage(ChatFont.defaultsKey) private var chatFontID = ChatFont.standardID
@@ -30,6 +11,7 @@ struct AskView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            if app.ask.sessions.count > 1 { AskTabStrip() }
             if let trouble = app.ask.trouble {
                 EmptyStateView(
                     glyph: "exclamationmark.triangle",
@@ -38,7 +20,8 @@ struct AskView: View {
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let transcript = app.ask.transcript {
-                conversation(transcript)
+                AskConversationView(transcript: transcript)
+                    .id(transcript.session.id)
             } else {
                 // The moment between the pane opening and the store answering. Nothing is drawn
                 // rather than an empty state, because an empty state that appears for one frame
@@ -47,41 +30,37 @@ struct AskView: View {
             }
         }
         .background(Palette.windowBackground)
-        // The window's busy signal, on the one edge this pane has to put it on.
-        //
-        // Every other chat says "an agent is working" on the rule that closes off its tab strip,
-        // and this pane has no strip. `ActivityRule` was already written for this conversation:
-        // its `isRunning` answers `SidebarSelection.ask` with `app.ask.isRunning` rather than
-        // reading `runningWorkspaceIDs`, which a chat scoped to no worktree is never in. But the
-        // only thing that mounts an `ActivityRule` is `Theme.tabStripMaterial`, reached from
-        // `SessionTabsView`, so with Ask selected there was no rule anywhere in the window and
-        // that branch was never evaluated. The signal was written and never drawn.
-        //
-        // The pane's own top edge is where it goes, because that is the boundary the strip's rule
-        // marks in a workspace: chrome above it, conversation below. Nothing else in this pane is
-        // that boundary, and the sidebar row's mark, which does light, is behind the reader rather
-        // than in front of them once Ask is the thing being looked at.
-        //
-        // An overlay rather than a row in the stack, so a turn starting does not shorten the
-        // transcript by three points and nothing here can ask it to lay out again.
-        // `ActivityRule` fades itself in and out, takes its phase from the shared `BusyPulse` so
-        // it moves in step with every lit mark in the window, and draws `StillActivityRule` under
-        // Reduce Motion. All three are settled by using it rather than by drawing a second figure.
-        //
-        // No accessibility label on it: the transcript's own `StreamingStatusView` already says
-        // "Working", and the same fact announced twice is noise.
         .overlay(alignment: .top) {
-            ActivityRule()
-                .frame(height: BusyCrest.thickness)
+            if app.ask.sessions.count <= 1 {
+                ActivityRule().frame(height: BusyCrest.thickness)
+            }
         }
         .environment(\.fontScale, textSize.scale)
         .environment(\.chatFont, ChatFont(rawValue: chatFontID))
         .environment(\.chatLineHeight, lineHeight)
         // Not in a body: `open()` writes observed state and can create a session row.
         .task { await app.ask.open() }
+        .confirmationDialog("Stop and close this conversation?", isPresented: Binding(
+            get: { app.ask.closingID != nil }, set: { if !$0 { app.ask.closingID = nil } }
+        ), titleVisibility: .visible) {
+            Button("Stop and Close", role: .destructive) {
+                if let id = app.ask.closingID { Task { await app.ask.close(id) } }
+                app.ask.closingID = nil
+            }
+            Button("Cancel", role: .cancel) { app.ask.closingID = nil }
+        } message: {
+            Text("The agent will stop. The conversation will be archived.")
+        }
     }
 
-    private func conversation(_ transcript: TranscriptModel) -> some View {
+}
+
+private struct AskConversationView: View {
+    let transcript: TranscriptModel
+    @State private var isTranscriptScrolledUp = false
+    @State private var room = ComposerRoom()
+
+    var body: some View {
         TranscriptView(transcript: transcript, emptyState: Self.opening) {
             isTranscriptScrolledUp = $0
         }

--- a/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
+++ b/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
@@ -117,18 +117,20 @@ struct BloomCommands: Commands {
             // a control you have to be looking at Ask Bloom to see, so it could not answer
             // somebody wondering whether the conversation can be started over at all.
             //
-            // The same notification the toolbar posts, rather than a second route into `AskModel`:
-            // `RootView` owns the flag, because starting fresh archives the old conversation and
-            // that is a store write which must not happen twice.
+            // The menu and toolbar both append a conversation and preserve the open tabs.
             MenuCommand(.newAskConversation) {
                 NotificationCenter.default.post(name: .bloomNewAskConversation, object: nil)
             }
 
             MenuCommand(.newSession) {
+                if model.selection == .ask {
+                    Task { await model.ask.newConversation() }
+                    return
+                }
                 guard let workspace = model.selectedModel else { return }
                 Task { await workspace.createSession() }
             }
-            .disabled(model.selectedModel == nil)
+            .disabled(model.selectedModel == nil && model.selection != .ask)
 
             // The other four things that open a tab in the workspace's centre column, which until
             // now existed only as key equivalents on hidden buttons inside `SessionTabsView`. The
@@ -214,7 +216,7 @@ struct BloomCommands: Commands {
             }
             // Scoped to the main window as well as to there being a tab, because this item holds
             // Cmd+W for the whole app. See `MainWindowFocus`.
-            .disabled(isMainWindowFocused != true || closableTab == nil)
+            .disabled(isMainWindowFocused != true || (closableTab == nil && !canCloseAskTab))
 
             Divider()
 
@@ -798,11 +800,18 @@ struct BloomCommands: Commands {
     /// Greyed on a strip with nothing to move to, rather than on no workspace at all, which is
     /// the same rule Split Right follows two items above.
     private var canCycleCentreTabs: Bool {
+        if model.selection == .ask { return model.ask.sessions.count > 1 }
         guard let workspace = model.selectedModel else { return false }
         return WorkspaceTabsStore.shared.entries(in: workspace).count > 1
     }
 
     private func cycleCentreTab(by offset: Int) {
+        if model.selection == .ask {
+            if let next = TabCycle.next(from: model.ask.selectedID, in: model.ask.sessions.map(\.id), offset: offset) {
+                Task { await model.ask.select(next) }
+            }
+            return
+        }
         guard let workspace = model.selectedModel else { return }
         WorkspaceTabsStore.shared.selectNextTab(offset: offset, in: workspace)
     }
@@ -820,7 +829,20 @@ struct BloomCommands: Commands {
     /// `TabCycle.numbered` in the core.
     @ViewBuilder
     private var goToTabMenu: some View {
-        if let workspace = model.selectedModel {
+        if model.selection == .ask {
+            MenuCommandGroup(.goToTab) {
+                ForEach(TabCycle.numbered(model.ask.sessions.map(\.id))) { entry in
+                    if let chat = model.ask.sessions.first(where: { $0.id == entry.tab }) {
+                        let button = Button(model.ask.title(for: chat)) {
+                            Task { await model.ask.select(chat.id) }
+                        }
+                        if let ordinal = entry.ordinal {
+                            button.keyboardShortcut(KeyEquivalent(Character("\(ordinal)")), modifiers: .command)
+                        } else { button }
+                    }
+                }
+            }
+        } else if let workspace = model.selectedModel {
             let entries = WorkspaceTabsStore.shared.entries(in: workspace)
             MenuCommandGroup(.goToTab) {
                 ForEach(TabCycle.numbered(entries), id: \.tab) { entry in
@@ -880,7 +902,13 @@ struct BloomCommands: Commands {
     /// Closing a conversation still goes through `CloseSessionAlert`, which asks when there is
     /// something to lose by it and never asks when there is not. That is the whole of what the old
     /// Close Session did, so nothing about a chat closes more quietly than it used to.
+    private var canCloseAskTab: Bool { model.selection == .ask && model.ask.sessions.count > 1 }
+
     private func closeSelectedTab() {
+        if canCloseAskTab, let id = model.ask.selectedID {
+            model.ask.requestClose(id)
+            return
+        }
         guard let workspace = model.selectedModel, let target = closableTab else { return }
         switch target {
         case .chat(let id):

--- a/Sources/Bloom/Views/Chrome/Settings/DirectorySettingsSection.swift
+++ b/Sources/Bloom/Views/Chrome/Settings/DirectorySettingsSection.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import BloomCore
+
+struct DirectorySettingsSection: View {
+    @Environment(AppModel.self) private var app
+    @State private var preferences = DirectoryPreferences()
+    @State private var isLoaded = false
+    @State private var saveTask: Task<Void, Never>?
+    @State private var error: String?
+
+    var body: some View {
+        Section("Project folders") {
+            folderRow("New projects", path: preferences.projects, fallback: "Automatic",
+                      message: "Choose where new projects are created.") {
+                preferences.projects = $0
+            }
+            ForEach(preferences.additionalProjects, id: \.self) { path in
+                HStack {
+                    Text((path as NSString).abbreviatingWithTildeInPath)
+                        .lineLimit(1).truncationMode(.middle)
+                    Spacer()
+                    Button("Remove") { preferences.additionalProjects.removeAll { $0 == path } }
+                }
+            }
+            Button("Add Search Folder…") {
+                Task {
+                    guard let path = await ProjectFolderPicker.chooseTarget(
+                        startingAt: nil, message: "Choose a folder containing your projects."
+                    ),
+                          !preferences.additionalProjects.contains(path) else { return }
+                    preferences.additionalProjects.append(path)
+                }
+            }
+            Text("Autocomplete also searches beside projects you have already added.")
+                .settingsFootnote()
+        }
+        .disabled(!isLoaded)
+
+        Section("Ask Bloom") {
+            folderRow("Working directory", path: preferences.ask, fallback: "Bloom’s own folder",
+                      message: "Choose the working directory for new Ask Bloom conversations.") {
+                preferences.ask = $0
+            }
+            Text("New conversations start here. Existing conversations keep their working directory.")
+                .settingsFootnote()
+            if let error { Text(error).foregroundStyle(Palette.negative) }
+        }
+        .disabled(!isLoaded)
+        .task {
+            guard !isLoaded, let store = app.store else { return }
+            preferences = await DirectoryPreferences.load(from: store)
+            isLoaded = true
+        }
+        .onChange(of: preferences) { _, updated in
+            guard isLoaded, let store = app.store else { return }
+            let pending = saveTask
+            saveTask = Task {
+                await pending?.value
+                do {
+                    try await updated.save(to: store)
+                    error = nil
+                } catch {
+                    self.error = error.readableMessage
+                }
+            }
+        }
+    }
+
+    private func folderRow(
+        _ title: String, path: String, fallback: String, message: String, set: @escaping (String) -> Void
+    ) -> some View {
+        SettingsRow(title) {
+            HStack {
+                Text(path.isEmpty ? fallback : (path as NSString).abbreviatingWithTildeInPath)
+                    .lineLimit(1).truncationMode(.middle).help(path)
+                Spacer()
+                if !path.isEmpty { Button("Reset") { set("") } }
+                Button("Choose…") {
+                    Task {
+                        if let chosen = await ProjectFolderPicker.chooseTarget(startingAt: path, message: message) { set(chosen) }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/Bloom/Views/Chrome/Settings/SettingsView.swift
+++ b/Sources/Bloom/Views/Chrome/Settings/SettingsView.swift
@@ -124,6 +124,8 @@ struct GeneralSettingsView: View {
                 }
             }
 
+            DirectorySettingsSection()
+
             SleepSettingsSection()
 
             Section("Workspaces") {

--- a/Sources/Bloom/Views/RootView.swift
+++ b/Sources/Bloom/Views/RootView.swift
@@ -26,7 +26,6 @@ struct RootView: View {
     @Bindable private var feedback = FeedbackPresenter.shared
 
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
-    @State private var isStartingFreshAskConversation = false
 
     var body: some View {
         @Bindable var app = app
@@ -81,7 +80,7 @@ struct RootView: View {
                             app: app,
                             isSidebarVisible: columnVisibility != .detailOnly,
                             toggleSidebar: toggleSidebar,
-                            startFreshAskConversation: { isStartingFreshAskConversation = true }
+                            startFreshAskConversation: { Task { await app.ask.newConversation() } }
                         )
                     }
                     // Said here as well as under `navigationTitle` below, and deliberately.
@@ -242,18 +241,6 @@ struct RootView: View {
                 // `ArchiveRequest` in the core, where it can be tested.
                 Text(request.message)
             }
-            .confirmationDialog(
-                "Start a new conversation?",
-                isPresented: $isStartingFreshAskConversation,
-                titleVisibility: .visible
-            ) {
-                Button("Start New Conversation") {
-                    Task { await app.ask.startFresh() }
-                }
-                Button("Cancel", role: .cancel) {}
-            } message: {
-                Text("The current Ask Bloom conversation will be cleared from view.")
-            }
             // The question asked before a session that is still working is closed. On the window for
             // the reason the archive confirmation above is: it is raised from the tab strip's close
             // button and from Cmd+W in the menu bar, and there is no one control both of those could
@@ -385,11 +372,10 @@ struct RootView: View {
         // where the post was already being received and because `openWindow` needs a view: the
         // window itself is `CreateWorkspaceWindow`, and it is keyed by project, so asking twice
         // for the same project brings the first one forward with its draft still in it.
-        // File, New Ask Bloom Conversation. It raises the same confirmation the toolbar's glyph
-        // raises rather than starting fresh outright: the act archives the conversation on screen,
-        // and a menu item that discards a conversation with no question asked is not one.
+        // File, New Ask Bloom Conversation opens a tab and keeps the existing conversations.
         .onReceive(NotificationCenter.default.publisher(for: .bloomNewAskConversation)) { _ in
-            isStartingFreshAskConversation = true
+            app.selection = .ask
+            Task { await app.ask.newConversation() }
         }
         .onReceive(NotificationCenter.default.publisher(for: .bloomNewWorkspace)) { note in
             if note.userInfo?[Notification.bloomPullRequestKey] as? Bool == true {

--- a/Sources/Bloom/Views/Sidebar/ProjectFolderPicker.swift
+++ b/Sources/Bloom/Views/Sidebar/ProjectFolderPicker.swift
@@ -44,7 +44,10 @@ extension ProjectFolderPicker {
     /// - Parameter startingAt: where to open, which the caller works out from what is in the
     ///   field: the target itself where it exists, and otherwise the deepest folder above it that
     ///   does, since a half typed path names a folder nobody has made.
-    static func chooseTarget(startingAt path: String?) async -> String? {
+    static func chooseTarget(
+        startingAt path: String?,
+        message: String = "Choose the folder your project should live in."
+    ) async -> String? {
         let panel = NSOpenPanel()
         panel.canChooseFiles = false
         panel.canChooseDirectories = true
@@ -53,7 +56,7 @@ extension ProjectFolderPicker {
         // rather than refuses. See `NewProjectVerdict.adopt`.
         panel.canCreateDirectories = true
         panel.prompt = "Choose"
-        panel.message = "Choose the folder your project should live in."
+        panel.message = message
         if let path, FileManager.default.fileExists(atPath: path) {
             panel.directoryURL = URL(fileURLWithPath: path)
         }

--- a/Sources/Bloom/Views/Sidebar/StartProjectView.swift
+++ b/Sources/Bloom/Views/Sidebar/StartProjectView.swift
@@ -54,6 +54,11 @@ struct StartProjectView: View {
     /// the window appears, so it cannot move while somebody is typing.
     @State private var defaultLocation = ""
     @State private var projectsThere = 0
+    @State private var searchLocations: [String] = []
+    @State private var isLocationLoaded = false
+    @State private var completions: [String] = []
+    @State private var selectedCompletion: Int?
+    @State private var acceptedCompletion: String?
     /// What the first commit's branch will be. Read from git rather than asserted, because a
     /// machine with `init.defaultBranch` set gets its own answer. See `NewProjectStarter`.
     @State private var branch = "main"
@@ -98,6 +103,9 @@ struct StartProjectView: View {
 
     /// The block, from the core: the instruction before anything is typed, and the verdict after.
     private var consequence: ProjectConsequence {
+        guard isLocationLoaded else {
+            return ProjectConsequence(detail: "Loading project folders…", tone: .waiting)
+        }
         guard hasTyped else {
             return .opening(location: defaultLocation, projectsThere: projectsThere, home: home)
         }
@@ -132,15 +140,17 @@ struct StartProjectView: View {
         // worth saying once, which is why it moves rather than goes: "Setting up bloom" is what
         // the window is doing, and a failure's title is what went wrong.
         .navigationTitle(title)
-        .onAppear {
-            if defaultLocation.isEmpty {
-                let paths = app.repos.map(\.path)
-                defaultLocation = NewProjectPlan.suggestedLocation(projectPaths: paths, home: home)
-                projectsThere = NewProjectPlan.projectsIn(defaultLocation, projectPaths: paths)
-            }
-            isFieldFocused = true
-        }
         .task {
+            let preferences: DirectoryPreferences
+            if let store = app.store { preferences = await DirectoryPreferences.load(from: store) } else {
+                preferences = DirectoryPreferences()
+            }
+            let paths = app.repos.map(\.path)
+            defaultLocation = preferences.projectLocation(projectPaths: paths, home: home)
+            searchLocations = preferences.searchLocations(projectPaths: paths, home: home)
+            projectsThere = NewProjectPlan.projectsIn(defaultLocation, projectPaths: paths)
+            isLocationLoaded = true
+            isFieldFocused = true
             branch = await NewProjectStarter.plannedBranch()
             identityProblem = await RepositoryStarter.identityProblem(at: home)
         }
@@ -157,6 +167,21 @@ struct StartProjectView: View {
             }.value
             guard !Task.isCancelled else { return }
             facts = found
+        }
+        .task(id: typed + searchLocations.joined(separator: "\n")) {
+            completions = []
+            selectedCompletion = nil
+            guard typed != acceptedCompletion else { return }
+            try? await Task.sleep(for: Self.inspectionDelay)
+            guard !Task.isCancelled else { return }
+            let line = typed
+            let locations = searchLocations
+            let userHome = home
+            let matches = await Task.detached {
+                ProjectCompletion.matches(line, locations: locations, home: userHome)
+            }.value
+            guard !Task.isCancelled else { return }
+            completions = matches
         }
         // The counts under a Start Tracking verdict, which are a walk of the whole folder and so
         // are asked only once the target has settled on one. Keyed on the path rather than on the
@@ -250,8 +275,58 @@ struct StartProjectView: View {
                 .textFieldStyle(.roundedBorder)
                 .font(Typo.body)
                 .focused($isFieldFocused)
-                .onSubmit(start)
+                .disabled(!isLocationLoaded)
+                .onKeyPress(.return) {
+                    guard let selectedCompletion else { return .ignored }
+                    acceptCompletion(selectedCompletion)
+                    return .handled
+                }
+                .onSubmit {
+                    if let selectedCompletion { acceptCompletion(selectedCompletion) } else { start() }
+                }
+                .onKeyPress(.downArrow) {
+                    guard !completions.isEmpty else { return .ignored }
+                    selectedCompletion = min((selectedCompletion ?? -1) + 1, completions.count - 1)
+                    return .handled
+                }
+                .onKeyPress(.upArrow) {
+                    guard !completions.isEmpty else { return .ignored }
+                    selectedCompletion = max((selectedCompletion ?? 1) - 1, 0)
+                    return .handled
+                }
+                .onKeyPress(.tab) {
+                    guard !completions.isEmpty else { return .ignored }
+                    acceptCompletion(selectedCompletion ?? 0)
+                    return .handled
+                }
+                .onKeyPress(.escape) {
+                    guard !completions.isEmpty else { return .ignored }
+                    completions = []
+                    selectedCompletion = nil
+                    return .handled
+                }
             Button("Choose\u{2026}", action: chooseFolder)
+        }
+
+        if !completions.isEmpty {
+            VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
+                ForEach(Array(completions.enumerated()), id: \.element) { index, path in
+                    Button { acceptCompletion(index) } label: {
+                        HStack {
+                            Image(systemName: "folder")
+                            Text((path as NSString).lastPathComponent)
+                            Spacer()
+                            Text(NewProjectPlan.display(path, home: home))
+                                .foregroundStyle(Palette.textSecondary)
+                                .lineLimit(1).truncationMode(.middle)
+                        }
+                        .padding(Metrics.spacingSmall)
+                        .background(selectedCompletion == index ? Palette.controlAccent.opacity(0.15) : .clear)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(NewProjectPlan.display(path, home: home))
+                }
+            }
         }
 
         // Only where a commit is about to be made. Adding a repository writes nothing, so an
@@ -458,11 +533,20 @@ struct StartProjectView: View {
     }
 
     private var canStart: Bool {
-        guard hasTyped, verdict.isAllowed else { return false }
+        guard isLocationLoaded, hasTyped, verdict.isAllowed else { return false }
         return identityProblem == nil || !verdict.makesACommit
     }
 
     // MARK: - Work
+
+    private func acceptCompletion(_ index: Int) {
+        guard completions.indices.contains(index) else { return }
+        let path = NewProjectPlan.display(completions[index], home: home)
+        acceptedCompletion = path
+        typed = path
+        completions = []
+        selectedCompletion = nil
+    }
 
     private func chooseFolder() {
         // The panel lands on THIS window, and nothing here had to change for that: `present()`

--- a/Sources/BloomCore/Agent/AskConversation.swift
+++ b/Sources/BloomCore/Agent/AskConversation.swift
@@ -33,7 +33,8 @@ public enum AskConversation {
     /// default landing on this chat the first time it is opened.
     public static let permissionMode = PermissionMode.auto
 
-    /// The chat's working directory: its own, empty, and made once.
+    /// The fallback working directory, used until the owner chooses a folder in Settings.
+    /// Each conversation keeps the directory it started in. See `AskTabs`.
     ///
     /// **This is a permission decision rather than a tidiness one**, and it is the second lock
     /// rather than the first. `permissionMode` above is what stops this chat opening on the mode

--- a/Sources/BloomCore/Agent/AskTabs.swift
+++ b/Sources/BloomCore/Agent/AskTabs.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Tab selection and working directories live beside the sessions they describe.
+public enum AskTabs {
+    public static let selectionKey = "ask.selectedSession"
+
+    public static func directoryKey(_ id: SessionID) -> String { "ask.directory.\(id.rawValue)" }
+
+    public static func selection(saved: String?, sessions: [Session]) -> SessionID? {
+        sessions.first { $0.id.rawValue == saved }?.id ?? sessions.first?.id
+    }
+
+    public static func selectionAfterClosing(
+        _ id: SessionID, selected: SessionID?, sessions: [Session]
+    ) -> SessionID? {
+        let remaining = sessions.filter { $0.id != id }
+        if selected != id, remaining.contains(where: { $0.id == selected }) { return selected }
+        let index = sessions.firstIndex { $0.id == id } ?? 0
+        return remaining.isEmpty ? nil : remaining[min(index, remaining.count - 1)].id
+    }
+
+    /// An explicitly chosen folder must exist. A missing volume must not silently change cwd.
+    public static func prepareDirectory(_ path: String, databasePath: String) -> String? {
+        if path.isEmpty { return AskConversation.prepareDirectory(besideDatabaseAt: databasePath) }
+        let expanded = NewProjectPlan.expand(path, home: FileManager.default.homeDirectoryForCurrentUser.path)
+        var isDirectory: ObjCBool = false
+        guard expanded.hasPrefix("/"),
+              FileManager.default.fileExists(atPath: expanded, isDirectory: &isDirectory),
+              isDirectory.boolValue else { return nil }
+        return FolderPath.normalize(expanded)
+    }
+}

--- a/Sources/BloomCore/Persistence/DirectoryPreferences.swift
+++ b/Sources/BloomCore/Persistence/DirectoryPreferences.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public struct DirectoryPreferences: Equatable, Sendable {
+    public static let projectKey = "directories.projects"
+    public static let additionalKey = "directories.additionalProjects"
+    public static let askKey = "directories.ask"
+    public var projects = ""
+    public var additionalProjects: [String] = []
+    public var ask = ""
+
+    public init() {}
+
+    public static func load(from store: Store) async -> Self {
+        var result = Self()
+        result.projects = (try? await store.setting(projectKey)) ?? ""
+        result.ask = (try? await store.setting(askKey)) ?? ""
+        if let raw = try? await store.setting(additionalKey), let data = raw.data(using: .utf8) {
+            result.additionalProjects = (try? JSONDecoder().decode([String].self, from: data)) ?? []
+        }
+        return result
+    }
+
+    public func save(to store: Store) async throws {
+        try await store.setSetting(Self.projectKey, projects.isEmpty ? nil : projects)
+        try await store.setSetting(Self.askKey, ask.isEmpty ? nil : ask)
+        let data = try JSONEncoder().encode(additionalProjects)
+        try await store.setSetting(Self.additionalKey, String(decoding: data, as: UTF8.self))
+    }
+
+    public func projectLocation(projectPaths: [String], home: String) -> String {
+        projects.isEmpty
+            ? NewProjectPlan.suggestedLocation(projectPaths: projectPaths, home: home)
+            : NewProjectPlan.expand(projects, home: home)
+    }
+
+    public func searchLocations(projectPaths: [String], home: String) -> [String] {
+        let parents = projectPaths.map { ($0 as NSString).deletingLastPathComponent }
+        return Array(Set(parents + additionalProjects.map { NewProjectPlan.expand($0, home: home) }
+            + [projectLocation(projectPaths: projectPaths, home: home)] )).sorted()
+    }
+}

--- a/Sources/BloomCore/Persistence/Store.swift
+++ b/Sources/BloomCore/Persistence/Store.swift
@@ -3104,7 +3104,7 @@ public actor Store {
                   current.archivedAt == nil else {
                 throw SQLiteError(message: "This conversation is no longer current.", sql: nil)
             }
-            var next = AskConversation.newSession()
+            var next = AskConversation.newSession(sortOrder: current.sortOrder)
             next.model = controls.model
             next.effort = controls.effort
             next.agentKind = controls.agentKind
@@ -3114,7 +3114,47 @@ public actor Store {
                 try setSetting(key, value)
             }
             try saveDraft(sessionID: next.id, body: draft)
+            let directory = try setting(AskTabs.directoryKey(id))
+                ?? AskConversation.directory(besideDatabaseAt: path)
+            try setSetting(AskTabs.directoryKey(next.id), directory)
+            try setSetting(AskTabs.selectionKey, next.id.rawValue)
             _ = try update(sessionID: id) { $0.archivedAt = Date() }
+            return next
+        }
+    }
+
+    /// Inserting the chat and its controls, draft, directory and selection is one transaction.
+    public func createAskConversation(
+        directory: String, controls: ComposerControls? = nil, draft: String = ""
+    ) throws -> Session {
+        try db.transaction {
+            let existing = try sessionsWithoutWorkspace()
+            var next = AskConversation.newSession(sortOrder: (existing.map(\.sortOrder).max() ?? -1) + 1)
+            if let controls {
+                next.model = controls.model
+                next.effort = controls.effort
+                next.agentKind = controls.agentKind
+                next.permissionMode = controls.permissionMode
+            }
+            try upsert(next)
+            if let controls {
+                for (key, value) in controls.settings(sessionID: next.id) { try setSetting(key, value) }
+            }
+            try saveDraft(sessionID: next.id, body: draft)
+            try setSetting(AskTabs.directoryKey(next.id), directory)
+            try setSetting(AskTabs.selectionKey, next.id.rawValue)
+            return next
+        }
+    }
+
+    /// Closing a tab archives its transcript and records the neighbouring selection together.
+    public func closeAskConversation(id: SessionID, selected: SessionID?) throws -> SessionID? {
+        try db.transaction {
+            let sessions = try sessionsWithoutWorkspace()
+            guard sessions.count > 1, sessions.contains(where: { $0.id == id }) else { return selected }
+            let next = AskTabs.selectionAfterClosing(id, selected: selected, sessions: sessions)
+            _ = try update(sessionID: id) { $0.archivedAt = Date() }
+            try setSetting(AskTabs.selectionKey, next?.rawValue)
             return next
         }
     }

--- a/Sources/BloomCore/Presentation/MenuBarCatalogue.swift
+++ b/Sources/BloomCore/Presentation/MenuBarCatalogue.swift
@@ -71,7 +71,7 @@ public enum MenuBarCatalogue {
         // makes directly above it.
         MenuBarItem(.newAskConversation, in: .file, "New Ask Bloom Conversation", availability: .always),
         MenuBarItem(.projectSettings, in: .file, "Project Settings…", key: .init("comma", .command, .shift), availability: .needsProject),
-        MenuBarItem(.newSession, in: .file, "New Session", key: .command("t"), availability: .needsWorkspace),
+        MenuBarItem(.newSession, in: .file, "New Session", key: .command("t"), availability: .needsConversationArea),
         MenuBarItem(.newTerminalTab, in: .file, "New Terminal Tab", key: .init("t", .command, .shift), availability: .needsWorkspace),
         MenuBarItem(.newBrowserTab, in: .file, "New Browser Tab", key: .init("b", .command, .shift), availability: .needsWorkspace),
         MenuBarItem(.showChanges, in: .file, "Show Changes", key: .init("d", .command, .shift), availability: .needsWorkspace),
@@ -335,6 +335,8 @@ public enum MenuBarAvailability: String, Equatable, Sendable {
     case needsProject
     /// A workspace is selected in the sidebar.
     case needsWorkspace
+    /// A workspace or Ask Bloom is selected.
+    case needsConversationArea
     /// Any workspace exists at all, selected or not.
     case needsAnyWorkspace
     /// A workspace is the Workspace menu's subject, and that subject allows this action. See

--- a/Sources/BloomCore/Workspace/ProjectCompletion.swift
+++ b/Sources/BloomCore/Workspace/ProjectCompletion.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Only immediate child folders are scanned. Typing a path narrows the scan to that parent.
+public enum ProjectCompletion {
+    public static func matches(
+        _ typed: String, locations: [String], home: String, limit: Int = 8
+    ) -> [String] {
+        let query = typed.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty, limit > 0 else { return [] }
+        let parents: [String]
+        let prefix: String
+        if ProjectTarget.looksLikeAPath(query) {
+            let expanded = NewProjectPlan.expand(query, home: home)
+            guard expanded.hasPrefix("/") else { return [] }
+            if query.hasSuffix("/") || query == "~" {
+                parents = [expanded]
+                prefix = ""
+            } else {
+                parents = [(expanded as NSString).deletingLastPathComponent]
+                prefix = (expanded as NSString).lastPathComponent
+            }
+        } else {
+            parents = locations
+            prefix = query
+        }
+        var paths = Set<String>()
+        for parent in Set(parents) {
+            let url = URL(fileURLWithPath: parent)
+            let children = (try? FileManager.default.contentsOfDirectory(
+                at: url, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]
+            )) ?? []
+            for child in children where child.lastPathComponent.lowercased().hasPrefix(prefix.lowercased()) {
+                guard (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else { continue }
+                paths.insert(child.standardizedFileURL.path)
+            }
+        }
+        return Array(paths.sorted {
+            let left = ($0 as NSString).lastPathComponent
+            let right = ($1 as NSString).lastPathComponent
+            return left == right ? $0 < $1 : left.localizedStandardCompare(right) == .orderedAscending
+        }.prefix(limit))
+    }
+}

--- a/Tests/BloomCoreTests/AskTabsTests.swift
+++ b/Tests/BloomCoreTests/AskTabsTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Ask conversation tabs", .scratchDirectory)
+struct AskTabsTests {
+    @Test func creatingTabsPreservesConversationsAndDirectories() async throws {
+        let store = try makeTestStore("ask-tabs")
+        let first = try await store.createAskConversation(directory: "/first")
+        let second = try await store.createAskConversation(directory: "/second")
+        let sessions = try await store.sessionsWithoutWorkspace()
+        #expect(sessions.map(\.id) == [first.id, second.id])
+        #expect(try await store.session(id: first.id)?.archivedAt == nil)
+        #expect(try await store.setting(AskTabs.directoryKey(first.id)) == "/first")
+        #expect(try await store.setting(AskTabs.directoryKey(second.id)) == "/second")
+        let saved = try await store.setting(AskTabs.selectionKey)
+        #expect(AskTabs.selection(saved: saved, sessions: sessions) == second.id)
+        #expect(AskTabs.selection(saved: "missing", sessions: sessions) == first.id)
+        #expect(AskTabs.selectionAfterClosing(first.id, selected: second.id, sessions: sessions) == second.id)
+        #expect(AskTabs.selectionAfterClosing(second.id, selected: second.id, sessions: sessions) == first.id)
+        #expect(AskTabs.selectionAfterClosing(first.id, selected: first.id, sessions: [first]) == nil)
+    }
+
+    @Test func replacingOneTabPreservesItsLocationAndNeighbours() async throws {
+        let store = try makeTestStore("ask-replace-tab")
+        let first = try await store.createAskConversation(directory: "/first")
+        let second = try await store.createAskConversation(directory: "/second")
+        let controls = ComposerControls(session: first, isFastMode: true, outputStyle: "Concise")
+        let replacement = try await store.replaceAskConversation(id: first.id, controls: controls, draft: "next")
+        #expect(try await store.setting(AskTabs.directoryKey(replacement.id)) == "/first")
+        #expect(try await store.sessionsWithoutWorkspace().map(\.id) == [replacement.id, second.id])
+        #expect(try await store.session(id: first.id)?.archivedAt != nil)
+    }
+
+    @Test func missingCustomDirectoryDoesNotFallBack() throws {
+        let root = TestScratch.unique("ask-custom-directory")
+        #expect(AskTabs.prepareDirectory(root + "/missing", databasePath: root + "/db") == nil)
+        try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
+        #expect(AskTabs.prepareDirectory(root, databasePath: root + "/db") == root)
+        try Data().write(to: URL(fileURLWithPath: root + "/file"))
+        #expect(AskTabs.prepareDirectory(root + "/file", databasePath: root + "/db") == nil)
+    }
+    @Test func closingArchivesWithoutDeletingAndKeepsTheLastTab() async throws {
+        let store = try makeTestStore("ask-close-tab")
+        let first = try await store.createAskConversation(directory: "/first", draft: "keep this")
+        let second = try await store.createAskConversation(directory: "/second")
+        let selected = try await store.closeAskConversation(id: first.id, selected: first.id)
+        #expect(selected == second.id)
+        #expect(try await store.setting(AskTabs.selectionKey) == second.id.rawValue)
+        #expect(try await store.session(id: first.id)?.archivedAt != nil)
+        #expect(try await store.draft(sessionID: first.id) == "keep this")
+        _ = try await store.closeAskConversation(id: second.id, selected: second.id)
+        #expect(try await store.sessionsWithoutWorkspace().map(\.id) == [second.id])
+    }
+
+    @Test func newTabCarriesControlsAndDraftAtomically() async throws {
+        let store = try makeTestStore("ask-tab-controls")
+        let controls = ComposerControls(session: AskConversation.newSession(), isFastMode: true, outputStyle: "Concise")
+        let chat = try await store.createAskConversation(directory: "/chosen", controls: controls, draft: "hello")
+        #expect(try await store.draft(sessionID: chat.id) == "hello")
+        #expect(try await store.setting(ComposerControls.fastModeKey(sessionID: chat.id)) == "1")
+        #expect(try await store.setting(ComposerControls.outputStyleKey(sessionID: chat.id)) == "Concise")
+    }
+
+    @Test func legacyConversationKeepsItsOriginalDirectoryWhenReplaced() async throws {
+        let store = try makeTestStore("ask-tab-legacy")
+        let original = try await store.upsert(AskConversation.newSession())
+        try await store.setSetting(DirectoryPreferences.askKey, "/new-default")
+        let controls = ComposerControls(session: original, isFastMode: false, outputStyle: "")
+        let chat = try await store.replaceAskConversation(id: original.id, controls: controls)
+        #expect(try await store.setting(AskTabs.directoryKey(chat.id)) == AskConversation.directory(besideDatabaseAt: store.path))
+    }
+
+}

--- a/Tests/BloomCoreTests/ProjectCompletionTests.swift
+++ b/Tests/BloomCoreTests/ProjectCompletionTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Project folder completion", .scratchDirectory)
+struct ProjectCompletionTests {
+    @Test func siblingsAndPaths() throws {
+        let home = TestScratch.unique("completion")
+        for folder in ["Code/bloom", "Code/BloomTools", "Code/other", "Elsewhere/bloom", "Code/.bloom-hidden"] {
+            try FileManager.default.createDirectory(atPath: home + "/" + folder, withIntermediateDirectories: true)
+        }
+        try Data().write(to: URL(fileURLWithPath: home + "/Code/bloom.txt"))
+        let locations = [home + "/Code", home + "/Elsewhere", home + "/Code"]
+        let matches = ProjectCompletion.matches("blo", locations: locations, home: home)
+        #expect(matches.count == 3)
+        #expect(Set(matches).count == 3)
+        #expect(!matches.contains { $0.hasSuffix(".txt") || $0.contains(".bloom-hidden") })
+        #expect(ProjectCompletion.matches("~/Elsewhere/blo", locations: locations, home: home) == [home + "/Elsewhere/bloom"])
+        #expect(ProjectCompletion.matches("~/Elsewhere/", locations: [], home: home) == [home + "/Elsewhere/bloom"])
+        #expect(ProjectCompletion.matches("", locations: locations, home: home).isEmpty)
+        #expect(ProjectCompletion.matches("blo", locations: locations, home: home, limit: 1).count == 1)
+        #expect(ProjectCompletion.matches("/missing/path/blo", locations: locations, home: home).isEmpty)
+    }
+
+    @Test func directoryPreferencesPersistAndInfer() async throws {
+        let store = try makeTestStore("directory-preferences")
+        var preferences = await DirectoryPreferences.load(from: store)
+        let paths = ["/home/me/Code/one", "/home/me/Code/two", "/home/me/Other/three"]
+        #expect(preferences.projectLocation(projectPaths: paths, home: "/home/me") == "/home/me/Code")
+        preferences.projects = "~/Projects"
+        preferences.additionalProjects = ["/more/projects"]
+        preferences.ask = "/ask/here"
+        try await preferences.save(to: store)
+        #expect(await DirectoryPreferences.load(from: store) == preferences)
+        #expect(preferences.searchLocations(projectPaths: paths, home: "/home/me") == [
+            "/home/me/Code", "/home/me/Other", "/home/me/Projects", "/more/projects",
+        ])
+    }
+}


### PR DESCRIPTION
Add project name and path autocomplete, configurable project search folders, and an Ask Bloom working directory setting.

Ask Bloom now supports persistent conversation tabs. The tab bar appears when a second chat opens; switching keeps agents running, and closing archives the chat.

Verified with an app build, 87 focused tests, and both linters. Native UI interaction has not been manually verified.
