### PR TITLE
Refresh saved run scripts and simplify the Workspace menu

### DIFF
--- a/Sources/Bloom/State/AppModel+RepoSettings.swift
+++ b/Sources/Bloom/State/AppModel+RepoSettings.swift
@@ -1,0 +1,12 @@
+import BloomCore
+
+/// Saving project settings must update the Run menu without a sidebar selection change.
+extension AppModel {
+    func refreshSettings(for repoID: RepoID, savedPaths: [String]) {
+        // A setting inherited from a home file can be shared by several projects.
+        let changedHome = !Set(savedPaths).isDisjoint(with: SettingsLoader.homePaths())
+        for model in workspaceModels.values where changedHome || model.workspace.repoID == repoID {
+            model.refreshSettings()
+        }
+    }
+}

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -338,12 +338,12 @@ final class WorkspaceModel {
     }
 
     /// What this workspace's repository asks for: the setup script, the run scripts, the rest of
-    /// `.conductor/settings.toml`.
+    /// the repository settings files.
     ///
     /// Held here rather than read where it is needed because the Workspace menu reads it, and a
     /// `Commands` body is not a view: it cannot await a file, and it cannot carry a task. It is
-    /// re-read whenever the workspace is selected, so a run script added in the project settings
-    /// window is in the menu the next time the workspace is on screen.
+    /// re-read whenever the workspace is selected and after project settings are saved, so a new
+    /// run script appears in the menu without switching workspaces.
     private(set) var settings = RepoSettings()
 
     /// Off the main actor, because this parses up to six files and is called on every switch.

--- a/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
+++ b/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
@@ -25,9 +25,6 @@ struct BloomCommands: Commands {
     /// The focused window's Save, when it has one. See `FocusedMenuValues`.
     @FocusedValue(\.saveAction) private var saveAction: SaveAction?
 
-    /// Landing the branch, published by the pull request band because that is where the
-    /// confirmation lives. Nil whenever that band is not on screen, which greys the item.
-    @FocusedValue(\.mergeAction) private var mergeAction
     @FocusedValue(\.isTypingProse) private var isTypingProse: Bool?
 
     /// Opens the project settings window, which is a scene rather than a sheet.
@@ -487,15 +484,6 @@ struct BloomCommands: Commands {
             }
 
             Divider()
-
-            // The title is the band's when the band is on screen, and the table's fallback when
-            // it is not, which is what lets a greyed row still say what the item is. It goes
-            // through the band's own `propose`, so the sign in gate and the confirmation are the
-            // ones the button raises rather than a second copy of them. See `MergeAction`.
-            Button(mergeAction?.title ?? MenuBarCatalogue[.merge].title) {
-                mergeAction?.perform()
-            }
-            .disabled(mergeAction?.isEnabled != true)
 
             // **Greyed while somebody is typing, and that is not tidiness.** Command-Backspace
             // deletes to the start of the line in every text box on macOS, and AppKit checks a

--- a/Sources/Bloom/Views/Chrome/App/FocusedMenuValues.swift
+++ b/Sources/Bloom/Views/Chrome/App/FocusedMenuValues.swift
@@ -28,19 +28,6 @@ extension FocusedValues {
     /// equivalent the menu bar cannot advertise, and unadvertised is undiscoverable.
     @Entry var saveAction: SaveAction?
 
-    /// Landing the branch, offered by the one control that can raise the confirmation for it.
-    ///
-    /// **Merging had no menu item at all.** `WorkspaceModel.requestMerge` had two callers, the
-    /// pull request band's button and the `workspace_merge` bridge tool an agent calls, so the
-    /// most consequential thing a person can ask Bloom to do to a workspace was reachable from one
-    /// button that is only drawn in some states, and from nothing at the top of the screen.
-    ///
-    /// It travels as a focused value rather than as a notification because the item has to grey
-    /// honestly. The confirmation is a modifier on `PullRequestSummary`, so a menu item can only
-    /// ask that view to raise it; with the inspector closed, or its pane on another tab, there is
-    /// no view to ask and the item has to say so rather than swallow the press.
-    @Entry var mergeAction: MergeAction?
-
     /// True while the keyboard is in a box somebody is typing prose into.
     ///
     /// **It exists for one key, and the report that produced it names the cost of not having it.**
@@ -86,35 +73,5 @@ struct SaveAction: Equatable {
 
     static func == (lhs: SaveAction, rhs: SaveAction) -> Bool {
         lhs.subject == rhs.subject && lhs.isEnabled == rhs.isEnabled
-    }
-}
-
-/// Landing this branch, offered to the menu bar by the band that owns the confirmation.
-///
-/// **The title names the method, and that is a decision rather than a detail.** The method is a
-/// per-project mode, set from the split button's chevron and remembered; an item that merely said
-/// "Merge" over a project set to squash would be the exact fault `MergeSplitButton` was built to
-/// remove, where the label and the press disagreed. So the item says `buttonLabel`, which is the
-/// same phrase the button says, and the two cannot come apart.
-///
-/// **And it is not a submenu of the three.** A submenu here would be a second place to set a
-/// project's mode, and picking a row in it would have to both change the mode and merge, which is
-/// the one thing `MergeSplitButton`'s own menu refuses to do: nothing in that menu performs
-/// anything. Choosing the method stays where the mode is set.
-///
-/// `perform` is the band's own `propose`, so a press from the menu bar goes through the sign in
-/// gate and the confirmation exactly as a press on the button does. Nothing here merges.
-struct MergeAction: Equatable {
-    /// What the item says, which is what the button says: "Merge", "Squash and merge", "Rebase
-    /// and merge". No ellipsis, even though a confirmation follows, because the button carries
-    /// none and one action may not be named two ways.
-    var title: String
-    /// False while a turn is running, while GitHub is refusing, or while the band is working. The
-    /// item greys rather than vanishing, which is the menu bar's rule.
-    var isEnabled: Bool
-    var perform: @MainActor () -> Void
-
-    static func == (lhs: MergeAction, rhs: MergeAction) -> Bool {
-        lhs.title == rhs.title && lhs.isEnabled == rhs.isEnabled
     }
 }

--- a/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
@@ -89,11 +89,6 @@ struct PullRequestSummary: View {
                 ShareLink(item: url) { Text("Share") }
             }
         }
-        // The Workspace menu's copy of the merge, which had no item anywhere until now. It is
-        // published from here because here is the only place that can raise the confirmation
-        // above, so the menu item asks this view rather than growing a second path to a merge.
-        // See `MergeAction`.
-        .focusedSceneValue(\.mergeAction, mergeAction)
         .onChange(of: canConfirmMerge) { _, available in
             if !available { pendingMerge = nil }
         }
@@ -102,20 +97,6 @@ struct PullRequestSummary: View {
         }
         .onChange(of: worktree) { _, _ in dismissConfirmation() }
         .onChange(of: pullRequest.url) { _, _ in dismissConfirmation() }
-    }
-
-    /// What the menu bar's Merge item says and does, or nil when this strip has nothing to land:
-    /// a pull request that is closed or already merged has no merge to offer, and neither has one
-    /// whose band is mid request.
-    private var mergeAction: MergeAction? {
-        guard pullRequest.isOpen, !isWorking else { return nil }
-        return MergeAction(
-            title: mergeMethod.buttonLabel,
-            // The same two answers the button reads, in the same order: the cluster's, which is
-            // whether a turn may start at all, and then GitHub's.
-            isEnabled: branchActions.isAllowed && status.canMerge,
-            perform: { propose(mergeMethod) }
-        )
     }
 
     // MARK: - Parts

--- a/Sources/Bloom/Views/RepoSettings/RepoSettingsModel.swift
+++ b/Sources/Bloom/Views/RepoSettings/RepoSettingsModel.swift
@@ -152,9 +152,9 @@ final class RepoSettingsModel {
         Array(Set(edits.map { destination(for: $0.key) })).sorted()
     }
 
-    func save() async {
+    func save() async -> Bool {
         let pending = edits
-        guard !pending.isEmpty else { return }
+        guard !pending.isEmpty else { return false }
         let path = repo.path
         let settings = loaded
 
@@ -166,9 +166,10 @@ final class RepoSettingsModel {
             saveError = nil
         } catch {
             saveError = error.readableMessage
-            return
+            return false
         }
 
         await load()
+        return true
     }
 }

--- a/Sources/Bloom/Views/RepoSettings/RepoSettingsSaveBar.swift
+++ b/Sources/Bloom/Views/RepoSettings/RepoSettingsSaveBar.swift
@@ -9,6 +9,7 @@ import BloomCore
 /// useless, and `git status` would flicker while you thought.
 struct RepoSettingsSaveBar: View {
     @Bindable var model: RepoSettingsModel
+    @Environment(AppModel.self) private var app
 
     var body: some View {
         HStack(spacing: Metrics.gutter) {
@@ -21,7 +22,7 @@ struct RepoSettingsSaveBar: View {
                 .disabled(!model.isDirty && !model.hasExternalChange)
 
             Button("Save Files") {
-                Task { await model.save() }
+                save()
             }
             .keyboardShortcut("s", modifiers: .command)
             .buttonStyle(.borderedProminent)
@@ -40,9 +41,16 @@ struct RepoSettingsSaveBar: View {
         .focusedValue(
             \.saveAction,
             SaveAction(subject: "project settings", isEnabled: model.isDirty) {
-                Task { await model.save() }
+                save()
             }
         )
+    }
+
+    private func save() {
+        Task {
+            guard await model.save() else { return }
+            app.refreshSettings(for: model.repo.id, savedPaths: model.savedPaths)
+        }
     }
 
     @ViewBuilder

--- a/Sources/BloomCore/Presentation/MenuBarCatalogue.swift
+++ b/Sources/BloomCore/Presentation/MenuBarCatalogue.swift
@@ -155,20 +155,6 @@ public enum MenuBarCatalogue {
             alternateTitle: UnreadMarkAction.markRead.title, availability: .needsWorkspaceSubject
         ),
         MenuBarItem(.colour, in: .workspace, "Colour", availability: .needsWorkspaceSubject),
-        // Landing the branch, which had no item in any menu: `requestMerge` was reachable from the
-        // pull request band's button and from the bridge tool an agent calls, and from nothing at
-        // the top of the screen. Directly above Archive because those two are the ends of a
-        // workspace's life and that is the order they happen in.
-        //
-        // **No key, and that is the point of it having one fewer thing than the items around it.**
-        // A key is worth spending on something done every few minutes; this is the most
-        // consequential thing a person can ask Bloom to do to a branch and it happens once per
-        // workspace. The item alone is what was missing.
-        //
-        // The title here is the greyed one. When the band is on screen the item says which merge,
-        // because the method is a per-project mode and a row reading "Merge" over a project set to
-        // squash is the fault the split button was built to remove. See `MergeAction`.
-        MenuBarItem(.merge, in: .workspace, "Merge", availability: .sometimes),
         MenuBarItem(.archive, in: .workspace, "Archive Workspace", key: .init(.delete, .command), availability: .needsWorkspaceSubject),
         MenuBarItem(.restore, in: .workspace, "Restore Workspace", availability: .needsWorkspaceSubject),
         MenuBarItem(.openInEditor, in: .workspace, "Open in Editor", key: .init("e", .command, .shift), availability: .needsWorkspaceSubject),
@@ -262,7 +248,6 @@ public enum MenuBarAction: String, CaseIterable, Sendable {
     case pin
     case unreadMark
     case colour
-    case merge
     case archive
     case restore
     case openInEditor

--- a/Tests/BloomCoreTests/MenuBarCatalogueTests.swift
+++ b/Tests/BloomCoreTests/MenuBarCatalogueTests.swift
@@ -213,31 +213,4 @@ struct MenuBarCatalogueTests {
             #expect(MenuBarCatalogue[action].key == nil, "\(action)")
         }
     }
-
-    /// Merging is the most consequential thing a person can ask Bloom to do to a branch, it
-    /// happens once per workspace, and it is the one item in the bar whose press is not undone by
-    /// pressing it again. A keystroke there buys a slip.
-    @Test("merging is an item and not a keystroke")
-    func mergeTakesNoKey() {
-        let item = MenuBarCatalogue[.merge]
-        #expect(item.menu == .workspace)
-        #expect(item.key == nil)
-        // The greyed wording. When the band is on screen the item says which merge, off
-        // `GitHub.MergeMethod.buttonLabel`, which is also what the split button says.
-        #expect(item.title == "Merge")
-    }
-
-    /// Merge sits directly above Archive, because those two are the ends of a workspace's life and
-    /// that is the order they happen in. Said as a test because a table is a list and an insert in
-    /// the wrong place is invisible in a diff.
-    @Test("merging is read directly above archiving")
-    func mergeSitsAboveArchive() {
-        let workspace = MenuBarCatalogue.items(in: .workspace).map(\.action)
-        guard let merge = workspace.firstIndex(of: .merge),
-              let archive = workspace.firstIndex(of: .archive) else {
-            Issue.record("the Workspace menu is missing one of the two")
-            return
-        }
-        #expect(archive == merge + 1)
-    }
 }

--- a/Tests/BloomCoreTests/SearchPanelCommandsTests.swift
+++ b/Tests/BloomCoreTests/SearchPanelCommandsTests.swift
@@ -56,12 +56,12 @@ struct SearchPanelCommandsTests {
         #expect(sections.map(\.title) == ["Help"])
     }
 
-    /// Nineteen items in the bar carry no shortcut at all, and a blank slot says nothing about
+    /// Some items in the bar carry no shortcut at all, and a blank slot says nothing about
     /// which of the two a row is.
     @Test("a row prints its key, or the words no key")
     func everyRowPrintsAKey() {
         #expect(MenuBarCatalogue[.archive].keyText == "\u{2318}\u{232B}")
-        #expect(MenuBarCatalogue[.merge].keyText == "no key")
+        #expect(MenuBarCatalogue[.pin].keyText == "no key")
         #expect(MenuBarCatalogue[.nextChangedFile].keyText == "\u{2325}\u{2318}J")
         #expect(MenuBarCatalogue[.projectSettings].keyText == "\u{21E7}\u{2318},")
         #expect(MenuBarCatalogue[.zoomPane].keyText == "\u{21E7}\u{2318}\u{21A9}")

--- a/docs/MENUS.md
+++ b/docs/MENUS.md
@@ -93,7 +93,6 @@ contribute for free.
 | Pin / Unpin | | a live workspace is the subject |
 | Mark as Unread / Mark as Read | | a live workspace is the subject |
 | Colour > None and ten colours | | a live workspace is the subject |
-| Merge / Squash and merge / Rebase and merge | | the pull request band is on screen and GitHub will take a merge |
 | Archive Workspace | `⌘⌫` | a live workspace is the subject |
 | Restore Workspace | | an archived workspace is the subject |
 | Open in Editor | `⇧⌘E` | a live workspace is the subject |
@@ -247,7 +246,7 @@ A browser with no Back in any menu is the second most obvious gap after the spli
 | Comment on This Line | diff line menu | **no** | none |
 | Send This Failure to the Agent | check row menu | **no** | none |
 | Open on GitHub, Copy link (pull request) | summary menu | **no** | none |
-| Merge, Squash and merge, Rebase and merge | the band's split button | yes | none |
+| Merge, Squash and merge, Rebase and merge | the band's split button | **no**, deliberately | none |
 | Choose the merge method | the split button's chevron | **no**, deliberately | none |
 | Create pull request, Continue, Archive, Fix merge conflicts | buttons | Archive only | `⌘⌫` |
 | Save an edited file | hidden button | greyed, always | `⌘S` |
@@ -339,9 +338,8 @@ decision about muscle memory rather than about menus.
 **This branch.** The split, which was the finding that started this: the View menu's two items take
 the same three kinds the context menus have, and `⌘\` and `⇧⌘\` move onto the row meaning "the same
 again". Then the actions that belong to the window and to a workspace: the Workspace menu becomes
-everything a workspace row's menu offers, plus the merge, which had no item in any menu at all; the
-tab actions are completed, the terminal pane's own actions are published, and the standard menus
-are checked for shape.
+everything a workspace row's menu offers. The tab actions are completed, the terminal pane's own
+actions are published, and the standard menus are checked for shape.
 
 **Left for a second pass**, in the order they are worth doing:
 
@@ -351,8 +349,7 @@ are checked for shape.
    are free.
 2. **The inspector.** The tab picker, the diff scope, the file bar's three toggles, Revert file,
    Copy path, and the remaining pull request items. Two of these need `⌘E` and `⌘S` moved off their
-   hidden buttons onto `@FocusedValue`s, which is what `FocusedMenuValues` already asks for and
-   what the merge item on this branch is the worked example of.
+   hidden buttons onto `@FocusedValue`s, which is what `FocusedMenuValues` already asks for.
 3. **A Project menu, or a project group in File.** Rename, Reveal in Finder, Hide, Remove. Four
    items that exist only on a right click.
 4. **The composer and the transcript.** Attach a file, insert a quick prompt, fast mode, and the
@@ -370,10 +367,9 @@ are checked for shape.
   a tree row. The tabs are in Go to Tab because nine keys hang off them and the selected tab is a
   real subject. The workspaces are in the sidebar and reachable with `⌥⌘↑↓`; a Workspaces submenu
   listing every workspace on the machine would be a second sidebar that goes stale.
-- **Choosing the merge method.** It is a per-project mode, set from the split button's chevron and
-  remembered. A submenu of the three in the menu bar would be a second place to set it, and a row
-  in it would have to both change the mode and merge, which is the one thing that button's own menu
-  refuses to do. The menu bar's item says which merge is in force and performs that one.
+- **Merging and choosing the merge method.** Both belong in the pull request panel, where the
+  checks, conflicts and target branch are visible. The split button performs the merge; its
+  chevron chooses the per-project method.
 - **Anything inside Settings or the project settings window.** Removing a run script is a button in
   the editor that owns it. A menu bar item for it would have to name which script.
 - **Discovered Seas.** A `Window` scene contributes its own Window menu item, and a command of our


### PR DESCRIPTION
Refresh workspace settings after Save Files so newly saved run scripts appear in Workspace > Run without switching workspaces. Refresh other projects too when the save changes a shared home settings file.

Remove the duplicate Merge entry from the Workspace menu. Merging remains in the pull request panel.

Validated with a warnings-as-errors app build, both linters, and 56 targeted menu, settings and refresh tests.
