### PR TITLE
Sort workspace projects into visible and hidden groups

### DIFF
--- a/Sources/Bloom/Views/CreateWorkspace/CreateWorkspaceView.swift
+++ b/Sources/Bloom/Views/CreateWorkspace/CreateWorkspaceView.swift
@@ -348,25 +348,25 @@ struct CreateWorkspaceView: View {
                 // arrives as a bitmap of the same `RepoIcon` the chip and the sidebar draw. See
                 // `RepoIconImage`.
                 //
-                // No heading over them. The rows are project names wearing their own badges and
-                // the control that opened the menu is showing one of them, so "Project" written
-                // above would be a word to read past. `labelsHidden` takes the heading off the
-                // picker without taking its name away from VoiceOver.
+                // One picker keeps a single selection across both visibility groups.
                 Picker("Project", selection: Binding(
                     get: { repoID ?? RepoID("") },
                     set: { repoID = $0.rawValue.isEmpty ? nil : $0 }
                 )) {
-                    ForEach(app.repos) { candidate in
-                        Label {
-                            Text(candidate.name)
-                        } icon: {
-                            if let mark = RepoIconImage.of(candidate) {
-                                // `.original`, because the tile is the project's colour and a
-                                // template image in a menu is painted flat in the label colour.
-                                Image(nsImage: mark).renderingMode(.original)
+                    ForEach(ProjectMenuGroup.grouped(app.repos)) { group in
+                        Section(group.title) {
+                            ForEach(group.repos) { candidate in
+                                Label {
+                                    Text(candidate.name)
+                                } icon: {
+                                    if let mark = RepoIconImage.of(candidate) {
+                                        // Keep the project's colours in the menu's image slot.
+                                        Image(nsImage: mark).renderingMode(.original)
+                                    }
+                                }
+                                .tag(candidate.id)
                             }
                         }
-                        .tag(candidate.id)
                     }
                 }
                 .pickerStyle(.inline)

--- a/Sources/BloomCore/Presentation/ProjectMenuGroup.swift
+++ b/Sources/BloomCore/Presentation/ProjectMenuGroup.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// The workspace picker has its own alphabetical order so hidden projects stay available
+/// without interrupting the projects shown in the sidebar.
+public struct ProjectMenuGroup: Identifiable, Sendable {
+    public let hidden: Bool
+    public let repos: [Repo]
+
+    public var id: Bool { hidden }
+    public var title: String { hidden ? "Hidden projects" : "Visible projects" }
+
+    public static func grouped(_ repos: [Repo]) -> [ProjectMenuGroup] {
+        let sorted = repos.sorted {
+            $0.name.localizedStandardCompare($1.name) == .orderedAscending
+        }
+
+        return [false, true].compactMap { hidden in
+            let members = sorted.filter { $0.hidden == hidden }
+            guard !members.isEmpty else { return nil }
+            return ProjectMenuGroup(hidden: hidden, repos: members)
+        }
+    }
+}

--- a/Tests/BloomCoreTests/ProjectMenuGroupTests.swift
+++ b/Tests/BloomCoreTests/ProjectMenuGroupTests.swift
@@ -1,0 +1,35 @@
+import Testing
+@testable import BloomCore
+
+@Suite("Project menu groups")
+struct ProjectMenuGroupTests {
+    @Test("visible projects come first and each group is alphabetical regardless of sidebar order")
+    func alphabeticalGroups() {
+        let repos = [
+            Repo(name: "zebra", path: "/zebra", sortOrder: 0, hidden: true),
+            Repo(name: "VicGames", path: "/VicGames", sortOrder: 1),
+            Repo(name: "alpha", path: "/alpha", sortOrder: 2, hidden: true),
+            Repo(name: "bloom", path: "/bloom", sortOrder: 3),
+            Repo(name: "runbloom.app", path: "/runbloom.app", sortOrder: 4)
+        ]
+
+        let groups = ProjectMenuGroup.grouped(repos)
+
+        #expect(groups.map(\.title) == ["Visible projects", "Hidden projects"])
+        #expect(groups.map(\.hidden) == [false, true])
+        #expect(groups.map { $0.repos.map(\.id) } == [
+            [repos[3].id, repos[4].id, repos[1].id],
+            [repos[2].id, repos[0].id]
+        ])
+    }
+
+    @Test("empty groups have no heading", arguments: [false, true])
+    func emptyGroups(hidden: Bool) {
+        let repo = Repo(name: "bloom", path: "/bloom", hidden: hidden)
+        let groups = ProjectMenuGroup.grouped([repo])
+
+        #expect(groups.map(\.hidden) == [hidden])
+        #expect(groups.flatMap(\.repos).map(\.id) == [repo.id])
+        #expect(ProjectMenuGroup.grouped([]).isEmpty)
+    }
+}


### PR DESCRIPTION
Group the New Workspace project menu under Visible projects and Hidden projects, with visible projects first and each group sorted alphabetically. Empty groups are omitted, and project icons and the current selection are preserved.

Verified with the focused sorting tests, a warnings-as-errors app build, and both linters.
