### PR TITLE
Allow pull request actions while the agent is busy

### DIFF
--- a/Sources/Bloom/Views/Inspector/PullRequestBar.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestBar.swift
@@ -123,17 +123,13 @@ struct PullRequestBar: View {
         }
     }
 
-    /// Whether the strip's buttons may touch this branch, decided once for the whole band.
-    ///
-    /// `AppModel.isRunning` rather than `model.isRunning`, though both answer the same question
-    /// with the same rule (`AgentTurns`, over every chat in the workspace, so a workspace with
-    /// four of them is busy if any one is mid turn). It is the one observable mirror every busy
-    /// reader in this window shares, rebuilt whole by `recomputeAgentTurns` from the session rows
-    /// and the live transcripts, so the strip greys out at the same moment the sidebar's row and
-    /// the menu bar say the agent started. A second route to the same fact is how this app came
-    /// to have three answers to it once already.
+    /// Message requests stay available during a turn. Continue and Archive still read the
+    /// workspace-wide busy signal, shared with the sidebar through `AppModel.isRunning`.
     private var branchActions: BranchActionAvailability {
-        .mayActOnBranch(isAgentBusy: app.isRunning(model.workspace))
+        .mayActOnBranch(
+            isAgentBusy: app.isRunning(model.workspace),
+            pullRequest: model.pullRequest
+        )
     }
 
     /// Whether the branch has anything on it. The inspector's own list first, because it is the

--- a/Sources/Bloom/Views/Inspector/PullRequestCreator.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestCreator.swift
@@ -29,9 +29,7 @@ struct PullRequestCreator: View {
     var branch: String
     var baseBranch: String
     var isWorking: Bool
-    /// Whether this strip may act on the branch at all. Opening a pull request pushes it, so a
-    /// turn already writing to the worktree holds the button back: see
-    /// `BranchActionAvailability`, which decides it for both halves of this band.
+    /// Creating a pull request submits a message, so a busy agent can still accept the request.
     var branchActions: BranchActionAvailability
     /// Where a sign in would run, if the quiet line below the branch is pressed.
     var worktree: String
@@ -171,10 +169,6 @@ struct PullRequestCreator: View {
             .buttonBorderShape(.roundedRectangle(radius: Metrics.corner))
             .tint(Palette.controlAccent)
             .controlSize(.regular)
-            // Held back while a turn runs, like every other button in this band: opening the
-            // pull request pushes the branch, and a worktree being written to as it is read
-            // pushes half of something. See `BranchActionAvailability`. A branch with nothing on
-            // it does not draw this button at all: see `body`.
             .disabled(!branchActions.isAllowed)
             .help(helpText)
     }

--- a/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
@@ -26,12 +26,8 @@ struct PullRequestSummary: View {
     /// still running, which is not the same as "nothing", and is drawn as nothing extra.
     var localWork: LocalWork?
     var isWorking: Bool
-    /// Whether this strip may act on the branch at all, decided once for the whole band.
-    ///
-    /// Every button here works by composing a turn and sending it, and what the agent then does
-    /// is commit, push, merge, cut a branch or bring the base in. While a turn is already running
-    /// none of that may start: see `BranchActionAvailability`, which holds the reason and the
-    /// words. `PullRequestCreator` takes the same value for the same reason.
+    /// Message requests stay available during a turn. Continue and Archive act immediately
+    /// and still require an idle workspace. `PullRequestCreator` shares the same decision.
     var branchActions: BranchActionAvailability
     /// How this project merges, which the split button promises and its menu ticks. Per project
     /// and remembered: see `MergeMethodChoice`.
@@ -111,8 +107,7 @@ struct PullRequestSummary: View {
         guard pullRequest.isOpen, !isWorking else { return nil }
         return MergeAction(
             title: mergeMethod.buttonLabel,
-            // The same two answers the button reads, in the same order: the cluster's, which is
-            // whether a turn may start at all, and then GitHub's.
+            // Match the button's availability, including GitHub's merge restrictions.
             isEnabled: branchActions.isAllowed && status.canMerge,
             perform: { propose(mergeMethod) }
         )
@@ -233,12 +228,8 @@ struct PullRequestSummary: View {
     /// the button now, on the trailing side where a split button carries it, and it is drawn
     /// nowhere else. See `mergeControl`.
     private var trailing: some View {
-        // Disabled here, for the cluster, rather than on each button in it. Everything in this
-        // slot ends in a turn that writes to the worktree or the branch, so it is one question,
-        // and a control added to the cluster later inherits the answer instead of having to
-        // remember to ask it. `BranchActionAvailability` carries what is held back and why.
-        // Nothing outside this slot is touched: the number, the arrow out to the browser and the
-        // strip's own context menu only ever read.
+        // Open pull requests submit messages. Finished ones offer immediate workspace actions,
+        // which remain disabled while any agent in the workspace is running.
         trailingControls
             .disabled(!branchActions.isAllowed)
             .popover(isPresented: Binding(
@@ -441,8 +432,6 @@ struct PullRequestSummary: View {
             .buttonBorderShape(.roundedRectangle(radius: Metrics.corner))
             .tint(status.tone.fill)
             .controlSize(.regular)
-            // Disabled with the rest of the cluster while a turn runs: pushing a worktree that
-            // is being written to as it is read publishes half of something.
             .help(
                 branchActions.reason
                     ?? "Ask this workspace's agent to \(pushLabel.lowercased()) branch "
@@ -499,8 +488,6 @@ struct PullRequestSummary: View {
             .buttonBorderShape(.roundedRectangle(radius: Metrics.corner))
             .tint(status.tone.fill)
             .controlSize(.regular)
-            // Disabled with the rest of the cluster while a turn runs: merging the base into a
-            // worktree an agent is editing is the same collision as the button above it.
             .help(
                 branchActions.reason
                     ?? "Ask this workspace's agent to bring \(baseBranch) into this worktree and "
@@ -542,8 +529,7 @@ struct PullRequestSummary: View {
         MergeSplitButton(
             method: mergeMethod,
             fill: status.tone.fill,
-            // Only what GitHub says about the pull request. A running agent is the cluster's
-            // answer rather than this control's: see `trailing`.
+            // Queueing a request does not bypass GitHub's merge restrictions.
             canMerge: status.canMerge,
             help: blockedReason,
             choose: onChooseMergeMethod,
@@ -563,10 +549,6 @@ struct PullRequestSummary: View {
     // MARK: - Text
 
     /// What the Merge button has to say for itself, or nil when there is nothing.
-    ///
-    /// The running agent comes first. It is true of every button in this strip rather than of one
-    /// of them, and it is the reason that goes away on its own, so a reader hovering while their
-    /// agent is working is told what they are waiting for rather than told about a draft.
     private var blockedReason: String? {
         branchActions.reason ?? status.blockedReason
     }

--- a/Sources/BloomCore/Presentation/BranchActionAvailability.swift
+++ b/Sources/BloomCore/Presentation/BranchActionAvailability.swift
@@ -1,32 +1,11 @@
 import Foundation
 
-/// Whether the pull request strip may act on this workspace's branch right now.
+/// Whether the pull request strip may accept its current action while an agent is busy.
 ///
-/// **One answer for the whole strip, rather than one `if` per button.** Every control in that
-/// band ends in the same place: a turn is composed and sent, and the agent then commits, pushes,
-/// merges, cuts a fresh branch or brings the base in. So the question is asked once, here, and
-/// the strip disables its action cluster on the answer. A button added to that cluster later is
-/// disabled by the cluster rather than by remembering to ask, which is the failure this shape
-/// exists to make impossible.
-///
-/// **Why a running agent is a no.** Merging while an agent is still writing to the worktree
-/// merges a branch whose commits may not all be pushed yet, and it is the kind of mistake that
-/// cannot be undone from inside the app: the commits land on somebody else's branch and the
-/// branch they came from is deleted on the server. The rest of the band is the same mistake a
-/// step short of the server. Commit and push publishes a worktree that is being written to as it
-/// is read, Fix merge conflicts merges the base into that worktree, Continue cuts a new branch
-/// out from under the turn, and Archive deletes the worktree entirely.
-///
-/// **This reverses an earlier decision, deliberately.** These buttons were live mid turn on the
-/// argument that a press queues rather than refusing: the turn goes into the chat's queue, drawn
-/// above the composer, and runs when the current one ends. That is a good answer for asking an
-/// agent to do more work and a bad one for landing a branch, because what the reader saw when
-/// they pressed is not what the queued turn will act on. The queue still exists and the composer
-/// still uses it; the strip's branch actions wait instead.
-///
-/// Nothing that only navigates or reveals is covered by this. The pull request number, the arrow
-/// out to the browser, Copy link and Share, the inspector's own tabs: none of them touches the
-/// worktree, and a reader whose agent is working still wants to read.
+/// Create, push, merge and conflict resolution submit messages through the transcript's delivery
+/// queue. They can be requested during a turn, just like a message typed into the composer.
+/// Continue and Archive act on the worktree immediately, so a finished pull request still needs
+/// an idle workspace before those controls become available.
 public struct BranchActionAvailability: Sendable, Hashable {
     /// Whether the strip's branch actions may be pressed.
     public var isAllowed: Bool
@@ -51,19 +30,16 @@ public struct BranchActionAvailability: Sendable, Hashable {
     /// Nothing in the way.
     public static let allowed = BranchActionAvailability(isAllowed: true)
 
-    /// The one decision, for the whole strip.
-    ///
-    /// One parameter today. It is a function rather than a computed property on the flag because
-    /// the next reason to hold the band back (a rebase in flight, a worktree being archived) is a
-    /// second argument here and nothing at all at any call site.
-    public static func mayActOnBranch(isAgentBusy: Bool) -> BranchActionAvailability {
-        guard isAgentBusy else { return .allowed }
+    public static func mayActOnBranch(
+        isAgentBusy: Bool,
+        pullRequest: PullRequest?
+    ) -> BranchActionAvailability {
+        guard isAgentBusy, let pullRequest, !pullRequest.isOpen else { return .allowed }
         return BranchActionAvailability(
             isAllowed: false,
             note: "The agent is still running here.",
-            reason: "The agent is still running in this worktree. Merging or pushing now would "
-                + "act on a branch whose commits may not all be pushed yet, and none of that can "
-                + "be undone from in here. It comes back when the turn ends."
+            reason: "The agent is still running in this worktree. Continue and Archive become "
+                + "available when the turn ends."
         )
     }
 }

--- a/Tests/BloomCoreTests/BranchActionAvailabilityTests.swift
+++ b/Tests/BloomCoreTests/BranchActionAvailabilityTests.swift
@@ -2,48 +2,46 @@ import Foundation
 import Testing
 @testable import BloomCore
 
-/// Whether the pull request strip may act on the branch.
-///
-/// The report: the green Merge button, and the red Fix merge conflicts button beside the same
-/// headline, were both live while the workspace's agent was mid turn. Merging there lands a
-/// branch whose commits may not all be pushed yet and deletes it on the server, which is the one
-/// thing this app offers that cannot be undone from inside it.
 @Suite("Whether the branch may be acted on")
 struct BranchActionAvailabilityTests {
-    @Test("An idle workspace may act, and says nothing about it")
-    func idleAllows() {
-        let availability = BranchActionAvailability.mayActOnBranch(isAgentBusy: false)
-        #expect(availability.isAllowed)
+    @Test("Creating a pull request can submit a message while idle or busy", arguments: [false, true])
+    func creationAllows(isAgentBusy: Bool) {
+        let availability = BranchActionAvailability.mayActOnBranch(
+            isAgentBusy: isAgentBusy, pullRequest: nil
+        )
+        #expect(availability == .allowed)
+    }
+
+    @Test("Open pull request actions can submit messages while idle or busy", arguments: [false, true])
+    func openAllows(isAgentBusy: Bool) {
+        let availability = BranchActionAvailability.mayActOnBranch(
+            isAgentBusy: isAgentBusy, pullRequest: pullRequest(state: "OPEN")
+        )
+        #expect(availability == .allowed)
         #expect(availability.note == nil)
         #expect(availability.reason == nil)
     }
 
-    @Test("A running agent holds every branch action back")
-    func busyBlocks() {
-        #expect(!BranchActionAvailability.mayActOnBranch(isAgentBusy: true).isAllowed)
-    }
-
-    /// Both of them, because they are two different readers. The note is read off the strip by
-    /// somebody who never hovers anything; the reason is what the disabled control answers with
-    /// when they do.
-    @Test("It says why, on the strip and in the tooltip")
-    func busyExplainsItself() {
-        let availability = BranchActionAvailability.mayActOnBranch(isAgentBusy: true)
+    @Test("Immediate workspace actions still wait for the agent", arguments: ["MERGED", "CLOSED"])
+    func finishedBlocksWhileBusy(state: String) {
+        let availability = BranchActionAvailability.mayActOnBranch(
+            isAgentBusy: true, pullRequest: pullRequest(state: state)
+        )
+        #expect(!availability.isAllowed)
         #expect(availability.note?.isEmpty == false)
-        #expect(availability.reason?.isEmpty == false)
-        #expect(availability.reason?.contains("worktree") == true)
+        #expect((availability.note?.count ?? 0) <= 40)
+        #expect(availability.reason?.contains("Continue and Archive") == true)
     }
 
-    /// The note shares one line of a strip that is exactly one row tall, beside a headline that
-    /// must not be the thing that truncates. A sentence is not what goes there.
-    @Test("The note is short enough for the line it takes over")
-    func noteIsShort() {
-        let note = BranchActionAvailability.mayActOnBranch(isAgentBusy: true).note ?? ""
-        #expect(note.count <= 40)
+    @Test("Immediate workspace actions become available when idle", arguments: ["MERGED", "CLOSED"])
+    func finishedAllowsWhenIdle(state: String) {
+        let availability = BranchActionAvailability.mayActOnBranch(
+            isAgentBusy: false, pullRequest: pullRequest(state: state)
+        )
+        #expect(availability == .allowed)
     }
 
-    @Test("Allowed is the same answer as an idle workspace")
-    func allowedMatchesIdle() {
-        #expect(BranchActionAvailability.mayActOnBranch(isAgentBusy: false) == .allowed)
+    private func pullRequest(state: String) -> PullRequest {
+        PullRequest(number: 42, title: "Ship it", url: "https://github.com/acme/app/pull/42", state: state)
     }
 }


### PR DESCRIPTION
Keep Create PR, Push, Merge and Fix Conflicts enabled during an agent turn. Requests use the existing message delivery path, including each backend's queue or mid-turn delivery behaviour.

Continue and Archive still require an idle workspace. Existing merge confirmations and GitHub restrictions remain in place.

Validated with 76 focused tests, a warnings-as-errors app build, and both linters.
