### PR TITLE
Smooth all-file review scrolling and preserve input focus

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -264,6 +264,15 @@ jobs:
       - name: Check diff scrolling and comment focus
         run: ./Tools/review-run-probe.sh
 
+      - name: Preserve failed review probe evidence
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: review-probe-evidence
+          path: ${{ runner.temp }}/bloom-review-probe
+          if-no-files-found: ignore
+          retention-days: 3
+
       # Everything below only happens on a manual run.
       #
       # Assembles Bloom.app: the icon, the App Intents metadata, the embedded

--- a/Sources/Bloom/Design/ReviewRunProbe.swift
+++ b/Sources/Bloom/Design/ReviewRunProbe.swift
@@ -176,24 +176,26 @@ enum ReviewRunProbe {
             save(host, name: "all-files-jump")
             model.selectedFilePath = "Sources/LongReview.swift"
             FileReview.open(path: "Sources/LongReview.swift", in: model)
-            for _ in 0..<5 { await settle(window) }
+            for _ in 0..<40 {
+                await settle(window)
+                if loadedLongReview(in: host) { break }
+            }
+            check(loadedLongReview(in: host), "navigation did not load the destination file")
             if let scroll = scrollView(in: host) {
-                let origin = scroll.contentView.bounds.origin
-                scroll.contentView.scroll(to: NSPoint(x: origin.x, y: origin.y + 300))
-                scroll.reflectScrolledClipView(scroll.contentView)
+                let lastFileOffset = scroll.contentView.bounds.origin.y
+                wheel(-300, in: scroll)
                 await settle(window)
                 save(host, name: "all-files-sticky")
                 let revision = CenterTabStore.shared.review(for: model.workspace.id)?.reviewNavigationRevision
-                check(model.selectedFilePath == "Sources/LongReview.swift", "inspector selection did not follow the sticky file")
+                check(model.selectedFilePath == "Sources/LongReview.swift", "inspector selected \(model.selectedFilePath ?? "nil") at \(scroll.contentView.bounds.origin.y) after scrolling the last file")
                 check(FileReview.currentPath(in: model) == model.selectedFilePath,
                       "review did not remember the file reached by scrolling")
-                if let wheel = CGEvent(scrollWheelEvent2Source: nil, units: .pixel,
-                                       wheelCount: 1, wheel1: 100_000, wheel2: 0, wheel3: 0),
-                   let event = NSEvent(cgEvent: wheel) {
-                    scroll.scrollWheel(with: event)
-                }
-                await settle(window)
+                await Self.scroll(to: 0, in: scroll, window: window)
                 check(model.selectedFilePath == model.changedFiles.first?.path, "scrolling upwards selected \(model.selectedFilePath ?? "nil") at \(scroll.contentView.bounds.origin.y)")
+                await Self.scroll(to: lastFileOffset + 300, in: scroll, window: window)
+                save(host, name: "all-files-scroll-down")
+                check(model.selectedFilePath == "Sources/LongReview.swift",
+                      "downward scrolling selected \(model.selectedFilePath ?? "nil") at \(scroll.contentView.bounds.origin.y), target \(lastFileOffset + 300)")
                 check(CenterTabStore.shared.review(for: model.workspace.id)?.reviewNavigationRevision == revision,
                       "scroll-follow issued another navigation request")
                 if CommandLine.arguments.contains("--review-scroll-profile") {
@@ -259,6 +261,28 @@ enum ReviewRunProbe {
 
     private static func progress(_ message: String) {
         FileHandle.standardError.write(Data((message + "\n").utf8))
+    }
+
+    private static func loadedLongReview(in view: NSView) -> Bool {
+        if let text = view as? WrappedCodeText.TextView, text.string.contains("let reviewLine0 = 0") { return true }
+        return view.subviews.contains { loadedLongReview(in: $0) }
+    }
+
+    private static func scroll(to target: CGFloat, in scroll: NSScrollView, window: NSWindow) async {
+        for _ in 0..<40 {
+            let remaining = target - scroll.contentView.bounds.origin.y
+            if abs(remaining) < 1 { return }
+            // AppKit limits the distance of one wheel event, even for a precise pixel event.
+            wheel(Int32(-max(-300, min(300, remaining))), in: scroll)
+            await settle(window)
+        }
+    }
+
+    private static func wheel(_ pixels: Int32, in scroll: NSScrollView) {
+        guard let wheel = CGEvent(scrollWheelEvent2Source: nil, units: .pixel,
+                                  wheelCount: 1, wheel1: pixels, wheel2: 0, wheel3: 0) else { return }
+        wheel.setIntegerValueField(.scrollWheelEventIsContinuous, value: 1)
+        if let event = NSEvent(cgEvent: wheel) { scroll.scrollWheel(with: event) }
     }
 
     private static func settle(_ window: NSWindow) async {

--- a/Sources/Bloom/Design/ReviewRunProbe.swift
+++ b/Sources/Bloom/Design/ReviewRunProbe.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// Checks the real diff controls in an invisible window without opening the app or its database.
 @MainActor
 enum ReviewRunProbe {
+    static var preparedLayouts: [String: String] = [:]
     static var isRequested: Bool { CommandLine.arguments.contains("--review-run-probe") }
 
     static func runAndExit() -> Never {
@@ -133,7 +134,12 @@ enum ReviewRunProbe {
                   "review-all toggle did not return to one file")
             check(CenterTabStore.shared.review(for: model.workspace.id)?.path == "README.md",
                   "review-all toggle forgot the selected file")
-            let inspector = NSHostingView(rootView: ChangedFileList(model: model).background(Palette.surface))
+            model.inspectorTab = .changes
+            let inspector = NSHostingView(rootView: VStack(spacing: 0) {
+                InspectorToolbar(model: model)
+                Hairline()
+                ChangedFileList(model: model)
+            }.background(Palette.surface))
             let inspectorWindow = NSWindow(
                 contentRect: NSRect(x: 0, y: 0, width: 340, height: 560),
                 styleMask: [.borderless], backing: .buffered, defer: false
@@ -183,6 +189,7 @@ enum ReviewRunProbe {
             if !loadedLongReview(in: host) {
                 let tab = CenterTabStore.shared.review(for: model.workspace.id)
                 progress("Navigation target: \(tab?.path ?? "nil"), revision: \(tab?.reviewNavigationRevision ?? -1)")
+                progress("Prepared layouts: \(preparedLayouts)")
                 if let file = model.changedFiles.first(where: { $0.path == "Sources/LongReview.swift" }) {
                     let held = model.heldDiff(for: file, ignoringWhitespace: false)
                     progress("Long review held additions: \(held?.document.file.additions ?? -1)")
@@ -303,8 +310,16 @@ enum ReviewRunProbe {
     private static func settle(_ window: NSWindow) async {
         for _ in 0..<3 {
             window.contentView?.layoutSubtreeIfNeeded()
+            if CommandLine.arguments.contains("--review-legacy-scrollers"), let view = window.contentView {
+                useLegacyScrollers(in: view)
+            }
             try? await Task.sleep(for: .milliseconds(30))
         }
+    }
+
+    private static func useLegacyScrollers(in view: NSView) {
+        if let scroll = view as? NSScrollView { scroll.scrollerStyle = .legacy }
+        for child in view.subviews { useLegacyScrollers(in: child) }
     }
 
     private static func scrollView(in view: NSView) -> NSScrollView? {

--- a/Sources/Bloom/Design/ReviewRunProbe.swift
+++ b/Sources/Bloom/Design/ReviewRunProbe.swift
@@ -20,6 +20,7 @@ enum ReviewRunProbe {
     private static func run() async {
         var failures: [String] = []
         var checks = 0
+        var scrollSteps: [Double] = []
         func check(_ condition: Bool, _ message: String) {
             checks += 1
             if !condition { failures.append(message) }
@@ -70,6 +71,8 @@ enum ReviewRunProbe {
         // Use the same nested scrollers as all-files review. A lazy stack inside the
         // horizontal scroller previously realised the whole file's text and controls.
         var realisedRuns: [String: JSONValue] = [:]
+        progress("Checking wrapped code")
+        await ReviewWrappingProbe.run(check: check, save: { save($0, name: $1) })
         progress("Checking embedded scrolling")
         let compareEager = CommandLine.arguments.contains("--review-compare-eager")
         for deferred in compareEager ? [false, true] : [true] {
@@ -141,10 +144,8 @@ enum ReviewRunProbe {
             FileReview.setShowsAllFiles(true, in: model)
             await settle(inspectorWindow)
             save(inspector, name: "review-toggle-on")
-            inspectorWindow.contentView = nil
-            var tab = CenterTab(workspaceID: model.workspace.id, kind: .review, title: "All changes")
-            tab.showsAllFiles = true
-            let host = NSHostingView(rootView: ReviewPaneView(model: model, tab: tab))
+            FileReview.open(path: model.changedFiles.first?.path ?? "", in: model)
+            let host = NSHostingView(rootView: LinkedReviewFixture(model: model))
             let window = NSWindow(
                 contentRect: NSRect(x: 0, y: 0, width: 1000, height: 680),
                 styleMask: [.borderless], backing: .buffered, defer: false
@@ -169,14 +170,12 @@ enum ReviewRunProbe {
             await settle(window)
             save(host, name: "all-files-split")
             UserDefaults.standard.set(false, forKey: DiffLayoutSetting.storageKey)
-            tab.path = "Sources/Checkout.swift"
-            tab.reviewNavigationRevision += 1
-            host.rootView = ReviewPaneView(model: model, tab: tab)
+            model.selectedFilePath = "Sources/Checkout.swift"
+            FileReview.open(path: "Sources/Checkout.swift", in: model)
             for _ in 0..<5 { await settle(window) }
             save(host, name: "all-files-jump")
-            tab.path = "Sources/LongReview.swift"
-            tab.reviewNavigationRevision += 1
-            host.rootView = ReviewPaneView(model: model, tab: tab)
+            model.selectedFilePath = "Sources/LongReview.swift"
+            FileReview.open(path: "Sources/LongReview.swift", in: model)
             for _ in 0..<5 { await settle(window) }
             if let scroll = scrollView(in: host) {
                 let origin = scroll.contentView.bounds.origin
@@ -184,6 +183,32 @@ enum ReviewRunProbe {
                 scroll.reflectScrolledClipView(scroll.contentView)
                 await settle(window)
                 save(host, name: "all-files-sticky")
+                let revision = CenterTabStore.shared.review(for: model.workspace.id)?.reviewNavigationRevision
+                check(model.selectedFilePath == "Sources/LongReview.swift", "inspector selection did not follow the sticky file")
+                check(FileReview.currentPath(in: model) == model.selectedFilePath,
+                      "review did not remember the file reached by scrolling")
+                if let wheel = CGEvent(scrollWheelEvent2Source: nil, units: .pixel,
+                                       wheelCount: 1, wheel1: 100_000, wheel2: 0, wheel3: 0),
+                   let event = NSEvent(cgEvent: wheel) {
+                    scroll.scrollWheel(with: event)
+                }
+                await settle(window)
+                check(model.selectedFilePath == model.changedFiles.first?.path, "scrolling upwards selected \(model.selectedFilePath ?? "nil") at \(scroll.contentView.bounds.origin.y)")
+                check(CenterTabStore.shared.review(for: model.workspace.id)?.reviewNavigationRevision == revision,
+                      "scroll-follow issued another navigation request")
+                if CommandLine.arguments.contains("--review-scroll-profile") {
+                    progress("Profiling continuous scroll")
+                    let bottom = max(0, (scroll.documentView?.bounds.height ?? 0) - scroll.contentView.bounds.height)
+                    for step in 0..<240 {
+                        let start = ProcessInfo.processInfo.systemUptime
+                        let fraction = CGFloat(step < 120 ? step : 239 - step) / 119
+                        scroll.contentView.scroll(to: NSPoint(x: 0, y: bottom * fraction))
+                        scroll.reflectScrolledClipView(scroll.contentView)
+                        host.layoutSubtreeIfNeeded()
+                        try? await Task.sleep(for: .milliseconds(16))
+                        scrollSteps.append(ProcessInfo.processInfo.systemUptime - start)
+                    }
+                }
             }
             check(!hoverViews(in: host).isEmpty, "review did not render code after jumping to a file")
             check(!window.isVisible && !window.isKeyWindow, "review probe activated its window")
@@ -219,9 +244,12 @@ enum ReviewRunProbe {
                 UserDefaults.standard.set(false, forKey: DiffWhitespaceSetting.storageKey)
                 window.contentView = nil
             }
+            inspectorWindow.contentView = nil
             withExtendedLifetime(app) {}
         }
         let result: JSONValue = .object([
+            "scrollStepP95Microseconds": .integer(scrollSteps.isEmpty ? 0
+                : Int(scrollSteps.sorted()[Int(Double(scrollSteps.count - 1) * 0.95)] * 1_000_000)),
             "realisedRuns": .object(realisedRuns),
             "checks": .integer(checks), "passed": .bool(failures.isEmpty), "failures": .strings(failures),
         ])
@@ -263,6 +291,16 @@ enum ReviewRunProbe {
         return view.subviews.flatMap { hoverViews(in: $0) }
     }
 
+}
+
+private struct LinkedReviewFixture: View {
+    let model: WorkspaceModel
+
+    var body: some View {
+        if let tab = CenterTabStore.shared.review(for: model.workspace.id) {
+            ReviewPaneView(model: model, tab: tab)
+        }
+    }
 }
 
 private struct ReviewCollapseFixture: View {

--- a/Sources/Bloom/Design/ReviewRunProbe.swift
+++ b/Sources/Bloom/Design/ReviewRunProbe.swift
@@ -180,6 +180,13 @@ enum ReviewRunProbe {
                 await settle(window)
                 if loadedLongReview(in: host) { break }
             }
+            if !loadedLongReview(in: host) {
+                let tab = CenterTabStore.shared.review(for: model.workspace.id)
+                progress("Navigation target: \(tab?.path ?? "nil"), revision: \(tab?.reviewNavigationRevision ?? -1)")
+                if let scroll = scrollView(in: host) {
+                    progress("Review offset: \(scroll.contentView.bounds), document: \(scroll.documentView?.bounds ?? .zero)")
+                }
+            }
             check(loadedLongReview(in: host), "navigation did not load the destination file")
             if let scroll = scrollView(in: host) {
                 let lastFileOffset = scroll.contentView.bounds.origin.y

--- a/Sources/Bloom/Design/ReviewRunProbe.swift
+++ b/Sources/Bloom/Design/ReviewRunProbe.swift
@@ -183,6 +183,14 @@ enum ReviewRunProbe {
             if !loadedLongReview(in: host) {
                 let tab = CenterTabStore.shared.review(for: model.workspace.id)
                 progress("Navigation target: \(tab?.path ?? "nil"), revision: \(tab?.reviewNavigationRevision ?? -1)")
+                if let file = model.changedFiles.first(where: { $0.path == "Sources/LongReview.swift" }) {
+                    let held = model.heldDiff(for: file, ignoringWhitespace: false)
+                    progress("Long review held additions: \(held?.document.file.additions ?? -1)")
+                    do {
+                        let patch = try await Git.patch(worktree: model.workspace.path, base: "main", file: file)
+                        progress("Long review patch: \(patch.prefix(250))")
+                    } catch { progress("Long review read failed: \(error)") }
+                }
                 if let scroll = scrollView(in: host) {
                     progress("Review offset: \(scroll.contentView.bounds), document: \(scroll.documentView?.bounds ?? .zero)")
                 }

--- a/Sources/Bloom/Design/ReviewWrappingProbe.swift
+++ b/Sources/Bloom/Design/ReviewWrappingProbe.swift
@@ -1,0 +1,144 @@
+import AppKit
+import SwiftUI
+import BloomCore
+
+#if DEBUG
+@MainActor
+enum ReviewWrappingProbe {
+    static func run(check: (Bool, String) -> Void, save: (NSView, String) -> Void) async {
+        checkKeyboardAndMenu(check: check)
+        for split in [false, true] {
+            let host = NSHostingView(rootView: Fixture(width: 640, split: split))
+            let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 640, height: 600),
+                                  styleMask: [.borderless], backing: .buffered, defer: false)
+            window.contentView = host
+            for width: CGFloat in [640, 320, 500] {
+                window.setContentSize(NSSize(width: width, height: 600))
+                host.rootView = Fixture(width: width, split: split)
+                for _ in 0..<4 {
+                    host.layoutSubtreeIfNeeded()
+                    try? await Task.sleep(for: .milliseconds(30))
+                }
+                let views = textViews(in: host)
+                check(views.count == (split ? 2 : 1), "wrapped code view was not rendered")
+                for view in views {
+                    let lines = view.string.components(separatedBy: "\n")
+                    let expected = Fixture.texts.map { $0 ?? "" }.joined(separator: "\n")
+                    let opposite = Fixture.opposite.map { $0 ?? "" }.joined(separator: "\n")
+                    check(view.string == expected || view.string == opposite, "wrapping changed the source text")
+                    guard let manager = view.layoutManager, let container = view.textContainer else {
+                        check(false, "wrapped code has no text layout")
+                        continue
+                    }
+                    manager.ensureLayout(for: container)
+                    check(manager.usedRect(for: container).width <= container.containerSize.width + 1,
+                          "wrapped code exceeded its column")
+                    var offset = 0
+                    var expectedY: CGFloat = 0
+                    for (index, line) in lines.enumerated() where offset < view.string.utf16.count {
+                        let glyph = manager.glyphIndexForCharacter(at: offset)
+                        let y = manager.lineFragmentRect(forGlyphAt: glyph, effectiveRange: nil).minY
+                        check(abs(y - expectedY) < 1,
+                              "wrapped source row \(index) started at \(y), expected \(expectedY)")
+                        expectedY += view.rowHeights[index]
+                        offset += line.utf16.count + 1
+                    }
+                    if width == 640 { view.setSelectedRange(NSRange(location: 0, length: view.string.utf16.count)) }
+                    check(view.selectedRange().length == view.string.utf16.count,
+                          "resizing wrapped code lost its selection")
+                }
+                save(host, "wrapped-\(split ? "split" : "unified")-\(Int(width))")
+            }
+            check(!window.isVisible && !window.isKeyWindow, "wrapping probe activated its window")
+            window.contentView = nil
+        }
+    }
+
+    private static func checkKeyboardAndMenu(check: (Bool, String) -> Void) {
+        let view = WrappedDiffChrome.ChromeView(frame: NSRect(x: 0, y: 0, width: 320, height: 90))
+        let window = NSWindow(contentRect: view.frame, styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = view
+        view.heights = [54, 18, 18]
+        view.commentable = [true, false, true]
+        view.editableRows = [true, false, true]
+        var commented: [Int] = []
+        view.onComment = { commented.append($0) }
+        check(window.makeFirstResponder(view), "wrapped gutter cannot receive keyboard focus")
+        func key(_ code: UInt16) {
+            if let event = NSEvent.keyEvent(with: .keyDown, location: .zero, modifierFlags: [],
+                                           timestamp: 0, windowNumber: window.windowNumber,
+                                           context: nil, characters: "", charactersIgnoringModifiers: "",
+                                           isARepeat: false, keyCode: code) { view.keyDown(with: event) }
+        }
+        key(125)
+        key(36)
+        key(126)
+        key(49)
+        check(commented == [2, 0], "keyboard comments did not skip empty wrapped rows")
+        if let event = NSEvent.mouseEvent(with: .rightMouseDown, location: NSPoint(x: 5, y: 85),
+                                         modifierFlags: [], timestamp: 0, windowNumber: window.windowNumber,
+                                         context: nil, eventNumber: 1, clickCount: 1, pressure: 1),
+           let menu = view.menu(for: event) {
+            view.onComment = { _ in commented.append(99) }
+            menu.performActionForItem(at: 0)
+            check(commented == [2, 0, 0], "native menu changed its anchor after a refresh")
+        } else { check(false, "wrapped gutter offered no comment menu") }
+        window.contentView = nil
+    }
+
+    private static func textViews(in view: NSView) -> [WrappedCodeText.TextView] {
+        if let text = view as? WrappedCodeText.TextView { return [text] }
+        return view.subviews.flatMap { textViews(in: $0) }
+    }
+
+    private struct Fixture: View {
+        var width: CGFloat
+        var split: Bool
+        static let texts: [String?] = [
+            "let message = \"" + String(repeating: "a longer piece of code ", count: 10) + "\"",
+            nil,
+            "let unicode = \"café 👩🏽‍💻 漢字\"",
+            "\tlet values = [" + String(repeating: "12345, ", count: 16) + "]",
+            "return result",
+        ]
+        static let opposite: [String?] = [
+            "let message = input", "// The other half contains a line here.",
+            String(repeating: "// another longer comment ", count: 12), nil, "return newResult",
+        ]
+
+        var body: some View {
+            let half = (width - Metrics.hairline) / 2
+            let codeWidth = floor(max(1, (split ? half : width)
+                - DiffGutter.width(for: split ? .old : .both) - CodeMetrics.markerWidth - CodeMetrics.gutterPadding))
+            let own = Self.texts.map { WrappedCodeLayout.height(of: $0 ?? "", width: codeWidth) }
+            let other = Self.opposite.map { WrappedCodeLayout.height(of: $0 ?? "", width: codeWidth) }
+            let heights = split ? zip(own, other).map { max($0, $1) } : own
+            ScrollView(.vertical) {
+                if split {
+                    HStack(spacing: 0) {
+                        run(Self.texts, width: half, heights: heights, numbers: .old)
+                        Hairline(axis: .vertical)
+                        run(Self.opposite, width: half, heights: heights, numbers: .new)
+                    }
+                } else {
+                    run(Self.texts, width: width, heights: heights, numbers: .both)
+                }
+            }
+            .defaultScrollAnchor(.topLeading)
+            .background(Palette.surface)
+        }
+
+        private func run(_ texts: [String?], width: CGFloat, heights: [CGFloat], numbers: DiffGutter.Numbers) -> some View {
+            DiffRunView(
+                lines: texts.enumerated().map { index, text in
+                    DiffRunLine(line: text.map {
+                        DiffLine(kind: .addition, text: $0, oldNumber: index + 1, newNumber: index + 1, index: index)
+                    })
+                },
+                language: .swift, numbers: numbers, width: width, wrappedHeights: heights,
+                onComment: { _ in }, onDragComment: { _, _ in }, onEndCommentDrag: {}, onEdit: { _ in }
+            )
+        }
+    }
+}
+#endif

--- a/Sources/Bloom/Design/ReviewWrappingProbe.swift
+++ b/Sources/Bloom/Design/ReviewWrappingProbe.swift
@@ -83,6 +83,12 @@ enum ReviewWrappingProbe {
             menu.performActionForItem(at: 0)
             check(commented == [2, 0, 0], "native menu changed its anchor after a refresh")
         } else { check(false, "wrapped gutter offered no comment menu") }
+        key(125)
+        view.commentable = [true]
+        view.heights = [18]
+        view.onComment = { commented.append($0) }
+        key(36)
+        check(commented.last == 0, "keyboard focus retained a row removed by a diff refresh")
         window.contentView = nil
     }
 

--- a/Sources/Bloom/Views/Center/Composer/ComposerTextEditor.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerTextEditor.swift
@@ -285,7 +285,10 @@ struct ComposerTextEditor: NSViewRepresentable {
         /// An update can precede attachment to a window, even from a SwiftUI task. Retry the
         /// current request on attachment, without retaining a stale request after focus moved.
         func applyFocus(to textView: ComposerTextView) {
-            guard let window = textView.window else { return }
+            guard let window = textView.window,
+                  AutomaticFocus.mayUpdateResponder(applicationIsActive: NSApp.isActive,
+                                                    windowIsKey: window.isKeyWindow,
+                                                    windowIsVisible: window.isVisible) else { return }
             let holdsKeyboard = window.firstResponder === textView
             if ComposerFocus.shouldTakeKeyboard(
                 wantsFocus: parent.isFocused, holdsKeyboard: holdsKeyboard,

--- a/Sources/Bloom/Views/Center/Composer/MenuKeyHost.swift
+++ b/Sources/Bloom/Views/Center/Composer/MenuKeyHost.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import BloomCore
 
 /// The keyboard for a floating list that has no field to type into.
 ///
@@ -58,7 +59,10 @@ final class MenuKeyHostView: NSView {
     }
 
     func takeFocus() {
-        guard !didFocus, let window else { return }
+        guard !didFocus, let window,
+              AutomaticFocus.mayUpdateResponder(applicationIsActive: NSApp.isActive,
+                                                windowIsKey: window.isKeyWindow,
+                                                windowIsVisible: window.isVisible) else { return }
         didFocus = window.makeFirstResponder(self)
     }
 

--- a/Sources/Bloom/Views/Center/Composer/MenuSearchField.swift
+++ b/Sources/Bloom/Views/Center/Composer/MenuSearchField.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import BloomCore
 
 /// A one line field that types into a list rather than into a document: the arrow keys and Return
 /// belong to whatever it is filtering, and only the characters are its own.
@@ -126,7 +127,10 @@ struct MenuSearchField: NSViewRepresentable {
         func takeFocus(_ field: NSTextField) {
             guard !didFocus else { return }
             DispatchQueue.main.async { [weak self] in
-                guard let self, !self.didFocus, let window = field.window else { return }
+                guard let self, !self.didFocus, let window = field.window,
+                      AutomaticFocus.mayUpdateResponder(applicationIsActive: NSApp.isActive,
+                                                        windowIsKey: window.isKeyWindow,
+                                                        windowIsVisible: window.isVisible) else { return }
                 didFocus = window.makeFirstResponder(field)
             }
         }

--- a/Sources/Bloom/Views/Center/Panes/AllFilesReviewView.swift
+++ b/Sources/Bloom/Views/Center/Panes/AllFilesReviewView.swift
@@ -37,7 +37,6 @@ struct AllFilesReviewView: View {
                                     }
                                 }
                             )
-                                .id(file.path)
                         }
                     }
                     .scrollTargetLayout()

--- a/Sources/Bloom/Views/Center/Panes/AllFilesReviewView.swift
+++ b/Sources/Bloom/Views/Center/Panes/AllFilesReviewView.swift
@@ -8,7 +8,9 @@ struct AllFilesReviewView: View {
     let selectedPath: String
     let navigationRevision: Int
     /// Keep the destination anchored while loading replaces short placeholders with full diffs.
-    @State private var position = ScrollPosition(idType: String.self)
+    @State private var pendingDestination: String?
+    @State private var layoutRevision = 0
+    @State private var preparedPaths: Set<String> = []
     @State private var collapsedPaths: Set<String> = []
     @State private var hasNavigated = false
 
@@ -21,46 +23,66 @@ struct AllFilesReviewView: View {
             )
         } else {
             GeometryReader { geometry in
-                ScrollView(.vertical) {
-                    LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
-                        ForEach(model.changedFiles) { file in
-                            DiffView(
-                                model: model, file: file, embeddedWidth: geometry.size.width,
-                                embeddedViewportHeight: geometry.size.height,
-                                isCollapsed: collapsedPaths.contains(file.path),
-                                onScrollFocus: {
-                                    if model.selectedFilePath != file.path { model.selectedFilePath = file.path }
-                                },
-                                onToggleCollapsed: {
-                                    if !collapsedPaths.insert(file.path).inserted {
-                                        collapsedPaths.remove(file.path)
+                ScrollViewReader { reader in
+                    ScrollView(.vertical) {
+                        LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+                            ForEach(model.changedFiles) { file in
+                                DiffView(
+                                    model: model, file: file, embeddedWidth: geometry.size.width,
+                                    embeddedViewportHeight: geometry.size.height,
+                                    isCollapsed: collapsedPaths.contains(file.path),
+                                    onScrollFocus: {
+                                        if model.selectedFilePath != file.path { model.selectedFilePath = file.path }
+                                    },
+                                    onPrepared: {
+                                        preparedPaths.insert(file.path)
+                                        layoutRevision += 1
+                                    },
+                                    onToggleCollapsed: {
+                                        pendingDestination = nil
+                                        if !collapsedPaths.insert(file.path).inserted {
+                                            collapsedPaths.remove(file.path)
+                                        }
                                     }
-                                }
-                            )
+                                )
+                                .id(file.path)
+                            }
                         }
                     }
-                    .scrollTargetLayout()
-                }
-                .defaultScrollAnchor(.topLeading)
-                .scrollPosition($position)
-                .onScrollGeometryChange(for: Bool.self) { geometry in
-                    geometry.contentOffset.y <= geometry.contentInsets.top
-                } action: { _, atTop in
-                    if atTop, let path = model.changedFiles.first?.path,
-                       model.selectedFilePath != path {
-                        model.selectedFilePath = path
+                    .defaultScrollAnchor(.topLeading)
+                    .onScrollPhaseChange { _, phase in
+                        if phase == .tracking || phase == .interacting || phase == .decelerating {
+                            pendingDestination = nil
+                        }
                     }
-                }
-                .onChange(of: navigationRevision, initial: true) { _, _ in
-                    let requested = hasNavigated ? selectedPath : model.selectedFilePath ?? selectedPath
-                    hasNavigated = true
-                    let path = requested.isEmpty ? model.changedFiles.first?.path : requested
-                    guard let path, model.changedFiles.contains(where: { $0.path == path }) else { return }
-                    collapsedPaths.remove(path)
-                    position.scrollTo(id: path, anchor: .top)
-                }
-                .onChange(of: model.changedFiles.map(\.path)) { _, paths in
-                    collapsedPaths.formIntersection(paths)
+                    .onScrollGeometryChange(for: Bool.self) { geometry in
+                        geometry.contentOffset.y <= geometry.contentInsets.top
+                    } action: { _, atTop in
+                        if atTop, let path = model.changedFiles.first?.path,
+                           model.selectedFilePath != path {
+                            model.selectedFilePath = path
+                        }
+                    }
+                    .onChange(of: navigationRevision, initial: true) { _, _ in
+                        let requested = hasNavigated ? selectedPath : model.selectedFilePath ?? selectedPath
+                        hasNavigated = true
+                        let path = requested.isEmpty ? model.changedFiles.first?.path : requested
+                        guard let path, model.changedFiles.contains(where: { $0.path == path }) else { return }
+                        collapsedPaths.remove(path)
+                        pendingDestination = preparedPaths.contains(path) ? nil : path
+                        reader.scrollTo(path, anchor: .top)
+                    }
+                    .onChange(of: layoutRevision) { _, _ in
+                        if let path = pendingDestination {
+                            reader.scrollTo(path, anchor: .top)
+                            if preparedPaths.contains(path) { pendingDestination = nil }
+                        }
+                    }
+                    .onChange(of: model.changedFiles.map(\.path)) { _, paths in
+                        collapsedPaths.formIntersection(paths)
+                        preparedPaths.formIntersection(paths)
+                        if let pendingDestination, !paths.contains(pendingDestination) { self.pendingDestination = nil }
+                    }
                 }
             }
         }

--- a/Sources/Bloom/Views/Center/Panes/AllFilesReviewView.swift
+++ b/Sources/Bloom/Views/Center/Panes/AllFilesReviewView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import BloomCore
 
-/// File sections share one vertical scroller. Each diff keeps its horizontal scrolling,
+/// File sections share one vertical scroller. Each diff keeps its wrapped code,
 /// comments and viewed control, and loads only as its section approaches the viewport.
 struct AllFilesReviewView: View {
     let model: WorkspaceModel
@@ -10,6 +10,7 @@ struct AllFilesReviewView: View {
     /// Keep the destination anchored while loading replaces short placeholders with full diffs.
     @State private var position = ScrollPosition(idType: String.self)
     @State private var collapsedPaths: Set<String> = []
+    @State private var hasNavigated = false
 
     var body: some View {
         if model.changedFiles.isEmpty {
@@ -27,6 +28,9 @@ struct AllFilesReviewView: View {
                                 model: model, file: file, embeddedWidth: geometry.size.width,
                                 embeddedViewportHeight: geometry.size.height,
                                 isCollapsed: collapsedPaths.contains(file.path),
+                                onScrollFocus: {
+                                    if model.selectedFilePath != file.path { model.selectedFilePath = file.path }
+                                },
                                 onToggleCollapsed: {
                                     if !collapsedPaths.insert(file.path).inserted {
                                         collapsedPaths.remove(file.path)
@@ -40,8 +44,18 @@ struct AllFilesReviewView: View {
                 }
                 .defaultScrollAnchor(.topLeading)
                 .scrollPosition($position)
+                .onScrollGeometryChange(for: Bool.self) { geometry in
+                    geometry.contentOffset.y <= geometry.contentInsets.top
+                } action: { _, atTop in
+                    if atTop, let path = model.changedFiles.first?.path,
+                       model.selectedFilePath != path {
+                        model.selectedFilePath = path
+                    }
+                }
                 .onChange(of: navigationRevision, initial: true) { _, _ in
-                    let path = selectedPath.isEmpty ? model.changedFiles.first?.path : selectedPath
+                    let requested = hasNavigated ? selectedPath : model.selectedFilePath ?? selectedPath
+                    hasNavigated = true
+                    let path = requested.isEmpty ? model.changedFiles.first?.path : requested
                     guard let path, model.changedFiles.contains(where: { $0.path == path }) else { return }
                     collapsedPaths.remove(path)
                     position.scrollTo(id: path, anchor: .top)

--- a/Sources/Bloom/Views/Center/Panes/FileReview.swift
+++ b/Sources/Bloom/Views/Center/Panes/FileReview.swift
@@ -15,6 +15,7 @@ import BloomCore
 enum FileReview {
     /// Opens the workspace's review on a file, or points the open one at it.
     static func open(path: String, in model: WorkspaceModel) {
+        if model.changedFiles.contains(where: { $0.path == path }) { model.selectedFilePath = path }
         // Unchanged files and attachments still open on their own.
         if !model.changedFiles.contains(where: { $0.path == path }),
            let tab = CenterTabStore.shared.review(for: model.workspace.id) {
@@ -59,13 +60,20 @@ enum FileReview {
     /// saying nothing differs from the base branch yet. Refusing here, or greying the menu row
     /// out, is what made this read as a control that did nothing.
     static func open(in model: WorkspaceModel) {
-        let remembered = CenterTabStore.shared.review(for: model.workspace.id)?.path
+        let remembered = currentPath(in: model)
         let fallback = model.selectedFilePath ?? model.changedFiles.first?.path
         show(
             path: remembered.flatMap { $0.isEmpty ? nil : $0 } ?? fallback ?? "",
             in: model,
             focusing: true
         )
+    }
+
+    /// Scroll-follow is transient selection, not a navigation request. Keeping it out of
+    /// the tab store avoids rebuilding every tool pane and writing defaults while scrolling.
+    static func currentPath(in model: WorkspaceModel) -> String? {
+        let tab = CenterTabStore.shared.review(for: model.workspace.id)
+        return tab?.showsAllFiles == true ? model.selectedFilePath ?? tab?.path : tab?.path
     }
 
     static func openAll(in model: WorkspaceModel) {
@@ -77,7 +85,7 @@ enum FileReview {
     static func setShowsAllFiles(_ all: Bool, in model: WorkspaceModel) {
         let store = CenterTabStore.shared
         let remembered = store.review(for: model.workspace.id)?.path
-        let candidates = [remembered, model.selectedFilePath].compactMap { $0 }
+        let candidates = [model.selectedFilePath, remembered].compactMap { $0 }
         let path = candidates.first { candidate in
             model.changedFiles.contains { $0.path == candidate }
         } ?? model.changedFiles.first?.path ?? ""
@@ -113,7 +121,7 @@ enum FileReview {
         let files = model.changedFiles
         guard !files.isEmpty else { return }
 
-        let current = CenterTabStore.shared.review(for: model.workspace.id)?.path
+        let current = currentPath(in: model)
         let index = files.firstIndex { $0.path == current }
         let next = index.map { ($0 + delta + files.count) % files.count } ?? 0
 

--- a/Sources/Bloom/Views/Center/Panes/NotesMarkdownEditor.swift
+++ b/Sources/Bloom/Views/Center/Panes/NotesMarkdownEditor.swift
@@ -125,7 +125,11 @@ final class NotesEditorController: NSHostingController<NativeTextViewWrapper> {
         }
         if needsFocus, let textView, textView.isEditable, let window = view.window {
             needsFocus = false
-            window.makeFirstResponder(textView)
+            if AutomaticFocus.mayUpdateResponder(applicationIsActive: NSApp.isActive,
+                                                 windowIsKey: window.isKeyWindow,
+                                                 windowIsVisible: window.isVisible) {
+                window.makeFirstResponder(textView)
+            }
         }
         reportFocus()
     }

--- a/Sources/Bloom/Views/Code/WrappedCodeText.swift
+++ b/Sources/Bloom/Views/Code/WrappedCodeText.swift
@@ -1,0 +1,184 @@
+import AppKit
+import SwiftUI
+import BloomCore
+
+/// Measures with the same text engine, font and paragraph settings used to draw wrapped code.
+/// Cached per source line and width, so scrolling and hover never repeat text layout.
+@MainActor
+enum WrappedCodeLayout {
+    private struct Key: Hashable {
+        var text: String
+        var width: CGFloat
+    }
+    private static var heights: [Key: CGFloat] = [:]
+
+    static func paragraph(spacing: CGFloat = 0) -> NSParagraphStyle {
+        let style = NSMutableParagraphStyle()
+        style.minimumLineHeight = CodeMetrics.rowHeight
+        style.maximumLineHeight = CodeMetrics.rowHeight
+        style.lineBreakMode = .byWordWrapping
+        style.paragraphSpacing = spacing
+        style.tabStops = []
+        style.defaultTabInterval = CodeMetrics.advance * 4
+        return style
+    }
+
+    static func height(of text: String, width: CGFloat) -> CGFloat {
+        let width = max(1, width)
+        let key = Key(text: text, width: width)
+        if let height = heights[key] { return height }
+        let height: CGFloat
+        if !text.contains("\t"), (text as NSString).size(withAttributes: [.font: CodeMetrics.font]).width <= width {
+            height = CodeMetrics.rowHeight
+        } else {
+            let storage = NSTextStorage(string: text, attributes: [
+                .font: CodeMetrics.font, .paragraphStyle: paragraph(),
+            ])
+            let manager = NSLayoutManager()
+            manager.backgroundLayoutEnabled = false
+            storage.addLayoutManager(manager)
+            let container = NSTextContainer(size: NSSize(width: width, height: .greatestFiniteMagnitude))
+            container.lineFragmentPadding = 0
+            manager.addTextContainer(container)
+            manager.ensureLayout(for: container)
+            height = max(CodeMetrics.rowHeight, ceil(manager.usedRect(for: container).height))
+        }
+        if heights.count >= 8_192 { heights.removeAll(keepingCapacity: true) }
+        heights[key] = height
+        return height
+    }
+}
+
+/// Native soft wrapping preserves the original newlines on the clipboard. Paragraph spacing
+/// pads the shorter half of a side-by-side row without inserting characters into its text.
+struct WrappedCodeText: NSViewRepresentable {
+    var lines: [CodeRunLine]
+    var language: Language
+    var width: CGFloat
+    var heights: [CGFloat]
+    var onComment: (Int) -> Void
+    var onEdit: (Int) -> Void
+    var commentable: [Bool]
+    var editable: [Bool]
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> TextView {
+        let storage = NSTextStorage()
+        let manager = NSLayoutManager()
+        manager.backgroundLayoutEnabled = false
+        storage.addLayoutManager(manager)
+        let container = NSTextContainer(size: NSSize(width: width, height: .greatestFiniteMagnitude))
+        container.lineFragmentPadding = 0
+        container.widthTracksTextView = true
+        manager.addTextContainer(container)
+        let view = TextView(frame: .zero, textContainer: container)
+        view.isEditable = false
+        view.isSelectable = true
+        view.isRichText = true
+        view.drawsBackground = false
+        view.textContainerInset = .zero
+        view.isHorizontallyResizable = false
+        view.isVerticallyResizable = false
+        view.font = CodeMetrics.font
+        view.defaultParagraphStyle = WrappedCodeLayout.paragraph()
+        return view
+    }
+
+    func updateNSView(_ view: TextView, context: Context) {
+        view.rowHeights = heights
+        view.onComment = onComment
+        view.onEdit = onEdit
+        view.commentable = commentable
+        view.editableRows = editable
+        let previous = context.coordinator
+        guard previous.lines != lines || previous.language != language || previous.width != width
+                || previous.heights != heights || previous.scheme != colorScheme else { return }
+        previous.lines = lines
+        previous.language = language
+        previous.width = width
+        previous.heights = heights
+        previous.scheme = colorScheme
+
+        let value = NSMutableAttributedString(string: "")
+        for (index, line) in lines.enumerated() {
+            let highlighted = CodeText.attributed(
+                line: line.text, language: language, carry: line.carry,
+                emphasis: line.emphasis, emphasisColor: line.emphasisColor
+            )
+            let text = line.text + (index + 1 < lines.count ? "\n" : "")
+            let spacing = max(0, heights[index] - WrappedCodeLayout.height(of: line.text, width: width))
+            let paragraph = NSMutableAttributedString(string: text, attributes: [
+                .font: CodeMetrics.font, .paragraphStyle: WrappedCodeLayout.paragraph(spacing: spacing),
+                .foregroundColor: NSColor(Palette.textPrimary),
+            ])
+            var offset = 0
+            for run in highlighted.runs {
+                let length = String(highlighted[run.range].characters).utf16.count
+                let range = NSRange(location: offset, length: length)
+                if let color = run.foregroundColor {
+                    paragraph.addAttribute(.foregroundColor, value: NSColor(color), range: range)
+                }
+                if let color = run.backgroundColor {
+                    paragraph.addAttribute(.backgroundColor, value: NSColor(color), range: range)
+                }
+                offset += length
+            }
+            value.append(paragraph)
+        }
+        let selection = view.selectedRanges
+        let sameText = view.string == value.string
+        view.textContainer?.containerSize = NSSize(width: width, height: .greatestFiniteMagnitude)
+        view.textStorage?.setAttributedString(value)
+        if sameText { view.selectedRanges = selection }
+    }
+
+    final class Coordinator {
+        var lines: [CodeRunLine] = []
+        var language: Language?
+        var width: CGFloat = 0
+        var heights: [CGFloat] = []
+        var scheme: ColorScheme?
+    }
+
+    final class TextView: NSTextView {
+        var rowHeights: [CGFloat] = []
+        var commentable: [Bool] = []
+        var editableRows: [Bool] = []
+        var onComment: ((Int) -> Void)?
+        var onEdit: ((Int) -> Void)?
+        private var menuRow: Int?
+        private var menuComment: (() -> Void)?
+        private var menuEdit: (() -> Void)?
+
+        override func menu(for event: NSEvent) -> NSMenu? {
+            let point = convert(event.locationInWindow, from: nil)
+            menuRow = DiffDragRange.row(at: point.y, heights: rowHeights)
+            let row = menuRow
+            menuComment = row.flatMap { row in onComment.map { callback in { callback(row) } } }
+            menuEdit = row.flatMap { row in onEdit.map { callback in { callback(row) } } }
+            let menu = NSMenu()
+            menu.autoenablesItems = false
+            if let row = menuRow {
+                if commentable.indices.contains(row), commentable[row] {
+                    let item = menu.addItem(withTitle: "Comment on This Line", action: #selector(comment), keyEquivalent: "")
+                    item.target = self
+                }
+                if editableRows.indices.contains(row), editableRows[row] {
+                    let item = menu.addItem(withTitle: "Edit These Lines", action: #selector(edit), keyEquivalent: "")
+                    item.target = self
+                }
+            }
+            if !menu.items.isEmpty { menu.addItem(.separator()) }
+            let copy = menu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "")
+            copy.target = self
+            copy.isEnabled = selectedRange().length > 0
+            return menu
+        }
+
+        @objc private func comment() { menuComment?() }
+        @objc private func edit() { menuEdit?() }
+    }
+}

--- a/Sources/Bloom/Views/Code/WrappedCodeText.swift
+++ b/Sources/Bloom/Views/Code/WrappedCodeText.swift
@@ -65,6 +65,10 @@ struct WrappedCodeText: NSViewRepresentable {
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
+    func sizeThatFits(_ proposal: ProposedViewSize, nsView: TextView, context: Context) -> CGSize? {
+        CGSize(width: width, height: heights.reduce(0, +))
+    }
+
     func makeNSView(context: Context) -> TextView {
         let storage = NSTextStorage()
         let manager = NSLayoutManager()

--- a/Sources/Bloom/Views/Inspector/ChangedFileList.swift
+++ b/Sources/Bloom/Views/Inspector/ChangedFileList.swift
@@ -112,7 +112,7 @@ struct ChangedFileList: View {
                 // key. Only while this list holds the keyboard: a cursor that moved because the
                 // agent rewrote the file list must not drag the reader's scroll position with it.
                 .onChange(of: cursor) { _, path in
-                    guard hasKeyboard, let path else { return }
+                    guard hasKeyboard || followsReviewScroll, let path else { return }
                     proxy.scrollTo(path)
                 }
             }
@@ -137,7 +137,16 @@ struct ChangedFileList: View {
         // The keyboard follows a selection taken anywhere else: Command+Option+J, the review
         // pane's own walk, a file chip in the transcript.
         .onChange(of: model.selectedFilePath, initial: true) { _, path in
-            if let path, path != cursor { cursor = path }
+            if let path, path != cursor {
+                if followsReviewScroll {
+                    let parents = closedFolders.filter { path.hasPrefix($0 + "/") }
+                    if !parents.isEmpty {
+                        if filtered == nil { collapsed.subtract(parents) } else { filterCollapsed.subtract(parents) }
+                        rebuild()
+                    }
+                }
+                cursor = path
+            }
         }
         .onChange(of: cursor) { _, _ in refreshPreview() }
         .onChange(of: hasKeyboard) { _, focused in
@@ -174,6 +183,10 @@ struct ChangedFileList: View {
         } message: { problem in
             Text(problem.message)
         }
+    }
+
+    private var followsReviewScroll: Bool {
+        CenterTabStore.shared.review(for: model.workspace.id)?.showsAllFiles == true
     }
 
     private var list: some View {

--- a/Sources/Bloom/Views/Inspector/ChangedFileList.swift
+++ b/Sources/Bloom/Views/Inspector/ChangedFileList.swift
@@ -75,12 +75,8 @@ struct ChangedFileList: View {
             // Only over a diff there is something to narrow. A filter above "No changes yet" is a
             // control that cannot do anything, offered at the one moment it is useless.
             if !model.changedFiles.isEmpty {
-                HStack(spacing: 0) {
-                    InspectorFilterField(query: $query, onEscape: escape, onReturn: enterList)
-                    ReviewAllFilesToggle(model: model)
-                        .padding(.trailing, InspectorLayout.inset)
-                }
-                .background(Palette.surfaceSunken)
+                InspectorFilterField(query: $query, onEscape: escape, onReturn: enterList)
+                    .background(Palette.surfaceSunken)
                 Hairline()
             }
 

--- a/Sources/Bloom/Views/Inspector/DiffRowHover.swift
+++ b/Sources/Bloom/Views/Inspector/DiffRowHover.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import BloomCore
 
 /// Which row of a run the pointer is over, told by AppKit rather than by SwiftUI.
 ///
@@ -35,6 +36,7 @@ struct DiffRowHover: NSViewRepresentable {
     var rowHeight: CGFloat
     /// How many rows the run holds, so a point past the last one reports nothing.
     var rowCount: Int
+    var rowHeights: [CGFloat]?
     /// Called when the row under the pointer changes, and with nil when it leaves.
     var onChange: (Int?) -> Void
 
@@ -42,6 +44,7 @@ struct DiffRowHover: NSViewRepresentable {
         let view = RowHoverView()
         view.rowHeight = rowHeight
         view.rowCount = rowCount
+        view.rowHeights = rowHeights
         view.onChange = onChange
         return view
     }
@@ -49,6 +52,7 @@ struct DiffRowHover: NSViewRepresentable {
     func updateNSView(_ view: RowHoverView, context: Context) {
         view.rowHeight = rowHeight
         view.rowCount = rowCount
+        view.rowHeights = rowHeights
         // Reassigned every pass because the closure is a fresh allocation each time, which is the
         // same reason `DiffRunView.==` cannot compare it.
         view.onChange = onChange
@@ -57,6 +61,7 @@ struct DiffRowHover: NSViewRepresentable {
     final class RowHoverView: NSView {
         var rowHeight: CGFloat = 1
         var rowCount = 0
+        var rowHeights: [CGFloat]?
         var onChange: ((Int?) -> Void)?
 
         /// The last row reported, so a move within one row says nothing. A run is 400 rows at
@@ -129,6 +134,7 @@ struct DiffRowHover: NSViewRepresentable {
 
         private func report(at point: NSPoint) {
             guard rowHeight > 0, bounds.contains(point) else { return report(nil) }
+            if let rowHeights { return report(DiffDragRange.row(at: point.y, heights: rowHeights)) }
             let index = Int(point.y / rowHeight)
             report((0..<rowCount).contains(index) ? index : nil)
         }

--- a/Sources/Bloom/Views/Inspector/DiffRunView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffRunView.swift
@@ -46,6 +46,7 @@ struct DiffRunView: View, Equatable {
     /// Total width of the run, including gutters. Fixed by the file's widest line so the whole
     /// diff scrolls horizontally as one sheet.
     var width: CGFloat
+    var wrappedHeights: [CGFloat]?
     /// Opens the review comment editor at a line. Nil, the default, draws no `+` at all.
     var onComment: ((ReviewSpot) -> Void)?
     /// A drag from one row's `+`, reporting where it began and which line it has reached. Where
@@ -89,34 +90,71 @@ struct DiffRunView: View, Equatable {
             && lhs.language == rhs.language
             && lhs.numbers == rhs.numbers
             && lhs.width == rhs.width
+            && lhs.wrappedHeights == rhs.wrappedHeights
     }
 
     var body: some View {
         ZStack(alignment: .topLeading) {
-            // A comment splits this run, so eagerly rebuilding up to 400 rows of controls stalls
-            // the main thread. Keep the selectable text whole and realise only nearby controls.
-            LazyVStack(spacing: 0) {
-                ForEach(rows) { row in
-                    chrome(row)
+            if let wrappedHeights {
+                WrappedDiffChrome(
+                    lines: lines, heights: wrappedHeights, numbers: numbers,
+                    onComment: { index in
+                        if let spot = spot(of: lines[index]) { onComment?(spot) }
+                    },
+                    onEdit: { index in
+                        if let line = editableLine(of: lines[index]) { onEdit?(line) }
+                    },
+                    commentable: lines.map { spot(of: $0) != nil },
+                    editable: lines.map { editableLine(of: $0) != nil }
+                )
+                .overlay(alignment: .topLeading) {
+                    if let hovered, lines.indices.contains(hovered) {
+                        commentButton(Row(id: hovered, entry: lines[hovered], isHovered: true))
+                            .frame(height: CodeMetrics.rowHeight)
+                            .offset(y: wrappedHeights.prefix(hovered).reduce(0, +))
+                    }
+                }
+            } else {
+                LazyVStack(spacing: 0) {
+                    ForEach(rows) { row in chrome(row) }
                 }
             }
-            HStack(spacing: 0) {
-                CodeRunText(lines: runLines, language: language)
-                    .padding(.leading, columnsWidth)
-                    // The sentence a reader hears is the row's, assembled by `DiffGutter.speech`
-                    // and already carrying this line's text. Left visible, VoiceOver read the
-                    // whole run a second time as one undifferentiated block.
-                    .accessibilityHidden(true)
-                Spacer(minLength: 0)
+            if let wrappedHeights {
+                WrappedCodeText(
+                    lines: runLines, language: language,
+                    width: wrappedCodeWidth, heights: wrappedHeights,
+                    onComment: { index in
+                        if let spot = spot(of: lines[index]) { onComment?(spot) }
+                    },
+                    onEdit: { index in
+                        if let line = editableLine(of: lines[index]) { onEdit?(line) }
+                    },
+                    commentable: lines.map { spot(of: $0) != nil },
+                    editable: lines.map { editableLine(of: $0) != nil }
+                )
+                .frame(width: wrappedCodeWidth, height: wrappedHeights.reduce(0, +))
+                .padding(.leading, columnsWidth)
+                .accessibilityHidden(true)
+            } else {
+                HStack(spacing: 0) {
+                    CodeRunText(lines: runLines, language: language)
+                        .padding(.leading, columnsWidth)
+                        // The sentence a reader hears is the row's, assembled by `DiffGutter.speech`
+                        // and already carrying this line's text. Left visible, VoiceOver read the
+                        // whole run a second time as one undifferentiated block.
+                        .accessibilityHidden(true)
+                    Spacer(minLength: 0)
+                }
             }
         }
-        .frame(width: width, height: CodeMetrics.rowHeight * CGFloat(lines.count), alignment: .leading)
+        .frame(width: width, height: wrappedHeights?.reduce(0, +) ?? CodeMetrics.rowHeight * CGFloat(lines.count), alignment: .topLeading)
         // For `DiffLineView`'s reason: most of a diff row draws nothing, and without a shape the
         // pointer finds the run only along the band of pixels the glyphs cover.
         .contentShape(Rectangle())
         // Over everything, including the code, and hit testable by nothing. See `DiffRowHover`.
         .overlay {
-            DiffRowHover(rowHeight: CodeMetrics.rowHeight, rowCount: lines.count) { hovered = $0 }
+            DiffRowHover(rowHeight: CodeMetrics.rowHeight, rowCount: lines.count,
+                         rowHeights: wrappedHeights) { hovered = $0 }
         }
     }
 
@@ -152,7 +190,8 @@ struct DiffRunView: View, Equatable {
             DiffMarker(line: entry.line)
             Spacer(minLength: 0)
         }
-        .frame(width: width, height: CodeMetrics.rowHeight, alignment: .leading)
+        .frame(height: CodeMetrics.rowHeight)
+        .frame(width: width, height: wrappedHeights?[row.id] ?? CodeMetrics.rowHeight, alignment: .topLeading)
         // Collapsed here, above the overlay and never below it, for the reason spelled out on
         // `DiffLineView` and on `DiffCommentButton`: `children: .ignore` swallows every descendant
         // of what it is applied to, and a `+` inside the collapsed element is one no keyboard and
@@ -160,7 +199,7 @@ struct DiffRunView: View, Equatable {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(DiffGutter.speech(for: entry.line))
         .accessibilityHidden(entry.line == nil)
-        .overlay(alignment: .leading) { commentButton(row) }
+        .overlay(alignment: .topLeading) { commentButton(row).frame(height: CodeMetrics.rowHeight) }
         // The same action the `+` carries, on the right click as well, and for the reason written
         // out on `DiffLineView`.
         //
@@ -224,6 +263,7 @@ struct DiffRunView: View, Equatable {
                 from: index,
                 translation: travel,
                 rowHeight: CodeMetrics.rowHeight,
+                rowHeights: wrappedHeights,
                 spots: dragSpots,
                 side: spot.side
             ) else { return }
@@ -246,6 +286,10 @@ struct DiffRunView: View, Equatable {
     /// Where the code starts: both gutters in the unified layout, one in either half of the split,
     /// plus the marker column. The one number the code layer needs, and it is arithmetic rather
     /// than a measurement for the same reason the sheet's width is.
+    private var wrappedCodeWidth: CGFloat {
+        floor(max(1, width - columnsWidth - CodeMetrics.gutterPadding))
+    }
+
     private var columnsWidth: CGFloat {
         DiffGutter.width(for: numbers) + CodeMetrics.markerWidth
     }

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -681,7 +681,6 @@ struct DiffView: View {
             }
         } else {
             standaloneDiff(document)
-                .id(document.file)
         }
     }
 
@@ -694,6 +693,7 @@ struct DiffView: View {
                         rowView(row, document: document, width: width)
                     }
                 }
+                .id(document.file)
                 .frame(width: width, alignment: .leading)
             }
             // A scroll view with two axes CENTRES content that does not fill it, so a short diff

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -15,6 +15,7 @@ struct DiffView: View {
     let embeddedViewportHeight: CGFloat?
     let isCollapsed: Bool
     var onScrollFocus: (() -> Void)?
+    var onPrepared: (() -> Void)?
     var onToggleCollapsed: (() -> Void)?
 
     /// Above this many changed lines the diff is gated behind a tap. Rendering is lazy and would
@@ -149,7 +150,8 @@ struct DiffView: View {
     init(
         model: WorkspaceModel, file: ChangedFile, embeddedWidth: CGFloat? = nil,
         embeddedViewportHeight: CGFloat? = nil, isCollapsed: Bool = false,
-        onScrollFocus: (() -> Void)? = nil, onToggleCollapsed: (() -> Void)? = nil
+        onScrollFocus: (() -> Void)? = nil, onPrepared: (() -> Void)? = nil,
+        onToggleCollapsed: (() -> Void)? = nil
     ) {
         self.model = model
         self.file = file
@@ -157,6 +159,7 @@ struct DiffView: View {
         self.embeddedViewportHeight = embeddedViewportHeight
         self.isCollapsed = isCollapsed
         self.onScrollFocus = onScrollFocus
+        self.onPrepared = onPrepared
         self.onToggleCollapsed = onToggleCollapsed
         let absolute = (model.workspace.path as NSString).appendingPathComponent(file.path)
         _mode = State(initialValue: FileEditSession.shared.isDirty(absolute) ? .edit : .diff)
@@ -225,7 +228,6 @@ struct DiffView: View {
                     }
                 } header: {
                     fileHeader
-                        .id(file.path)
                         .onGeometryChange(for: Bool.self) { proxy in
                             let frame = proxy.frame(in: .scrollView(axis: .vertical))
                             return isCollapsed && frame.minY <= 0 && frame.maxY > 0
@@ -851,6 +853,7 @@ struct DiffView: View {
             revision: revision, document: document, rows: currentRows, width: width, heights: heights,
             codeHeight: heights.values.reduce(0) { $0 + $1.reduce(0, +) }
         )
+        onPrepared?()
         #if DEBUG
         if CommandLine.arguments.contains("--review-run-probe") {
             ReviewRunProbe.preparedLayouts[file.path] = "rows=\(currentRows.count), blocks=\(heights.count), height=\(heights.values.flatMap { $0 }.reduce(0, +)), width=\(width), viewport=\(embeddedViewportHeight ?? -1)"

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -14,6 +14,7 @@ struct DiffView: View {
     let embeddedWidth: CGFloat?
     let embeddedViewportHeight: CGFloat?
     let isCollapsed: Bool
+    var onScrollFocus: (() -> Void)?
     var onToggleCollapsed: (() -> Void)?
 
     /// Above this many changed lines the diff is gated behind a tap. Rendering is lazy and would
@@ -30,6 +31,22 @@ struct DiffView: View {
 
     @State private var phase: Phase = .loading
     @State private var rows: [DiffRow] = []
+    @State private var rowRevision = 0
+    @State private var wrappedPresentation: WrappedPresentation?
+
+    private struct WrapRequest: Equatable {
+        var width: CGFloat?
+        var revision: Int
+        var collapsed: Bool
+    }
+
+    private struct WrappedPresentation {
+        var revision: Int
+        var document: DiffDocument
+        var rows: [DiffRow]
+        var width: CGFloat
+        var heights: [String: [CGFloat]]
+    }
     @State private var expandedRuns: Set<Int> = []
     @State private var revealedGaps: [Int: Int] = [:]
     @State private var fileLines: [String]?
@@ -131,13 +148,14 @@ struct DiffView: View {
     init(
         model: WorkspaceModel, file: ChangedFile, embeddedWidth: CGFloat? = nil,
         embeddedViewportHeight: CGFloat? = nil, isCollapsed: Bool = false,
-        onToggleCollapsed: (() -> Void)? = nil
+        onScrollFocus: (() -> Void)? = nil, onToggleCollapsed: (() -> Void)? = nil
     ) {
         self.model = model
         self.file = file
         self.embeddedWidth = embeddedWidth
         self.embeddedViewportHeight = embeddedViewportHeight
         self.isCollapsed = isCollapsed
+        self.onScrollFocus = onScrollFocus
         self.onToggleCollapsed = onToggleCollapsed
         let absolute = (model.workspace.path as NSString).appendingPathComponent(file.path)
         _mode = State(initialValue: FileEditSession.shared.isDirty(absolute) ? .edit : .diff)
@@ -195,10 +213,23 @@ struct DiffView: View {
                 Section {
                     if !isCollapsed {
                         fileContent
+                            .onGeometryChange(for: Bool.self) { proxy in
+                                let frame = proxy.frame(in: .scrollView(axis: .vertical))
+                                let edge = InspectorLayout.reviewHeaderHeight
+                                return frame.minY <= edge && frame.maxY > edge
+                            } action: { active in
+                                if active { onScrollFocus?() }
+                            }
                             .overlay(alignment: .bottom) { Hairline() }
                     }
                 } header: {
                     fileHeader
+                        .onGeometryChange(for: Bool.self) { proxy in
+                            let frame = proxy.frame(in: .scrollView(axis: .vertical))
+                            return isCollapsed && frame.minY <= 0 && frame.maxY > 0
+                        } action: { active in
+                            if active { onScrollFocus?() }
+                        }
                         .overlay(alignment: .bottom) { Hairline() }
                 }
             } else {
@@ -222,6 +253,9 @@ struct DiffView: View {
                 return
             }
             await load()
+        }
+        .task(id: WrapRequest(width: embeddedWidth, revision: rowRevision, collapsed: isCollapsed)) {
+            await prepareWrappedRows()
         }
         .onChange(of: isSideBySide) { _, _ in rebuild() }
         .onChange(of: fileComments) { _, _ in rebuild() }
@@ -624,29 +658,30 @@ struct DiffView: View {
     @ViewBuilder
     private func diff(_ document: DiffDocument) -> some View {
         if let embeddedWidth {
-            let width = max(embeddedWidth, intrinsicWidth(document))
-            ScrollView(.horizontal) {
+            if let prepared = wrappedPresentation {
                 VStack(alignment: .leading, spacing: 0) {
-                    ForEach(rows) { row in
-                        if let count = row.codeLineCount, let embeddedViewportHeight {
-                            ReviewDiffBlock(
-                                height: CGFloat(count) * CodeMetrics.rowHeight,
-                                viewportHeight: embeddedViewportHeight
-                            ) {
-                                rowView(row, document: document, width: width)
+                    ForEach(prepared.rows) { row in
+                        if let heights = prepared.heights[row.id], let embeddedViewportHeight {
+                            ReviewDiffBlock(height: heights.reduce(0, +), viewportHeight: embeddedViewportHeight) {
+                                rowView(row, document: prepared.document, width: prepared.width, wrappedHeights: heights)
                             }
                         } else {
-                            rowView(row, document: document, width: width)
+                            rowView(row, document: prepared.document, width: prepared.width)
                         }
                     }
                 }
-                .frame(width: width, alignment: .leading)
+                .id(prepared.document.file)
+                .frame(width: embeddedWidth, alignment: .leading)
+                .clipped()
+                .disabled(prepared.revision != rowRevision)
+                .allowsHitTesting(prepared.revision == rowRevision)
+            } else {
+                LoadingView("Laying out the diff")
+                    .frame(width: embeddedWidth, height: 120)
             }
-            .fixedSize(horizontal: false, vertical: true)
-            .defaultScrollAnchor(.topLeading)
-            .scrollBounceBehavior(.basedOnSize)
         } else {
             standaloneDiff(document)
+                .id(document.file)
         }
     }
 
@@ -681,110 +716,192 @@ struct DiffView: View {
     }
 
     @ViewBuilder
-    private func rowView(_ row: DiffRow, document: DiffDocument, width: CGFloat) -> some View {
-        switch row {
-        case let .header(_, text):
-            DiffHunkHeaderView(text: text, width: width)
+    private func rowView(
+        _ row: DiffRow, document: DiffDocument, width: CGFloat, wrappedHeights: [CGFloat]? = nil
+    ) -> some View {
+        if let wrappedHeights {
+            wrappedRow(row, document: document, width: width, heights: wrappedHeights)
+        } else {
+            switch row {
+            case let .header(_, text):
+                DiffHunkHeaderView(text: text, width: width)
 
-        case let .runExpander(runID, hidden):
-            DiffExpanderView(title: "Expand \(Counted.of(hidden, "line"))", width: width) {
-                expandedRuns.insert(runID)
-                rebuild()
-            }
-
-        case let .gapExpander(gapID, hidden):
-            DiffExpanderView(
-                title: "Expand \(Counted.of(min(hidden, Self.gapStep), "line"))", width: width
-            ) {
-                revealedGaps[gapID, default: 0] += min(hidden, Self.gapStep)
-                rebuild()
-            }
-
-        case let .line(line):
-            DiffLineView(
-                line: line,
-                language: document.language,
-                carry: document.carries[line.index] ?? LexState(),
-                emphasis: document.emphasis[line.index] ?? [],
-                numbers: .both,
-                width: width,
-                isCommented: isCommented(line, numbers: .both),
-                onComment: { beginDraft(at: $0) },
-                onDragComment: { extendDrag(from: $0, to: $1) },
-                onEndCommentDrag: finishDrag,
-                onEdit: { beginEdit(at: $0) }
-            )
-            // Every pass over this diff rebuilds every row the stack has already realised, and a
-            // long file realises hundreds. Comparing the row's own values first is what keeps a
-            // second pass free, and the closure above is why it has to be said: see `DiffLineView`.
-            .equatable()
-
-        case let .commentBand(placement):
-            ReviewCommentBandView(
-                placement: placement,
-                width: width,
-                editing: editBinding(for: placement.comment.id),
-                onBeginEdit: { beginEdit(of: placement.comment) },
-                onCommitEdit: { commitEdit(of: placement.comment) },
-                onCancelEdit: { cancelEdit(of: placement.comment) },
-                onRemove: {
-                    let model = model
-                    Task { await model.removeReviewComment(id: placement.comment.id) }
+            case let .runExpander(runID, hidden):
+                DiffExpanderView(title: "Expand \(Counted.of(hidden, "line"))", width: width) {
+                    expandedRuns.insert(runID)
+                    rebuild()
                 }
-            )
 
-        case .commentEditor:
-            ReviewCommentEditorView(
-                // Read out of `reviewText` rather than off the draft, so a keystroke invalidates
-                // this one editor instead of everything that had to ask where the editor is. See
-                // `ReviewTextHost`.
-                text: Binding(
-                    get: { model.reviewText.drafts[file.path] ?? "" },
-                    set: { model.reviewText.drafts[file.path] = $0 }
-                ),
-                width: width,
-                onCommit: commitDraft,
-                onCancel: cancelDraft
-            )
+            case let .gapExpander(gapID, hidden):
+                DiffExpanderView(
+                    title: "Expand \(Counted.of(min(hidden, Self.gapStep), "line"))", width: width
+                ) {
+                    revealedGaps[gapID, default: 0] += min(hidden, Self.gapStep)
+                    rebuild()
+                }
 
-        case let .lineEditor(region):
-            DiffEditBandView(
-                region: region,
-                // Read out of `typed` rather than off the editor, so a keystroke invalidates this
-                // one band instead of everything that had to ask where the box is. The same split
-                // `ReviewTextHost` makes, and for the same measured reason.
-                text: edits.binding(for: absolutePath),
-                language: document.language,
-                status: edits.editor(for: absolutePath)?.status ?? .editing,
-                width: width,
-                onSave: saveEdit,
-                onCancel: cancelEdit
-            )
+            case let .line(line):
+                DiffLineView(
+                    line: line,
+                    language: document.language,
+                    carry: document.carries[line.index] ?? LexState(),
+                    emphasis: document.emphasis[line.index] ?? [],
+                    numbers: .both,
+                    width: width,
+                    isCommented: isCommented(line, numbers: .both),
+                    onComment: { if isCurrent(document) { beginDraft(at: $0) } },
+                    onDragComment: { if isCurrent(document) { extendDrag(from: $0, to: $1) } },
+                    onEndCommentDrag: {
+                        if isCurrent(document) { finishDrag() } else { rangeDrag = nil }
+                    },
+                    onEdit: { if isCurrent(document) { beginEdit(at: $0) } }
+                )
+                // Every pass over this diff rebuilds every row the stack has already realised, and a
+                // long file realises hundreds. Comparing the row's own values first is what keeps a
+                // second pass free, and the closure above is why it has to be said: see `DiffLineView`.
+                .equatable()
 
-        case let .pair(pair):
-            // The two panes split whatever the hairline between them leaves, so they stay the
-            // same width as each other on any display.
-            HStack(spacing: 0) {
-                let half = (width - Metrics.hairline) / 2
-                side(pair.left, document: document, numbers: .old, width: half)
-                Hairline(axis: .vertical)
-                side(pair.right, document: document, numbers: .new, width: half)
-            }
+            case let .commentBand(placement):
+                ReviewCommentBandView(
+                    placement: placement,
+                    width: width,
+                    editing: editBinding(for: placement.comment.id),
+                    onBeginEdit: { beginEdit(of: placement.comment) },
+                    onCommitEdit: { commitEdit(of: placement.comment) },
+                    onCancelEdit: { cancelEdit(of: placement.comment) },
+                    onRemove: {
+                        let model = model
+                        Task { await model.removeReviewComment(id: placement.comment.id) }
+                    }
+                )
 
-        case let .lineRun(lines):
-            run(lines.map(Optional.some), document: document, numbers: .both, width: width)
+            case .commentEditor:
+                ReviewCommentEditorView(
+                    // Read out of `reviewText` rather than off the draft, so a keystroke invalidates
+                    // this one editor instead of everything that had to ask where the editor is. See
+                    // `ReviewTextHost`.
+                    text: Binding(
+                        get: { model.reviewText.drafts[file.path] ?? "" },
+                        set: { model.reviewText.drafts[file.path] = $0 }
+                    ),
+                    width: width,
+                    onCommit: commitDraft,
+                    onCancel: cancelDraft
+                )
 
-        case let .pairRun(pairs):
-            // Each half is its own block, so a selection runs down one pane rather than zigzagging
-            // between them. That is what every side by side diff on the web does too, and the
-            // alternative is a copied fragment interleaving two versions of the same file.
-            HStack(spacing: 0) {
-                let half = (width - Metrics.hairline) / 2
-                run(pairs.map(\.left), document: document, numbers: .old, width: half)
-                Hairline(axis: .vertical)
-                run(pairs.map(\.right), document: document, numbers: .new, width: half)
+            case let .lineEditor(region):
+                DiffEditBandView(
+                    region: region,
+                    // Read out of `typed` rather than off the editor, so a keystroke invalidates this
+                    // one band instead of everything that had to ask where the box is. The same split
+                    // `ReviewTextHost` makes, and for the same measured reason.
+                    text: edits.binding(for: absolutePath),
+                    language: document.language,
+                    status: edits.editor(for: absolutePath)?.status ?? .editing,
+                    width: width,
+                    onSave: saveEdit,
+                    onCancel: cancelEdit
+                )
+
+            case let .pair(pair):
+                // The two panes split whatever the hairline between them leaves, so they stay the
+                // same width as each other on any display.
+                HStack(spacing: 0) {
+                    let half = (width - Metrics.hairline) / 2
+                    side(pair.left, document: document, numbers: .old, width: half)
+                    Hairline(axis: .vertical)
+                    side(pair.right, document: document, numbers: .new, width: half)
+                }
+
+            case let .lineRun(lines):
+                run(lines.map(Optional.some), document: document, numbers: .both, width: width)
+
+            case let .pairRun(pairs):
+                // Each half is its own block, so a selection runs down one pane rather than zigzagging
+                // between them. That is what every side by side diff on the web does too, and the
+                // alternative is a copied fragment interleaving two versions of the same file.
+                HStack(spacing: 0) {
+                    let half = (width - Metrics.hairline) / 2
+                    run(pairs.map(\.left), document: document, numbers: .old, width: half)
+                    Hairline(axis: .vertical)
+                    run(pairs.map(\.right), document: document, numbers: .new, width: half)
+                }
             }
         }
+    }
+
+    /// Layout is retained with the document and width, never recomputed by a scroll or hover.
+    /// Yield between runs so revealing a large diff cannot monopolise the main actor.
+    private func prepareWrappedRows() async {
+        guard let width = embeddedWidth, !isCollapsed, case let .ready(document) = phase else { return }
+        let currentRows = rows
+        let revision = rowRevision
+        var heights: [String: [CGFloat]] = [:]
+        for row in currentRows {
+            guard !Task.isCancelled else { return }
+            if let measured = wrappedHeights(for: row, width: width) { heights[row.id] = measured }
+            await Task.yield()
+        }
+        guard !Task.isCancelled else { return }
+        wrappedPresentation = WrappedPresentation(revision: revision, document: document, rows: currentRows, width: width, heights: heights)
+    }
+
+    private func wrappedHeights(for row: DiffRow, width: CGFloat) -> [CGFloat]? {
+        func height(_ line: DiffLine?, numbers: DiffGutter.Numbers, width: CGFloat) -> CGFloat {
+            let codeWidth = floor(max(1, width - DiffGutter.width(for: numbers)
+                - CodeMetrics.markerWidth - CodeMetrics.gutterPadding))
+            return WrappedCodeLayout.height(of: line?.text ?? "", width: codeWidth)
+        }
+        func pairHeight(_ pair: SideBySideRow) -> CGFloat {
+            let half = (width - Metrics.hairline) / 2
+            return max(height(pair.left, numbers: .old, width: half),
+                       height(pair.right, numbers: .new, width: half))
+        }
+        switch row {
+        case let .line(line) where line.kind != .noNewline:
+            return [height(line, numbers: .both, width: width)]
+        case let .lineRun(lines):
+            return lines.map { height($0, numbers: .both, width: width) }
+        case let .pair(pair) where pair.left?.kind != .noNewline && pair.right?.kind != .noNewline:
+            return [pairHeight(pair)]
+        case let .pairRun(pairs):
+            return pairs.map(pairHeight)
+        default:
+            return nil
+        }
+    }
+
+    @ViewBuilder
+    private func wrappedRow(_ row: DiffRow, document: DiffDocument, width: CGFloat, heights: [CGFloat]) -> some View {
+        switch row {
+        case let .line(line):
+            run([line], document: document, numbers: .both, width: width, wrappedHeights: heights)
+        case let .lineRun(lines):
+            run(lines, document: document, numbers: .both, width: width, wrappedHeights: heights)
+        case let .pair(pair):
+            wrappedPairs([pair], document: document, width: width, heights: heights)
+        case let .pairRun(pairs):
+            wrappedPairs(pairs, document: document, width: width, heights: heights)
+        default:
+            EmptyView()
+        }
+    }
+
+    private func wrappedPairs(
+        _ pairs: [SideBySideRow], document: DiffDocument, width: CGFloat, heights: [CGFloat]
+    ) -> some View {
+        let half = (width - Metrics.hairline) / 2
+        return HStack(spacing: 0) {
+            run(pairs.map(\.left), document: document, numbers: .old, width: half, wrappedHeights: heights)
+            Hairline(axis: .vertical)
+            run(pairs.map(\.right), document: document, numbers: .new, width: half, wrappedHeights: heights)
+        }
+    }
+
+    /// Pending native menu actions still refer to the document that was visible when opened.
+    private func isCurrent(_ displayed: DiffDocument) -> Bool {
+        guard case let .ready(current) = phase else { return false }
+        return current.file == displayed.file
     }
 
     /// A stretch of consecutive lines, drawn as one block of selectable text. One helper for both
@@ -793,7 +910,8 @@ struct DiffView: View {
         _ lines: [DiffLine?],
         document: DiffDocument,
         numbers: DiffLineView.Numbers,
-        width: CGFloat
+        width: CGFloat,
+        wrappedHeights: [CGFloat]? = nil
     ) -> some View {
         DiffRunView(
             lines: lines.map { line in
@@ -807,10 +925,13 @@ struct DiffView: View {
             language: document.language,
             numbers: numbers,
             width: width,
-            onComment: { beginDraft(at: $0) },
-            onDragComment: { extendDrag(from: $0, to: $1) },
-            onEndCommentDrag: finishDrag,
-            onEdit: { beginEdit(at: $0) }
+            wrappedHeights: wrappedHeights,
+            onComment: { if isCurrent(document) { beginDraft(at: $0) } },
+            onDragComment: { if isCurrent(document) { extendDrag(from: $0, to: $1) } },
+            onEndCommentDrag: {
+                if isCurrent(document) { finishDrag() } else { rangeDrag = nil }
+            },
+            onEdit: { if isCurrent(document) { beginEdit(at: $0) } }
         )
         // For the reason given at the per line call sites above, and up to four hundred times as
         // much of it: one of these stands in for a whole run of rows.
@@ -831,10 +952,12 @@ struct DiffView: View {
             numbers: numbers,
             width: width,
             isCommented: isCommented(line, numbers: numbers),
-            onComment: { beginDraft(at: $0) },
-            onDragComment: { extendDrag(from: $0, to: $1) },
-            onEndCommentDrag: finishDrag,
-            onEdit: { beginEdit(at: $0) }
+            onComment: { if isCurrent(document) { beginDraft(at: $0) } },
+            onDragComment: { if isCurrent(document) { extendDrag(from: $0, to: $1) } },
+            onEndCommentDrag: {
+                if isCurrent(document) { finishDrag() } else { rangeDrag = nil }
+            },
+            onEdit: { if isCurrent(document) { beginEdit(at: $0) } }
         )
         // For the reason given at the unified call site above, and twice as much of it: the split
         // layout builds two of these per row.
@@ -1184,6 +1307,7 @@ struct DiffView: View {
     // MARK: Row building
 
     private func rebuild() {
+        rowRevision += 1
         guard case let .ready(document) = phase else {
             rows = []
             placements = []

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -224,6 +224,7 @@ struct DiffView: View {
                     }
                 } header: {
                     fileHeader
+                        .id(file.path)
                         .onGeometryChange(for: Bool.self) { proxy in
                             let frame = proxy.frame(in: .scrollView(axis: .vertical))
                             return isCollapsed && frame.minY <= 0 && frame.maxY > 0

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -46,6 +46,7 @@ struct DiffView: View {
         var rows: [DiffRow]
         var width: CGFloat
         var heights: [String: [CGFloat]]
+        var codeHeight: CGFloat
     }
     @State private var expandedRuns: Set<Int> = []
     @State private var revealedGaps: [Int: Int] = [:]
@@ -307,9 +308,9 @@ struct DiffView: View {
         switch mode {
         case .diff:
             content
-                // Empty states have an intrinsic size; centre them in the whole pane.
-                // The actual diff fills this frame and owns its top-leading scroll anchor.
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                // A standalone diff fills its pane. A file section must grow with its code,
+                // rather than accepting the short height proposed for its loading placeholder.
+                .frame(maxWidth: .infinity, maxHeight: embeddedWidth == nil ? .infinity : nil)
                 // Both of these hang on the diff rather than on the view around it, and that
                 // is not tidiness: a second `.alert` and a second `.sheet` on one view is one
                 // presentation modifier of each kind too many, and which of the pair wins is
@@ -673,6 +674,8 @@ struct DiffView: View {
                 }
                 .id(prepared.document.file)
                 .frame(width: embeddedWidth, alignment: .leading)
+                .frame(minHeight: prepared.codeHeight, alignment: .top)
+                .fixedSize(horizontal: false, vertical: true)
                 .clipped()
                 .disabled(prepared.revision != rowRevision)
                 .allowsHitTesting(prepared.revision == rowRevision)
@@ -844,7 +847,15 @@ struct DiffView: View {
             await Task.yield()
         }
         guard !Task.isCancelled else { return }
-        wrappedPresentation = WrappedPresentation(revision: revision, document: document, rows: currentRows, width: width, heights: heights)
+        wrappedPresentation = WrappedPresentation(
+            revision: revision, document: document, rows: currentRows, width: width, heights: heights,
+            codeHeight: heights.values.reduce(0) { $0 + $1.reduce(0, +) }
+        )
+        #if DEBUG
+        if CommandLine.arguments.contains("--review-run-probe") {
+            ReviewRunProbe.preparedLayouts[file.path] = "rows=\(currentRows.count), blocks=\(heights.count), height=\(heights.values.flatMap { $0 }.reduce(0, +)), width=\(width), viewport=\(embeddedViewportHeight ?? -1)"
+        }
+        #endif
     }
 
     private func wrappedHeights(for row: DiffRow, width: CGFloat) -> [CGFloat]? {

--- a/Sources/Bloom/Views/Inspector/FileHeaderBar.swift
+++ b/Sources/Bloom/Views/Inspector/FileHeaderBar.swift
@@ -118,7 +118,7 @@ struct FileHeaderBar: View {
             }
         }
         .padding(.horizontal, InspectorLayout.inset)
-        .frame(height: onToggleCollapsed == nil ? InspectorLayout.barHeight : 40)
+        .frame(height: onToggleCollapsed == nil ? InspectorLayout.barHeight : InspectorLayout.reviewHeaderHeight)
         .background(Palette.surfaceSunken)
         .onGeometryChange(for: CGFloat.self) { $0.size.width } action: { width = $0 }
         .confirmationDialog(

--- a/Sources/Bloom/Views/Inspector/InspectorLayout.swift
+++ b/Sources/Bloom/Views/Inspector/InspectorLayout.swift
@@ -17,6 +17,7 @@ enum InspectorLayout {
     static let inset = Metrics.inset
     /// The tab row, and every other strip in the column.
     static let barHeight = Metrics.barHeight
+    static let reviewHeaderHeight: CGFloat = 40
     /// The pull request strip, which is taller than the rest of them on purpose.
     ///
     /// Derived from the type it holds, measured rather than guessed. `NSFont` reports the line

--- a/Sources/Bloom/Views/Inspector/InspectorToolbar.swift
+++ b/Sources/Bloom/Views/Inspector/InspectorToolbar.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 import BloomCore
 
-/// The inspector's own tab row: which pane, and the two chrome level choices that outlive
-/// whichever file happens to be selected.
+/// The inspector's tab row and actions for reviewing and arranging its files.
 ///
 /// Tabs connect the selected scope to the pane below. When the inspector becomes too narrow for
 /// the labels, `ViewThatFits` falls back to a pop-up button.
@@ -49,10 +48,9 @@ struct InspectorToolbar: View {
     private var trailing: some View {
         HStack(spacing: Metrics.spacingTight) {
             if model.inspectorTab == .changes {
-                // No Review toggle. It existed to hide this list so that the diff under it had
-                // room, and the diff is not under it any more: it is a tab in the centre column
-                // at the full height of the window, and the list stays beside it the whole time.
-                // Walking the files one at a time is Cmd+Option+J and K.
+                ReviewAllFilesToggle(model: model)
+                    .disabled(model.changedFiles.isEmpty)
+
                 Button {
                     isTree.toggle()
                 } label: {

--- a/Sources/Bloom/Views/Inspector/ReviewAllFilesToggle.swift
+++ b/Sources/Bloom/Views/Inspector/ReviewAllFilesToggle.swift
@@ -19,13 +19,13 @@ struct ReviewAllFilesToggle: View {
                 Text("Review all")
             }
             .font(Typo.captionEmphasis)
-            .foregroundStyle(isOn ? Palette.selectedEmphasizedText : Palette.textSecondary)
+            .foregroundStyle(isOn ? Palette.textPrimary : Palette.textSecondary)
             .padding(.horizontal, InspectorLayout.gap)
             .padding(.vertical, InspectorLayout.tight)
             .background {
                 RoundedRectangle(cornerRadius: Metrics.cornerSmall)
-                    .fill(isOn ? Palette.accent : Palette.surface)
-                    .strokeBorder(isOn ? Palette.accent : Palette.border, lineWidth: Metrics.outline)
+                    .fill(isOn ? Palette.selected : Palette.surface)
+                    .strokeBorder(Palette.border, lineWidth: Metrics.outline)
             }
             .contentShape(Rectangle())
         }

--- a/Sources/Bloom/Views/Inspector/ReviewAllFilesToggle.swift
+++ b/Sources/Bloom/Views/Inspector/ReviewAllFilesToggle.swift
@@ -13,21 +13,17 @@ struct ReviewAllFilesToggle: View {
             get: { isOn },
             set: { FileReview.setShowsAllFiles($0, in: model) }
         )) {
-            HStack(spacing: InspectorLayout.tight) {
-                Image(systemName: isOn ? "checkmark" : "doc.text")
-                    .frame(width: 12)
-                Text("Review all")
-            }
-            .font(Typo.captionEmphasis)
-            .foregroundStyle(isOn ? Palette.textPrimary : Palette.textSecondary)
-            .padding(.horizontal, InspectorLayout.gap)
-            .padding(.vertical, InspectorLayout.tight)
-            .background {
-                RoundedRectangle(cornerRadius: Metrics.cornerSmall)
-                    .fill(isOn ? Palette.selected : Palette.surface)
-                    .strokeBorder(Palette.border, lineWidth: Metrics.outline)
-            }
-            .contentShape(Rectangle())
+            Image(systemName: "doc.text")
+                .foregroundStyle(isOn ? Palette.textPrimary : Palette.textSecondary)
+                .frame(width: Metrics.controlHeight + 4, height: Metrics.controlHeight)
+                .background {
+                    if isOn {
+                        RoundedRectangle(cornerRadius: Metrics.cornerSmall)
+                            .fill(Palette.selected)
+                    }
+                }
+                .frame(width: Metrics.controlHeight + 8, height: InspectorLayout.barHeight)
+                .contentShape(Rectangle())
         }
         .toggleStyle(.button)
         .buttonStyle(.plain)

--- a/Sources/Bloom/Views/Inspector/WrappedDiffChrome.swift
+++ b/Sources/Bloom/Views/Inspector/WrappedDiffChrome.swift
@@ -1,0 +1,193 @@
+import AppKit
+import SwiftUI
+import BloomCore
+
+/// A single drawing surface for the washes and gutters. A wrapped run can span hundreds
+/// of visual rows; none of those needs a separate SwiftUI layout graph during scrolling.
+struct WrappedDiffChrome: NSViewRepresentable {
+    var lines: [DiffRunLine]
+    var heights: [CGFloat]
+    var numbers: DiffGutter.Numbers
+    var onComment: (Int) -> Void
+    var onEdit: (Int) -> Void
+    var commentable: [Bool]
+    var editable: [Bool]
+    @Environment(\.colorScheme) private var colorScheme
+
+    func makeNSView(context: Context) -> ChromeView {
+        let view = ChromeView()
+        view.toolTip = "Use Up and Down to choose a line, then Return to comment."
+        return view
+    }
+
+    func updateNSView(_ view: ChromeView, context: Context) {
+        view.onComment = onComment
+        view.onEdit = onEdit
+        view.commentable = commentable
+        view.editableRows = editable
+        guard view.lines != lines || view.heights != heights || view.numbers != numbers
+                || view.scheme != colorScheme else { return }
+        view.lines = lines
+        view.heights = heights
+        view.numbers = numbers
+        view.scheme = colorScheme
+        view.accessibleRows = nil
+        view.needsDisplay = true
+    }
+
+    final class ChromeView: NSView {
+        var lines: [DiffRunLine] = []
+        var heights: [CGFloat] = []
+        var numbers = DiffGutter.Numbers.both
+        var scheme: ColorScheme?
+        var onComment: ((Int) -> Void)?
+        var onEdit: ((Int) -> Void)?
+        var commentable: [Bool] = []
+        var editableRows: [Bool] = []
+        var accessibleRows: [NSAccessibilityElement]?
+        private var keyboardRow: Int?
+        private var menuRow: Int?
+        private var menuComment: (() -> Void)?
+        private var menuEdit: (() -> Void)?
+
+        override var isFlipped: Bool { true }
+        override var acceptsFirstResponder: Bool { commentable.contains(true) }
+        override var canBecomeKeyView: Bool { acceptsFirstResponder }
+
+        override func becomeFirstResponder() -> Bool {
+            keyboardRow = commentable.firstIndex(of: true)
+            needsDisplay = true
+            return true
+        }
+
+        override func resignFirstResponder() -> Bool {
+            keyboardRow = nil
+            needsDisplay = true
+            return true
+        }
+
+        override func keyDown(with event: NSEvent) {
+            guard let row = keyboardRow else { super.keyDown(with: event); return }
+            switch event.keyCode {
+            case 125, 126:
+                let candidates = commentable.indices.filter { commentable[$0] }
+                let next = event.keyCode == 125
+                    ? candidates.first(where: { $0 > row }) : candidates.last(where: { $0 < row })
+                if let next {
+                    keyboardRow = next
+                    scrollToVisible(NSRect(x: 0, y: heights.prefix(next).reduce(0, +),
+                                           width: bounds.width, height: heights[next]))
+                    needsDisplay = true
+                }
+            case 36, 49: onComment?(row)
+            case 48:
+                if event.modifierFlags.contains(.shift) {
+                    window?.selectPreviousKeyView(self)
+                } else {
+                    window?.selectNextKeyView(self)
+                }
+            default: super.keyDown(with: event)
+            }
+        }
+
+        override func setFrameSize(_ newSize: NSSize) {
+            let changed = newSize != frame.size
+            super.setFrameSize(newSize)
+            if changed { accessibleRows = nil; needsDisplay = true }
+        }
+
+        override func draw(_ dirtyRect: NSRect) {
+            var y: CGFloat = 0
+            let gutter = DiffGutter.width(for: numbers)
+            for (index, entry) in lines.enumerated() {
+                let rect = NSRect(x: 0, y: y, width: bounds.width, height: heights[index])
+                defer { y += heights[index] }
+                guard rect.intersects(dirtyRect) else { continue }
+                NSColor(DiffWash.background(of: entry.line)).setFill()
+                rect.fill()
+                if entry.isCommented { NSColor(Palette.reviewLine).setFill(); rect.fill() }
+                if keyboardRow == index, window?.firstResponder === self {
+                    NSColor.keyboardFocusIndicatorColor.setStroke()
+                    NSBezierPath(rect: rect.insetBy(dx: 1, dy: 1)).stroke()
+                }
+                if entry.line == nil {
+                    NSColor(Palette.surfaceSunken).setFill()
+                    NSRect(x: gutter, y: y, width: max(0, bounds.width - gutter), height: rect.height).fill()
+                }
+                let cell = CodeMetrics.numberWidth + CodeMetrics.gutterPadding
+                if numbers == .both {
+                    drawNumber(entry.line?.oldNumber, x: 0, y: y)
+                    drawNumber(entry.line?.newNumber, x: cell, y: y)
+                } else {
+                    drawNumber(numbers == .old ? entry.line?.oldNumber : entry.line?.newNumber, x: 0, y: y)
+                }
+                let marker = entry.line?.kind == .addition ? "+" : entry.line?.kind == .deletion ? "−" : ""
+                drawText(marker, x: gutter, y: y, width: CodeMetrics.markerWidth, rightAligned: false)
+            }
+        }
+
+        private func drawNumber(_ number: Int?, x: CGFloat, y: CGFloat) {
+            guard let number else { return }
+            drawText(String(number), x: x, y: y, width: CodeMetrics.numberWidth, rightAligned: true)
+        }
+
+        private func drawText(_ text: String, x: CGFloat, y: CGFloat, width: CGFloat, rightAligned: Bool) {
+            let value = NSAttributedString(string: text, attributes: [
+                .font: CodeMetrics.numberFont, .foregroundColor: NSColor(Palette.textTertiary),
+            ])
+            let size = value.size()
+            value.draw(at: NSPoint(x: x + (rightAligned ? width - size.width : (width - size.width) / 2),
+                                   y: y + (CodeMetrics.rowHeight - size.height) / 2))
+        }
+
+        override func accessibilityChildren() -> [Any]? {
+            if let accessibleRows { return accessibleRows }
+            var elements: [NSAccessibilityElement] = []
+            var y: CGFloat = 0
+            for (index, entry) in lines.enumerated() {
+                defer { y += heights[index] }
+                guard entry.line != nil else { continue }
+                let element = NSAccessibilityElement()
+                element.setAccessibilityRole(.row)
+                element.setAccessibilityLabel(DiffGutter.speech(for: entry.line))
+                element.setAccessibilityParent(self)
+                element.setAccessibilityFrameInParentSpace(NSRect(x: 0, y: y, width: bounds.width, height: heights[index]))
+                var actions: [NSAccessibilityCustomAction] = []
+                if commentable[index] {
+                    actions.append(NSAccessibilityCustomAction(name: "Comment on This Line") { [onComment] in
+                        onComment?(index)
+                        return true
+                    })
+                }
+                if editableRows[index] {
+                    actions.append(NSAccessibilityCustomAction(name: "Edit These Lines") { [onEdit] in
+                        onEdit?(index)
+                        return true
+                    })
+                }
+                element.setAccessibilityCustomActions(actions)
+                elements.append(element)
+            }
+            accessibleRows = elements
+            return elements
+        }
+
+        override func menu(for event: NSEvent) -> NSMenu? {
+            menuRow = DiffDragRange.row(at: convert(event.locationInWindow, from: nil).y, heights: heights)
+            guard let row = menuRow else { return nil }
+            menuComment = onComment.map { callback in { callback(row) } }
+            menuEdit = onEdit.map { callback in { callback(row) } }
+            let menu = NSMenu()
+            if commentable[row] {
+                menu.addItem(withTitle: "Comment on This Line", action: #selector(comment), keyEquivalent: "").target = self
+            }
+            if editableRows[row] {
+                menu.addItem(withTitle: "Edit These Lines", action: #selector(edit), keyEquivalent: "").target = self
+            }
+            return menu.items.isEmpty ? nil : menu
+        }
+
+        @objc private func comment() { menuComment?() }
+        @objc private func edit() { menuEdit?() }
+    }
+}

--- a/Sources/Bloom/Views/Inspector/WrappedDiffChrome.swift
+++ b/Sources/Bloom/Views/Inspector/WrappedDiffChrome.swift
@@ -14,6 +14,10 @@ struct WrappedDiffChrome: NSViewRepresentable {
     var editable: [Bool]
     @Environment(\.colorScheme) private var colorScheme
 
+    func sizeThatFits(_ proposal: ProposedViewSize, nsView: ChromeView, context: Context) -> CGSize? {
+        CGSize(width: proposal.width ?? nsView.bounds.width, height: heights.reduce(0, +))
+    }
+
     func makeNSView(context: Context) -> ChromeView {
         let view = ChromeView()
         view.toolTip = "Use Up and Down to choose a line, then Return to comment."

--- a/Sources/Bloom/Views/Inspector/WrappedDiffChrome.swift
+++ b/Sources/Bloom/Views/Inspector/WrappedDiffChrome.swift
@@ -67,6 +67,10 @@ struct WrappedDiffChrome: NSViewRepresentable {
         }
 
         override func keyDown(with event: NSEvent) {
+            if let row = keyboardRow, !commentable.indices.contains(row) || !commentable[row] {
+                keyboardRow = commentable.firstIndex(of: true)
+                needsDisplay = true
+            }
             guard let row = keyboardRow else { super.keyDown(with: event); return }
             switch event.keyCode {
             case 125, 126:

--- a/Sources/Bloom/Views/Terminal/TerminalView.swift
+++ b/Sources/Bloom/Views/Terminal/TerminalView.swift
@@ -552,15 +552,21 @@ final class TerminalHostView: NSView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        guard window != nil, isFocusedPane else { return }
-        // Give the shell the keyboard as soon as the tab is shown.
-        DispatchQueue.main.async { [weak self] in
-            self?.takeKeyboard()
+        guard let window, isFocusedPane else { return }
+        let previousResponder = window.firstResponder
+        // A later click wins over a focus request queued while this terminal was attaching.
+        DispatchQueue.main.async { [weak self, weak window, weak previousResponder] in
+            guard let self, let window, self.window === window,
+                  window.firstResponder === previousResponder else { return }
+            self.takeKeyboard()
         }
     }
 
     private func takeKeyboard() {
-        guard let terminal, let window, window.firstResponder !== terminal else { return }
+        guard isFocusedPane, let terminal, let window, window.firstResponder !== terminal,
+              AutomaticFocus.mayUpdateResponder(applicationIsActive: NSApp.isActive,
+                                                windowIsKey: window.isKeyWindow,
+                                                windowIsVisible: window.isVisible) else { return }
         window.makeFirstResponder(terminal)
     }
 }

--- a/Sources/BloomCore/Presentation/AutomaticFocus.swift
+++ b/Sources/BloomCore/Presentation/AutomaticFocus.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Redraws may prepare an unseen window, but must not change input focus in a visible
+/// background window. Its responder should survive switching between app instances.
+public enum AutomaticFocus {
+    public static func mayUpdateResponder(
+        applicationIsActive: Bool, windowIsKey: Bool, windowIsVisible: Bool
+    ) -> Bool {
+        !windowIsVisible || (applicationIsActive && windowIsKey)
+    }
+}

--- a/Sources/BloomCore/Presentation/DiffDragRange.swift
+++ b/Sources/BloomCore/Presentation/DiffDragRange.swift
@@ -62,16 +62,32 @@ public enum DiffDragRange {
     ///     is the merge base's copy of the file and the new side is the worktree's.
     /// - Returns: the line the range now ends at, or nil when no row between the start and the
     ///   pointer answers for that side, which the caller reads as "leave the range as it was".
+    /// Hit a logical source line after wrapping has given rows different heights.
+    public static func row(at offset: CGFloat, heights: [CGFloat]) -> Int? {
+        guard offset >= 0, offset.isFinite else { return nil }
+        var end: CGFloat = 0
+        for (index, height) in heights.enumerated() {
+            end += height
+            if offset < end { return index }
+        }
+        return nil
+    }
+
     public static func spot(
         from start: Int,
         translation: CGFloat,
         rowHeight: CGFloat,
+        rowHeights: [CGFloat]? = nil,
         spots: [ReviewSpot?],
         side: ReviewCommentSide
     ) -> ReviewSpot? {
-        let target = row(
-            from: start, translation: translation, rowHeight: rowHeight, count: spots.count
-        )
+        let target: Int
+        if let rowHeights, rowHeights.count == spots.count, rowHeights.indices.contains(start) {
+            let y = rowHeights.prefix(start).reduce(0, +) + rowHeight / 2 + translation
+            target = row(at: max(0, y), heights: rowHeights) ?? max(0, spots.count - 1)
+        } else {
+            target = row(from: start, translation: translation, rowHeight: rowHeight, count: spots.count)
+        }
         guard spots.indices.contains(target), spots.indices.contains(start) else { return nil }
         let step = target >= start ? -1 : 1
         var index = target

--- a/Tests/BloomCoreTests/AutomaticFocusTests.swift
+++ b/Tests/BloomCoreTests/AutomaticFocusTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import BloomCore
+
+@Suite("Automatic input focus")
+struct AutomaticFocusTests {
+    @Test("a background app cannot change the responder in its visible window")
+    func backgroundInstance() {
+        #expect(!AutomaticFocus.mayUpdateResponder(applicationIsActive: false, windowIsKey: true, windowIsVisible: true))
+        #expect(!AutomaticFocus.mayUpdateResponder(applicationIsActive: false, windowIsKey: false, windowIsVisible: true))
+    }
+
+    @Test("a sheet or another window keeps input focus")
+    func anotherWindow() {
+        #expect(!AutomaticFocus.mayUpdateResponder(applicationIsActive: true, windowIsKey: false, windowIsVisible: true))
+    }
+
+    @Test("the foreground window and unseen preparation can accept focus")
+    func intendedFocus() {
+        #expect(AutomaticFocus.mayUpdateResponder(applicationIsActive: true, windowIsKey: true, windowIsVisible: true))
+        #expect(AutomaticFocus.mayUpdateResponder(applicationIsActive: false, windowIsKey: false, windowIsVisible: false))
+    }
+}

--- a/Tests/BloomCoreTests/ReviewRangeTests.swift
+++ b/Tests/BloomCoreTests/ReviewRangeTests.swift
@@ -308,6 +308,24 @@ struct DiffDragRangeTests {
         #expect(DiffDragRange.row(from: 2, translation: -36, rowHeight: Self.rowHeight, count: 10) == 0)
     }
 
+    @Test("wrapped rows retain their source line for hover and drag")
+    func wrappedRows() {
+        let heights: [CGFloat] = [18, 72, 18]
+        #expect(DiffDragRange.row(at: 17, heights: heights) == 0)
+        #expect(DiffDragRange.row(at: 18, heights: heights) == 1)
+        #expect(DiffDragRange.row(at: 89, heights: heights) == 1)
+        #expect(DiffDragRange.row(at: 90, heights: heights) == 2)
+        #expect(DiffDragRange.row(at: 108, heights: heights) == nil)
+        #expect(DiffDragRange.row(at: -1, heights: heights) == nil)
+        let spots = (1...3).map { Optional(ReviewSpot(side: .new, line: $0)) }
+        #expect(DiffDragRange.spot(from: 0, translation: 70, rowHeight: 18,
+                                  rowHeights: heights, spots: spots, side: .new)?.line == 2)
+        #expect(DiffDragRange.spot(from: 0, translation: 82, rowHeight: 18,
+                                  rowHeights: heights, spots: spots, side: .new)?.line == 3)
+        #expect(DiffDragRange.spot(from: 2, translation: -25, rowHeight: 18,
+                                  rowHeights: heights, spots: spots, side: .new)?.line == 2)
+    }
+
     @Test("a drag is clamped to the block it began in")
     func clamps() {
         #expect(DiffDragRange.row(from: 1, translation: 900, rowHeight: Self.rowHeight, count: 4) == 3)

--- a/Tools/review-run-probe.sh
+++ b/Tools/review-run-probe.sh
@@ -77,6 +77,7 @@ except subprocess.TimeoutExpired:
 report = pathlib.Path(root, 'result.json').read_text()
 print(report)
 if not json.loads(report)['passed']:
+    print(pathlib.Path(root, 'probe.log').read_text(), file=sys.stderr)
     raise SystemExit(f'Probe failed; evidence: {root}')
 print(f'Probe evidence: {root}')
 PY

--- a/Tools/review-run-probe.sh
+++ b/Tools/review-run-probe.sh
@@ -22,6 +22,8 @@ codesign --force --deep --sign - "$probe_app" >/dev/null 2>&1
 # Refuse a release or stale binary, which would ignore the flag and start the application.
 python3 - "$probe_app/Contents/MacOS/Bloom" "$probe_root" "$@" <<'PY'
 import json
+import os
+import shutil
 import pathlib
 import subprocess
 import sys
@@ -77,6 +79,12 @@ except subprocess.TimeoutExpired:
 report = pathlib.Path(root, 'result.json').read_text()
 print(report)
 if not json.loads(report)['passed']:
+    if os.environ.get('RUNNER_TEMP'):
+        evidence = pathlib.Path(os.environ['RUNNER_TEMP'], 'bloom-review-probe')
+        evidence.mkdir(exist_ok=True)
+        for item in pathlib.Path(root).iterdir():
+            if item.suffix in {'.png', '.json', '.log'}:
+                shutil.copy2(item, evidence / item.name)
     print(pathlib.Path(root, 'probe.log').read_text(), file=sys.stderr)
     raise SystemExit(f'Probe failed; evidence: {root}')
 print(f'Probe evidence: {root}')

--- a/Tools/review-run-probe.sh
+++ b/Tools/review-run-probe.sh
@@ -62,7 +62,7 @@ git('-c', 'commit.gpgsign=false', '-c', 'user.name=Review Probe',
     '}\n'
 )
 (fixture / 'Sources/LongReview.swift').write_text(
-    ''.join(f'let reviewLine{line} = {line}\n' for line in range(120))
+    ''.join(f'let reviewLine{line} = {line}\n' for line in range(1800 if '--review-scroll-profile' in arguments else 120))
 )
 try:
     subprocess.run(


### PR DESCRIPTION
Wrap long lines to a consistent review width and keep the inspector selection aligned with the sticky file. Move the review toggle from the filter row into the inspector toolbar with a muted active state. Retain measured text layout and draw gutters natively to reduce scrolling work.

Preserve keyboard commenting, validate pending actions against the displayed diff, and give native text and file sections their full measured height. Prevent background windows from changing input focus and let newer clicks supersede queued terminal focus requests.

Validated with 136 native review checks, permanent-scrollbar and scrolling stress probes, focused core tests, app builds, and both linters. CI retains screenshots when a review probe fails.
