### PR TITLE
Close update window when installation is postponed

### DIFF
--- a/Sources/Bloom/System/SoftwareUpdater.swift
+++ b/Sources/Bloom/System/SoftwareUpdater.swift
@@ -182,6 +182,9 @@ final class SoftwareUpdater: NSObject, SPUUpdaterDelegate {
 
         Log.updates.info("Install postponed until \(running, privacy: .public) agents finish")
         postponedInstall = installHandler
+        // Dismiss Sparkle's UI while we wait. The relaunch callback above belongs to the updater,
+        // so it remains available after the user driver releases its windows and button handlers.
+        controller?.userDriver.dismissUpdateInstallation()
         waitForAgentsThenInstall()
         return true
     }


### PR DESCRIPTION
Dismiss the Ready to Install window after choosing Install When They Finish, while retaining the callback that installs the update once agents finish.