### PR TITLE
Make all-files review faster and easier to navigate

### DIFF
--- a/Sources/Bloom/Design/ReviewRunProbe.swift
+++ b/Sources/Bloom/Design/ReviewRunProbe.swift
@@ -25,6 +25,7 @@ enum ReviewRunProbe {
             if !condition { failures.append(message) }
         }
 
+        progress("Checking comment scrolling and focus")
         for numbers in [DiffGutter.Numbers.both, .old, .new] {
             let fixture = ReviewRunFixture()
             let host = NSHostingView(rootView: ReviewRunFixtureView(fixture: fixture, numbers: numbers))
@@ -69,7 +70,9 @@ enum ReviewRunProbe {
         // Use the same nested scrollers as all-files review. A lazy stack inside the
         // horizontal scroller previously realised the whole file's text and controls.
         var realisedRuns: [String: JSONValue] = [:]
-        for deferred in [false, true] {
+        progress("Checking embedded scrolling")
+        let compareEager = CommandLine.arguments.contains("--review-compare-eager")
+        for deferred in compareEager ? [false, true] : [true] {
             let host = NSHostingView(rootView: EmbeddedReviewFixture(deferred: deferred))
             let window = NSWindow(
                 contentRect: NSRect(x: 0, y: 0, width: 760, height: 600),
@@ -101,6 +104,7 @@ enum ReviewRunProbe {
             }
             window.contentView = nil
         }
+        progress("Checking complete review layouts and collapse")
         if let directory = ProbeHarness.value(for: "--review-run-probe") {
             let app = AppModel()
             let model = WorkspaceModel(
@@ -169,6 +173,10 @@ enum ReviewRunProbe {
         ])
         if let data = try? JSONEncoder().encode(result) { FileHandle.standardOutput.write(data) }
         exit(failures.isEmpty ? 0 : 1)
+    }
+
+    private static func progress(_ message: String) {
+        FileHandle.standardError.write(Data((message + "\n").utf8))
     }
 
     private static func settle(_ window: NSWindow) async {

--- a/Sources/Bloom/Design/ReviewRunProbe.swift
+++ b/Sources/Bloom/Design/ReviewRunProbe.swift
@@ -82,6 +82,13 @@ enum ReviewRunProbe {
             await settle(window)
             if let scroll = scrollView(in: host) {
                 let initial = hoverViews(in: host).count
+                // Classic scrollbars add height around the horizontal scroller on CI.
+                // The code keeps its exact height; the outer extent must stay stable.
+                let initialHeight = scroll.documentView?.bounds.height ?? 0
+                let inner = scroll.documentView.flatMap { scrollView(in: $0) }
+                let codeHeight = inner?.documentView?.bounds.height ?? 0
+                check(abs(codeHeight - CodeMetrics.rowHeight * 5000) < 1,
+                      "embedded code height was \(codeHeight), expected \(CodeMetrics.rowHeight * 5000)")
                 realisedRuns[deferred ? "deferred" : "eager"] = .integer(initial)
                 check(deferred ? (1...2).contains(initial) : initial == 13,
                       "unexpected number of realised text runs: \(initial), deferred: \(deferred)")
@@ -90,8 +97,8 @@ enum ReviewRunProbe {
                     scroll.reflectScrolledClipView(scroll.contentView)
                     await settle(window)
                     let height = scroll.documentView?.bounds.height ?? 0
-                    check(abs(height - CodeMetrics.rowHeight * 5000) < 1,
-                          "embedded diff changed height while scrolling")
+                    check(abs(height - initialHeight) < 1,
+                          "embedded diff height moved from \(initialHeight) to \(height)")
                     if deferred {
                         check((1...2).contains(hoverViews(in: host).count),
                               "embedded diff did not keep rendering bounded at line \(line)")
@@ -113,7 +120,28 @@ enum ReviewRunProbe {
                 app: app
             )
             await model.refreshChanges()
-            check(model.changedFiles.count == 5, "review fixture did not load its five changed files")
+            check(model.changedFiles.count == 6, "review fixture did not load its six changed files")
+            model.selectedFilePath = "README.md"
+            FileReview.setShowsAllFiles(true, in: model)
+            check(CenterTabStore.shared.review(for: model.workspace.id)?.showsAllFiles == true,
+                  "review-all toggle did not activate all-files mode")
+            FileReview.setShowsAllFiles(false, in: model)
+            check(CenterTabStore.shared.review(for: model.workspace.id)?.showsAllFiles == false,
+                  "review-all toggle did not return to one file")
+            check(CenterTabStore.shared.review(for: model.workspace.id)?.path == "README.md",
+                  "review-all toggle forgot the selected file")
+            let inspector = NSHostingView(rootView: ChangedFileList(model: model).background(Palette.surface))
+            let inspectorWindow = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 340, height: 560),
+                styleMask: [.borderless], backing: .buffered, defer: false
+            )
+            inspectorWindow.contentView = inspector
+            await settle(inspectorWindow)
+            save(inspector, name: "review-toggle-off")
+            FileReview.setShowsAllFiles(true, in: model)
+            await settle(inspectorWindow)
+            save(inspector, name: "review-toggle-on")
+            inspectorWindow.contentView = nil
             var tab = CenterTab(workspaceID: model.workspace.id, kind: .review, title: "All changes")
             tab.showsAllFiles = true
             let host = NSHostingView(rootView: ReviewPaneView(model: model, tab: tab))
@@ -146,6 +174,17 @@ enum ReviewRunProbe {
             host.rootView = ReviewPaneView(model: model, tab: tab)
             for _ in 0..<5 { await settle(window) }
             save(host, name: "all-files-jump")
+            tab.path = "Sources/LongReview.swift"
+            tab.reviewNavigationRevision += 1
+            host.rootView = ReviewPaneView(model: model, tab: tab)
+            for _ in 0..<5 { await settle(window) }
+            if let scroll = scrollView(in: host) {
+                let origin = scroll.contentView.bounds.origin
+                scroll.contentView.scroll(to: NSPoint(x: origin.x, y: origin.y + 300))
+                scroll.reflectScrolledClipView(scroll.contentView)
+                await settle(window)
+                save(host, name: "all-files-sticky")
+            }
             check(!hoverViews(in: host).isEmpty, "review did not render code after jumping to a file")
             check(!window.isVisible && !window.isKeyWindow, "review probe activated its window")
             window.contentView = nil
@@ -163,6 +202,21 @@ enum ReviewRunProbe {
                 section.rootView = ReviewCollapseFixture(model: model, file: file)
                 for _ in 0..<5 { await settle(window) }
                 check(!hoverViews(in: section).isEmpty, "reopened file stayed on its loading placeholder")
+                window.contentView = nil
+            }
+            if let file = model.changedFiles.first(where: { $0.path == "Sources/Checkout.swift" }) {
+                model.forgetHeldDiff(for: file.path)
+                let whitespaceHost = NSHostingView(rootView: DiffView(model: model, file: file))
+                window.contentView = whitespaceHost
+                window.contentView?.layoutSubtreeIfNeeded()
+                await Task.yield()
+                UserDefaults.standard.set(true, forKey: DiffWhitespaceSetting.storageKey)
+                for _ in 0..<8 { await settle(window) }
+                let raw = DiffDocument.parse(patch: await model.patch(for: file), path: file.path)
+                let held = model.heldDiff(for: file, ignoringWhitespace: true)
+                check(held != nil && raw != nil && held?.document.file == raw?.ignoringWhitespace(),
+                      "whitespace change during loading cached the wrong presentation")
+                UserDefaults.standard.set(false, forKey: DiffWhitespaceSetting.storageKey)
                 window.contentView = nil
             }
             withExtendedLifetime(app) {}
@@ -218,8 +272,10 @@ private struct ReviewCollapseFixture: View {
 
     var body: some View {
         ScrollView(.vertical) {
-            DiffView(model: model, file: file, embeddedWidth: 1000, embeddedViewportHeight: 680,
-                     isCollapsed: collapsed, onToggleCollapsed: {})
+            LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+                DiffView(model: model, file: file, embeddedWidth: 1000, embeddedViewportHeight: 680,
+                         isCollapsed: collapsed, onToggleCollapsed: {})
+            }
         }
         .defaultScrollAnchor(.topLeading)
     }

--- a/Sources/Bloom/Design/ReviewRunProbe.swift
+++ b/Sources/Bloom/Design/ReviewRunProbe.swift
@@ -66,7 +66,105 @@ enum ReviewRunProbe {
             check(!window.isVisible && !window.isKeyWindow, "probe showed or activated its window")
             window.contentView = nil
         }
+        // Use the same nested scrollers as all-files review. A lazy stack inside the
+        // horizontal scroller previously realised the whole file's text and controls.
+        var realisedRuns: [String: JSONValue] = [:]
+        for deferred in [false, true] {
+            let host = NSHostingView(rootView: EmbeddedReviewFixture(deferred: deferred))
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 760, height: 600),
+                styleMask: [.borderless], backing: .buffered, defer: false
+            )
+            window.contentView = host
+            await settle(window)
+            if let scroll = scrollView(in: host) {
+                let initial = hoverViews(in: host).count
+                realisedRuns[deferred ? "deferred" : "eager"] = .integer(initial)
+                check(deferred ? (1...2).contains(initial) : initial == 13,
+                      "unexpected number of realised text runs: \(initial), deferred: \(deferred)")
+                for line in [1, 2400, 4900, 10] {
+                    scroll.contentView.scroll(to: NSPoint(x: 0, y: CGFloat(line - 1) * CodeMetrics.rowHeight))
+                    scroll.reflectScrolledClipView(scroll.contentView)
+                    await settle(window)
+                    let height = scroll.documentView?.bounds.height ?? 0
+                    check(abs(height - CodeMetrics.rowHeight * 5000) < 1,
+                          "embedded diff changed height while scrolling")
+                    if deferred {
+                        check((1...2).contains(hoverViews(in: host).count),
+                              "embedded diff did not keep rendering bounded at line \(line)")
+                        save(host, name: "embedded-\(line)")
+                    }
+                }
+                check(!window.isVisible && !window.isKeyWindow, "embedded probe activated its window")
+            } else {
+                check(false, "embedded diff has no vertical scroll view")
+            }
+            window.contentView = nil
+        }
+        if let directory = ProbeHarness.value(for: "--review-run-probe") {
+            let app = AppModel()
+            let model = WorkspaceModel(
+                workspace: Workspace(repoID: .new(), name: "Review", branch: "main",
+                                     path: directory + "/fixture", baseBranch: "main"),
+                app: app
+            )
+            await model.refreshChanges()
+            check(model.changedFiles.count == 5, "review fixture did not load its five changed files")
+            var tab = CenterTab(workspaceID: model.workspace.id, kind: .review, title: "All changes")
+            tab.showsAllFiles = true
+            let host = NSHostingView(rootView: ReviewPaneView(model: model, tab: tab))
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 1000, height: 680),
+                styleMask: [.borderless], backing: .buffered, defer: false
+            )
+            window.contentView = host
+            // Let the per-file git reads land, including files newly exposed by shorter diffs.
+            for _ in 0..<10 { await settle(window) }
+            save(host, name: "all-files-light")
+            window.appearance = NSAppearance(named: .darkAqua)
+            await settle(window)
+            save(host, name: "all-files-dark")
+            window.appearance = NSAppearance(named: .aqua)
+            window.setContentSize(NSSize(width: 500, height: 680))
+            await settle(window)
+            save(host, name: "all-files-narrow")
+            window.setContentSize(NSSize(width: 320, height: 680))
+            await settle(window)
+            save(host, name: "all-files-compact")
+            window.setContentSize(NSSize(width: 1000, height: 680))
+            await settle(window)
+            UserDefaults.standard.set(true, forKey: DiffLayoutSetting.storageKey)
+            await settle(window)
+            save(host, name: "all-files-split")
+            UserDefaults.standard.set(false, forKey: DiffLayoutSetting.storageKey)
+            tab.path = "Sources/Checkout.swift"
+            tab.reviewNavigationRevision += 1
+            host.rootView = ReviewPaneView(model: model, tab: tab)
+            for _ in 0..<5 { await settle(window) }
+            save(host, name: "all-files-jump")
+            check(!hoverViews(in: host).isEmpty, "review did not render code after jumping to a file")
+            check(!window.isVisible && !window.isKeyWindow, "review probe activated its window")
+            window.contentView = nil
+            if let file = model.changedFiles.first {
+                let section = NSHostingView(rootView: ReviewCollapseFixture(model: model, file: file))
+                window.contentView = section
+                await settle(window)
+                check(!hoverViews(in: section).isEmpty, "expanded file did not render its code")
+                section.rootView = ReviewCollapseFixture(model: model, file: file, collapsed: true)
+                await settle(window)
+                check(hoverViews(in: section).isEmpty, "collapsed file kept its code views alive")
+                let height = scrollView(in: section)?.documentView?.bounds.height ?? 0
+                check(abs(height - 40) < 1, "collapsed file did not shrink to its header")
+                save(section, name: "all-files-collapsed")
+                section.rootView = ReviewCollapseFixture(model: model, file: file)
+                for _ in 0..<5 { await settle(window) }
+                check(!hoverViews(in: section).isEmpty, "reopened file stayed on its loading placeholder")
+                window.contentView = nil
+            }
+            withExtendedLifetime(app) {}
+        }
         let result: JSONValue = .object([
+            "realisedRuns": .object(realisedRuns),
             "checks": .integer(checks), "passed": .bool(failures.isEmpty), "failures": .strings(failures),
         ])
         if let data = try? JSONEncoder().encode(result) { FileHandle.standardOutput.write(data) }
@@ -103,6 +201,63 @@ enum ReviewRunProbe {
         return view.subviews.flatMap { hoverViews(in: $0) }
     }
 
+}
+
+private struct ReviewCollapseFixture: View {
+    let model: WorkspaceModel
+    let file: ChangedFile
+    var collapsed = false
+
+    var body: some View {
+        ScrollView(.vertical) {
+            DiffView(model: model, file: file, embeddedWidth: 1000, embeddedViewportHeight: 680,
+                     isCollapsed: collapsed, onToggleCollapsed: {})
+        }
+        .defaultScrollAnchor(.topLeading)
+    }
+}
+
+private struct EmbeddedReviewFixture: View {
+    let deferred: Bool
+
+    var body: some View {
+        ScrollView(.vertical) {
+            LazyVStack(spacing: 0) {
+                ScrollView(.horizontal) {
+                    VStack(spacing: 0) {
+                        ForEach(Array(stride(from: 0, to: 5000, by: 400)), id: \.self) { start in
+                            let count = min(400, 5000 - start)
+                            if deferred {
+                                ReviewDiffBlock(height: CGFloat(count) * CodeMetrics.rowHeight,
+                                                viewportHeight: 600) {
+                                    run(start: start, count: count)
+                                }
+                            } else {
+                                run(start: start, count: count)
+                            }
+                        }
+                    }
+                    .frame(width: 1400)
+                }
+                .fixedSize(horizontal: false, vertical: true)
+                .defaultScrollAnchor(.topLeading)
+            }
+        }
+        .defaultScrollAnchor(.topLeading)
+    }
+
+    private func run(start: Int, count: Int) -> some View {
+        DiffRunView(
+            lines: (start..<(start + count)).map { line in
+                DiffRunLine(line: DiffLine(
+                    kind: .addition, text: "let value\(line) = input",
+                    oldNumber: nil, newNumber: line + 1, index: line
+                ))
+            },
+            language: .swift, width: 1400,
+            onComment: { _ in }, onDragComment: { _, _ in }, onEndCommentDrag: {}, onEdit: { _ in }
+        ).equatable()
+    }
 }
 
 @MainActor

--- a/Sources/Bloom/Views/Center/Panes/AllFilesReviewControls.swift
+++ b/Sources/Bloom/Views/Center/Panes/AllFilesReviewControls.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import BloomCore
+
+/// Settings shared by every file, drawn once above the continuous review.
+struct AllFilesReviewControls: View {
+    let model: WorkspaceModel
+
+    @AppStorage(DiffLayoutSetting.storageKey) private var isSideBySide = false
+    @AppStorage(DiffWhitespaceSetting.storageKey) private var ignoresWhitespace = false
+
+    var body: some View {
+        HStack(spacing: InspectorLayout.gap) {
+            ViewThatFits(in: .horizontal) {
+                Text(model.diffScope.isNarrowed
+                     ? model.diffScope.badge
+                     : model.viewedSummary ?? Counted.of(model.changedFiles.count, "file"))
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textSecondary)
+                    .fixedSize()
+                Color.clear.frame(width: 0, height: 0)
+            }
+
+            ViewThatFits(in: .horizontal) {
+                Picker("Diff layout", selection: $isSideBySide) {
+                    Text(FileBarControls.unified).tag(false)
+                    Text(FileBarControls.sideBySide).tag(true)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .controlSize(.small)
+                .fixedSize()
+                Color.clear.frame(width: 0, height: 0)
+            }
+
+            Menu {
+                Text(model.diffScope.badge)
+                Divider()
+                Picker("Diff layout", selection: $isSideBySide) {
+                    Text(FileBarControls.unified).tag(false)
+                    Text(FileBarControls.sideBySide).tag(true)
+                }
+                .pickerStyle(.inline)
+                Toggle("Ignore whitespace", isOn: $ignoresWhitespace)
+            } label: {
+                Label("Review display options", systemImage: "slider.horizontal.3")
+            }
+            .labelStyle(.iconOnly)
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .help("Review display options")
+        }
+    }
+}

--- a/Sources/Bloom/Views/Center/Panes/AllFilesReviewView.swift
+++ b/Sources/Bloom/Views/Center/Panes/AllFilesReviewView.swift
@@ -21,7 +21,7 @@ struct AllFilesReviewView: View {
         } else {
             GeometryReader { geometry in
                 ScrollView(.vertical) {
-                    LazyVStack(spacing: Metrics.spacingWide) {
+                    LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
                         ForEach(model.changedFiles) { file in
                             DiffView(
                                 model: model, file: file, embeddedWidth: geometry.size.width,
@@ -33,7 +33,6 @@ struct AllFilesReviewView: View {
                                     }
                                 }
                             )
-                                .overlay(alignment: .bottom) { Hairline() }
                                 .id(file.path)
                         }
                     }

--- a/Sources/Bloom/Views/Center/Panes/AllFilesReviewView.swift
+++ b/Sources/Bloom/Views/Center/Panes/AllFilesReviewView.swift
@@ -9,6 +9,7 @@ struct AllFilesReviewView: View {
     let navigationRevision: Int
     /// Keep the destination anchored while loading replaces short placeholders with full diffs.
     @State private var position = ScrollPosition(idType: String.self)
+    @State private var collapsedPaths: Set<String> = []
 
     var body: some View {
         if model.changedFiles.isEmpty {
@@ -22,7 +23,16 @@ struct AllFilesReviewView: View {
                 ScrollView(.vertical) {
                     LazyVStack(spacing: Metrics.spacingWide) {
                         ForEach(model.changedFiles) { file in
-                            DiffView(model: model, file: file, embeddedWidth: geometry.size.width)
+                            DiffView(
+                                model: model, file: file, embeddedWidth: geometry.size.width,
+                                embeddedViewportHeight: geometry.size.height,
+                                isCollapsed: collapsedPaths.contains(file.path),
+                                onToggleCollapsed: {
+                                    if !collapsedPaths.insert(file.path).inserted {
+                                        collapsedPaths.remove(file.path)
+                                    }
+                                }
+                            )
                                 .overlay(alignment: .bottom) { Hairline() }
                                 .id(file.path)
                         }
@@ -34,7 +44,11 @@ struct AllFilesReviewView: View {
                 .onChange(of: navigationRevision, initial: true) { _, _ in
                     let path = selectedPath.isEmpty ? model.changedFiles.first?.path : selectedPath
                     guard let path, model.changedFiles.contains(where: { $0.path == path }) else { return }
+                    collapsedPaths.remove(path)
                     position.scrollTo(id: path, anchor: .top)
+                }
+                .onChange(of: model.changedFiles.map(\.path)) { _, paths in
+                    collapsedPaths.formIntersection(paths)
                 }
             }
         }

--- a/Sources/Bloom/Views/Center/Panes/FileReview.swift
+++ b/Sources/Bloom/Views/Center/Panes/FileReview.swift
@@ -69,9 +69,20 @@ enum FileReview {
     }
 
     static func openAll(in model: WorkspaceModel) {
+        setShowsAllFiles(true, in: model)
+    }
+
+    /// Both mode controls use the review tab's state and remember the selected file.
+    /// Returning to one file must not land on an empty review or silently choose another file.
+    static func setShowsAllFiles(_ all: Bool, in model: WorkspaceModel) {
         let store = CenterTabStore.shared
-        let tab = store.showReview(path: "", workspaceID: model.workspace.id)
-        store.setShowsAllFiles(true, for: tab)
+        let remembered = store.review(for: model.workspace.id)?.path
+        let candidates = [remembered, model.selectedFilePath].compactMap { $0 }
+        let path = candidates.first { candidate in
+            model.changedFiles.contains { $0.path == candidate }
+        } ?? model.changedFiles.first?.path ?? ""
+        let tab = store.showReview(path: path, workspaceID: model.workspace.id)
+        store.setShowsAllFiles(all, for: tab)
         WorkspaceTabsStore.shared.reveal(.tool(tab.id), in: model)
     }
 

--- a/Sources/Bloom/Views/Center/Panes/ReviewPaneView.swift
+++ b/Sources/Bloom/Views/Center/Panes/ReviewPaneView.swift
@@ -9,8 +9,8 @@ import BloomCore
 /// trade: the list keeps the whole inspector, the file keeps the whole column, and the split
 /// (Cmd+\) puts the conversation beside the diff instead of above it.
 ///
-/// The shared review offers a choice between one file and all files. Each `DiffView` carries
-/// its own filename, Viewed tick, revert, layout controls and Diff / Edit pair.
+/// The shared review offers a choice between one file and all files. In all-files mode,
+/// layout controls live above the review and each file keeps a compact, collapsible header.
 struct ReviewPaneView: View {
     @Bindable var model: WorkspaceModel
     var tab: CenterTab
@@ -229,10 +229,14 @@ struct ReviewPaneView: View {
 
             Spacer(minLength: 0)
 
-            Text(model.diffScope.badge)
-                .font(Typo.caption)
-                .foregroundStyle(Palette.textSecondary)
-                .lineLimit(1)
+            if tab.showsAllFiles {
+                AllFilesReviewControls(model: model)
+            } else {
+                Text(model.diffScope.badge)
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textSecondary)
+                    .lineLimit(1)
+            }
         }
         .padding(.horizontal, InspectorLayout.inset)
         .frame(height: InspectorLayout.barHeight)

--- a/Sources/Bloom/Views/Center/Panes/ReviewPaneView.swift
+++ b/Sources/Bloom/Views/Center/Panes/ReviewPaneView.swift
@@ -211,13 +211,7 @@ struct ReviewPaneView: View {
         HStack(spacing: InspectorLayout.gap) {
             Picker("Review files", selection: Binding(
                 get: { tab.showsAllFiles },
-                set: { all in
-                    let store = CenterTabStore.shared
-                    store.setShowsAllFiles(all, for: tab)
-                    if !all, changed == nil, let first = model.changedFiles.first {
-                        FileReview.open(path: first.path, in: model)
-                    }
-                }
+                set: { FileReview.setShowsAllFiles($0, in: model) }
             )) {
                 Text("Selected file").tag(false)
                 Text("All files").tag(true)

--- a/Sources/Bloom/Views/Inspector/ChangedFileList.swift
+++ b/Sources/Bloom/Views/Inspector/ChangedFileList.swift
@@ -75,18 +75,12 @@ struct ChangedFileList: View {
             // Only over a diff there is something to narrow. A filter above "No changes yet" is a
             // control that cannot do anything, offered at the one moment it is useless.
             if !model.changedFiles.isEmpty {
-                Button {
-                    FileReview.openAll(in: model)
-                } label: {
-                    Label("Review all files", systemImage: "doc.text")
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                HStack(spacing: 0) {
+                    InspectorFilterField(query: $query, onEscape: escape, onReturn: enterList)
+                    ReviewAllFilesToggle(model: model)
+                        .padding(.trailing, InspectorLayout.inset)
                 }
-                .buttonStyle(.plain)
-                .font(Typo.captionEmphasis)
-                .padding(.horizontal, InspectorLayout.inset)
-                .frame(height: InspectorLayout.barHeight)
-                Hairline()
-                InspectorFilterField(query: $query, onEscape: escape, onReturn: enterList)
+                .background(Palette.surfaceSunken)
                 Hairline()
             }
 

--- a/Sources/Bloom/Views/Inspector/DiffRow.swift
+++ b/Sources/Bloom/Views/Inspector/DiffRow.swift
@@ -59,6 +59,16 @@ enum DiffRow: Identifiable {
         }
     }
 
+    /// Code rows have an exact height; comment and edit bands size themselves from their text.
+    var codeLineCount: Int? {
+        switch self {
+        case let .lineRun(lines): lines.count
+        case let .pairRun(pairs): pairs.count
+        case .line, .pair: 1
+        default: nil
+        }
+    }
+
     /// Whether this row may be drawn inside a run with its neighbours.
     ///
     /// Only plain lines may. A heading, either expander, a comment band and the open editor each

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -12,6 +12,9 @@ struct DiffView: View {
     let file: ChangedFile
     /// Non-nil when the all-files review owns vertical scrolling.
     let embeddedWidth: CGFloat?
+    let embeddedViewportHeight: CGFloat?
+    let isCollapsed: Bool
+    var onToggleCollapsed: (() -> Void)?
 
     /// Above this many changed lines the diff is gated behind a tap. Rendering is lazy and would
     /// survive it, but the preparation pass and the user's attention would both rather not.
@@ -124,10 +127,17 @@ struct DiffView: View {
     /// The whitespace setting is read straight out of user defaults because `@AppStorage` is not
     /// available yet here, and it has to be part of the question: ignoring whitespace changes
     /// which hunks there are.
-    init(model: WorkspaceModel, file: ChangedFile, embeddedWidth: CGFloat? = nil) {
+    init(
+        model: WorkspaceModel, file: ChangedFile, embeddedWidth: CGFloat? = nil,
+        embeddedViewportHeight: CGFloat? = nil, isCollapsed: Bool = false,
+        onToggleCollapsed: (() -> Void)? = nil
+    ) {
         self.model = model
         self.file = file
         self.embeddedWidth = embeddedWidth
+        self.embeddedViewportHeight = embeddedViewportHeight
+        self.isCollapsed = isCollapsed
+        self.onToggleCollapsed = onToggleCollapsed
         let absolute = (model.workspace.path as NSString).appendingPathComponent(file.path)
         _mode = State(initialValue: FileEditSession.shared.isDirty(absolute) ? .edit : .diff)
 
@@ -153,6 +163,7 @@ struct DiffView: View {
         var workspaceID: WorkspaceID
         var file: ChangedFile
         var scope: DiffScope
+        var isCollapsed: Bool
     }
 
     /// One cancel that has been asked about: what would be lost, and which editor to close once
@@ -183,52 +194,63 @@ struct DiffView: View {
                 diff: source,
                 mode: $mode,
                 isEditable: isEditable,
-                onRevert: revert
+                onRevert: revert,
+                isCollapsed: isCollapsed,
+                onToggleCollapsed: onToggleCollapsed
             )
-            Hairline()
+            if !isCollapsed {
+                Hairline()
 
-            switch mode {
-            case .diff:
-                content
-                    // Empty states have an intrinsic size; centre them in the whole pane.
-                    // The actual diff fills this frame and owns its top-leading scroll anchor.
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    // Both of these hang on the diff rather than on the view around it, and that
-                    // is not tidiness: a second `.alert` and a second `.sheet` on one view is one
-                    // presentation modifier of each kind too many, and which of the pair wins is
-                    // not something to find out in a build. The revert's alert and the review's
-                    // discard sheet own the outer view; these two are about the diff and live on
-                    // it. Not on the band either, which is a row in a lazy stack: scrolled away,
-                    // it would take its own sheet with it.
-                    .alert(
-                        "Cannot edit these lines",
-                        isPresented: $editProblem.isPresent(),
-                        presenting: editProblem
-                    ) { _ in
-                    } message: { problem in
-                        Text(problem)
-                    }
-                    .confirmation($discardingEdit) { _ in
-                        Confirmation(
-                            title: DiffEdit.Discard.title,
-                            message: DiffEdit.Discard.message,
-                            confirmLabel: DiffEdit.Discard.confirmLabel,
-                            cancelLabel: DiffEdit.Discard.cancelLabel
-                        )
-                    } onConfirm: { _ in
-                        closeEdit()
-                    }
-            case .edit:
-                FileEditPane(model: model, path: file.path, session: session)
-                    .frame(height: embeddedWidth == nil ? nil : 400)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                switch mode {
+                case .diff:
+                    content
+                        // Empty states have an intrinsic size; centre them in the whole pane.
+                        // The actual diff fills this frame and owns its top-leading scroll anchor.
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        // Both of these hang on the diff rather than on the view around it, and that
+                        // is not tidiness: a second `.alert` and a second `.sheet` on one view is one
+                        // presentation modifier of each kind too many, and which of the pair wins is
+                        // not something to find out in a build. The revert's alert and the review's
+                        // discard sheet own the outer view; these two are about the diff and live on
+                        // it. Not on the band either, which is a row in a lazy stack: scrolled away,
+                        // it would take its own sheet with it.
+                        .alert(
+                            "Cannot edit these lines",
+                            isPresented: $editProblem.isPresent(),
+                            presenting: editProblem
+                        ) { _ in
+                        } message: { problem in
+                            Text(problem)
+                        }
+                        .confirmation($discardingEdit) { _ in
+                            Confirmation(
+                                title: DiffEdit.Discard.title,
+                                message: DiffEdit.Discard.message,
+                                confirmLabel: DiffEdit.Discard.confirmLabel,
+                                cancelLabel: DiffEdit.Discard.cancelLabel
+                            )
+                        } onConfirm: { _ in
+                            closeEdit()
+                        }
+                case .edit:
+                    FileEditPane(model: model, path: file.path, session: session)
+                        .frame(height: embeddedWidth == nil ? nil : 400)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
             }
         }
         .background(Palette.surface)
         .background {
             if embeddedWidth == nil { shortcut }
         }
-        .task(id: LoadID(workspaceID: model.workspace.id, file: file, scope: model.diffScope)) {
+        .task(id: LoadID(
+            workspaceID: model.workspace.id, file: file, scope: model.diffScope,
+            isCollapsed: isCollapsed
+        )) {
+            guard !isCollapsed else {
+                priming?.cancel()
+                return
+            }
             await load()
         }
         .onChange(of: isSideBySide) { _, _ in rebuild() }
@@ -348,6 +370,7 @@ struct DiffView: View {
         }
 
         let patch = await model.patch(for: file)
+        guard !Task.isCancelled else { return }
         let path = file.path
         let parsed = await Task.detached(priority: .userInitiated) {
             DiffDocument.parse(patch: patch, path: path)
@@ -375,8 +398,11 @@ struct DiffView: View {
         // Show anyway on is held as what it became, so coming back to it does not put the gate
         // in front of them a second time.
         if parsed != source {
-            source = parsed
             await apply(parsed)
+            guard !Task.isCancelled else { return }
+            // A collapse can cancel preparation. Only remember the patch once it was
+            // presented, so expanding retries instead of leaving a loading placeholder.
+            source = parsed
         }
 
         // Whether Edit mode is even offered is a question about the bytes on disk rather than
@@ -416,7 +442,7 @@ struct DiffView: View {
             phase = .gated(fileDiff, changed: changed)
             return
         }
-        await present(fileDiff)
+        await present(fileDiff, raw: raw)
     }
 
     /// Refolding drops what the reader expanded, because a run that was expanded no longer exists
@@ -445,7 +471,7 @@ struct DiffView: View {
         }
     }
 
-    private func present(_ fileDiff: FileDiff) async {
+    private func present(_ fileDiff: FileDiff, raw: FileDiff? = nil) async {
         let path = file.path
         let worktree = model.workspace.path
         // The worktree copy is read here rather than after the await, which is where it used to be
@@ -474,7 +500,7 @@ struct DiffView: View {
         // the whitespace setting was applied to it, which is what a later visit compares against.
         // See `DiffPresentationCache`.
         model.holdDiff(
-            DiffPresentation(source: source ?? fileDiff, document: document, lines: prepared.lines),
+            DiffPresentation(source: raw ?? source ?? fileDiff, document: document, lines: prepared.lines),
             for: file,
             ignoringWhitespace: ignoresWhitespace
         )
@@ -584,7 +610,16 @@ struct DiffView: View {
             ScrollView(.horizontal) {
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(rows) { row in
-                        rowView(row, document: document, width: width)
+                        if let count = row.codeLineCount, let embeddedViewportHeight {
+                            ReviewDiffBlock(
+                                height: CGFloat(count) * CodeMetrics.rowHeight,
+                                viewportHeight: embeddedViewportHeight
+                            ) {
+                                rowView(row, document: document, width: width)
+                            }
+                        } else {
+                            rowView(row, document: document, width: width)
+                        }
                     }
                 }
                 .frame(width: width, alignment: .leading)

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -83,6 +83,7 @@ struct DiffView: View {
     /// The patch as git wrote it, kept so the whitespace toggle can refold it without going back
     /// to git for a diff it has already been given.
     @State private var source: FileDiff?
+    @State private var preparedWhitespace: Bool?
     @State private var mode: FileViewMode
     @State private var isEditable = false
     /// The file whose diff is on screen, which is not the same question as `file`.
@@ -148,6 +149,8 @@ struct DiffView: View {
         let opening: Phase = held.map { .ready($0.document) } ?? .loading
         _phase = State(initialValue: opening)
         _source = State(initialValue: held?.source)
+        _preparedWhitespace = State(initialValue: held == nil ? nil
+            : UserDefaults.standard.bool(forKey: DiffWhitespaceSetting.storageKey))
         _fileLines = State(initialValue: held?.lines)
         _presented = State(initialValue: held == nil ? nil : file.path)
     }
@@ -155,7 +158,7 @@ struct DiffView: View {
     private enum Phase {
         case loading
         case notice(symbol: String, title: String, detail: String)
-        case gated(FileDiff, changed: Int)
+        case gated(FileDiff, changed: Int, ignoringWhitespace: Bool)
         case ready(DiffDocument)
     }
 
@@ -164,6 +167,7 @@ struct DiffView: View {
         var file: ChangedFile
         var scope: DiffScope
         var isCollapsed: Bool
+        var ignoringWhitespace: Bool
     }
 
     /// One cancel that has been asked about: what would be lost, and which editor to close once
@@ -186,56 +190,22 @@ struct DiffView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            FileHeaderBar(
-                model: model,
-                file: file,
-                session: session,
-                diff: source,
-                mode: $mode,
-                isEditable: isEditable,
-                onRevert: revert,
-                isCollapsed: isCollapsed,
-                onToggleCollapsed: onToggleCollapsed
-            )
-            if !isCollapsed {
-                Hairline()
-
-                switch mode {
-                case .diff:
-                    content
-                        // Empty states have an intrinsic size; centre them in the whole pane.
-                        // The actual diff fills this frame and owns its top-leading scroll anchor.
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        // Both of these hang on the diff rather than on the view around it, and that
-                        // is not tidiness: a second `.alert` and a second `.sheet` on one view is one
-                        // presentation modifier of each kind too many, and which of the pair wins is
-                        // not something to find out in a build. The revert's alert and the review's
-                        // discard sheet own the outer view; these two are about the diff and live on
-                        // it. Not on the band either, which is a row in a lazy stack: scrolled away,
-                        // it would take its own sheet with it.
-                        .alert(
-                            "Cannot edit these lines",
-                            isPresented: $editProblem.isPresent(),
-                            presenting: editProblem
-                        ) { _ in
-                        } message: { problem in
-                            Text(problem)
-                        }
-                        .confirmation($discardingEdit) { _ in
-                            Confirmation(
-                                title: DiffEdit.Discard.title,
-                                message: DiffEdit.Discard.message,
-                                confirmLabel: DiffEdit.Discard.confirmLabel,
-                                cancelLabel: DiffEdit.Discard.cancelLabel
-                            )
-                        } onConfirm: { _ in
-                            closeEdit()
-                        }
-                case .edit:
-                    FileEditPane(model: model, path: file.path, session: session)
-                        .frame(height: embeddedWidth == nil ? nil : 400)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        Group {
+            if embeddedWidth != nil {
+                Section {
+                    if !isCollapsed {
+                        fileContent
+                            .overlay(alignment: .bottom) { Hairline() }
+                    }
+                } header: {
+                    fileHeader
+                        .overlay(alignment: .bottom) { Hairline() }
+                }
+            } else {
+                VStack(spacing: 0) {
+                    fileHeader
+                    Hairline()
+                    fileContent
                 }
             }
         }
@@ -245,7 +215,7 @@ struct DiffView: View {
         }
         .task(id: LoadID(
             workspaceID: model.workspace.id, file: file, scope: model.diffScope,
-            isCollapsed: isCollapsed
+            isCollapsed: isCollapsed, ignoringWhitespace: ignoresWhitespace
         )) {
             guard !isCollapsed else {
                 priming?.cancel()
@@ -254,7 +224,6 @@ struct DiffView: View {
             await load()
         }
         .onChange(of: isSideBySide) { _, _ in rebuild() }
-        .onChange(of: ignoresWhitespace) { _, _ in refold() }
         .onChange(of: fileComments) { _, _ in rebuild() }
         .onChange(of: draftSelection) { _, _ in rebuild() }
         .onChange(of: model.changesGeneration) { _, _ in refreshWorktreeCopy() }
@@ -290,6 +259,54 @@ struct DiffView: View {
         }
     }
 
+    private var fileHeader: some View {
+        FileHeaderBar(
+            model: model, file: file, session: session, diff: source,
+            mode: $mode, isEditable: isEditable, onRevert: revert,
+            isCollapsed: isCollapsed, onToggleCollapsed: onToggleCollapsed
+        )
+    }
+
+    @ViewBuilder
+    private var fileContent: some View {
+        switch mode {
+        case .diff:
+            content
+                // Empty states have an intrinsic size; centre them in the whole pane.
+                // The actual diff fills this frame and owns its top-leading scroll anchor.
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // Both of these hang on the diff rather than on the view around it, and that
+                // is not tidiness: a second `.alert` and a second `.sheet` on one view is one
+                // presentation modifier of each kind too many, and which of the pair wins is
+                // not something to find out in a build. The revert's alert and the review's
+                // discard sheet own the outer view; these two are about the diff and live on
+                // it. Not on the band either, which is a row in a lazy stack: scrolled away,
+                // it would take its own sheet with it.
+                .alert(
+                    "Cannot edit these lines",
+                    isPresented: $editProblem.isPresent(),
+                    presenting: editProblem
+                ) { _ in
+                } message: { problem in
+                    Text(problem)
+                }
+                .confirmation($discardingEdit) { _ in
+                    Confirmation(
+                        title: DiffEdit.Discard.title,
+                        message: DiffEdit.Discard.message,
+                        confirmLabel: DiffEdit.Discard.confirmLabel,
+                        cancelLabel: DiffEdit.Discard.cancelLabel
+                    )
+                } onConfirm: { _ in
+                    closeEdit()
+                }
+        case .edit:
+            FileEditPane(model: model, path: file.path, session: session)
+                .frame(height: embeddedWidth == nil ? nil : 400)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
     /// Cmd+E flips between the diff and the file, which is what Conductor binds the same choice
     /// to. A hidden button rather than a menu command, for the reason spelled out in
     /// `SessionTabsView`: the menu bar is built elsewhere, and a key equivalent is only offered to
@@ -316,8 +333,8 @@ struct DiffView: View {
                 )
         case let .notice(symbol, title, detail):
             placeholder(symbol: symbol, title: title, detail: detail)
-        case let .gated(fileDiff, changed):
-            gate(fileDiff, changed: changed)
+        case let .gated(fileDiff, changed, ignoringWhitespace):
+            gate(fileDiff, changed: changed, ignoringWhitespace: ignoringWhitespace)
         case let .ready(document):
             diff(document)
         }
@@ -327,6 +344,11 @@ struct DiffView: View {
 
     private func load() async {
         priming?.cancel()
+        let ignoringWhitespace = ignoresWhitespace
+        if let preparedWhitespace, preparedWhitespace != ignoringWhitespace {
+            expandedRuns = []
+            revealedGaps = [:]
+        }
 
         // The rows a seeded document needs. The initialiser can put the document in place but not
         // build the rows over it: that pass reads the review comments, the draft and the layout
@@ -397,12 +419,13 @@ struct DiffView: View {
         // It also keeps a decision the reader made. A diff over `largeDiffLimit` that they pressed
         // Show anyway on is held as what it became, so coming back to it does not put the gate
         // in front of them a second time.
-        if parsed != source {
-            await apply(parsed)
+        if parsed != source || preparedWhitespace != ignoringWhitespace {
+            await apply(parsed, ignoringWhitespace: ignoringWhitespace)
             guard !Task.isCancelled else { return }
             // A collapse can cancel preparation. Only remember the patch once it was
             // presented, so expanding retries instead of leaving a loading placeholder.
             source = parsed
+            preparedWhitespace = ignoringWhitespace
         }
 
         // Whether Edit mode is even offered is a question about the bytes on disk rather than
@@ -421,10 +444,10 @@ struct DiffView: View {
     }
 
     /// Turn the parsed patch into whatever the current settings say it should be.
-    private func apply(_ raw: FileDiff) async {
-        let fileDiff = ignoresWhitespace ? raw.ignoringWhitespace() : raw
+    private func apply(_ raw: FileDiff, ignoringWhitespace: Bool) async {
+        let fileDiff = ignoringWhitespace ? raw.ignoringWhitespace() : raw
 
-        if ignoresWhitespace, fileDiff.hunks.isEmpty, !raw.hunks.isEmpty {
+        if ignoringWhitespace, fileDiff.hunks.isEmpty, !raw.hunks.isEmpty {
             phase = .notice(
                 symbol: "paragraphsign",
                 title: "Only whitespace changed",
@@ -439,19 +462,10 @@ struct DiffView: View {
 
         let changed = fileDiff.additions + fileDiff.deletions
         if changed > Self.largeDiffLimit {
-            phase = .gated(fileDiff, changed: changed)
+            phase = .gated(fileDiff, changed: changed, ignoringWhitespace: ignoringWhitespace)
             return
         }
-        await present(fileDiff, raw: raw)
-    }
-
-    /// Refolding drops what the reader expanded, because a run that was expanded no longer exists
-    /// once whitespace-only changes have folded back into context.
-    private func refold() {
-        guard let source else { return }
-        expandedRuns = []
-        revealedGaps = [:]
-        Task { await apply(source) }
+        await present(fileDiff, raw: raw, ignoringWhitespace: ignoringWhitespace)
     }
 
     /// Throw the file's changes away. Only ever reached through the confirmation in the header
@@ -471,7 +485,11 @@ struct DiffView: View {
         }
     }
 
-    private func present(_ fileDiff: FileDiff, raw: FileDiff? = nil) async {
+    private func present(
+        _ fileDiff: FileDiff, raw: FileDiff? = nil, ignoringWhitespace: Bool? = nil
+    ) async {
+        let whitespace = ignoringWhitespace ?? ignoresWhitespace
+        guard whitespace == ignoresWhitespace else { return }
         let path = file.path
         let worktree = model.workspace.path
         // The worktree copy is read here rather than after the await, which is where it used to be
@@ -491,7 +509,7 @@ struct DiffView: View {
             )
         }.value
 
-        guard !Task.isCancelled else { return }
+        guard !Task.isCancelled, whitespace == ignoresWhitespace else { return }
 
         let document = prepared.document
         fileLines = prepared.lines
@@ -502,7 +520,7 @@ struct DiffView: View {
         model.holdDiff(
             DiffPresentation(source: raw ?? source ?? fileDiff, document: document, lines: prepared.lines),
             for: file,
-            ignoringWhitespace: ignoresWhitespace
+            ignoringWhitespace: whitespace
         )
         rebuild()
         prime(document)
@@ -590,13 +608,13 @@ struct DiffView: View {
             .frame(minHeight: embeddedWidth == nil ? nil : 160)
     }
 
-    private func gate(_ fileDiff: FileDiff, changed: Int) -> some View {
+    private func gate(_ fileDiff: FileDiff, changed: Int, ignoringWhitespace: Bool) -> some View {
         EmptyStateView(
             glyph: "doc.text.magnifyingglass",
             title: "\(changed.formatted()) changed lines",
             message: "Highlighting a diff this size takes a moment.",
             actionTitle: "Show anyway",
-            action: { Task { await present(fileDiff) } }
+            action: { Task { await present(fileDiff, ignoringWhitespace: ignoringWhitespace) } }
         )
         .frame(minHeight: embeddedWidth == nil ? nil : 160)
     }

--- a/Sources/Bloom/Views/Inspector/FileHeaderBar.swift
+++ b/Sources/Bloom/Views/Inspector/FileHeaderBar.swift
@@ -43,6 +43,8 @@ struct FileHeaderBar: View {
     /// Absent when the file cannot be edited: binary, gone, or too large to open.
     var isEditable: Bool
     var onRevert: () -> Void
+    var isCollapsed = false
+    var onToggleCollapsed: (() -> Void)?
 
     @AppStorage(DiffLayoutSetting.storageKey) private var isSideBySide = false
     @AppStorage(DiffWhitespaceSetting.storageKey) private var ignoresWhitespace = false
@@ -68,6 +70,18 @@ struct FileHeaderBar: View {
 
     var body: some View {
         HStack(spacing: InspectorLayout.gap) {
+            if let onToggleCollapsed {
+                Button(action: onToggleCollapsed) {
+                    Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
+                        .font(Typo.micro)
+                        .foregroundStyle(Palette.textSecondary)
+                        .frame(width: 20, height: 28)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("\(isCollapsed ? "Expand" : "Collapse") \(file.filename)")
+                .accessibilityLabel("\(isCollapsed ? "Expand" : "Collapse") \(file.filename)")
+            }
             FilePathLabel(path: file.path, width: width)
 
             // Whether Edit mode is holding changes that are not on disk yet. Asked by
@@ -90,17 +104,21 @@ struct FileHeaderBar: View {
             // boundary between two of `ViewThatFits`'s arrangements would swap them as the pointer
             // arrived. The controls have to be the one thing in this bar that never moves while
             // it is being pointed at.
-            FileBarHintLabel(text: hint ?? "")
-                .layoutPriority(-2)
+            if onToggleCollapsed != nil {
+                reviewControls
+            } else {
+                FileBarHintLabel(text: hint ?? "")
+                    .layoutPriority(-2)
 
-            ViewThatFits(in: .horizontal) {
-                controls
-                compact
-                collapsed
+                ViewThatFits(in: .horizontal) {
+                    controls
+                    compact
+                    collapsed
+                }
             }
         }
         .padding(.horizontal, InspectorLayout.inset)
-        .frame(height: InspectorLayout.barHeight)
+        .frame(height: onToggleCollapsed == nil ? InspectorLayout.barHeight : 40)
         .background(Palette.surfaceSunken)
         .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { width = $0 }
         .confirmationDialog(
@@ -139,6 +157,50 @@ struct FileHeaderBar: View {
             copyButton(labelled: true)
             overflowMenu(full: false)
             modePicker
+        }
+    }
+
+    /// All-files review owns the layout settings. Keep each file's identity and progress
+    /// visible, with less frequent and destructive actions in its menu.
+    private var reviewControls: some View {
+        HStack(spacing: InspectorLayout.gap) {
+            if !file.isBinary {
+                HStack(spacing: 4) {
+                    Text("+\(file.additions)").foregroundStyle(Palette.positive)
+                    Text("−\(file.deletions)").foregroundStyle(Palette.negative)
+                }
+                .font(Typo.caption)
+                .monospacedDigit()
+                .fixedSize()
+                .accessibilityLabel("\(file.additions) additions, \(file.deletions) deletions")
+            }
+            ViewThatFits(in: .horizontal) {
+                viewedToggle(labelled: true)
+                viewedToggle(labelled: false)
+            }
+            Menu {
+                Button(FileBarControls.copy(mode: mode).title, action: copy)
+                ShareLink(item: sharedDiff, preview: SharePreview(file.filename)) {
+                    Text(FileBarControls.share(filename: file.filename).title)
+                }
+                if isEditable {
+                    Button(mode == .diff ? "Edit file" : "Show diff") {
+                        if isCollapsed { onToggleCollapsed?() }
+                        mode = mode == .diff ? .edit : .diff
+                    }
+                }
+                Divider()
+                Button(FileBarControls.revert(filename: file.filename).title, role: .destructive) {
+                    isConfirmingRevert = true
+                }
+            } label: {
+                Label("File actions", systemImage: "ellipsis.circle")
+            }
+            .labelStyle(.iconOnly)
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .help("File actions")
         }
     }
 

--- a/Sources/Bloom/Views/Inspector/ReviewAllFilesToggle.swift
+++ b/Sources/Bloom/Views/Inspector/ReviewAllFilesToggle.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Shares the review pane's mode, with an explicit on state and a way back to one file.
+struct ReviewAllFilesToggle: View {
+    let model: WorkspaceModel
+
+    private var isOn: Bool {
+        CenterTabStore.shared.review(for: model.workspace.id)?.showsAllFiles == true
+    }
+
+    var body: some View {
+        Toggle(isOn: Binding(
+            get: { isOn },
+            set: { FileReview.setShowsAllFiles($0, in: model) }
+        )) {
+            HStack(spacing: InspectorLayout.tight) {
+                Image(systemName: isOn ? "checkmark" : "doc.text")
+                    .frame(width: 12)
+                Text("Review all")
+            }
+            .font(Typo.captionEmphasis)
+            .foregroundStyle(isOn ? Palette.selectedEmphasizedText : Palette.textSecondary)
+            .padding(.horizontal, InspectorLayout.gap)
+            .padding(.vertical, InspectorLayout.tight)
+            .background {
+                RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+                    .fill(isOn ? Palette.accent : Palette.surface)
+                    .strokeBorder(isOn ? Palette.accent : Palette.border, lineWidth: Metrics.outline)
+            }
+            .contentShape(Rectangle())
+        }
+        .toggleStyle(.button)
+        .buttonStyle(.plain)
+        .fixedSize()
+        .help(isOn ? "Show only the selected file" : "Review all changed files together")
+        .accessibilityLabel("Review all files")
+        .accessibilityIdentifier("review-all-files-toggle")
+    }
+}

--- a/Sources/Bloom/Views/Inspector/ReviewDiffBlock.swift
+++ b/Sources/Bloom/Views/Inspector/ReviewDiffBlock.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// Reserves a run's exact height without laying out its selectable text offscreen.
+/// A horizontal scroller gives its contents unlimited vertical room, so a lazy stack
+/// inside it cannot virtualise against the all-files review's vertical viewport.
+struct ReviewDiffBlock<Content: View>: View {
+    var height: CGFloat
+    var viewportHeight: CGFloat
+    @ViewBuilder var content: () -> Content
+
+    @State private var isNearViewport = false
+    @Environment(\.accessibilityVoiceOverEnabled) private var voiceOverEnabled
+
+    var body: some View {
+        Color.clear
+            .frame(height: height)
+            .overlay(alignment: .topLeading) {
+                // VoiceOver must be able to move to lines beyond the visual viewport.
+                if isNearViewport || voiceOverEnabled { content() }
+            }
+            .onGeometryChange(for: Bool.self) { [viewportHeight] proxy in
+                let frame = proxy.frame(in: .scrollView(axis: .vertical))
+                // Prepare half a screen ahead without publishing every scroll offset.
+                return frame.maxY > -viewportHeight / 2 && frame.minY < viewportHeight * 1.5
+            } action: {
+                isNearViewport = $0
+            }
+    }
+}

--- a/Tools/review-run-probe.sh
+++ b/Tools/review-run-probe.sh
@@ -28,11 +28,42 @@ import sys
 binary, root = sys.argv[1:]
 if b'--review-run-probe' not in pathlib.Path(binary).read_bytes():
     raise SystemExit('Build the debug app with swift build before running this probe.')
+# A real, disposable worktree for full-screen review snapshots and navigation checks.
+fixture = pathlib.Path(root, 'fixture')
+fixture.mkdir()
+for name, body in {
+    'Config/features.json': '{"free_shipping": false}\n',
+    'Docs/legacy-shipping.md': 'Shipping costs 4.95 for every order.\n',
+    'README.md': '# Checkout\n\nShipping costs 4.95 for every order.\n',
+    'Sources/Checkout.swift': 'struct Checkout {\n    var shipping: Decimal { 4.95 }\n}\n',
+}.items():
+    target = fixture / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body)
+def git(*args):
+    subprocess.run(['git', '-C', str(fixture), *args], check=True, capture_output=True)
+git('init', '-b', 'main')
+git('add', '.')
+git('-c', 'user.name=Review Probe', '-c', 'user.email=probe@example.test', 'commit', '-m', 'Fixture')
+(fixture / 'Config/features.json').write_text('{"free_shipping": true, "threshold": 50}\n')
+(fixture / 'Docs/legacy-shipping.md').unlink()
+(fixture / 'Docs/review-checklist.md').write_text('# Review checklist\n\n- Check empty carts.\n- Check quantities.\n')
+(fixture / 'README.md').write_text(
+    '# Checkout\n\nOrders of 50 or more qualify for free shipping.\n'
+    'Smaller orders cost 4.95 to ship.\nEmpty carts have no shipping charge.\n'
+    '\n## Review\n\nRead the changes and add comments beside the relevant lines.\n'
+)
+(fixture / 'Sources/Checkout.swift').write_text(
+    'struct Checkout {\n    var freeShippingThreshold: Decimal = 50\n'
+    '    var shippingFee: Decimal = 4.95\n\n'
+    '    var qualifiesForFreeShipping: Bool {\n        subtotal >= freeShippingThreshold\n    }\n'
+    '}\n'
+)
 subprocess.run(
     ['open', '-g', '-n', '-W', '-a', str(pathlib.Path(binary).parents[2]),
      '--stdout', f'{root}/result.json', '--stderr', f'{root}/probe.log',
      '--args', '--review-run-probe', root],
-    timeout=45, check=True,
+    timeout=60, check=True,
 )
 report = pathlib.Path(root, 'result.json').read_text()
 print(report)

--- a/Tools/review-run-probe.sh
+++ b/Tools/review-run-probe.sh
@@ -45,7 +45,8 @@ def git(*args):
     subprocess.run(['git', '-C', str(fixture), *args], check=True, capture_output=True)
 git('init', '-b', 'main')
 git('add', '.')
-git('-c', 'user.name=Review Probe', '-c', 'user.email=probe@example.test', 'commit', '-m', 'Fixture')
+git('-c', 'commit.gpgsign=false', '-c', 'user.name=Review Probe',
+    '-c', 'user.email=probe@example.test', 'commit', '-m', 'Fixture')
 (fixture / 'Config/features.json').write_text('{"free_shipping": true, "threshold": 50}\n')
 (fixture / 'Docs/legacy-shipping.md').unlink()
 (fixture / 'Docs/review-checklist.md').write_text('# Review checklist\n\n- Check empty carts.\n- Check quantities.\n')
@@ -55,10 +56,13 @@ git('-c', 'user.name=Review Probe', '-c', 'user.email=probe@example.test', 'comm
     '\n## Review\n\nRead the changes and add comments beside the relevant lines.\n'
 )
 (fixture / 'Sources/Checkout.swift').write_text(
-    'struct Checkout {\n    var freeShippingThreshold: Decimal = 50\n'
+    '    struct Checkout {\n    var freeShippingThreshold: Decimal = 50\n'
     '    var shippingFee: Decimal = 4.95\n\n'
     '    var qualifiesForFreeShipping: Bool {\n        subtotal >= freeShippingThreshold\n    }\n'
     '}\n'
+)
+(fixture / 'Sources/LongReview.swift').write_text(
+    ''.join(f'let reviewLine{line} = {line}\n' for line in range(120))
 )
 try:
     subprocess.run(

--- a/Tools/review-run-probe.sh
+++ b/Tools/review-run-probe.sh
@@ -1,5 +1,6 @@
 #!/bin/zsh
 # Runs the diff comment regression in an invisible, isolated bundle after swift build.
+# Pass --review-compare-eager to also measure the previous 5,000-line renderer.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -19,13 +20,13 @@ install_name_tool -add_rpath '@executable_path/../Frameworks' "$probe_app/Conten
 codesign --force --deep --sign - "$probe_app" >/dev/null 2>&1
 
 # Refuse a release or stale binary, which would ignore the flag and start the application.
-python3 - "$probe_app/Contents/MacOS/Bloom" "$probe_root" <<'PY'
+python3 - "$probe_app/Contents/MacOS/Bloom" "$probe_root" "$@" <<'PY'
 import json
 import pathlib
 import subprocess
 import sys
 
-binary, root = sys.argv[1:]
+binary, root, *arguments = sys.argv[1:]
 if b'--review-run-probe' not in pathlib.Path(binary).read_bytes():
     raise SystemExit('Build the debug app with swift build before running this probe.')
 # A real, disposable worktree for full-screen review snapshots and navigation checks.
@@ -59,12 +60,16 @@ git('-c', 'user.name=Review Probe', '-c', 'user.email=probe@example.test', 'comm
     '    var qualifiesForFreeShipping: Bool {\n        subtotal >= freeShippingThreshold\n    }\n'
     '}\n'
 )
-subprocess.run(
-    ['open', '-g', '-n', '-W', '-a', str(pathlib.Path(binary).parents[2]),
-     '--stdout', f'{root}/result.json', '--stderr', f'{root}/probe.log',
-     '--args', '--review-run-probe', root],
-    timeout=60, check=True,
-)
+try:
+    subprocess.run(
+        ['open', '-g', '-n', '-W', '-a', str(pathlib.Path(binary).parents[2]),
+         '--stdout', f'{root}/result.json', '--stderr', f'{root}/probe.log',
+         '--args', '--review-run-probe', root, *arguments],
+        timeout=120, check=True,
+    )
+except subprocess.TimeoutExpired:
+    print(pathlib.Path(root, 'probe.log').read_text(), file=sys.stderr)
+    raise
 report = pathlib.Path(root, 'result.json').read_text()
 print(report)
 if not json.loads(report)['passed']:


### PR DESCRIPTION
Make all-files review render code only near the viewport, with stable scroll heights and sticky, collapsible file headers. Shared display controls appear once, and a compact Review all toggle beside the filter shows its active state and returns to the selected file when switched off.

Fix whitespace-setting changes during loading. The 5,000-line comparison renders 1 initial text block instead of 13; 46 UI checks, the app build, and both linters pass locally. Inspected light, dark, narrow, side-by-side, and sticky-header layouts.
