### PR TITLE
Add responsive browser previews

### DIFF
--- a/Sources/Bloom/BloomApp.swift
+++ b/Sources/Bloom/BloomApp.swift
@@ -12,6 +12,7 @@ struct BloomApp: App {
         if InspectorVisibilityProbe.isRequested { InspectorVisibilityProbe.runAndExit() }
         if MarkdownTableProbe.isRequested { MarkdownTableProbe.runAndExit() }
         #endif
+        if BrowserViewportDemo.isRequested { BrowserViewportDemo.schedule() }
         // First, before anything else in the process. Every `@AppStorage` binding in the app
         // resolves its key the moment the view holding it is created, and a binding that has
         // already answered from an empty domain would then WRITE that empty answer back, which

--- a/Sources/Bloom/Design/BrowserViewportDemo.swift
+++ b/Sources/Bloom/Design/BrowserViewportDemo.swift
@@ -120,12 +120,8 @@ private struct BrowserViewportDemoView: View {
         VStack(spacing: 0) {
             BrowserToolbarView(
                 toolbar: BrowserToolbar(), address: $address, addressFocus: $addressFocused,
-                isRingVisible: addressFocused, isResponsive: session.viewport.isEnabled,
-                toggleResponsive: { session.viewport.isEnabled.toggle() }
+                isRingVisible: addressFocused, viewport: $session.viewport
             )
-            if session.viewport.isEnabled {
-                BrowserViewportBar(viewport: $session.viewport)
-            }
             Hairline()
             BrowserViewportView(session: session)
         }

--- a/Sources/Bloom/Design/BrowserViewportDemo.swift
+++ b/Sources/Bloom/Design/BrowserViewportDemo.swift
@@ -1,0 +1,134 @@
+import AppKit
+import BloomCore
+import SwiftUI
+
+/// An interactive fixture using the production viewport and controls. Available only in an
+/// isolated app, so checking layout never opens a workspace or talks to an agent.
+@MainActor
+enum BrowserViewportDemo {
+    static var isRequested: Bool { CommandLine.arguments.contains("--browser-viewport-demo") }
+    private static var window: NSWindow?
+
+    static func schedule() {
+        guard Bundle.main.bundleIdentifier == "be.spatie.bloom.dev" else { return }
+        Task {
+            try? await Task.sleep(for: .seconds(1))
+            let session = BrowserSession(url: "")
+            session.viewport.isEnabled = true
+            session.webView.loadHTMLString(page, baseURL: nil)
+            let demo = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 1000, height: 820),
+                styleMask: [.titled, .closable, .miniaturizable, .resizable],
+                backing: .buffered, defer: false
+            )
+            demo.title = "[DEV] Responsive preview"
+            demo.isReleasedWhenClosed = false
+            demo.contentView = NSHostingView(rootView: BrowserViewportDemoView(session: session))
+            demo.center()
+            demo.orderFrontRegardless()
+            window = demo
+            if let index = CommandLine.arguments.firstIndex(of: "--viewport-checks"),
+               CommandLine.arguments.indices.contains(index + 1) {
+                await check(session, window: demo, output: CommandLine.arguments[index + 1])
+            }
+        }
+    }
+
+    private static func check(_ session: BrowserSession, window: NSWindow, output: String) async {
+        var results: [[String: Any]] = []
+        do {
+            for _ in 0..<100 where session.webView.isLoading {
+                try await Task.sleep(for: .milliseconds(100))
+            }
+            _ = try await session.webView.evaluateJavaScript("document.querySelector('input').value = 'Kept across resizing'")
+            for (width, height, fit) in [(390, 844, true), (1440, 900, true), (768, 1024, true), (844, 390, true), (1440, 900, false)] {
+                session.viewport.resize(width: width, height: height)
+                session.viewport.fitsPane = fit
+                try await Task.sleep(for: .milliseconds(450))
+                window.contentView?.layoutSubtreeIfNeeded()
+                let actual = try await session.webView.evaluateJavaScript(
+                    "[innerWidth, innerHeight, document.querySelector('input').value, matchMedia('(min-width: 1000px)').matches]"
+                ) as? [Any] ?? []
+                results.append([
+                    "requested": [width, height], "fit": fit, "actual": actual,
+                    "passed": (actual.first as? Int == width) && (actual.dropFirst().first as? Int == height)
+                        && (actual.dropFirst(2).first as? String == "Kept across resizing")
+                        && (actual.last as? Bool == (width >= 1000)),
+                ])
+            }
+            session.viewport.isEnabled = false
+            try await Task.sleep(for: .milliseconds(450))
+            let normal = try await session.webView.evaluateJavaScript("[innerWidth, innerHeight]") as? [Int] ?? []
+            results.append(["normal": normal, "passed": normal.first == 1000])
+            session.viewport.isEnabled = true
+            session.viewport.fitsPane = true
+            session.viewport.select(.phone)
+            try await Task.sleep(for: .milliseconds(450))
+            let restored = try await session.webView.evaluateJavaScript("[innerWidth, innerHeight]") as? [Int] ?? []
+            results.append(["restored": restored, "passed": restored == [390, 844]])
+        } catch {
+            results.append(["passed": false, "error": error.localizedDescription])
+        }
+        do {
+            let data = try JSONSerialization.data(withJSONObject: results, options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: URL(fileURLWithPath: output))
+        } catch {
+            FileHandle.standardError.write(Data("Viewport checks could not be written: \(error)\n".utf8))
+        }
+    }
+
+    private static let page = """
+    <!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+    * { box-sizing: border-box } body { margin: 0; color: #24392f; background: #f5f3ec;
+    font: 16px -apple-system, sans-serif } header { padding: 24px 28px; border-bottom: 1px solid #d9ded3;
+    display: flex; justify-content: space-between; align-items: center } header b { font-size: 22px }
+    nav { display: flex; gap: 28px } main { padding: 42px 28px; max-width: 1240px; margin: auto }
+    .eyebrow { text-transform: uppercase; letter-spacing: 2px; font-size: 11px; color: #60786a }
+    h1 { font: 54px Georgia, serif; line-height: 1.05; letter-spacing: -2px; max-width: 620px; margin: 18px 0 }
+    .intro { max-width: 510px; line-height: 1.65; color: #607065 }
+    .grid { display: grid; grid-template-columns: 1fr; gap: 18px; margin-top: 32px }
+    article { border: 1px solid #d9ded3; border-radius: 12px; padding: 26px; background: #fffcf5 }
+    .number { color: #7c8d72; font: 38px Georgia, serif } h2 { font-size: 18px; margin-top: 22px }
+    article p { font-size: 14px; line-height: 1.6; color: #607065 }
+    input { font: inherit; padding: 12px; border: 1px solid #b7c5b2; border-radius: 6px; max-width: 100%; width: 350px }
+    label { display: block; margin: 32px 0 10px; font-size: 13px }
+    .wide { display: none } @media(min-width: 600px) { .grid { grid-template-columns: repeat(2, 1fr) } }
+    @media(min-width: 1000px) { .grid { grid-template-columns: repeat(3, 1fr) } h1 { font-size: 72px }
+    .wide { display: inline } } @media(max-width: 599px) { nav { display: none } }
+    </style></head><body>
+    <header><b>Fieldwork.</b><nav><span>Work</span><span>Studio</span><span>Contact</span></nav></header>
+    <main><div class="eyebrow">Independent design studio <span class="wide"> / Desktop layout</span></div>
+    <h1>Good things.<br>Thoughtfully made.</h1><p class="intro">A small studio for useful ideas, considered details,
+    and websites that feel at home on every screen.</p>
+    <div class="grid"><article><div class="number">01</div><h2>A clear starting point</h2>
+    <p>Give your ideas room to grow. Find the structure that makes everything feel simple.</p></article>
+    <article><div class="number">02</div><h2>Details that matter</h2><p>From the first impression to the smallest
+    interaction, make every part feel considered.</p></article><article><div class="number">03</div>
+    <h2>Room for every screen</h2><p>Try the presets above or drag the page edges. This grid responds to its real viewport.</p></article></div>
+    <label for="note">Your notes stay here while you resize</label><input id="note" placeholder="Try typing something…">
+    </main></body></html>
+    """
+}
+
+private struct BrowserViewportDemoView: View {
+    @Bindable var session: BrowserSession
+    @State private var address = "Responsive preview example"
+    @FocusState private var addressFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            BrowserToolbarView(
+                toolbar: BrowserToolbar(), address: $address, addressFocus: $addressFocused,
+                isRingVisible: addressFocused, isResponsive: session.viewport.isEnabled,
+                toggleResponsive: { session.viewport.isEnabled.toggle() }
+            )
+            if session.viewport.isEnabled {
+                BrowserViewportBar(viewport: $session.viewport)
+            }
+            Hairline()
+            BrowserViewportView(session: session)
+        }
+        .background(Palette.surface)
+    }
+}

--- a/Sources/Bloom/Design/BrowserViewportDemo.swift
+++ b/Sources/Bloom/Design/BrowserViewportDemo.swift
@@ -6,7 +6,12 @@ import SwiftUI
 /// isolated app, so checking layout never opens a workspace or talks to an agent.
 @MainActor
 enum BrowserViewportDemo {
-    static var isRequested: Bool { CommandLine.arguments.contains("--browser-viewport-demo") }
+    static var isRequested: Bool {
+        CommandLine.arguments.contains("--browser-viewport-demo") || checksAreHidden
+    }
+    private static var checksAreHidden: Bool {
+        CommandLine.arguments.contains("--browser-viewport-checks")
+    }
     private static var window: NSWindow?
 
     static func schedule() {
@@ -25,11 +30,17 @@ enum BrowserViewportDemo {
             demo.isReleasedWhenClosed = false
             demo.contentView = NSHostingView(rootView: BrowserViewportDemoView(session: session))
             demo.center()
-            demo.orderFrontRegardless()
+            if !checksAreHidden { demo.orderFrontRegardless() }
+            demo.contentView?.layoutSubtreeIfNeeded()
             window = demo
-            if let index = CommandLine.arguments.firstIndex(of: "--viewport-checks"),
+            if let index = CommandLine.arguments.firstIndex(of: "--browser-viewport-checks")
+                ?? CommandLine.arguments.firstIndex(of: "--viewport-checks"),
                CommandLine.arguments.indices.contains(index + 1) {
                 await check(session, window: demo, output: CommandLine.arguments[index + 1])
+                if checksAreHidden {
+                    demo.close()
+                    window = nil
+                }
             }
         }
     }
@@ -41,7 +52,7 @@ enum BrowserViewportDemo {
                 try await Task.sleep(for: .milliseconds(100))
             }
             _ = try await session.webView.evaluateJavaScript("document.querySelector('input').value = 'Kept across resizing'")
-            for (width, height, fit) in [(390, 844, true), (1440, 900, true), (768, 1024, true), (844, 390, true), (1440, 900, false)] {
+            for (width, height, fit) in [(390, 844, true), (1440, 900, true), (768, 1024, true), (844, 390, true), (1440, 900, false), (703, 1002, true)] {
                 session.viewport.resize(width: width, height: height)
                 session.viewport.fitsPane = fit
                 try await Task.sleep(for: .milliseconds(450))
@@ -49,11 +60,13 @@ enum BrowserViewportDemo {
                 let actual = try await session.webView.evaluateJavaScript(
                     "[innerWidth, innerHeight, document.querySelector('input').value, matchMedia('(min-width: 1000px)').matches]"
                 ) as? [Any] ?? []
+                let fillsViewport = try await paintedToEdges(session)
                 results.append([
+                    "paintedToEdges": fillsViewport,
                     "requested": [width, height], "fit": fit, "actual": actual,
                     "passed": (actual.first as? Int == width) && (actual.dropFirst().first as? Int == height)
                         && (actual.dropFirst(2).first as? String == "Kept across resizing")
-                        && (actual.last as? Bool == (width >= 1000)),
+                        && (actual.last as? Bool == (width >= 1000)) && fillsViewport,
                 ])
             }
             session.viewport.isEnabled = false
@@ -77,8 +90,23 @@ enum BrowserViewportDemo {
         }
     }
 
+    /// A correct innerWidth alone missed a white strip at the right and bottom of large
+    /// previews. The fixture has a cream background at both right corners at every breakpoint.
+    private static func paintedToEdges(_ session: BrowserSession) async throws -> Bool {
+        let image = try await session.webView.takeSnapshot(configuration: nil)
+        guard let tiff = image.tiffRepresentation, let bitmap = NSBitmapImageRep(data: tiff) else { return false }
+        return [12, bitmap.pixelsHigh - 12].allSatisfy { y in
+            guard let colour = bitmap.colorAt(x: bitmap.pixelsWide - 12, y: y)?.usingColorSpace(.sRGB) else {
+                return false
+            }
+            return abs(colour.redComponent - 245.0 / 255) < 0.02
+                && abs(colour.greenComponent - 243.0 / 255) < 0.02
+                && abs(colour.blueComponent - 236.0 / 255) < 0.02
+        }
+    }
+
     private static let page = """
-    <!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1">
+    <!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
     * { box-sizing: border-box } body { margin: 0; color: #24392f; background: #f5f3ec;
     font: 16px -apple-system, sans-serif } header { padding: 24px 28px; border-bottom: 1px solid #d9ded3;

--- a/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserSession.swift
@@ -29,6 +29,8 @@ final class BrowserSession {
     /// the web view, so the two move between panes together.
     let pageView = BrowserHostView()
 
+    var viewport = BrowserViewport()
+
     private(set) var canGoBack = false
     private(set) var canGoForward = false
     private(set) var isLoading = false

--- a/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
@@ -51,6 +51,10 @@ struct BrowserTabView: View {
         VStack(spacing: 0) {
             toolbar(session)
             Hairline()
+            if session.viewport.isEnabled {
+                BrowserViewportBar(viewport: Binding(get: { session.viewport }, set: { session.viewport = $0 }))
+                Hairline()
+            }
             if session.find.isShowing {
                 BrowserFindBar(
                     find: session.find,
@@ -66,7 +70,7 @@ struct BrowserTabView: View {
                 )
             }
             ZStack {
-                BrowserWebView(session: session, paneMenu: pageMenu, host: host)
+                BrowserViewportView(session: session, paneMenu: pageMenu, host: host)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
 
                 // A tab nobody has given an address is a white rectangle under a toolbar, which
@@ -151,6 +155,8 @@ struct BrowserTabView: View {
                 if session.isLoading { session.webView.stopLoading() } else { session.reload() }
             },
             capture: capture,
+            isResponsive: session.viewport.isEnabled,
+            toggleResponsive: { session.viewport.isEnabled.toggle() },
             submit: {
                 session.load(address)
                 isAddressFocused = false
@@ -241,7 +247,9 @@ struct BrowserTabView: View {
     private func pageMenu() -> NSMenu {
         let menu = paneMenu?() ?? NSMenu()
 
-        var items: [NSMenuItem] = []
+        var items: [NSMenuItem] = [item(
+            session.viewport.isEnabled ? "Exit Responsive Preview" : "Responsive Preview"
+        ) { session.viewport.isEnabled.toggle() }]
         // Never the raw address. What may be handed to another application is `BrowserAddress`'s
         // decision, because the string was written by the page.
         if let url = BrowserAddress.external(from: session.displayAddress) {

--- a/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
@@ -51,10 +51,6 @@ struct BrowserTabView: View {
         VStack(spacing: 0) {
             toolbar(session)
             Hairline()
-            if session.viewport.isEnabled {
-                BrowserViewportBar(viewport: Binding(get: { session.viewport }, set: { session.viewport = $0 }))
-                Hairline()
-            }
             if session.find.isShowing {
                 BrowserFindBar(
                     find: session.find,
@@ -155,8 +151,7 @@ struct BrowserTabView: View {
                 if session.isLoading { session.webView.stopLoading() } else { session.reload() }
             },
             capture: capture,
-            isResponsive: session.viewport.isEnabled,
-            toggleResponsive: { session.viewport.isEnabled.toggle() },
+            viewport: Binding(get: { session.viewport }, set: { session.viewport = $0 }),
             submit: {
                 session.load(address)
                 isAddressFocused = false
@@ -248,7 +243,7 @@ struct BrowserTabView: View {
         let menu = paneMenu?() ?? NSMenu()
 
         var items: [NSMenuItem] = [item(
-            session.viewport.isEnabled ? "Exit Responsive Preview" : "Responsive Preview"
+            session.viewport.isEnabled ? "Restore Full Browser Size" : "Responsive Preview"
         ) { session.viewport.isEnabled.toggle() }]
         // Never the raw address. What may be handed to another application is `BrowserAddress`'s
         // decision, because the string was written by the page.

--- a/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
@@ -161,6 +161,15 @@ struct BrowserToolbarView: View {
             BrowserViewportButton(viewport: viewport)
                 .frame(width: pageActionWidth, height: Metrics.controlHeight)
             Hairline(axis: .vertical)
+            pageAction(BrowserToolbar.Control(
+                symbol: "arrow.up.left.and.arrow.down.right",
+                name: "Full size",
+                help: "Restore the page to the full browser pane",
+                isEnabled: viewport.wrappedValue.isEnabled
+            )) {
+                viewport.wrappedValue.isEnabled = false
+            }
+            Hairline(axis: .vertical)
             pageAction(toolbar.reload, action: reloadOrStop)
             Hairline(axis: .vertical)
             pageAction(toolbar.screenshot, action: capture)

--- a/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
@@ -65,6 +65,8 @@ struct BrowserToolbarView: View {
     var goToHistory: @MainActor (Int) -> Void = { _ in }
     var reloadOrStop: @MainActor () -> Void = {}
     var capture: @MainActor () -> Void = {}
+    var isResponsive = false
+    var toggleResponsive: @MainActor () -> Void = {}
     var submit: @MainActor () -> Void = {}
 
     /// Drawn inside the field's own edge rather than outside it, so the bar does not have to give
@@ -157,6 +159,16 @@ struct BrowserToolbarView: View {
     /// action's hover and pressed feedback.
     private var pageActions: some View {
         HStack(spacing: 0) {
+            Button(action: toggleResponsive) {
+                Label("Responsive Preview", systemImage: "iphone.and.ipad")
+                    .labelStyle(.iconOnly)
+                    .foregroundStyle(isResponsive ? Palette.accent : Palette.textSecondary)
+            }
+            .buttonStyle(.accessoryBar)
+            .frame(width: pageActionWidth, height: Metrics.controlHeight)
+            .help(isResponsive ? "Exit responsive preview" : "Preview at phone, tablet and desktop sizes")
+            .accessibilityValue(isResponsive ? "On" : "Off")
+            Hairline(axis: .vertical)
             pageAction(toolbar.reload, action: reloadOrStop)
             Hairline(axis: .vertical)
             pageAction(toolbar.screenshot, action: capture)

--- a/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
@@ -65,8 +65,7 @@ struct BrowserToolbarView: View {
     var goToHistory: @MainActor (Int) -> Void = { _ in }
     var reloadOrStop: @MainActor () -> Void = {}
     var capture: @MainActor () -> Void = {}
-    var isResponsive = false
-    var toggleResponsive: @MainActor () -> Void = {}
+    var viewport: Binding<BrowserViewport> = .constant(BrowserViewport())
     var submit: @MainActor () -> Void = {}
 
     /// Drawn inside the field's own edge rather than outside it, so the bar does not have to give
@@ -159,15 +158,8 @@ struct BrowserToolbarView: View {
     /// action's hover and pressed feedback.
     private var pageActions: some View {
         HStack(spacing: 0) {
-            Button(action: toggleResponsive) {
-                Label("Responsive Preview", systemImage: "iphone.and.ipad")
-                    .labelStyle(.iconOnly)
-                    .foregroundStyle(isResponsive ? Palette.accent : Palette.textSecondary)
-            }
-            .buttonStyle(.accessoryBar)
-            .frame(width: pageActionWidth, height: Metrics.controlHeight)
-            .help(isResponsive ? "Exit responsive preview" : "Preview at phone, tablet and desktop sizes")
-            .accessibilityValue(isResponsive ? "On" : "Off")
+            BrowserViewportButton(viewport: viewport)
+                .frame(width: pageActionWidth, height: Metrics.controlHeight)
             Hairline(axis: .vertical)
             pageAction(toolbar.reload, action: reloadOrStop)
             Hairline(axis: .vertical)

--- a/Sources/Bloom/Views/Center/Browser/BrowserViewportBar.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserViewportBar.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import BloomCore
 
-/// Revealed only during responsive preview, leaving the address bar room for the page's URL.
+/// Compact controls shared by the toolbar popover and the interactive preview fixture.
 struct BrowserViewportBar: View {
     @Binding var viewport: BrowserViewport
 
@@ -22,7 +22,6 @@ struct BrowserViewportBar: View {
         .padding(.horizontal, Metrics.spacingWide)
         .padding(.vertical, Metrics.spacingSmall)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Palette.surfaceSunken)
     }
 
     private var presets: some View {
@@ -49,24 +48,32 @@ struct BrowserViewportBar: View {
             }
         } label: {
             Text(viewport.preset?.rawValue ?? "Custom")
-                .frame(width: 82, alignment: .leading)
         }
+        // Native menu buttons derive their intrinsic size from the title, ignoring a frame on
+        // the label. Constrain the control itself so Phone, Custom and Small phone align alike.
+        .frame(width: 110)
         .help("Choose a viewport size")
         .accessibilityLabel("Viewport preset")
     }
 
     private var dimensions: some View {
         HStack(spacing: 4) {
-            dimension("Width", value: viewport.width) { viewport.resize(width: $0, height: viewport.height) }
+            dimension("Width", value: viewport.width) {
+                viewport.resize(width: $0, height: viewport.height)
+            }
             Text("×").foregroundStyle(Palette.textSecondary)
-            dimension("Height", value: viewport.height) { viewport.resize(width: viewport.width, height: $0) }
+            dimension("Height", value: viewport.height) {
+                viewport.resize(width: viewport.width, height: $0)
+            }
         }
         .help("Viewport dimensions in CSS pixels")
     }
 
     private var actions: some View {
         HStack(spacing: Metrics.spacingSmall) {
-            Button("Rotate", systemImage: "rotate.right") { viewport.rotate() }
+            Button("Rotate", systemImage: "rotate.right") {
+                viewport.rotate()
+            }
                 .labelStyle(.iconOnly)
                 .help("Swap viewport width and height")
             Picker("Preview scale", selection: $viewport.fitsPane) {
@@ -107,7 +114,7 @@ private struct ViewportDimensionField: View {
     }
 
     private func commit() {
-        if let number = Int(text.trimmingCharacters(in: .whitespaces)) { change(number) }
+        if let number = Int(text.trimmingCharacters(in: .whitespaces)), number != value { change(number) }
         text = String(value)
     }
 }

--- a/Sources/Bloom/Views/Center/Browser/BrowserViewportBar.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserViewportBar.swift
@@ -19,8 +19,6 @@ struct BrowserViewportBar: View {
         }
         .controlSize(.small)
         .font(Typo.label)
-        .padding(.horizontal, Metrics.spacingWide)
-        .padding(.vertical, Metrics.spacingSmall)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
@@ -51,7 +49,7 @@ struct BrowserViewportBar: View {
         }
         // Native menu buttons derive their intrinsic size from the title, ignoring a frame on
         // the label. Constrain the control itself so Phone, Custom and Small phone align alike.
-        .frame(width: 110)
+        .frame(width: 110, alignment: .leading)
         .help("Choose a viewport size")
         .accessibilityLabel("Viewport preset")
     }

--- a/Sources/Bloom/Views/Center/Browser/BrowserViewportBar.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserViewportBar.swift
@@ -9,12 +9,12 @@ struct BrowserViewportBar: View {
         ViewThatFits(in: .horizontal) {
             HStack(spacing: Metrics.spacingSmall) {
                 presets
-                dimensions
-                actions
+                dimensions.disabled(!viewport.isEnabled)
+                actions.disabled(!viewport.isEnabled)
             }
             VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
-                HStack { presets; Spacer(); actions }
-                dimensions
+                HStack { presets; Spacer(); actions.disabled(!viewport.isEnabled) }
+                dimensions.disabled(!viewport.isEnabled)
             }
         }
         .controlSize(.small)
@@ -24,9 +24,12 @@ struct BrowserViewportBar: View {
 
     private var presets: some View {
         Menu {
+            Button("Full size") { viewport.isEnabled = false }
+            Divider()
             ForEach(BrowserViewport.Preset.allCases, id: \.self) { preset in
                 Button("\(preset.rawValue) (\(preset.width) × \(preset.height))") {
                     viewport.select(preset)
+                    viewport.isEnabled = true
                 }
             }
             if !viewport.savedSizes.isEmpty {
@@ -34,6 +37,7 @@ struct BrowserViewportBar: View {
                     ForEach(viewport.savedSizes, id: \.self) { size in
                         Button("\(size.width) × \(size.height)") {
                             viewport.resize(width: size.width, height: size.height)
+                            viewport.isEnabled = true
                         }
                     }
                 }
@@ -45,7 +49,7 @@ struct BrowserViewportBar: View {
                 Button("Remove Saved Sizes") { viewport.removeSavedSizes() }
             }
         } label: {
-            Text(viewport.preset?.rawValue ?? "Custom")
+            Text(viewport.isEnabled ? (viewport.preset?.rawValue ?? "Custom") : "Full size")
         }
         // Native menu buttons derive their intrinsic size from the title, ignoring a frame on
         // the label. Constrain the control itself so Phone, Custom and Small phone align alike.

--- a/Sources/Bloom/Views/Center/Browser/BrowserViewportBar.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserViewportBar.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import BloomCore
+
+/// Revealed only during responsive preview, leaving the address bar room for the page's URL.
+struct BrowserViewportBar: View {
+    @Binding var viewport: BrowserViewport
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: Metrics.spacingSmall) {
+                presets
+                dimensions
+                actions
+            }
+            VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
+                HStack { presets; Spacer(); actions }
+                dimensions
+            }
+        }
+        .controlSize(.small)
+        .font(Typo.label)
+        .padding(.horizontal, Metrics.spacingWide)
+        .padding(.vertical, Metrics.spacingSmall)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Palette.surfaceSunken)
+    }
+
+    private var presets: some View {
+        Menu {
+            ForEach(BrowserViewport.Preset.allCases, id: \.self) { preset in
+                Button("\(preset.rawValue) (\(preset.width) × \(preset.height))") {
+                    viewport.select(preset)
+                }
+            }
+            if !viewport.savedSizes.isEmpty {
+                Section("Saved sizes") {
+                    ForEach(viewport.savedSizes, id: \.self) { size in
+                        Button("\(size.width) × \(size.height)") {
+                            viewport.resize(width: size.width, height: size.height)
+                        }
+                    }
+                }
+            }
+            Divider()
+            Button("Save Current Size") { viewport.saveSize() }
+                .disabled(!viewport.canSaveSize)
+            if !viewport.savedSizes.isEmpty {
+                Button("Remove Saved Sizes") { viewport.removeSavedSizes() }
+            }
+        } label: {
+            Text(viewport.preset?.rawValue ?? "Custom")
+                .frame(width: 82, alignment: .leading)
+        }
+        .help("Choose a viewport size")
+        .accessibilityLabel("Viewport preset")
+    }
+
+    private var dimensions: some View {
+        HStack(spacing: 4) {
+            dimension("Width", value: viewport.width) { viewport.resize(width: $0, height: viewport.height) }
+            Text("×").foregroundStyle(Palette.textSecondary)
+            dimension("Height", value: viewport.height) { viewport.resize(width: viewport.width, height: $0) }
+        }
+        .help("Viewport dimensions in CSS pixels")
+    }
+
+    private var actions: some View {
+        HStack(spacing: Metrics.spacingSmall) {
+            Button("Rotate", systemImage: "rotate.right") { viewport.rotate() }
+                .labelStyle(.iconOnly)
+                .help("Swap viewport width and height")
+            Picker("Preview scale", selection: $viewport.fitsPane) {
+                Text("Fit").tag(true)
+                Text("100%").tag(false)
+            }
+            .labelsHidden()
+            .frame(width: 72)
+            .help("Scale the preview to fit, or show it at actual size")
+        }
+    }
+
+    private func dimension(_ name: String, value: Int, change: @escaping (Int) -> Void) -> some View {
+        ViewportDimensionField(name: name, value: value, change: change)
+    }
+}
+
+/// Commit a whole number on Return or focus loss. Clamping each keystroke would turn the first
+/// digit of 1440 into 240 before the reader could finish typing.
+private struct ViewportDimensionField: View {
+    var name: String
+    var value: Int
+    var change: (Int) -> Void
+    @State private var text = ""
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        TextField(name, text: $text)
+            .textFieldStyle(.roundedBorder)
+            .monospacedDigit()
+            .multilineTextAlignment(.trailing)
+            .frame(width: 56)
+            .focused($focused)
+            .accessibilityLabel("Viewport \(name.lowercased()) in CSS pixels")
+            .onSubmit(commit)
+            .onChange(of: focused) { if !focused { commit() } }
+            .onChange(of: value, initial: true) { text = String(value) }
+    }
+
+    private func commit() {
+        if let number = Int(text.trimmingCharacters(in: .whitespaces)) { change(number) }
+        text = String(value)
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserViewportButton.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserViewportButton.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+import BloomCore
+
+/// Size controls live behind the toolbar button so previewing a narrow page does not cost a
+/// permanent second toolbar. Closing the popover keeps the viewport; Full size leaves preview.
+struct BrowserViewportButton: View {
+    @Binding var viewport: BrowserViewport
+    @State private var showsControls = false
+
+    var body: some View {
+        Button {
+            if !viewport.isEnabled { viewport.isEnabled = true }
+            showsControls.toggle()
+        } label: {
+            Label("Responsive Preview", systemImage: "iphone.and.ipad")
+                .labelStyle(.iconOnly)
+                .foregroundStyle(viewport.isEnabled ? Palette.accent : Palette.textSecondary)
+        }
+        .buttonStyle(.accessoryBar)
+        .help(viewport.isEnabled
+            ? "Viewport: \(viewport.width) × \(viewport.height). Show size controls or restore full size"
+            : "Preview at phone, tablet and desktop sizes")
+        .accessibilityValue(viewport.isEnabled ? "\(viewport.width) × \(viewport.height)" : "Full size")
+        .popover(isPresented: $showsControls, arrowEdge: .bottom) {
+            VStack(alignment: .leading, spacing: Metrics.spacingWide) {
+                HStack {
+                    Text("Responsive preview").font(Typo.labelEmphasis)
+                    Spacer()
+                    Button("Full size") {
+                        viewport.isEnabled = false
+                        showsControls = false
+                    }
+                    .disabled(!viewport.isEnabled)
+                    .help("Restore the page to the full browser pane")
+                }
+                .padding(.horizontal, Metrics.spacingWide)
+                BrowserViewportBar(viewport: $viewport)
+            }
+            .controlSize(.small)
+            .padding(.vertical, Metrics.spacingWide)
+            .frame(width: 410)
+        }
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserViewportButton.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserViewportButton.swift
@@ -12,7 +12,7 @@ struct BrowserViewportButton: View {
             if !viewport.isEnabled { viewport.isEnabled = true }
             showsControls.toggle()
         } label: {
-            Label("Responsive Preview", systemImage: "iphone.and.ipad")
+            Label("Responsive Preview", systemImage: "ipad.and.iphone")
                 .labelStyle(.iconOnly)
                 .foregroundStyle(viewport.isEnabled ? Palette.accent : Palette.textSecondary)
         }
@@ -22,7 +22,7 @@ struct BrowserViewportButton: View {
             : "Preview at phone, tablet and desktop sizes")
         .accessibilityValue(viewport.isEnabled ? "\(viewport.width) × \(viewport.height)" : "Full size")
         .popover(isPresented: $showsControls, arrowEdge: .bottom) {
-            VStack(alignment: .leading, spacing: Metrics.spacingWide) {
+            VStack(alignment: .leading, spacing: 16) {
                 HStack {
                     Text("Responsive preview").font(Typo.labelEmphasis)
                     Spacer()
@@ -33,12 +33,14 @@ struct BrowserViewportButton: View {
                     .disabled(!viewport.isEnabled)
                     .help("Restore the page to the full browser pane")
                 }
-                .padding(.horizontal, Metrics.spacingWide)
                 BrowserViewportBar(viewport: $viewport)
             }
             .controlSize(.small)
-            .padding(.vertical, Metrics.spacingWide)
-            .frame(width: 410)
+            .padding(20)
+            .frame(width: 430)
+        }
+        .onChange(of: viewport.isEnabled) {
+            if !viewport.isEnabled { showsControls = false }
         }
     }
 }

--- a/Sources/Bloom/Views/Center/Browser/BrowserViewportButton.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserViewportButton.swift
@@ -9,7 +9,6 @@ struct BrowserViewportButton: View {
 
     var body: some View {
         Button {
-            if !viewport.isEnabled { viewport.isEnabled = true }
             showsControls.toggle()
         } label: {
             Label("Responsive Preview", systemImage: "ipad.and.iphone")
@@ -23,24 +22,20 @@ struct BrowserViewportButton: View {
         .accessibilityValue(viewport.isEnabled ? "\(viewport.width) × \(viewport.height)" : "Full size")
         .popover(isPresented: $showsControls, arrowEdge: .bottom) {
             VStack(alignment: .leading, spacing: 16) {
-                HStack {
-                    Text("Responsive preview").font(Typo.labelEmphasis)
-                    Spacer()
-                    Button("Full size") {
-                        viewport.isEnabled = false
-                        showsControls = false
-                    }
-                    .disabled(!viewport.isEnabled)
-                    .help("Restore the page to the full browser pane")
-                }
+                Text("Responsive preview").font(Typo.labelEmphasis)
                 BrowserViewportBar(viewport: $viewport)
+                Divider()
+                Button("Full size", systemImage: "arrow.up.left.and.arrow.down.right") {
+                    viewport.isEnabled = false
+                    showsControls = false
+                }
+                .buttonStyle(.borderless)
+                .disabled(!viewport.isEnabled)
+                .help("Restore the page to the full browser pane")
             }
             .controlSize(.small)
             .padding(20)
             .frame(width: 430)
-        }
-        .onChange(of: viewport.isEnabled) {
-            if !viewport.isEnabled { showsControls = false }
         }
     }
 }

--- a/Sources/Bloom/Views/Center/Browser/BrowserViewportHostView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserViewportHostView.swift
@@ -1,0 +1,45 @@
+import AppKit
+
+/// Magnify the document through AppKit's scroll container. Scaling BrowserHostView's bounds
+/// directly leaves WebKit's remote drawing surface clipped to its old visible rectangle. Page
+/// zoom paints correctly but rounds CSS dimensions, which can miss a breakpoint by a pixel.
+final class BrowserViewportHostView: NSView {
+    private let scrollView = NSScrollView()
+    var viewportSize: CGSize? {
+        didSet { if oldValue != viewportSize { needsLayout = true } }
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+        scrollView.hasHorizontalScroller = false
+        scrollView.hasVerticalScroller = false
+        scrollView.minMagnification = 0.01
+        scrollView.maxMagnification = 1
+        addSubview(scrollView)
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    func attach(_ view: NSView) {
+        guard scrollView.documentView !== view else { return }
+        view.removeFromSuperview()
+        view.autoresizingMask = []
+        scrollView.documentView = view
+        needsLayout = true
+    }
+
+    override func layout() {
+        super.layout()
+        guard let page = scrollView.documentView, bounds.width > 0, bounds.height > 0 else { return }
+        scrollView.frame = bounds
+        let size = viewportSize ?? bounds.size
+        page.frame = CGRect(origin: .zero, size: size)
+        let scale = min(1, bounds.width / size.width, bounds.height / size.height)
+        if scrollView.magnification != scale { scrollView.magnification = scale }
+        scrollView.contentView.scroll(to: .zero)
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        page.layoutSubtreeIfNeeded()
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserViewportView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserViewportView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+import BloomCore
+
+/// The live page stays at one structural identity while its native coordinate space changes.
+/// The surrounding scroll view makes oversized previews reachable at 100 percent.
+struct BrowserViewportView: View {
+    @Bindable var session: BrowserSession
+    var paneMenu: (@MainActor () -> NSMenu)?
+    var host = BrowserPaneHost()
+    @State private var drag: ResizeStart?
+
+    private let gutter: CGFloat = 18
+
+    var body: some View {
+        GeometryReader { geometry in
+            let viewport = session.viewport
+            let padding = viewport.isEnabled ? gutter : 0
+            let scale = viewport.scale(
+                availableWidth: geometry.size.width - padding * 2,
+                availableHeight: geometry.size.height - padding * 2
+            )
+            let width = viewport.isEnabled ? CGFloat(viewport.width) * scale : geometry.size.width
+            let height = viewport.isEnabled ? CGFloat(viewport.height) * scale : geometry.size.height
+            ScrollView([.horizontal, .vertical]) {
+                BrowserWebView(
+                    session: session, paneMenu: paneMenu, host: host,
+                    viewportSize: viewport.isEnabled
+                        ? CGSize(width: viewport.width, height: viewport.height) : nil
+                )
+                .frame(width: width, height: height)
+                .overlay {
+                    if viewport.isEnabled {
+                        Rectangle().strokeBorder(Palette.border, lineWidth: 1)
+                            .allowsHitTesting(false)
+                    }
+                }
+                .overlay(alignment: .leading) {
+                    if viewport.isEnabled {
+                        handle(.left, scale: scale, centred: width + padding * 2 < geometry.size.width)
+                            .offset(x: -gutter)
+                    }
+                }
+                .overlay(alignment: .trailing) {
+                    if viewport.isEnabled {
+                        handle(.right, scale: scale, centred: width + padding * 2 < geometry.size.width)
+                            .offset(x: gutter)
+                    }
+                }
+                .overlay(alignment: .bottom) {
+                    if viewport.isEnabled {
+                        handle(.bottom, scale: scale, centred: false).offset(y: gutter)
+                    }
+                }
+                .padding(padding)
+                .frame(minWidth: geometry.size.width, minHeight: geometry.size.height, alignment: .top)
+            }
+            .scrollDisabled(!viewport.isEnabled)
+            .background(viewport.isEnabled ? Palette.surfaceSunken : Palette.surface)
+        }
+        .clipped()
+    }
+
+    private func handle(_ edge: Edge, scale: Double, centred: Bool) -> some View {
+        Capsule()
+            .fill(Palette.textTertiary)
+            .frame(width: edge == .bottom ? 32 : 4, height: edge == .bottom ? 4 : 32)
+            .frame(width: edge == .bottom ? 64 : gutter, height: edge == .bottom ? gutter : 64)
+            .contentShape(Rectangle())
+            .help(edge == .bottom ? "Drag to resize viewport height" : "Drag to resize viewport width")
+            .accessibilityLabel(edge == .bottom ? "Viewport height" : "Viewport width")
+            .accessibilityValue("\(edge == .bottom ? session.viewport.height : session.viewport.width) pixels")
+            .accessibilityAdjustableAction { direction in
+                let step = direction == .increment ? 10 : -10
+                session.viewport.resize(
+                    width: session.viewport.width + (edge == .bottom ? 0 : step),
+                    height: session.viewport.height + (edge == .bottom ? step : 0)
+                )
+            }
+            .gesture(DragGesture(minimumDistance: 0, coordinateSpace: .global)
+                .onChanged { value in
+                    if drag == nil {
+                        drag = ResizeStart(viewport: session.viewport, scale: scale, centred: centred)
+                    }
+                    guard let drag else { return }
+                    let horizontal = value.translation.width / drag.scale * (drag.centred ? 2 : 1)
+                    session.viewport.resize(
+                        width: drag.viewport.width + (edge == .bottom ? 0 : Int(horizontal * (edge == .left ? -1 : 1))),
+                        height: drag.viewport.height + (edge == .bottom ? Int(value.translation.height / drag.scale) : 0)
+                    )
+                }
+                .onEnded { _ in drag = nil })
+    }
+
+    private enum Edge { case left, right, bottom }
+    private struct ResizeStart {
+        var viewport: BrowserViewport
+        var scale: Double
+        var centred: Bool
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserViewportView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserViewportView.swift
@@ -66,6 +66,7 @@ struct BrowserViewportView: View {
             .frame(width: edge == .bottom ? 32 : 4, height: edge == .bottom ? 4 : 32)
             .frame(width: edge == .bottom ? 64 : gutter, height: edge == .bottom ? gutter : 64)
             .contentShape(Rectangle())
+            .pointerStyle(edge == .bottom ? .rowResize : .columnResize)
             .help(edge == .bottom ? "Drag to resize viewport height" : "Drag to resize viewport width")
             .accessibilityLabel(edge == .bottom ? "Viewport height" : "Viewport width")
             .accessibilityValue("\(edge == .bottom ? session.viewport.height : session.viewport.width) pixels")

--- a/Sources/Bloom/Views/Center/Browser/BrowserWebView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserWebView.swift
@@ -11,6 +11,9 @@ import BloomCore
 /// any `NSView` for that reason.
 final class BrowserHostView: NSView {
     private weak var page: NSView?
+    var viewportSize: CGSize? {
+        didSet { if oldValue != viewportSize { needsLayout = true } }
+    }
 
     func attach(_ view: NSView) {
         guard page !== view || view.superview !== self else { return }
@@ -25,7 +28,11 @@ final class BrowserHostView: NSView {
 
     override func layout() {
         super.layout()
-        page?.frame = bounds
+        guard let page else { return }
+        page.frame = bounds
+        // Transform the native coordinate space, not WebKit's page zoom. CSS still sees the
+        // requested size and AppKit converts pointer coordinates through the same transform.
+        page.bounds = CGRect(origin: .zero, size: viewportSize ?? bounds.size)
     }
 }
 
@@ -168,15 +175,18 @@ struct BrowserWebView: NSViewRepresentable {
     /// What the page can ask the window for, handed down for the same reason and on the same
     /// schedule as the menu above. See `BrowserPaneHost`.
     var host = BrowserPaneHost()
+    var viewportSize: CGSize?
 
     func makeNSView(context: Context) -> BrowserHostView {
         let view = BrowserHostView()
+        view.viewportSize = viewportSize
         view.attach(session.pageView)
         wire()
         return view
     }
 
     func updateNSView(_ nsView: BrowserHostView, context: Context) {
+        nsView.viewportSize = viewportSize
         nsView.attach(session.pageView)
         wire()
     }

--- a/Sources/Bloom/Views/Center/Browser/BrowserWebView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserWebView.swift
@@ -11,9 +11,6 @@ import BloomCore
 /// any `NSView` for that reason.
 final class BrowserHostView: NSView {
     private weak var page: NSView?
-    var viewportSize: CGSize? {
-        didSet { if oldValue != viewportSize { needsLayout = true } }
-    }
 
     func attach(_ view: NSView) {
         guard page !== view || view.superview !== self else { return }
@@ -28,11 +25,7 @@ final class BrowserHostView: NSView {
 
     override func layout() {
         super.layout()
-        guard let page else { return }
-        page.frame = bounds
-        // Transform the native coordinate space, not WebKit's page zoom. CSS still sees the
-        // requested size and AppKit converts pointer coordinates through the same transform.
-        page.bounds = CGRect(origin: .zero, size: viewportSize ?? bounds.size)
+        page?.frame = bounds
     }
 }
 
@@ -177,15 +170,15 @@ struct BrowserWebView: NSViewRepresentable {
     var host = BrowserPaneHost()
     var viewportSize: CGSize?
 
-    func makeNSView(context: Context) -> BrowserHostView {
-        let view = BrowserHostView()
+    func makeNSView(context: Context) -> BrowserViewportHostView {
+        let view = BrowserViewportHostView()
         view.viewportSize = viewportSize
         view.attach(session.pageView)
         wire()
         return view
     }
 
-    func updateNSView(_ nsView: BrowserHostView, context: Context) {
+    func updateNSView(_ nsView: BrowserViewportHostView, context: Context) {
         nsView.viewportSize = viewportSize
         nsView.attach(session.pageView)
         wire()

--- a/Sources/BloomCore/System/BrowserViewport.swift
+++ b/Sources/BloomCore/System/BrowserViewport.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// A tab's layout size is independent of the space available to display it. Scaling the preview
+/// must not change CSS breakpoints, and toggling it off must not discard the chosen dimensions.
+public struct BrowserViewport: Equatable, Sendable {
+    public static let limits = 240...3840
+    public var isEnabled = false
+    public var fitsPane = true
+    public private(set) var width = 390
+    public private(set) var height = 844
+    public private(set) var savedSizes: [Size] = []
+
+    public struct Size: Hashable, Sendable {
+        public let width: Int
+        public let height: Int
+    }
+
+    public var canSaveSize: Bool {
+        preset == nil && !savedSizes.contains(Size(width: width, height: height))
+    }
+
+    public mutating func saveSize() {
+        guard canSaveSize else { return }
+        savedSizes.append(Size(width: width, height: height))
+    }
+
+    public mutating func removeSavedSizes() { savedSizes.removeAll() }
+
+    public init() {}
+
+    public mutating func resize(width: Int, height: Int) {
+        self.width = min(max(width, Self.limits.lowerBound), Self.limits.upperBound)
+        self.height = min(max(height, Self.limits.lowerBound), Self.limits.upperBound)
+    }
+
+    public mutating func rotate() {
+        resize(width: height, height: width)
+    }
+
+    public func scale(availableWidth: Double, availableHeight: Double) -> Double {
+        guard isEnabled, fitsPane else { return 1 }
+        return max(0.01, min(1, availableWidth / Double(width), availableHeight / Double(height)))
+    }
+
+    public var preset: Preset? {
+        Preset.allCases.first { $0.width == width && $0.height == height }
+    }
+
+    public mutating func select(_ preset: Preset) {
+        resize(width: preset.width, height: preset.height)
+    }
+
+    public enum Preset: String, CaseIterable, Sendable {
+        case smallPhone = "Small phone"
+        case phone = "Phone"
+        case tablet = "Tablet"
+        case laptop = "Laptop"
+        case desktop = "Desktop"
+
+        public var width: Int {
+            switch self {
+            case .smallPhone: 320
+            case .phone: 390
+            case .tablet: 768
+            case .laptop: 1280
+            case .desktop: 1440
+            }
+        }
+
+        public var height: Int {
+            switch self {
+            case .smallPhone: 568
+            case .phone: 844
+            case .tablet: 1024
+            case .laptop, .desktop: 900
+            }
+        }
+    }
+}

--- a/Tests/BloomCoreTests/BrowserViewportTests.swift
+++ b/Tests/BloomCoreTests/BrowserViewportTests.swift
@@ -1,0 +1,58 @@
+import Testing
+@testable import BloomCore
+
+struct BrowserViewportTests {
+    @Test func desktopFitsWithoutChangingLayoutDimensions() {
+        var viewport = BrowserViewport()
+        viewport.isEnabled = true
+        viewport.select(.desktop)
+        #expect(viewport.scale(availableWidth: 720, availableHeight: 600) == 0.5)
+        #expect(viewport.width == 1440)
+        #expect(viewport.height == 900)
+        viewport.fitsPane = false
+        #expect(viewport.scale(availableWidth: 720, availableHeight: 600) == 1)
+    }
+
+    @Test func phoneFitsHeightAndNeverEnlarges() {
+        var viewport = BrowserViewport()
+        viewport.isEnabled = true
+        #expect(viewport.scale(availableWidth: 1000, availableHeight: 422) == 0.5)
+        #expect(viewport.scale(availableWidth: 1000, availableHeight: 2000) == 1)
+        #expect(viewport.scale(availableWidth: -10, availableHeight: 0) > 0)
+    }
+
+    @Test func toggleAndRotationPreserveCustomSize() {
+        var viewport = BrowserViewport()
+        viewport.resize(width: 412, height: 915)
+        viewport.isEnabled = true
+        viewport.isEnabled = false
+        #expect(viewport.width == 412)
+        #expect(viewport.height == 915)
+        #expect(viewport.preset == nil)
+        viewport.rotate()
+        #expect(viewport.width == 915)
+        #expect(viewport.height == 412)
+    }
+
+    @Test func savedCustomSizesSurvivePresetChangesWithoutDuplicates() {
+        var viewport = BrowserViewport()
+        viewport.saveSize()
+        #expect(viewport.savedSizes.isEmpty)
+        viewport.resize(width: 412, height: 915)
+        viewport.saveSize()
+        viewport.saveSize()
+        viewport.select(.desktop)
+        #expect(viewport.savedSizes.count == 1)
+        #expect(viewport.savedSizes.first?.width == 412)
+        #expect(viewport.savedSizes.first?.height == 915)
+        viewport.removeSavedSizes()
+        #expect(viewport.savedSizes.isEmpty)
+    }
+
+    @Test func invalidDimensionsAreBounded() {
+        var viewport = BrowserViewport()
+        viewport.resize(width: -5, height: Int.max)
+        #expect(viewport.width == 240)
+        #expect(viewport.height == 3840)
+    }
+}


### PR DESCRIPTION
Preview browser pages at phone, tablet, desktop and custom CSS dimensions with draggable edges, saved sizes, rotation and Fit/100% scaling. Preserve the live page across resizing, reloads and tab switches.

Put size controls in a compact popover with stable preset widths and resize cursors. Opening the controls preserves full size; a separate toolbar button restores it in one click. Use native scroll magnification so larger previews paint completely while keeping exact viewport dimensions.

Includes core regression tests and an isolated native fixture checking viewport dimensions, breakpoints, form preservation and painting at the page edges.
