### PR TITLE
Add browser region capture with comments

### DIFF
--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -598,12 +598,14 @@ final class TranscriptModel {
     /// screen from the frame the key went down, in the state `Delivery.goesImmediately` says it is
     /// in: as a sent bubble if nothing is holding the queue, as a pending one if something is. See
     /// `sending`.
-    func submit(_ text: String) async {
+    func submit(_ text: String, clearingDraft sourceDraft: String? = nil) async {
         guard !isWorkspaceArchiving else { return }
         let body = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !body.isEmpty, let store else { return }
 
-        let submittedDraft = draft.trimmingCharacters(in: .whitespacesAndNewlines) == body ? draft : nil
+        // Review payloads expand compact chips into comments. Clear the source draft, while
+        // retaining anything the reader typed after that payload began being prepared.
+        let submittedDraft = SubmittedDraft.matching(current: draft, message: body, source: sourceDraft)
         if submittedDraft != nil { draft = "" }
 
         // Built here rather than inside the enqueue, so the row that goes in the table and the

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -1466,6 +1466,9 @@ final class WorkspaceModel {
     /// be a reason to make one.
     var reviewDrafts: [String: ReviewDraft] = [:]
 
+    /// A browser review survives switching tabs, just like a half-written diff comment.
+    var browserReviews: [String: BrowserRegionCapture] = [:]
+
     /// Which comments are open for editing in place. Here for the same reason `reviewDrafts` is,
     /// and the reason is not hypothetical for an edit either: the band being edited sits in the
     /// same lazy stack, so scrolling it out of sight destroys it, and `ReviewPaneView` keys the

--- a/Sources/Bloom/Views/Center/Attachments/AttachmentCard.swift
+++ b/Sources/Bloom/Views/Center/Attachments/AttachmentCard.swift
@@ -59,6 +59,23 @@ struct AttachmentCard: View {
                     .frame(maxWidth: .infinity, alignment: isImage ? .center : .leading)
                     .padding(Metrics.inset)
 
+                if let comment = attachment.imageComment {
+                    Hairline()
+                    HStack(alignment: .firstTextBaseline, spacing: Metrics.spacing) {
+                        Image(systemName: "text.bubble")
+                            .font(Typo.caption)
+                            .foregroundStyle(Palette.textSecondary)
+                        Text(comment.body)
+                            .font(Typo.body)
+                            .foregroundStyle(Palette.textPrimary)
+                            .lineLimit(8)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .padding(Metrics.inset)
+                    .background(Palette.reviewBand)
+                }
+
                 // A picture answers the question the hover asked, so a path and a byte count
                 // under it are furniture. Everything else leaves "which file is this" open,
                 // and for those the path is the useful half.

--- a/Sources/Bloom/Views/Center/Attachments/PromptAttachment.swift
+++ b/Sources/Bloom/Views/Center/Attachments/PromptAttachment.swift
@@ -8,7 +8,8 @@ import BloomCore
 /// `AttachmentDraft`. This is what the composer knows *besides* the path, and every field is
 /// either something the path cannot say or something it would cost a trip to the disk to ask.
 ///
-/// Nothing here is required to draw a chip, open a file or send a turn. A draft restored after a
+/// An image review also carries the comment and source URL to include when sending its chip.
+/// Ordinary attachments need only their path to draw a chip, open a file or send a turn. A draft restored after a
 /// relaunch whose records were lost still names its files, still draws them and still sends them,
 /// on the strength of the paths alone.
 ///
@@ -29,6 +30,7 @@ struct PromptAttachment: Identifiable, Hashable, Codable, Sendable {
     /// so taking its chip off must not touch the user's work.
     var isCopy: Bool
     var byteCount: Int = 0
+    var imageComment: BrowserImageComment?
 
     var filename: String { (path as NSString).lastPathComponent }
     var directory: String { (path as NSString).deletingLastPathComponent }

--- a/Sources/Bloom/Views/Center/Attachments/PromptAttachmentStore.swift
+++ b/Sources/Bloom/Views/Center/Attachments/PromptAttachmentStore.swift
@@ -240,6 +240,16 @@ final class PromptAttachmentStore {
 
     // MARK: - Persistence
 
+    func annotate(paths: [String], with comment: BrowserImageComment, sessionID: String) {
+        let paths = Set(paths)
+        let updated = attachments(for: sessionID).map { attachment in
+            var attachment = attachment
+            if paths.contains(attachment.path) { attachment.imageComment = comment }
+            return attachment
+        }
+        apply(updated, to: sessionID)
+    }
+
     private func apply(_ attachments: [PromptAttachment], to sessionID: String) {
         box(for: sessionID).list = attachments
         Self.persist(attachments, sessionID: sessionID)

--- a/Sources/Bloom/Views/Center/Browser/BrowserRegionCanvas.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserRegionCanvas.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+import BloomCore
+
+/// All drag coordinates belong to the canvas, including the moving handles. A handle's own
+/// coordinate space moves during a drag and would otherwise make the crop jump back and forth.
+struct BrowserRegionCanvas: View {
+    @Bindable var capture: BrowserRegionCapture
+    var finishSelection: @MainActor () -> Void
+    @State private var moveStart: CGRect?
+    @State private var resizeStart: CGRect?
+
+    private let inset: CGFloat = 16
+    private let coordinateSpace = "browser-region-canvas"
+
+    var body: some View {
+        GeometryReader { proxy in
+            let available = CGSize(width: max(0, proxy.size.width - inset * 2), height: max(0, proxy.size.height - inset * 2))
+            let frame = BrowserRegion.imageFrame(image: capture.imageSize, canvas: available)
+                .offsetBy(dx: inset, dy: inset)
+            let selected = capture.selection.map { BrowserRegion.rect($0, in: frame) }
+            ZStack(alignment: .topLeading) {
+                Palette.surfaceSunken
+                Image(decorative: capture.image, scale: 1)
+                    .resizable()
+                    .frame(width: frame.width, height: frame.height)
+                    .overlay { Rectangle().strokeBorder(.black.opacity(0.12), lineWidth: 0.5) }
+                    .shadow(color: .black.opacity(0.12), radius: 8, y: 3)
+                    .offset(x: frame.minX, y: frame.minY)
+                    .allowsHitTesting(false)
+                Path { path in
+                    path.addRect(frame)
+                    if let selected { path.addRect(selected) }
+                }
+                .fill(.black.opacity(selected == nil ? 0 : 0.38), style: FillStyle(eoFill: true))
+                .allowsHitTesting(false)
+                Color.clear
+                    .contentShape(Rectangle())
+                    .pointerStyle(.rectSelection)
+                    .gesture(select(in: frame))
+                if let selected {
+                    selectionOutline(selected, frame: frame)
+                    dimensions(selected, canvas: proxy.size)
+                    ForEach(BrowserRegion.Corner.allCases, id: \.self) { corner in
+                        handle(corner, selection: selected, frame: frame)
+                    }
+                }
+            }
+            .coordinateSpace(name: coordinateSpace)
+            .clipped()
+            .allowsHitTesting(!capture.isAdding)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Selected area of the page")
+            .accessibilityValue(sizeLabel)
+            .accessibilityHint("Drag to select. Drag inside to move, or drag a corner to resize.")
+            .accessibilityAction(named: "Move left") { nudge(x: -1, y: 0) }
+            .accessibilityAction(named: "Move right") { nudge(x: 1, y: 0) }
+            .accessibilityAction(named: "Move up") { nudge(x: 0, y: -1) }
+            .accessibilityAction(named: "Move down") { nudge(x: 0, y: 1) }
+        }
+    }
+
+    private var sizeLabel: String {
+        guard let selection = capture.selection,
+              let pixels = BrowserRegion.pixels(selection, image: capture.imageSize) else { return "No area selected" }
+        return "\(Int(pixels.width)) × \(Int(pixels.height)) px"
+    }
+
+    private func select(in frame: CGRect) -> some Gesture {
+        DragGesture(minimumDistance: 0, coordinateSpace: .named(coordinateSpace))
+            .onChanged { value in
+                guard frame.contains(value.startLocation) else { return }
+                capture.selection = BrowserRegion.selection(from: value.startLocation, to: value.location, in: frame)
+            }
+            .onEnded { _ in
+                if capture.selection != nil { finishSelection() }
+            }
+    }
+
+    private func selectionOutline(_ selected: CGRect, frame: CGRect) -> some View {
+        Rectangle()
+            .fill(.clear)
+            .overlay { Rectangle().strokeBorder(.white, lineWidth: 2) }
+            .overlay { Rectangle().stroke(Palette.accent, lineWidth: 1) }
+            .contentShape(Rectangle())
+            .frame(width: selected.width, height: selected.height)
+            .offset(x: selected.minX, y: selected.minY)
+            .pointerStyle(moveStart == nil ? .grabIdle : .grabActive)
+            .gesture(DragGesture(minimumDistance: 0, coordinateSpace: .named(coordinateSpace))
+                .onChanged { value in
+                    if moveStart == nil { moveStart = capture.selection }
+                    guard let moveStart, frame.width > 0, frame.height > 0 else { return }
+                    capture.selection = BrowserRegion.moved(moveStart, by: CGSize(
+                        width: value.translation.width / frame.width,
+                        height: value.translation.height / frame.height
+                    ))
+                }
+                .onEnded { _ in
+                    moveStart = nil
+                    finishSelection()
+                })
+    }
+
+    private func handle(_ corner: BrowserRegion.Corner, selection: CGRect, frame: CGRect) -> some View {
+        RoundedRectangle(cornerRadius: 2)
+            .fill(.white)
+            .overlay { RoundedRectangle(cornerRadius: 2).strokeBorder(Palette.accent, lineWidth: 1.5) }
+            .frame(width: 8, height: 8)
+            .shadow(color: .black.opacity(0.2), radius: 2, y: 1)
+            .frame(width: min(20, selection.width), height: min(20, selection.height))
+            .contentShape(Rectangle())
+            .position(x: corner.isLeft ? selection.minX : selection.maxX, y: corner.isTop ? selection.minY : selection.maxY)
+            .pointerStyle(.frameResize(position: resizePosition(corner)))
+            .gesture(DragGesture(minimumDistance: 0, coordinateSpace: .named(coordinateSpace))
+                .onChanged { value in
+                    if resizeStart == nil { resizeStart = capture.selection }
+                    guard let resizeStart, frame.width > 0, frame.height > 0 else { return }
+                    capture.selection = BrowserRegion.resized(resizeStart, corner: corner, to: CGPoint(
+                        x: (value.location.x - frame.minX) / frame.width,
+                        y: (value.location.y - frame.minY) / frame.height
+                    ))
+                }
+                .onEnded { _ in
+                    resizeStart = nil
+                    finishSelection()
+                })
+    }
+
+    private func resizePosition(_ corner: BrowserRegion.Corner) -> FrameResizePosition {
+        switch corner {
+        case .topLeft: .topLeading
+        case .topRight: .topTrailing
+        case .bottomLeft: .bottomLeading
+        case .bottomRight: .bottomTrailing
+        }
+    }
+
+    private func dimensions(_ selected: CGRect, canvas: CGSize) -> some View {
+        Text(sizeLabel)
+            .font(Typo.codeTiny)
+            .monospacedDigit()
+            .foregroundStyle(Palette.textPrimary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Palette.surfaceRaised, in: Capsule())
+            .overlay { Capsule().strokeBorder(Palette.border, lineWidth: Metrics.outline) }
+            .fixedSize()
+            .position(
+                x: min(max(selected.midX, 80), max(80, canvas.width - 80)),
+                y: min(selected.maxY + 20, max(14, canvas.height - 14))
+            )
+            .allowsHitTesting(false)
+    }
+
+    private func nudge(x: CGFloat, y: CGFloat) {
+        guard let selection = capture.selection, !capture.isAdding else { return }
+        capture.selection = BrowserRegion.moved(selection, by: CGSize(
+            width: x * 10 / capture.imageSize.width, height: y * 10 / capture.imageSize.height
+        ))
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserRegionCanvas.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserRegionCanvas.swift
@@ -9,22 +9,16 @@ struct BrowserRegionCanvas: View {
     @State private var moveStart: CGRect?
     @State private var resizeStart: CGRect?
 
-    private let inset: CGFloat = 16
     private let coordinateSpace = "browser-region-canvas"
 
     var body: some View {
         GeometryReader { proxy in
-            let available = CGSize(width: max(0, proxy.size.width - inset * 2), height: max(0, proxy.size.height - inset * 2))
-            let frame = BrowserRegion.imageFrame(image: capture.imageSize, canvas: available)
-                .offsetBy(dx: inset, dy: inset)
+            let frame = BrowserRegion.rect(capture.pageRect, in: CGRect(origin: .zero, size: proxy.size))
             let selected = capture.selection.map { BrowserRegion.rect($0, in: frame) }
             ZStack(alignment: .topLeading) {
-                Palette.surfaceSunken
                 Image(decorative: capture.image, scale: 1)
                     .resizable()
                     .frame(width: frame.width, height: frame.height)
-                    .overlay { Rectangle().strokeBorder(.black.opacity(0.12), lineWidth: 0.5) }
-                    .shadow(color: .black.opacity(0.12), radius: 8, y: 3)
                     .offset(x: frame.minX, y: frame.minY)
                     .allowsHitTesting(false)
                 Path { path in

--- a/Sources/Bloom/Views/Center/Browser/BrowserRegionCanvas.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserRegionCanvas.swift
@@ -8,6 +8,7 @@ struct BrowserRegionCanvas: View {
     var finishSelection: @MainActor () -> Void
     @State private var moveStart: CGRect?
     @State private var resizeStart: CGRect?
+    @State private var isSelecting = false
 
     private let coordinateSpace = "browser-region-canvas"
 
@@ -31,6 +32,28 @@ struct BrowserRegionCanvas: View {
                     .contentShape(Rectangle())
                     .pointerStyle(.rectSelection)
                     .gesture(select(in: frame))
+                ForEach(capture.comments) { note in
+                    let rect = BrowserRegion.rect(note.selection, in: frame)
+                    Rectangle().stroke(Palette.accent.opacity(0.65), lineWidth: 1)
+                        .frame(width: rect.width, height: rect.height)
+                        .offset(x: rect.minX, y: rect.minY)
+                        .allowsHitTesting(false)
+                    Button {
+                        capture.focusedCommentPath = note.id
+                        capture.selection = nil
+                        capture.isEditing = false
+                    } label: {
+                        Image(systemName: "text.bubble.fill")
+                            .font(Typo.caption)
+                            .foregroundStyle(Palette.accent)
+                            .padding(4)
+                            .background(Palette.reviewBand, in: RoundedRectangle(cornerRadius: Metrics.cornerSmall))
+                    }
+                    .buttonStyle(.plain)
+                    .position(x: max(rect.minX, 12), y: max(rect.minY, 12))
+                    .help(note.body)
+                    .accessibilityLabel("Show image comment: \(note.body)")
+                }
                 if let selected {
                     selectionOutline(selected, frame: frame)
                     dimensions(selected, canvas: proxy.size)
@@ -63,9 +86,14 @@ struct BrowserRegionCanvas: View {
         DragGesture(minimumDistance: 0, coordinateSpace: .named(coordinateSpace))
             .onChanged { value in
                 guard frame.contains(value.startLocation) else { return }
+                if !isSelecting {
+                    capture.beginSelection()
+                    isSelecting = true
+                }
                 capture.selection = BrowserRegion.selection(from: value.startLocation, to: value.location, in: frame)
             }
             .onEnded { _ in
+                isSelecting = false
                 if capture.selection != nil { finishSelection() }
             }
     }
@@ -81,7 +109,10 @@ struct BrowserRegionCanvas: View {
             .pointerStyle(moveStart == nil ? .grabIdle : .grabActive)
             .gesture(DragGesture(minimumDistance: 0, coordinateSpace: .named(coordinateSpace))
                 .onChanged { value in
-                    if moveStart == nil { moveStart = capture.selection }
+                    if moveStart == nil {
+                        moveStart = capture.selection
+                        capture.isEditing = false
+                    }
                     guard let moveStart, frame.width > 0, frame.height > 0 else { return }
                     capture.selection = BrowserRegion.moved(moveStart, by: CGSize(
                         width: value.translation.width / frame.width,
@@ -106,7 +137,10 @@ struct BrowserRegionCanvas: View {
             .pointerStyle(.frameResize(position: resizePosition(corner)))
             .gesture(DragGesture(minimumDistance: 0, coordinateSpace: .named(coordinateSpace))
                 .onChanged { value in
-                    if resizeStart == nil { resizeStart = capture.selection }
+                    if resizeStart == nil {
+                        resizeStart = capture.selection
+                        capture.isEditing = false
+                    }
                     guard let resizeStart, frame.width > 0, frame.height > 0 else { return }
                     capture.selection = BrowserRegion.resized(resizeStart, corner: corner, to: CGPoint(
                         x: (value.location.x - frame.minX) / frame.width,

--- a/Sources/Bloom/Views/Center/Browser/BrowserRegionCapture.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserRegionCapture.swift
@@ -1,0 +1,64 @@
+import AppKit
+import Observation
+import BloomCore
+
+/// Holds the captured page and conversation while the reader writes. Neither a navigation nor a
+/// switch to another chat should change what the comment refers to or where it is attached.
+@MainActor @Observable
+final class BrowserRegionCapture {
+    let image: CGImage
+    let address: String
+    let sessionID: SessionID
+    let conversation: String
+    var selection: CGRect?
+    var comment = ""
+    var isAdding = false
+    var failure: String?
+
+    var imageSize: CGSize { CGSize(width: image.width, height: image.height) }
+    var canAdd: Bool {
+        selection != nil && !comment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isAdding
+    }
+
+    init(data: Data, address: String, session: Session) throws {
+        guard let bitmap = NSBitmapImageRep(data: data), let image = bitmap.cgImage else {
+            throw BrowserSnapshotFailure()
+        }
+        self.image = image
+        self.address = address
+        sessionID = session.id
+        conversation = session.title
+    }
+
+    func add(to model: WorkspaceModel, completion: @escaping @MainActor () -> Void) {
+        guard canAdd, let selection,
+              let rect = BrowserRegion.pixels(selection, image: imageSize),
+              let crop = image.cropping(to: rect),
+              let data = NSBitmapImageRep(cgImage: crop).representation(using: .png, properties: [:]) else {
+            failure = "Select an area and write a comment before adding it."
+            return
+        }
+        isAdding = true
+        failure = nil
+        let comment = self.comment
+        let address = self.address
+        // Once Add is pressed the handoff belongs to the draft, even if this pane closes while
+        // the attachment is being written. It must finish without revealing a different tab.
+        Task {
+            defer { isAdding = false }
+            let taken = Set(PromptAttachmentStore.shared.attachments(for: sessionID.rawValue).map(\.filename))
+            let name = BrowserSnapshot.filename(for: address, avoiding: taken)
+            let outcome = await ComposerHandoff.attach(
+                [.image(data, format: .png, named: name)], to: model,
+                sessionID: sessionID, revealConversation: false
+            ) { paths in
+                BrowserRegion.draft(comment: comment, address: address, paths: paths)
+            }
+            if let failure = outcome.failure {
+                self.failure = failure
+            } else {
+                completion()
+            }
+        }
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserRegionCapture.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserRegionCapture.swift
@@ -10,8 +10,11 @@ final class BrowserRegionCapture {
     let address: String
     let sessionID: SessionID
     let conversation: String
+    /// The web content's position within the viewport, excluding an attached web inspector.
+    let pageRect: CGRect
     var selection: CGRect?
     var comment = ""
+    var isEditing = false
     var isAdding = false
     var failure: String?
 
@@ -20,7 +23,10 @@ final class BrowserRegionCapture {
         selection != nil && !comment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isAdding
     }
 
-    init(data: Data, address: String, session: Session) throws {
+    init(
+        data: Data, address: String, session: Session,
+        pageRect: CGRect = CGRect(x: 0, y: 0, width: 1, height: 1)
+    ) throws {
         guard let bitmap = NSBitmapImageRep(data: data), let image = bitmap.cgImage else {
             throw BrowserSnapshotFailure()
         }
@@ -28,6 +34,15 @@ final class BrowserRegionCapture {
         self.address = address
         sessionID = session.id
         conversation = session.title
+        self.pageRect = pageRect
+    }
+
+    static func pageRect(in browser: BrowserSession) -> CGRect {
+        BrowserRegion.pageFrame(
+            content: browser.webView.convert(browser.webView.bounds, to: browser.pageView),
+            viewport: browser.pageView.bounds,
+            originAtTop: browser.pageView.isFlipped
+        )
     }
 
     func add(to model: WorkspaceModel, completion: @escaping @MainActor () -> Void) {

--- a/Sources/Bloom/Views/Center/Browser/BrowserRegionCapture.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserRegionCapture.swift
@@ -12,11 +12,82 @@ final class BrowserRegionCapture {
     let conversation: String
     /// The web content's position within the viewport, excluding an attached web inspector.
     let pageRect: CGRect
+    let viewportSize: CGSize?
     var selection: CGRect?
     var comment = ""
     var isEditing = false
     var isAdding = false
     var failure: String?
+    var comments: [BrowserRegionComment] = []
+    var focusedCommentPath: String?
+    var editingCommentPath: String?
+    private var editDrafts: [String: String] = [:]
+
+    var focusedComment: BrowserRegionComment? { comments.first { $0.id == focusedCommentPath } }
+
+    func beginSelection() {
+        if let editingCommentPath {
+            editDrafts[editingCommentPath] = comment
+            comment = ""
+        }
+        editingCommentPath = nil
+        focusedCommentPath = nil
+        isEditing = false
+    }
+
+    func beginEdit(_ note: BrowserRegionComment) {
+        selection = nil
+        focusedCommentPath = note.id
+        editingCommentPath = note.id
+        comment = editDrafts[note.id] ?? note.body
+        isEditing = true
+    }
+
+    func cancelEdit() {
+        if let editingCommentPath { editDrafts[editingCommentPath] = nil }
+        editingCommentPath = nil
+        comment = ""
+        isEditing = false
+    }
+
+    func synchronise(with draft: String) {
+        let paths = Set(AttachmentDraft.parse(draft).paths)
+        comments.removeAll { !paths.contains($0.path) }
+        if let focusedCommentPath, !comments.contains(where: { $0.id == focusedCommentPath }) {
+            self.focusedCommentPath = nil
+            editingCommentPath = nil
+            isEditing = false
+        }
+    }
+
+    func saveEdit(in model: WorkspaceModel) {
+        guard let note = focusedComment, editingCommentPath == note.id,
+              !comment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let transcript = model.existingTranscript(for: sessionID),
+              AttachmentDraft.parse(transcript.draft).paths.contains(note.path),
+              let index = comments.firstIndex(where: { $0.id == note.id }) else { return }
+        comments[index].body = comment
+        PromptAttachmentStore.shared.annotate(
+            paths: [note.path], with: BrowserImageComment(body: comment, address: address), sessionID: sessionID.rawValue
+        )
+        cancelEdit()
+    }
+
+    func remove(_ note: BrowserRegionComment, from model: WorkspaceModel) {
+        guard let transcript = model.existingTranscript(for: sessionID) else { return }
+        let draft = AttachmentDraft.parse(transcript.draft).keeping { $0 != note.path }
+        transcript.draft = draft
+        comments.removeAll { $0.id == note.id }
+        editDrafts[note.id] = nil
+        if focusedCommentPath == note.id {
+            focusedCommentPath = nil
+            cancelEdit()
+        }
+        if !AttachmentDraft.parse(draft).paths.contains(note.path),
+           let attachment = PromptAttachmentStore.shared.attachments(for: sessionID.rawValue).first(where: { $0.path == note.path }) {
+            PromptAttachmentStore.shared.remove(attachment, sessionID: sessionID.rawValue, workspace: model.workspace.path)
+        }
+    }
 
     var imageSize: CGSize { CGSize(width: image.width, height: image.height) }
     var canAdd: Bool {
@@ -25,7 +96,8 @@ final class BrowserRegionCapture {
 
     init(
         data: Data, address: String, session: Session,
-        pageRect: CGRect = CGRect(x: 0, y: 0, width: 1, height: 1)
+        pageRect: CGRect = CGRect(x: 0, y: 0, width: 1, height: 1),
+        viewportSize: CGSize? = nil
     ) throws {
         guard let bitmap = NSBitmapImageRep(data: data), let image = bitmap.cgImage else {
             throw BrowserSnapshotFailure()
@@ -35,6 +107,7 @@ final class BrowserRegionCapture {
         sessionID = session.id
         conversation = session.title
         self.pageRect = pageRect
+        self.viewportSize = viewportSize
     }
 
     static func pageRect(in browser: BrowserSession) -> CGRect {
@@ -65,13 +138,20 @@ final class BrowserRegionCapture {
             let name = BrowserSnapshot.filename(for: address, avoiding: taken)
             let outcome = await ComposerHandoff.attach(
                 [.image(data, format: .png, named: name)], to: model,
-                sessionID: sessionID, revealConversation: false
-            ) { paths in
-                BrowserRegion.draft(comment: comment, address: address, paths: paths)
-            }
+                sessionID: sessionID, revealConversation: false,
+                imageComment: BrowserImageComment(body: comment, address: address)
+            )
             if let failure = outcome.failure {
                 self.failure = failure
             } else {
+                if let path = outcome.paths.first {
+                    let note = BrowserRegionComment(path: path, selection: selection, address: address, body: comment)
+                    comments.append(note)
+                    focusedCommentPath = note.id
+                }
+                self.selection = nil
+                self.comment = ""
+                isEditing = false
                 completion()
             }
         }

--- a/Sources/Bloom/Views/Center/Browser/BrowserRegionCaptureView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserRegionCaptureView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 import BloomCore
 
-/// Selection takes place on the snapshot itself. A live page can animate or reflow between a
-/// drag and Add, which would otherwise attach a different region from the one the reader saw.
+/// The page and the feedback have separate surfaces: the crop stays readable while the comment
+/// grows, and the destination is visible before anything is added to a conversation.
 struct BrowserRegionCaptureView: View {
     @Bindable var capture: BrowserRegionCapture
     var cancel: @MainActor () -> Void
@@ -11,84 +11,129 @@ struct BrowserRegionCaptureView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            canvas
+            header
             Hairline()
-            VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
-                Text(capture.selection == nil ? "Drag to select an area" : "Drag again to change the area")
-                    .font(Typo.label)
-                    .foregroundStyle(Palette.textSecondary)
-                TextField("What should change?", text: $capture.comment, axis: .vertical)
-                    .textFieldStyle(.roundedBorder)
-                    .lineLimit(2...4)
-                    .focused($commentFocused)
-                    .accessibilityLabel("Comment about the selected area")
-                if let failure = capture.failure {
-                    Text(failure).font(Typo.caption).foregroundStyle(Palette.textPrimary)
-                }
-                Text("Adds to the draft in \(capture.conversation)")
-                    .font(Typo.caption)
-                    .foregroundStyle(Palette.textSecondary)
-                    .lineLimit(1)
-                    .help(capture.conversation)
-                HStack {
-                    Button("Select All") {
-                        capture.selection = CGRect(x: 0, y: 0, width: 1, height: 1)
-                        commentFocused = true
-                    }
-                    Spacer(minLength: Metrics.spacingSmall)
-                    Button("Cancel", action: cancel).keyboardShortcut(.cancelAction)
-                    Button(capture.isAdding ? "Adding…" : "Add to Draft", action: add)
-                        .keyboardShortcut(.return, modifiers: .command)
-                        .disabled(!capture.canAdd)
-                }
-                .controlSize(.small)
-            }
-            .padding(Metrics.spacingWide)
-            .disabled(capture.isAdding)
+            BrowserRegionCanvas(capture: capture) { commentFocused = true }
+            Hairline()
+            composer
         }
         .background(Palette.surface)
     }
 
-    private var canvas: some View {
-        GeometryReader { proxy in
-            let frame = BrowserRegion.imageFrame(image: capture.imageSize, canvas: proxy.size)
-            let selected = capture.selection.map { BrowserRegion.rect($0, in: frame) }
-            ZStack(alignment: .topLeading) {
-                Palette.surfaceSunken
-                Image(decorative: capture.image, scale: 1)
-                    .resizable()
-                    .frame(width: frame.width, height: frame.height)
-                    .offset(x: frame.minX, y: frame.minY)
-                Path { path in
-                    path.addRect(frame)
-                    if let selected { path.addRect(selected) }
-                }
-                .fill(.black.opacity(0.4), style: FillStyle(eoFill: true))
-                if let selected {
-                    Rectangle()
-                        .strokeBorder(.white, lineWidth: 2)
-                        .background { Rectangle().stroke(.black, lineWidth: 1) }
-                        .frame(width: selected.width, height: selected.height)
-                        .offset(x: selected.minX, y: selected.minY)
-                }
+    private var header: some View {
+        HStack(spacing: Metrics.gutter) {
+            Image(systemName: "crop")
+                .font(Typo.bodyEmphasis)
+                .foregroundStyle(Palette.accent)
+                .frame(width: 30, height: 30)
+                .background(Palette.questionWash, in: RoundedRectangle(cornerRadius: Metrics.corner))
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Comment on an area")
+                    .font(Typo.labelEmphasis)
+                    .foregroundStyle(Palette.textPrimary)
+                Text("Snapshot · \(source)")
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textSecondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(capture.address)
             }
-            .contentShape(Rectangle())
-            .gesture(
-                DragGesture(minimumDistance: 0)
-                    .onChanged { value in
-                        capture.selection = BrowserRegion.selection(
-                            from: value.startLocation, to: value.location, in: frame
-                        )
-                    }
-                    .onEnded { _ in
-                        if capture.selection != nil { commentFocused = true }
-                    }
-            )
-            .allowsHitTesting(!capture.isAdding)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel("Page screenshot")
-            .accessibilityValue(capture.selection == nil ? "No area selected" : "Area selected")
-            .accessibilityHint("Drag to select an area, or use Select All to attach the visible page.")
+            Spacer(minLength: 0)
+            Button("Cancel", systemImage: "xmark", action: cancel)
+                .labelStyle(.iconOnly)
+                .buttonStyle(.accessoryBar)
+                .keyboardShortcut(.cancelAction)
+                .help("Cancel capture (Esc)")
+                .disabled(capture.isAdding)
         }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var composer: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 6) {
+                Image(systemName: capture.selection == nil ? "cursorarrow" : "checkmark.circle.fill")
+                    .foregroundStyle(capture.selection == nil ? Palette.textSecondary : Palette.accent)
+                    .accessibilityHidden(true)
+                Text(capture.selection == nil
+                    ? "Drag over the area you want to discuss."
+                    : "Drag inside to move. Use the corners to resize.")
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            TextField("What should change?", text: $capture.comment, axis: .vertical)
+                .textFieldStyle(.plain)
+                .font(Typo.body)
+                .lineLimit(2...5)
+                .focused($commentFocused)
+                .accessibilityLabel("Comment about the selected area")
+                .padding(12)
+                .background(Palette.surfaceRaised, in: RoundedRectangle(cornerRadius: 10))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 10).strokeBorder(
+                        commentFocused ? Palette.focusRing : Palette.border,
+                        lineWidth: commentFocused ? 1.5 : Metrics.outline
+                    )
+                }
+            if let failure = capture.failure {
+                Label(failure, systemImage: "exclamationmark.circle")
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.negative)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            HStack(alignment: .center, spacing: 8) {
+                Label(capture.conversation, systemImage: "text.bubble")
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textSecondary)
+                    .lineLimit(1)
+                    .help("Adds to the draft in \(capture.conversation). Nothing is sent yet.")
+                Spacer(minLength: 0)
+                Text("Draft only")
+                    .font(Typo.micro)
+                    .foregroundStyle(Palette.textTertiary)
+            }
+            HStack {
+                Menu {
+                    Button("Select All") {
+                        capture.selection = CGRect(x: 0, y: 0, width: 1, height: 1)
+                        commentFocused = true
+                    }
+                    Button("Clear Selection") { capture.selection = nil }
+                        .disabled(capture.selection == nil)
+                } label: {
+                    Label("Selection", systemImage: "rectangle.dashed")
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .font(Typo.label)
+                .help("Select the whole screenshot or start a new selection")
+                Spacer(minLength: Metrics.spacingSmall)
+                Button(action: add) {
+                    HStack(spacing: 8) {
+                        if capture.isAdding { ProgressView().controlSize(.mini) }
+                        Text(capture.isAdding ? "Adding…" : "Add to Draft")
+                    }
+                    .padding(.horizontal, 4)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Palette.accentFill)
+                .keyboardShortcut(.return, modifiers: .command)
+                .help("Add screenshot and comment to the draft (⌘Return)")
+                .disabled(!capture.canAdd)
+            }
+            .controlSize(.regular)
+        }
+        .padding(16)
+        .background(Palette.surfaceSunken)
+        .disabled(capture.isAdding)
+    }
+
+    private var source: String {
+        let display = BrowserAddressDisplay.of(capture.address)
+        let label = display.host + display.trailing
+        return label.isEmpty ? capture.address : label
     }
 }

--- a/Sources/Bloom/Views/Center/Browser/BrowserRegionCaptureView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserRegionCaptureView.swift
@@ -1,139 +1,42 @@
 import SwiftUI
 import BloomCore
 
-/// The page and the feedback have separate surfaces: the crop stays readable while the comment
-/// grows, and the destination is visible before anything is added to a conversation.
+/// The selection is an overlay on the viewport, never a replacement layout. The same editor a
+/// diff line opens lives in a popover, so neither selecting nor typing changes the page's size.
 struct BrowserRegionCaptureView: View {
     @Bindable var capture: BrowserRegionCapture
     var cancel: @MainActor () -> Void
     var add: @MainActor () -> Void
-    @FocusState private var commentFocused: Bool
 
     var body: some View {
-        VStack(spacing: 0) {
-            header
-            Hairline()
-            BrowserRegionCanvas(capture: capture) { commentFocused = true }
-            Hairline()
-            composer
-        }
-        .background(Palette.surface)
-    }
-
-    private var header: some View {
-        HStack(spacing: Metrics.gutter) {
-            Image(systemName: "crop")
-                .font(Typo.bodyEmphasis)
-                .foregroundStyle(Palette.accent)
-                .frame(width: 30, height: 30)
-                .background(Palette.questionWash, in: RoundedRectangle(cornerRadius: Metrics.corner))
-                .accessibilityHidden(true)
-            VStack(alignment: .leading, spacing: 3) {
-                Text("Comment on an area")
-                    .font(Typo.labelEmphasis)
-                    .foregroundStyle(Palette.textPrimary)
-                Text("Snapshot · \(source)")
-                    .font(Typo.caption)
-                    .foregroundStyle(Palette.textSecondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .help(capture.address)
-            }
-            Spacer(minLength: 0)
-            Button("Cancel", systemImage: "xmark", action: cancel)
-                .labelStyle(.iconOnly)
-                .buttonStyle(.accessoryBar)
-                .keyboardShortcut(.cancelAction)
-                .help("Cancel capture (Esc)")
-                .disabled(capture.isAdding)
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-    }
-
-    private var composer: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 6) {
-                Image(systemName: capture.selection == nil ? "cursorarrow" : "checkmark.circle.fill")
-                    .foregroundStyle(capture.selection == nil ? Palette.textSecondary : Palette.accent)
-                    .accessibilityHidden(true)
-                Text(capture.selection == nil
-                    ? "Drag over the area you want to discuss."
-                    : "Drag inside to move. Use the corners to resize.")
-                    .font(Typo.caption)
-                    .foregroundStyle(Palette.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            TextField("What should change?", text: $capture.comment, axis: .vertical)
-                .textFieldStyle(.plain)
-                .font(Typo.body)
-                .lineLimit(2...5)
-                .focused($commentFocused)
-                .accessibilityLabel("Comment about the selected area")
-                .padding(12)
-                .background(Palette.surfaceRaised, in: RoundedRectangle(cornerRadius: 10))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 10).strokeBorder(
-                        commentFocused ? Palette.focusRing : Palette.border,
-                        lineWidth: commentFocused ? 1.5 : Metrics.outline
-                    )
+        GeometryReader { proxy in
+            let page = BrowserRegion.rect(capture.pageRect, in: CGRect(origin: .zero, size: proxy.size))
+            let anchor = capture.selection.map { BrowserRegion.rect($0, in: page) } ?? page
+            BrowserRegionCanvas(capture: capture) { capture.isEditing = true }
+                .popover(isPresented: $capture.isEditing, attachmentAnchor: .rect(.rect(anchor))) {
+                    editor
                 }
+        }
+    }
+
+    private var editor: some View {
+        VStack(spacing: 0) {
+            ReviewCommentEditorView(
+                text: $capture.comment,
+                width: 380,
+                onCommit: { if capture.canAdd { add() } },
+                onCancel: cancel
+            )
+            .disabled(capture.isAdding)
             if let failure = capture.failure {
                 Label(failure, systemImage: "exclamationmark.circle")
                     .font(Typo.caption)
                     .foregroundStyle(Palette.negative)
                     .fixedSize(horizontal: false, vertical: true)
+                    .padding(Metrics.inset)
             }
-            HStack(alignment: .center, spacing: 8) {
-                Label(capture.conversation, systemImage: "text.bubble")
-                    .font(Typo.caption)
-                    .foregroundStyle(Palette.textSecondary)
-                    .lineLimit(1)
-                    .help("Adds to the draft in \(capture.conversation). Nothing is sent yet.")
-                Spacer(minLength: 0)
-                Text("Draft only")
-                    .font(Typo.micro)
-                    .foregroundStyle(Palette.textTertiary)
-            }
-            HStack {
-                Menu {
-                    Button("Select All") {
-                        capture.selection = CGRect(x: 0, y: 0, width: 1, height: 1)
-                        commentFocused = true
-                    }
-                    Button("Clear Selection") { capture.selection = nil }
-                        .disabled(capture.selection == nil)
-                } label: {
-                    Label("Selection", systemImage: "rectangle.dashed")
-                }
-                .menuStyle(.borderlessButton)
-                .fixedSize()
-                .font(Typo.label)
-                .help("Select the whole screenshot or start a new selection")
-                Spacer(minLength: Metrics.spacingSmall)
-                Button(action: add) {
-                    HStack(spacing: 8) {
-                        if capture.isAdding { ProgressView().controlSize(.mini) }
-                        Text(capture.isAdding ? "Adding…" : "Add to Draft")
-                    }
-                    .padding(.horizontal, 4)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(Palette.accentFill)
-                .keyboardShortcut(.return, modifiers: .command)
-                .help("Add screenshot and comment to the draft (⌘Return)")
-                .disabled(!capture.canAdd)
-            }
-            .controlSize(.regular)
         }
-        .padding(16)
-        .background(Palette.surfaceSunken)
-        .disabled(capture.isAdding)
-    }
-
-    private var source: String {
-        let display = BrowserAddressDisplay.of(capture.address)
-        let label = display.host + display.trailing
-        return label.isEmpty ? capture.address : label
+        .frame(width: 380)
+        .background(Palette.reviewBand)
     }
 }

--- a/Sources/Bloom/Views/Center/Browser/BrowserRegionCaptureView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserRegionCaptureView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+import BloomCore
+
+/// Selection takes place on the snapshot itself. A live page can animate or reflow between a
+/// drag and Add, which would otherwise attach a different region from the one the reader saw.
+struct BrowserRegionCaptureView: View {
+    @Bindable var capture: BrowserRegionCapture
+    var cancel: @MainActor () -> Void
+    var add: @MainActor () -> Void
+    @FocusState private var commentFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            canvas
+            Hairline()
+            VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
+                Text(capture.selection == nil ? "Drag to select an area" : "Drag again to change the area")
+                    .font(Typo.label)
+                    .foregroundStyle(Palette.textSecondary)
+                TextField("What should change?", text: $capture.comment, axis: .vertical)
+                    .textFieldStyle(.roundedBorder)
+                    .lineLimit(2...4)
+                    .focused($commentFocused)
+                    .accessibilityLabel("Comment about the selected area")
+                if let failure = capture.failure {
+                    Text(failure).font(Typo.caption).foregroundStyle(Palette.textPrimary)
+                }
+                Text("Adds to the draft in \(capture.conversation)")
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textSecondary)
+                    .lineLimit(1)
+                    .help(capture.conversation)
+                HStack {
+                    Button("Select All") {
+                        capture.selection = CGRect(x: 0, y: 0, width: 1, height: 1)
+                        commentFocused = true
+                    }
+                    Spacer(minLength: Metrics.spacingSmall)
+                    Button("Cancel", action: cancel).keyboardShortcut(.cancelAction)
+                    Button(capture.isAdding ? "Adding…" : "Add to Draft", action: add)
+                        .keyboardShortcut(.return, modifiers: .command)
+                        .disabled(!capture.canAdd)
+                }
+                .controlSize(.small)
+            }
+            .padding(Metrics.spacingWide)
+            .disabled(capture.isAdding)
+        }
+        .background(Palette.surface)
+    }
+
+    private var canvas: some View {
+        GeometryReader { proxy in
+            let frame = BrowserRegion.imageFrame(image: capture.imageSize, canvas: proxy.size)
+            let selected = capture.selection.map { BrowserRegion.rect($0, in: frame) }
+            ZStack(alignment: .topLeading) {
+                Palette.surfaceSunken
+                Image(decorative: capture.image, scale: 1)
+                    .resizable()
+                    .frame(width: frame.width, height: frame.height)
+                    .offset(x: frame.minX, y: frame.minY)
+                Path { path in
+                    path.addRect(frame)
+                    if let selected { path.addRect(selected) }
+                }
+                .fill(.black.opacity(0.4), style: FillStyle(eoFill: true))
+                if let selected {
+                    Rectangle()
+                        .strokeBorder(.white, lineWidth: 2)
+                        .background { Rectangle().stroke(.black, lineWidth: 1) }
+                        .frame(width: selected.width, height: selected.height)
+                        .offset(x: selected.minX, y: selected.minY)
+                }
+            }
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        capture.selection = BrowserRegion.selection(
+                            from: value.startLocation, to: value.location, in: frame
+                        )
+                    }
+                    .onEnded { _ in
+                        if capture.selection != nil { commentFocused = true }
+                    }
+            )
+            .allowsHitTesting(!capture.isAdding)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Page screenshot")
+            .accessibilityValue(capture.selection == nil ? "No area selected" : "Area selected")
+            .accessibilityHint("Drag to select an area, or use Select All to attach the visible page.")
+        }
+    }
+}

--- a/Sources/Bloom/Views/Center/Browser/BrowserRegionCaptureView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserRegionCaptureView.swift
@@ -1,33 +1,84 @@
 import SwiftUI
 import BloomCore
 
-/// The selection is an overlay on the viewport, never a replacement layout. The same editor a
-/// diff line opens lives in a popover, so neither selecting nor typing changes the page's size.
+/// These bands are ordinary overlays, not popovers. Only the band itself takes clicks, so the
+/// same mouse-down that starts a new selection reaches the page while a comment is open.
 struct BrowserRegionCaptureView: View {
     @Bindable var capture: BrowserRegionCapture
-    var cancel: @MainActor () -> Void
+    var model: WorkspaceModel
+    var viewportFrame: CGRect
     var add: @MainActor () -> Void
+    @State private var panelSize = CGSize(width: 380, height: 100)
 
     var body: some View {
         GeometryReader { proxy in
-            let page = BrowserRegion.rect(capture.pageRect, in: CGRect(origin: .zero, size: proxy.size))
-            let anchor = capture.selection.map { BrowserRegion.rect($0, in: page) } ?? page
-            BrowserRegionCanvas(capture: capture) { capture.isEditing = true }
-                .popover(isPresented: $capture.isEditing, attachmentAnchor: .rect(.rect(anchor))) {
-                    editor
+            let page = BrowserRegion.rect(capture.pageRect, in: viewportFrame)
+            let selection = capture.selection ?? capture.focusedComment?.selection
+            if let selection, capture.isEditing || capture.focusedComment != nil {
+                let anchor = BrowserRegion.rect(selection, in: page)
+                let size = CGSize(width: min(380, max(0, proxy.size.width - 16)), height: panelSize.height)
+                let frame = BrowserRegion.commentFrame(near: anchor, in: CGRect(origin: .zero, size: proxy.size), size: size)
+                ScrollView {
+                    panel(width: frame.width)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .onGeometryChange(for: CGSize.self) { $0.size } action: { panelSize = $0 }
                 }
+                    .scrollBounceBehavior(.basedOnSize)
+                    .frame(width: frame.width, height: frame.height)
+                    .background(Palette.reviewBand, in: RoundedRectangle(cornerRadius: Metrics.cornerSmall))
+                    .background(Palette.surface, in: RoundedRectangle(cornerRadius: Metrics.cornerSmall))
+                    .clipShape(RoundedRectangle(cornerRadius: Metrics.cornerSmall))
+                    .overlay { RoundedRectangle(cornerRadius: Metrics.cornerSmall).strokeBorder(Palette.border, lineWidth: Metrics.outline) }
+                    .elevation(.resting)
+                    .position(x: frame.midX, y: frame.midY)
+            }
+        }
+        .onChange(of: model.existingTranscript(for: capture.sessionID)?.draft) {
+            guard let transcript = model.existingTranscript(for: capture.sessionID) else { return }
+            capture.synchronise(with: transcript.draft)
         }
     }
 
-    private var editor: some View {
+    @ViewBuilder private func panel(width: CGFloat) -> some View {
         VStack(spacing: 0) {
-            ReviewCommentEditorView(
-                text: $capture.comment,
-                width: 380,
-                onCommit: { if capture.canAdd { add() } },
-                onCancel: cancel
-            )
-            .disabled(capture.isAdding)
+            if capture.isEditing {
+                if capture.editingCommentPath != nil {
+                    VStack(spacing: Metrics.spacing) {
+                        ReviewCommentField(text: $capture.comment, placeholder: "Leave a comment", onSubmit: save, onCancel: capture.cancelEdit)
+                        ReviewCommentEditorButtons(
+                            confirmTitle: "Save", canConfirm: ReviewCommentEdit.canSubmit(capture.comment),
+                            confirmHelp: "Save the comment (Return)", onConfirm: save, onCancel: capture.cancelEdit
+                        )
+                    }
+                    .padding(.horizontal, Metrics.inset)
+                    .padding(.vertical, Metrics.spacingWide)
+                    .frame(width: width)
+                } else {
+                    ReviewCommentEditorView(
+                        text: $capture.comment, width: width,
+                        onCommit: { if capture.canAdd { add() } }, onCancel: capture.cancelEdit
+                    )
+                }
+            } else if let note = capture.focusedComment {
+                HStack(alignment: .firstTextBaseline, spacing: Metrics.spacing) {
+                    Image(systemName: "text.bubble").font(Typo.micro).foregroundStyle(Palette.textSecondary)
+                    Text(note.body)
+                        .font(Typo.body)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .help(note.body)
+                    Button("Edit comment", systemImage: "pencil") { capture.beginEdit(note) }
+                        .labelStyle(.iconOnly)
+                    Button("Remove comment", systemImage: "xmark") { capture.remove(note, from: model) }
+                        .labelStyle(.iconOnly)
+                }
+                .buttonStyle(.plain)
+                .font(Typo.micro)
+                .padding(.horizontal, Metrics.inset)
+                .padding(.vertical, Metrics.spacingWide)
+                .frame(width: width)
+            }
             if let failure = capture.failure {
                 Label(failure, systemImage: "exclamationmark.circle")
                     .font(Typo.caption)
@@ -36,7 +87,11 @@ struct BrowserRegionCaptureView: View {
                     .padding(Metrics.inset)
             }
         }
-        .frame(width: 380)
-        .background(Palette.reviewBand)
+        .disabled(capture.isAdding)
+    }
+
+    private func save() {
+        guard !capture.isAdding else { return }
+        capture.saveEdit(in: model)
     }
 }

--- a/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
@@ -70,10 +70,12 @@ struct BrowserTabView: View {
                 )
             }
             ZStack {
-                BrowserViewportView(session: session, paneMenu: pageMenu, host: host)
+                BrowserViewportView(
+                    session: session, paneMenu: pageMenu, host: host,
+                    isSelectingRegion: isSelectingRegion, regionCapture: regionCapture,
+                    cancelRegion: cancelRegion, addRegion: addRegion
+                )
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .allowsHitTesting(!isSelectingRegion)
-                    .accessibilityHidden(isSelectingRegion)
 
                 // A tab nobody has given an address is a white rectangle under a toolbar, which
                 // reads as a page that failed to load rather than as a pane waiting to be told
@@ -127,23 +129,9 @@ struct BrowserTabView: View {
                     .padding(12)
                 }
             }
-            .overlay {
+            .overlay(alignment: .bottom) {
                 if isSelectingRegion {
-                    if let regionCapture {
-                        BrowserRegionCaptureView(capture: regionCapture, cancel: cancelRegion) {
-                            regionCapture.add(to: model) {
-                                regionNotice = (regionCapture.sessionID, regionCapture.conversation)
-                                cancelRegion()
-                            }
-                        }
-                    } else {
-                        VStack(spacing: Metrics.spacingWide) {
-                            ProgressView("Capturing page…")
-                            Button("Cancel", action: cancelRegion).keyboardShortcut(.cancelAction)
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .background(Palette.surface)
-                    }
+                    regionControls
                 }
             }
         }
@@ -236,6 +224,56 @@ struct BrowserTabView: View {
 
     // MARK: - Screenshot
 
+    @ViewBuilder private var regionControls: some View {
+        if regionCapture?.isEditing != true {
+            HStack(spacing: Metrics.spacingWide) {
+                if let regionCapture {
+                    Menu {
+                        Button("Select All") {
+                            regionCapture.selection = CGRect(x: 0, y: 0, width: 1, height: 1)
+                            regionCapture.isEditing = true
+                        }
+                        Button("Clear Selection") { regionCapture.selection = nil }
+                            .disabled(regionCapture.selection == nil)
+                    } label: {
+                        Image(systemName: "rectangle.dashed")
+                    }
+                    .menuStyle(.borderlessButton)
+                    .fixedSize()
+                    .accessibilityLabel("Selection")
+                    Text(regionCapture.selection == nil ? "Drag to select an area" : "Area selected")
+                        .font(Typo.caption)
+                    if regionCapture.selection != nil {
+                        Button("Comment") { regionCapture.isEditing = true }
+                            .controlSize(.small)
+                    }
+                } else {
+                    ProgressView().controlSize(.mini)
+                    Text("Capturing page…").font(Typo.caption)
+                }
+                Button("Cancel", action: cancelRegion)
+                    .buttonStyle(.borderless)
+                    .font(Typo.caption)
+                    .keyboardShortcut(.cancelAction)
+            }
+            .disabled(regionCapture?.isAdding == true)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Palette.surfaceRaised, in: RoundedRectangle(cornerRadius: Metrics.corner))
+            .overlay { RoundedRectangle(cornerRadius: Metrics.corner).strokeBorder(Palette.border, lineWidth: Metrics.outline) }
+            .elevation(.resting)
+            .padding(12)
+        }
+    }
+
+    private func addRegion() {
+        guard let regionCapture else { return }
+        regionCapture.add(to: model) {
+            regionNotice = (regionCapture.sessionID, regionCapture.conversation)
+            cancelRegion()
+        }
+    }
+
     private func beginRegion() {
         guard !isCapturing, !isSelectingRegion else { return }
         regionNotice = nil
@@ -258,6 +296,7 @@ struct BrowserTabView: View {
         }
         let session = self.session
         let address = session.displayAddress
+        let pageRect = BrowserRegionCapture.pageRect(in: session)
         do {
             let data = try await session.snapshot()
             try Task.checkCancellation()
@@ -269,7 +308,7 @@ struct BrowserTabView: View {
                 )
                 return
             }
-            regionCapture = try BrowserRegionCapture(data: data, address: address, session: destination)
+            regionCapture = try BrowserRegionCapture(data: data, address: address, session: destination, pageRect: pageRect)
         } catch {
             guard !Task.isCancelled else { return }
             cancelRegion()

--- a/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
@@ -14,6 +14,7 @@ struct BrowserTabView: View {
     /// down rather than reached for, for the reason `ToolPaneView.splitColumn` is: only the pane
     /// above knows which pane it is.
     var paneMenu: (@MainActor () -> NSMenu)?
+    var siblings: [PaneContent] = []
 
     /// What the field shows, which is not where the page is. Typing has to be allowed to disagree
     /// with the page until Return is pressed, so this is local state and the session is only told
@@ -32,7 +33,8 @@ struct BrowserTabView: View {
     @State private var isCapturing = false
     @State private var isSelectingRegion = false
     @State private var regionCapture: BrowserRegionCapture?
-    @State private var regionNotice: (sessionID: SessionID, conversation: String)?
+    @State private var viewportFrame: CGRect = .zero
+    @State private var room = ComposerRoom()
 
     @Environment(AppModel.self) private var app
 
@@ -53,7 +55,6 @@ struct BrowserTabView: View {
 
         VStack(spacing: 0) {
             toolbar(session)
-                .disabled(isSelectingRegion)
             Hairline()
             if session.find.isShowing {
                 BrowserFindBar(
@@ -73,7 +74,7 @@ struct BrowserTabView: View {
                 BrowserViewportView(
                     session: session, paneMenu: pageMenu, host: host,
                     isSelectingRegion: isSelectingRegion, regionCapture: regionCapture,
-                    cancelRegion: cancelRegion, addRegion: addRegion
+                    onViewportFrame: { viewportFrame = $0 }
                 )
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -102,31 +103,13 @@ struct BrowserTabView: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .overlay(alignment: .top) {
-                if let regionNotice {
-                    HStack(spacing: 8) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(Palette.accent)
-                            .accessibilityHidden(true)
-                        Text("Added to draft").font(Typo.labelEmphasis)
-                        Spacer(minLength: 0)
-                        if model.sessions.contains(where: { $0.id == regionNotice.sessionID }) {
-                            Button("View Draft") {
-                                WorkspaceTabsStore.shared.reveal(.chat(regionNotice.sessionID), in: model)
-                                self.regionNotice = nil
-                            }
-                            .controlSize(.small)
-                            .help(regionNotice.conversation)
-                        }
-                        Button("Dismiss", systemImage: "xmark") { self.regionNotice = nil }
-                            .labelStyle(.iconOnly)
-                            .buttonStyle(.accessoryBar)
-                    }
-                    .padding(12)
-                    .background(Palette.surfaceRaised, in: RoundedRectangle(cornerRadius: 10))
-                    .overlay { RoundedRectangle(cornerRadius: 10).strokeBorder(Palette.border, lineWidth: Metrics.outline) }
-                    .elevation(.resting)
-                    .padding(12)
+            .coordinateSpace(name: "browser-feedback-pane")
+            .overlay(alignment: .topLeading) {
+                if let regionCapture {
+                    BrowserRegionCaptureView(
+                        capture: regionCapture, model: model, viewportFrame: viewportFrame,
+                        add: addRegion
+                    )
                 }
             }
             .overlay(alignment: .bottom) {
@@ -134,7 +117,11 @@ struct BrowserTabView: View {
                     regionControls
                 }
             }
+            if ReviewComposer.isDrawn(destination: regionCapture?.sessionID ?? model.reviewDestination?.id, panes: siblings) {
+                ReviewPaneComposer(model: model, room: room, destinationID: regionCapture?.sessionID)
+            }
         }
+        .onGeometryChange(for: CGFloat.self) { PaneMeasure.room($0.size.height) } action: { room.height = $0 }
         .background(Palette.surface)
         .task(id: isSelectingRegion) {
             guard isSelectingRegion, regionCapture == nil else { return }
@@ -152,6 +139,10 @@ struct BrowserTabView: View {
         // keyboard off the composer next to it.
         .task(id: tab.id) {
             address = session.displayAddress
+            if let held = model.browserReviews[tab.id] {
+                regionCapture = held
+                isSelectingRegion = true
+            }
             if address.isEmpty { isAddressFocused = true }
             // A pane redrawn onto a session that has been loading all along, which is what
             // switching workspace and coming back is. Nothing changed while this view was gone,
@@ -195,7 +186,9 @@ struct BrowserTabView: View {
                 if session.isLoading { session.webView.stopLoading() } else { session.reload() }
             },
             capture: capture,
-            captureRegion: beginRegion,
+            captureRegion: isSelectingRegion ? cancelRegion : beginRegion,
+            isReviewing: isSelectingRegion,
+            isSavingReview: regionCapture?.isAdding == true,
             viewport: Binding(get: { session.viewport }, set: { session.viewport = $0 }),
             submit: {
                 session.load(address)
@@ -225,7 +218,7 @@ struct BrowserTabView: View {
     // MARK: - Screenshot
 
     @ViewBuilder private var regionControls: some View {
-        if regionCapture?.isEditing != true {
+        if regionCapture?.isEditing != true && regionCapture?.focusedComment == nil {
             HStack(spacing: Metrics.spacingWide) {
                 if let regionCapture {
                     Menu {
@@ -251,7 +244,7 @@ struct BrowserTabView: View {
                     ProgressView().controlSize(.mini)
                     Text("Capturing page…").font(Typo.caption)
                 }
-                Button("Cancel", action: cancelRegion)
+                Button(regionCapture == nil ? "Cancel" : "Done", action: cancelRegion)
                     .buttonStyle(.borderless)
                     .font(Typo.caption)
                     .keyboardShortcut(.cancelAction)
@@ -269,24 +262,23 @@ struct BrowserTabView: View {
     private func addRegion() {
         guard let regionCapture else { return }
         regionCapture.add(to: model) {
-            regionNotice = (regionCapture.sessionID, regionCapture.conversation)
-            cancelRegion()
+            model.browserReviews[tab.id] = regionCapture
         }
     }
 
     private func beginRegion() {
         guard !isCapturing, !isSelectingRegion else { return }
-        regionNotice = nil
         isSelectingRegion = true
     }
 
     private func cancelRegion() {
         isSelectingRegion = false
         regionCapture = nil
+        model.browserReviews[tab.id] = nil
     }
 
     private func prepareRegion() async {
-        guard let destination = model.activeSession else {
+        guard let destination = model.reviewDestination else {
             cancelRegion()
             app.alert = BloomAlert(
                 title: "No conversation yet",
@@ -308,7 +300,11 @@ struct BrowserTabView: View {
                 )
                 return
             }
-            regionCapture = try BrowserRegionCapture(data: data, address: address, session: destination, pageRect: pageRect)
+            regionCapture = try BrowserRegionCapture(
+                data: data, address: address, session: destination,
+                pageRect: pageRect, viewportSize: viewportFrame.size
+            )
+            model.browserReviews[tab.id] = regionCapture
         } catch {
             guard !Task.isCancelled else { return }
             cancelRegion()

--- a/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
@@ -32,7 +32,7 @@ struct BrowserTabView: View {
     @State private var isCapturing = false
     @State private var isSelectingRegion = false
     @State private var regionCapture: BrowserRegionCapture?
-    @State private var regionNotice: String?
+    @State private var regionNotice: (sessionID: SessionID, conversation: String)?
 
     @Environment(AppModel.self) private var app
 
@@ -102,13 +102,29 @@ struct BrowserTabView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .overlay(alignment: .top) {
                 if let regionNotice {
-                    HStack {
-                        Text(regionNotice).font(Typo.caption).lineLimit(2)
-                        Spacer()
-                        Button("Dismiss") { self.regionNotice = nil }.controlSize(.small)
+                    HStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(Palette.accent)
+                            .accessibilityHidden(true)
+                        Text("Added to draft").font(Typo.labelEmphasis)
+                        Spacer(minLength: 0)
+                        if model.sessions.contains(where: { $0.id == regionNotice.sessionID }) {
+                            Button("View Draft") {
+                                WorkspaceTabsStore.shared.reveal(.chat(regionNotice.sessionID), in: model)
+                                self.regionNotice = nil
+                            }
+                            .controlSize(.small)
+                            .help(regionNotice.conversation)
+                        }
+                        Button("Dismiss", systemImage: "xmark") { self.regionNotice = nil }
+                            .labelStyle(.iconOnly)
+                            .buttonStyle(.accessoryBar)
                     }
-                    .padding(Metrics.spacingSmall)
-                    .background(Palette.surface)
+                    .padding(12)
+                    .background(Palette.surfaceRaised, in: RoundedRectangle(cornerRadius: 10))
+                    .overlay { RoundedRectangle(cornerRadius: 10).strokeBorder(Palette.border, lineWidth: Metrics.outline) }
+                    .elevation(.resting)
+                    .padding(12)
                 }
             }
             .overlay {
@@ -116,7 +132,7 @@ struct BrowserTabView: View {
                     if let regionCapture {
                         BrowserRegionCaptureView(capture: regionCapture, cancel: cancelRegion) {
                             regionCapture.add(to: model) {
-                                regionNotice = "Added to the draft in \(regionCapture.conversation)"
+                                regionNotice = (regionCapture.sessionID, regionCapture.conversation)
                                 cancelRegion()
                             }
                         }

--- a/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserTabView.swift
@@ -30,6 +30,9 @@ struct BrowserTabView: View {
     /// then the file is written into the worktree off the main actor. A second press in the middle
     /// of that would attach the same page twice, so the button goes quiet rather than counting.
     @State private var isCapturing = false
+    @State private var isSelectingRegion = false
+    @State private var regionCapture: BrowserRegionCapture?
+    @State private var regionNotice: String?
 
     @Environment(AppModel.self) private var app
 
@@ -50,6 +53,7 @@ struct BrowserTabView: View {
 
         VStack(spacing: 0) {
             toolbar(session)
+                .disabled(isSelectingRegion)
             Hairline()
             if session.find.isShowing {
                 BrowserFindBar(
@@ -68,6 +72,8 @@ struct BrowserTabView: View {
             ZStack {
                 BrowserWebView(session: session, paneMenu: pageMenu, host: host)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .allowsHitTesting(!isSelectingRegion)
+                    .accessibilityHidden(isSelectingRegion)
 
                 // A tab nobody has given an address is a white rectangle under a toolbar, which
                 // reads as a page that failed to load rather than as a pane waiting to be told
@@ -94,8 +100,42 @@ struct BrowserTabView: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .overlay(alignment: .top) {
+                if let regionNotice {
+                    HStack {
+                        Text(regionNotice).font(Typo.caption).lineLimit(2)
+                        Spacer()
+                        Button("Dismiss") { self.regionNotice = nil }.controlSize(.small)
+                    }
+                    .padding(Metrics.spacingSmall)
+                    .background(Palette.surface)
+                }
+            }
+            .overlay {
+                if isSelectingRegion {
+                    if let regionCapture {
+                        BrowserRegionCaptureView(capture: regionCapture, cancel: cancelRegion) {
+                            regionCapture.add(to: model) {
+                                regionNotice = "Added to the draft in \(regionCapture.conversation)"
+                                cancelRegion()
+                            }
+                        }
+                    } else {
+                        VStack(spacing: Metrics.spacingWide) {
+                            ProgressView("Capturing page…")
+                            Button("Cancel", action: cancelRegion).keyboardShortcut(.cancelAction)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(Palette.surface)
+                    }
+                }
+            }
         }
         .background(Palette.surface)
+        .task(id: isSelectingRegion) {
+            guard isSelectingRegion, regionCapture == nil else { return }
+            await prepareRegion()
+        }
         // Per tab, so switching between two browser tabs puts each field back where its own page
         // is rather than leaving the address of the one that was showing a moment ago.
         //
@@ -137,7 +177,7 @@ struct BrowserTabView: View {
                 canGoForward: session.canGoForward,
                 isLoading: session.isLoading,
                 loadProgress: session.loadProgress,
-                isCapturing: isCapturing
+                isCapturing: isCapturing || isSelectingRegion
             ),
             address: $address,
             addressFocus: $isAddressFocused,
@@ -151,6 +191,7 @@ struct BrowserTabView: View {
                 if session.isLoading { session.webView.stopLoading() } else { session.reload() }
             },
             capture: capture,
+            captureRegion: beginRegion,
             submit: {
                 session.load(address)
                 isAddressFocused = false
@@ -178,6 +219,47 @@ struct BrowserTabView: View {
 
     // MARK: - Screenshot
 
+    private func beginRegion() {
+        guard !isCapturing, !isSelectingRegion else { return }
+        regionNotice = nil
+        isSelectingRegion = true
+    }
+
+    private func cancelRegion() {
+        isSelectingRegion = false
+        regionCapture = nil
+    }
+
+    private func prepareRegion() async {
+        guard let destination = model.activeSession else {
+            cancelRegion()
+            app.alert = BloomAlert(
+                title: "No conversation yet",
+                message: "Open a conversation in this workspace before adding feedback."
+            )
+            return
+        }
+        let session = self.session
+        let address = session.displayAddress
+        do {
+            let data = try await session.snapshot()
+            try Task.checkCancellation()
+            guard address == session.displayAddress else {
+                cancelRegion()
+                app.alert = BloomAlert(
+                    title: "The page changed during capture",
+                    message: "Wait for the page to finish loading, then select the area again."
+                )
+                return
+            }
+            regionCapture = try BrowserRegionCapture(data: data, address: address, session: destination)
+        } catch {
+            guard !Task.isCancelled else { return }
+            cancelRegion()
+            app.alert = BloomAlert(title: "That page could not be captured", message: error.readableMessage)
+        }
+    }
+
     /// Takes the page as it is on screen and puts it in the composer, in one press.
     ///
     /// **One press, with no confirmation.** The alternative, a sheet asking where the picture
@@ -189,7 +271,7 @@ struct BrowserTabView: View {
     /// **It does not send the turn.** Nobody wants an agent handed a screenshot with no sentence
     /// attached. What lands is an attachment and a caret, and the user writes what is wrong with it.
     private func capture() {
-        guard !isCapturing else { return }
+        guard !isCapturing, !isSelectingRegion else { return }
         isCapturing = true
         Task {
             defer { isCapturing = false }
@@ -249,10 +331,13 @@ struct BrowserTabView: View {
             // `TranscriptLinkMenu`.
             items.append(item("Open in External Browser") { NSWorkspace.shared.open(url) })
         }
-        if !isCapturing {
+        if !isCapturing, !isSelectingRegion {
             // The same words as the toolbar's own camera, taken from the one place that says them,
             // so the glyph and the menu item cannot drift into naming the same thing two ways.
             items.append(item(BrowserToolbar().screenshot.name, perform: capture))
+            if BrowserToolbar(page: session.page).regionCapture.isEnabled {
+                items.append(item(BrowserToolbar().regionCapture.name, perform: beginRegion))
+            }
         }
         guard !items.isEmpty else { return menu }
 

--- a/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
@@ -65,6 +65,7 @@ struct BrowserToolbarView: View {
     var goToHistory: @MainActor (Int) -> Void = { _ in }
     var reloadOrStop: @MainActor () -> Void = {}
     var capture: @MainActor () -> Void = {}
+    var captureRegion: @MainActor () -> Void = {}
     var submit: @MainActor () -> Void = {}
 
     /// Drawn inside the field's own edge rather than outside it, so the bar does not have to give
@@ -160,6 +161,8 @@ struct BrowserToolbarView: View {
             pageAction(toolbar.reload, action: reloadOrStop)
             Hairline(axis: .vertical)
             pageAction(toolbar.screenshot, action: capture)
+            Hairline(axis: .vertical)
+            pageAction(toolbar.regionCapture, action: captureRegion)
             Hairline(axis: .vertical)
             BrowserShareButton(
                 control: toolbar.share,

--- a/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
@@ -102,27 +102,17 @@ struct BrowserToolbarView: View {
         .background(Palette.surfaceSunken)
     }
 
-    /// The pair, as one control with a divider through it, which is what `NSToolbarItemGroup`
-    /// draws for Safari and what nothing in a pane can ask for.
+    /// Navigation stays together, including the action that refreshes the current page.
     private var navigation: some View {
-        HStack(spacing: 0) {
+        actionGroup {
             BrowserToolbarButton(control: toolbar.back, action: goBack)
                 .modifier(HistoryMenu(entries: backHistory, go: goToHistory))
             Hairline(axis: .vertical)
             BrowserToolbarButton(control: toolbar.forward, action: goForward)
                 .modifier(HistoryMenu(entries: forwardHistory, go: goToHistory))
+            Hairline(axis: .vertical)
+            pageAction(toolbar.reload, action: reloadOrStop)
         }
-        .frame(height: Metrics.controlHeight)
-        // Clipped before the glass, not after it. `glassEffect` shapes only its own background, so
-        // the two hover fills still need this to stop at the capsule.
-        .clipShape(Capsule())
-        // `.interactive()` here and nowhere else in the bar: this shape is nothing but controls,
-        // and the material answering the pointer is what separates glass from a picture of it.
-        // Which arrow is under the pointer is still said by `.accessoryBar`'s own fill inside.
-        .glassEffect(.regular.interactive(), in: Capsule())
-        // The rim is drawn rather than left to the material's, because it is what still says where
-        // the capsule ends once Reduce Transparency has turned the glass opaque.
-        .overlay { Capsule().strokeBorder(Palette.border, lineWidth: Metrics.outline) }
     }
 
     private var addressField: some View {
@@ -154,40 +144,45 @@ struct BrowserToolbarView: View {
         }
     }
 
-    /// Reload, capture and share are one family of page actions. A joined glass capsule gives
-    /// them equal hit targets and one boundary, while the native button style still supplies each
-    /// action's hover and pressed feedback.
+    /// Separate capsules distinguish preview sizing, feedback capture and system sharing.
+    /// Joining all six buttons made unrelated actions read as one segmented control.
     private var pageActions: some View {
-        HStack(spacing: 0) {
-            BrowserViewportButton(viewport: viewport)
-                .frame(width: pageActionWidth, height: Metrics.controlHeight)
-            Hairline(axis: .vertical)
-            pageAction(BrowserToolbar.Control(
-                symbol: "arrow.up.left.and.arrow.down.right",
-                name: "Full size",
-                help: "Restore the page to the full browser pane",
-                isEnabled: viewport.wrappedValue.isEnabled
-            )) {
-                viewport.wrappedValue.isEnabled = false
+        HStack(spacing: Metrics.spacing) {
+            actionGroup {
+                BrowserViewportButton(viewport: viewport)
+                    .frame(width: pageActionWidth, height: Metrics.controlHeight)
+                Hairline(axis: .vertical)
+                pageAction(BrowserToolbar.Control(
+                    symbol: "arrow.up.left.and.arrow.down.right",
+                    name: "Full size",
+                    help: "Restore the page to the full browser pane",
+                    isEnabled: viewport.wrappedValue.isEnabled
+                )) {
+                    viewport.wrappedValue.isEnabled = false
+                }
             }
-            Hairline(axis: .vertical)
-            pageAction(toolbar.reload, action: reloadOrStop)
-            Hairline(axis: .vertical)
-            pageAction(toolbar.screenshot, action: capture)
-            Hairline(axis: .vertical)
-            pageAction(toolbar.regionCapture, action: captureRegion)
-            Hairline(axis: .vertical)
-            BrowserShareButton(
-                control: toolbar.share,
-                shareable: toolbar.shareable,
-                opticalOffsetY: -0.5
-            )
+            actionGroup {
+                pageAction(toolbar.screenshot, action: capture)
+                Hairline(axis: .vertical)
+                pageAction(toolbar.regionCapture, action: captureRegion)
+            }
+            actionGroup {
+                BrowserShareButton(
+                    control: toolbar.share,
+                    shareable: toolbar.shareable,
+                    opticalOffsetY: -0.5
+                )
                 .frame(width: pageActionWidth, height: Metrics.controlHeight)
+            }
         }
-        .frame(height: Metrics.controlHeight)
-        .clipShape(Capsule())
-        .glassEffect(.regular.interactive(), in: Capsule())
-        .overlay { Capsule().strokeBorder(Palette.border, lineWidth: Metrics.outline) }
+    }
+
+    private func actionGroup<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        HStack(spacing: 0, content: content)
+            .frame(height: Metrics.controlHeight)
+            .clipShape(Capsule())
+            .glassEffect(.regular.interactive(), in: Capsule())
+            .overlay { Capsule().strokeBorder(Palette.border, lineWidth: Metrics.outline) }
     }
 
     private func pageAction(

--- a/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserToolbarView.swift
@@ -66,6 +66,8 @@ struct BrowserToolbarView: View {
     var reloadOrStop: @MainActor () -> Void = {}
     var capture: @MainActor () -> Void = {}
     var captureRegion: @MainActor () -> Void = {}
+    var isReviewing = false
+    var isSavingReview = false
     var viewport: Binding<BrowserViewport> = .constant(BrowserViewport())
     var submit: @MainActor () -> Void = {}
 
@@ -88,8 +90,8 @@ struct BrowserToolbarView: View {
         // exactly what the three groups above must not become.
         GlassEffectContainer(spacing: 0) {
             HStack(spacing: Metrics.spacingWide) {
-                navigation
-                addressField
+                navigation.disabled(isReviewing)
+                addressField.disabled(isReviewing)
                 pageActions
             }
         }
@@ -161,10 +163,20 @@ struct BrowserToolbarView: View {
                     viewport.wrappedValue.isEnabled = false
                 }
             }
+            .disabled(isReviewing)
             actionGroup {
                 pageAction(toolbar.screenshot, action: capture)
                 Hairline(axis: .vertical)
-                pageAction(toolbar.regionCapture, action: captureRegion)
+                Button(action: captureRegion) {
+                    Label(isReviewing ? "Done" : "Comment", systemImage: isReviewing ? "checkmark" : "text.bubble")
+                        .font(Typo.label)
+                        .padding(.horizontal, Metrics.spacingSmall)
+                }
+                .buttonStyle(.accessoryBar)
+                .fixedSize(horizontal: true, vertical: false)
+                .foregroundStyle(isReviewing ? Palette.accent : Palette.textSecondary)
+                .disabled(isSavingReview || (!isReviewing && !toolbar.regionCapture.isEnabled))
+                .help(isReviewing ? "Finish reviewing this page" : "Drag over part of this page to leave a comment")
             }
             actionGroup {
                 BrowserShareButton(

--- a/Sources/Bloom/Views/Center/Browser/BrowserViewportView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserViewportView.swift
@@ -7,6 +7,10 @@ struct BrowserViewportView: View {
     @Bindable var session: BrowserSession
     var paneMenu: (@MainActor () -> NSMenu)?
     var host = BrowserPaneHost()
+    var isSelectingRegion = false
+    var regionCapture: BrowserRegionCapture?
+    var cancelRegion: @MainActor () -> Void = {}
+    var addRegion: @MainActor () -> Void = {}
     @State private var drag: ResizeStart?
 
     private let gutter: CGFloat = 18
@@ -22,11 +26,18 @@ struct BrowserViewportView: View {
             let width = viewport.isEnabled ? CGFloat(viewport.width) * scale : geometry.size.width
             let height = viewport.isEnabled ? CGFloat(viewport.height) * scale : geometry.size.height
             ScrollView([.horizontal, .vertical]) {
-                BrowserWebView(
-                    session: session, paneMenu: paneMenu, host: host,
-                    viewportSize: viewport.isEnabled
-                        ? CGSize(width: viewport.width, height: viewport.height) : nil
-                )
+                ZStack {
+                    BrowserWebView(
+                        session: session, paneMenu: paneMenu, host: host,
+                        viewportSize: viewport.isEnabled
+                            ? CGSize(width: viewport.width, height: viewport.height) : nil
+                    )
+                    .allowsHitTesting(!isSelectingRegion)
+                    .accessibilityHidden(isSelectingRegion)
+                    if let regionCapture {
+                        BrowserRegionCaptureView(capture: regionCapture, cancel: cancelRegion, add: addRegion)
+                    }
+                }
                 .frame(width: width, height: height)
                 .overlay {
                     if viewport.isEnabled {
@@ -54,7 +65,7 @@ struct BrowserViewportView: View {
                 .padding(padding)
                 .frame(minWidth: geometry.size.width, minHeight: geometry.size.height, alignment: .top)
             }
-            .scrollDisabled(!viewport.isEnabled)
+            .scrollDisabled(!viewport.isEnabled || isSelectingRegion)
             .background(viewport.isEnabled ? Palette.surfaceSunken : Palette.surface)
         }
         .clipped()
@@ -66,6 +77,7 @@ struct BrowserViewportView: View {
             .frame(width: edge == .bottom ? 32 : 4, height: edge == .bottom ? 4 : 32)
             .frame(width: edge == .bottom ? 64 : gutter, height: edge == .bottom ? gutter : 64)
             .contentShape(Rectangle())
+            .allowsHitTesting(!isSelectingRegion)
             .pointerStyle(edge == .bottom ? .rowResize : .columnResize)
             .help(edge == .bottom ? "Drag to resize viewport height" : "Drag to resize viewport width")
             .accessibilityLabel(edge == .bottom ? "Viewport height" : "Viewport width")

--- a/Sources/Bloom/Views/Center/Browser/BrowserViewportView.swift
+++ b/Sources/Bloom/Views/Center/Browser/BrowserViewportView.swift
@@ -9,8 +9,7 @@ struct BrowserViewportView: View {
     var host = BrowserPaneHost()
     var isSelectingRegion = false
     var regionCapture: BrowserRegionCapture?
-    var cancelRegion: @MainActor () -> Void = {}
-    var addRegion: @MainActor () -> Void = {}
+    var onViewportFrame: @MainActor (CGRect) -> Void = { _ in }
     @State private var drag: ResizeStart?
 
     private let gutter: CGFloat = 18
@@ -23,8 +22,10 @@ struct BrowserViewportView: View {
                 availableWidth: geometry.size.width - padding * 2,
                 availableHeight: geometry.size.height - padding * 2
             )
-            let width = viewport.isEnabled ? CGFloat(viewport.width) * scale : geometry.size.width
-            let height = viewport.isEnabled ? CGFloat(viewport.height) * scale : geometry.size.height
+            let width = regionCapture?.viewportSize?.width
+                ?? (viewport.isEnabled ? CGFloat(viewport.width) * scale : geometry.size.width)
+            let height = regionCapture?.viewportSize?.height
+                ?? (viewport.isEnabled ? CGFloat(viewport.height) * scale : geometry.size.height)
             ScrollView([.horizontal, .vertical]) {
                 ZStack {
                     BrowserWebView(
@@ -35,10 +36,13 @@ struct BrowserViewportView: View {
                     .allowsHitTesting(!isSelectingRegion)
                     .accessibilityHidden(isSelectingRegion)
                     if let regionCapture {
-                        BrowserRegionCaptureView(capture: regionCapture, cancel: cancelRegion, add: addRegion)
+                        BrowserRegionCanvas(capture: regionCapture) { regionCapture.isEditing = true }
                     }
                 }
                 .frame(width: width, height: height)
+                .onGeometryChange(for: CGRect.self) { $0.frame(in: .named("browser-feedback-pane")) } action: {
+                    onViewportFrame($0)
+                }
                 .overlay {
                     if viewport.isEnabled {
                         Rectangle().strokeBorder(Palette.border, lineWidth: 1)
@@ -65,7 +69,7 @@ struct BrowserViewportView: View {
                 .padding(padding)
                 .frame(minWidth: geometry.size.width, minHeight: geometry.size.height, alignment: .top)
             }
-            .scrollDisabled(!viewport.isEnabled || isSelectingRegion)
+            .scrollDisabled(regionCapture == nil && (!viewport.isEnabled || isSelectingRegion))
             .background(viewport.isEnabled ? Palette.surfaceSunken : Palette.surface)
         }
         .clipped()

--- a/Sources/Bloom/Views/Center/Composer/ComposerHandoff.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerHandoff.swift
@@ -41,10 +41,21 @@ enum ComposerHandoff {
     static func attach(
         _ sources: [AttachmentSource],
         to model: WorkspaceModel,
+        sessionID: SessionID? = nil,
+        revealConversation: Bool = true,
         body: @escaping @Sendable ([String]) -> String = { $0.map(AttachmentDraft.token(for:)).joined(separator: " ") }
     ) async -> Outcome {
-        guard let session = model.activeSession else {
-            return Outcome(failure: "This workspace has no conversation to attach to yet.")
+        // A review can stay open while another chat becomes active. An explicit destination
+        // must never fall back to that new chat if the original conversation has been closed.
+        let destination: Session? = if let sessionID {
+            model.sessions.first { $0.id == sessionID }
+        } else {
+            model.activeSession
+        }
+        guard let session = destination else {
+            return Outcome(failure: sessionID == nil
+                ? "This workspace has no conversation to attach to yet."
+                : "The conversation for this feedback has been closed.")
         }
         model.prepareTranscript(for: session.id)
         guard let transcript = model.existingTranscript(for: session.id) else {
@@ -61,7 +72,7 @@ enum ComposerHandoff {
         }
 
         append(body(added.paths), to: transcript)
-        WorkspaceTabsStore.shared.reveal(.chat(session.id), in: model)
+        if revealConversation { WorkspaceTabsStore.shared.reveal(.chat(session.id), in: model) }
 
         return Outcome(failure: added.failures.first)
     }

--- a/Sources/Bloom/Views/Center/Composer/ComposerHandoff.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerHandoff.swift
@@ -21,6 +21,7 @@ enum ComposerHandoff {
     /// promise is that the file is now in the prompt.
     struct Outcome: Sendable {
         var failure: String?
+        var paths: [String] = []
     }
 
     /// Attaches to the workspace's active session, writes `body` at the end of that draft, and
@@ -43,6 +44,7 @@ enum ComposerHandoff {
         to model: WorkspaceModel,
         sessionID: SessionID? = nil,
         revealConversation: Bool = true,
+        imageComment: BrowserImageComment? = nil,
         body: @escaping @Sendable ([String]) -> String = { $0.map(AttachmentDraft.token(for:)).joined(separator: " ") }
     ) async -> Outcome {
         // A review can stay open while another chat becomes active. An explicit destination
@@ -71,10 +73,11 @@ enum ComposerHandoff {
             return Outcome(failure: added.failures.first ?? "Nothing could be attached.")
         }
 
+        if let imageComment { store.annotate(paths: added.paths, with: imageComment, sessionID: key) }
         append(body(added.paths), to: transcript)
         if revealConversation { WorkspaceTabsStore.shared.reveal(.chat(session.id), in: model) }
 
-        return Outcome(failure: added.failures.first)
+        return Outcome(failure: added.failures.first, paths: added.paths)
     }
 
     /// A sentence with nothing attached to it, put in the same place by the same rules.

--- a/Sources/Bloom/Views/Center/Composer/ComposerView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerView.swift
@@ -382,25 +382,31 @@ struct ComposerView: View {
         // and a file that fails it is taken out of the sentence rather than sent as a path to
         // nothing.
         let worktree = transcript.cwd
-        let text = AttachmentDraft
-            .parse(transcript.draft, paths: attachments.map(\.path))
+        let sourceDraft = transcript.draft
+        let draftText = AttachmentDraft
+            .parse(sourceDraft, paths: attachments.map(\.path))
             .keeping { path in
                 FileManager.default.fileExists(
                     atPath: PromptAttachment.sent(path: path).url(in: worktree).path
                 )
             }
 
+        let imageComments = Dictionary(attachments.compactMap { attachment in
+            attachment.imageComment.map { (attachment.path, $0) }
+        }, uniquingKeysWith: { first, _ in first })
+        let text = BrowserImageComment.expand(draftText, comments: imageComments)
+
         // The records go and the files the message names stay. The prompt the agent is now reading
         // names those paths, and deleting them out from under it would break the one thing they
         // were for.
         PromptAttachmentStore.shared.settle(
-            sent: text, sessionID: transcript.session.id.rawValue, workspace: worktree
+            sent: draftText, sessionID: transcript.session.id.rawValue, workspace: worktree
         )
         caret = 0
         let transcript = transcript
         let comments = reviewComments
         guard !comments.isEmpty else {
-            Task { await transcript.submit(text) }
+            Task { await transcript.submit(text, clearingDraft: sourceDraft) }
             return
         }
 
@@ -421,7 +427,7 @@ struct ComposerView: View {
                     template: template
                 )
             }.value
-            await transcript.submit(composed)
+            await transcript.submit(composed, clearingDraft: sourceDraft)
             await model?.removeReviewComments(ids: comments.map(\.id))
         }
     }

--- a/Sources/Bloom/Views/Center/Composer/ReviewPaneComposer.swift
+++ b/Sources/Bloom/Views/Center/Composer/ReviewPaneComposer.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+import BloomCore
+
+/// File and browser reviews use the conversation's real draft and send path. Reserving this
+/// space when the pane opens means adding a comment cannot change the content's viewport.
+struct ReviewPaneComposer: View {
+    @Bindable var model: WorkspaceModel
+    var room: ComposerRoom
+    var destinationID: SessionID?
+
+    @AppStorage(ChatTextSize.defaultsKey) private var textSize = ChatTextSize.defaultChoice
+    @AppStorage(ChatFont.defaultsKey) private var chatFontID = ChatFont.standardID
+    @AppStorage(ChatLineHeight.defaultsKey) private var lineHeight = ChatLineHeight.defaultChoice
+
+    private var destination: Session? {
+        if let destinationID { return model.sessions.first { $0.id == destinationID } }
+        return model.reviewDestination
+    }
+
+    var body: some View {
+        Group {
+            if let destination, let transcript = model.existingTranscript(for: destination.id) {
+                ComposerView(
+                    transcript: transcript, model: model, room: room,
+                    destinationLabel: ReviewDestination.label(for: destination.title),
+                    destinations: destinationID == nil
+                        ? model.sessions.map { ComposerDestination(id: $0.id, title: $0.title) } : [],
+                    onSelectDestination: choose
+                )
+                .environment(\.fontScale, textSize.scale)
+                .environment(\.chatFont, ChatFont(rawValue: chatFontID))
+                .environment(\.chatLineHeight, lineHeight)
+            }
+        }
+        .task(id: destination?.id) {
+            guard let destination else { return }
+            model.prepareTranscript(for: destination.id)
+        }
+    }
+
+    private func choose(_ id: SessionID) {
+        guard model.reviewDestinationID != id else { return }
+        model.reviewDestinationID = id
+        model.prepareTranscript(for: id)
+    }
+}

--- a/Sources/Bloom/Views/Center/Panes/ReviewPaneView.swift
+++ b/Sources/Bloom/Views/Center/Panes/ReviewPaneView.swift
@@ -50,14 +50,6 @@ struct ReviewPaneView: View {
     /// beside the box, every time the draft rewrapped a line.
     @State private var room = ComposerRoom()
 
-    /// The conversation's text size, face and line height, applied to the composer here exactly
-    /// as `ChatPaneView` applies them to its whole subtree. Without this the same composer would
-    /// change as the reader moved between the conversation and the review, which reads as a bug
-    /// rather than a setting.
-    @AppStorage(ChatTextSize.defaultsKey) private var textSize = ChatTextSize.defaultChoice
-    @AppStorage(ChatFont.defaultsKey) private var chatFontID = ChatFont.standardID
-    @AppStorage(ChatLineHeight.defaultsKey) private var lineHeight = ChatLineHeight.defaultChoice
-
     var body: some View {
         VStack(spacing: 0) {
             if !tab.isPinnedToPath {
@@ -71,32 +63,8 @@ struct ReviewPaneView: View {
                 // this holds reads top down, and the empty states inside them centre themselves.
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
-            // The same composer the conversation shows, bound to the same transcript, so the
-            // chips a review has accumulated are visible from the diff they were written on and
-            // Return sends from here. It used to live only in the chat pane, which meant placing
-            // comments on this screen and then leaving it to send them. A second composer view
-            // was considered and rejected: one draft, one send path, nothing to keep in step.
-            //
-            // One draft is exactly why it is not always drawn. Split a tab so the conversation
-            // sits beside the file and both composers were on screen at once, bound to the same
-            // draft, so typing into this one put the same words in the one under the chat. The
-            // rule is `ReviewComposer`, in the core: this box is for when the conversation it
-            // sends to is not already on screen in this tab.
-            if drawsComposer, let destination = model.reviewDestination,
-               let transcript = model.existingTranscript(for: destination.id) {
-                ComposerView(
-                    transcript: transcript,
-                    model: model,
-                    room: room,
-                    destinationLabel: ReviewDestination.label(for: destination.title),
-                    destinations: model.sessions.map {
-                        ComposerDestination(id: $0.id, title: $0.title)
-                    },
-                    onSelectDestination: choose(destination:)
-                )
-                    .environment(\.fontScale, textSize.scale)
-                    .environment(\.chatFont, ChatFont(rawValue: chatFontID))
-                    .environment(\.chatLineHeight, lineHeight)
+            if drawsComposer {
+                ReviewPaneComposer(model: model, room: room)
             }
         }
         .onGeometryChange(for: CGFloat.self) { PaneMeasure.room($0.size.height) } action: {
@@ -115,15 +83,6 @@ struct ReviewPaneView: View {
                 Task { await model.setViewed(!model.isViewed(changed), file: changed) }
             }
         }
-        // A pane can be pointed at a session this launch has never opened, so the transcript is
-        // built here rather than assumed, exactly as `CenterPaneView.prepare` does for a chat.
-        // Keyed on the destination rather than on the active session, because those are now two
-        // different questions: a review sent to a chat nobody has opened this launch needs that
-        // chat's transcript, and the active one may be somewhere else entirely.
-        .task(id: model.reviewDestination?.id) {
-            guard let destination = model.reviewDestination else { return }
-            model.prepareTranscript(for: destination.id)
-        }
         // Keyed on the poll as well as the path, because a file can be deleted underneath a reader
         // who has not moved: the changes generation is what says the worktree has been looked at
         // again.
@@ -134,17 +93,6 @@ struct ReviewPaneView: View {
                 !path.isEmpty && FileManager.default.fileExists(atPath: absolute)
             }.value
         }
-    }
-
-    /// Points this review at another chat.
-    ///
-    /// The transcript is prepared here rather than left to the `task` above, so the composer has
-    /// something to bind to on the frame the choice is made instead of a frame later, which would
-    /// read as the box blinking out and back.
-    private func choose(destination id: SessionID) {
-        guard model.reviewDestinationID != id else { return }
-        model.reviewDestinationID = id
-        model.prepareTranscript(for: id)
     }
 
     /// Whether this pane draws that composer at all. The rule and the reasoning are

--- a/Sources/Bloom/Views/Center/Panes/ToolPaneView.swift
+++ b/Sources/Bloom/Views/Center/Panes/ToolPaneView.swift
@@ -73,7 +73,7 @@ struct ToolPaneView: View {
             .task(id: tab.id) { await prepareTerminal() }
 
         case .browser:
-            BrowserTabView(model: model, tab: tab, paneMenu: paneMenu)
+            BrowserTabView(model: model, tab: tab, paneMenu: paneMenu, siblings: siblings)
                 .id(tab.id)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
 

--- a/Sources/BloomCore/System/BrowserImageComment.swift
+++ b/Sources/BloomCore/System/BrowserImageComment.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// The chip stays compact in the draft, like a diff comment. Its words and page address travel
+/// with the screenshot when the message is composed, and persist with the attachment meanwhile.
+public struct BrowserImageComment: Codable, Hashable, Sendable {
+    public var body: String
+    public var address: String
+
+    public init(body: String, address: String) {
+        self.body = body
+        self.address = address
+    }
+
+    public static func expand(_ draft: String, comments: [String: BrowserImageComment]) -> String {
+        AttachmentDraft.parse(draft, paths: Array(comments.keys)).segments.map { segment in
+            guard case .attachment(let path) = segment, let comment = comments[path] else { return segment.text }
+            return BrowserRegion.draft(comment: comment.body, address: comment.address, paths: [path])
+        }.joined()
+    }
+}

--- a/Sources/BloomCore/System/BrowserRegion.swift
+++ b/Sources/BloomCore/System/BrowserRegion.swift
@@ -3,6 +3,34 @@ import Foundation
 /// A selection uses top-left, unit coordinates so resizing the pane never changes the crop.
 /// Pixel rounding happens only at export, retaining the retina detail in the original snapshot.
 public enum BrowserRegion {
+    public enum Corner: String, CaseIterable, Sendable {
+        case topLeft, topRight, bottomLeft, bottomRight
+
+        public var isLeft: Bool { self == .topLeft || self == .bottomLeft }
+        public var isTop: Bool { self == .topLeft || self == .topRight }
+    }
+
+    /// Moving keeps the size intact, even when the pointer travels beyond the screenshot.
+    public static func moved(_ selection: CGRect, by delta: CGSize) -> CGRect {
+        CGRect(
+            x: min(max(selection.minX + delta.width, 0), 1 - selection.width),
+            y: min(max(selection.minY + delta.height, 0), 1 - selection.height),
+            width: selection.width, height: selection.height
+        )
+    }
+
+    /// A handle cannot cross its opposite corner or escape the image. Keeping that corner fixed
+    /// avoids a selection flipping under the pointer while someone is making a small adjustment.
+    public static func resized(_ selection: CGRect, corner: Corner, to point: CGPoint) -> CGRect {
+        let minimumWidth = min(0.01, selection.width)
+        let minimumHeight = min(0.01, selection.height)
+        let left = corner.isLeft ? min(max(point.x, 0), selection.maxX - minimumWidth) : selection.minX
+        let right = corner.isLeft ? selection.maxX : max(min(point.x, 1), selection.minX + minimumWidth)
+        let top = corner.isTop ? min(max(point.y, 0), selection.maxY - minimumHeight) : selection.minY
+        let bottom = corner.isTop ? selection.maxY : max(min(point.y, 1), selection.minY + minimumHeight)
+        return CGRect(x: left, y: top, width: right - left, height: bottom - top)
+    }
+
     public static func imageFrame(image: CGSize, canvas: CGSize) -> CGRect {
         guard image.width > 0, image.height > 0, canvas.width > 0, canvas.height > 0 else {
             return .zero

--- a/Sources/BloomCore/System/BrowserRegion.swift
+++ b/Sources/BloomCore/System/BrowserRegion.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// A selection uses top-left, unit coordinates so resizing the pane never changes the crop.
+/// Pixel rounding happens only at export, retaining the retina detail in the original snapshot.
+public enum BrowserRegion {
+    public static func imageFrame(image: CGSize, canvas: CGSize) -> CGRect {
+        guard image.width > 0, image.height > 0, canvas.width > 0, canvas.height > 0 else {
+            return .zero
+        }
+        let scale = min(canvas.width / image.width, canvas.height / image.height)
+        let size = CGSize(width: image.width * scale, height: image.height * scale)
+        return CGRect(
+            x: (canvas.width - size.width) / 2, y: (canvas.height - size.height) / 2,
+            width: size.width, height: size.height
+        )
+    }
+
+    public static func selection(from start: CGPoint, to end: CGPoint, in frame: CGRect) -> CGRect? {
+        guard frame.width > 0, frame.height > 0, frame.contains(start) else { return nil }
+        let clipped = CGRect(
+            x: min(start.x, end.x), y: min(start.y, end.y),
+            width: abs(end.x - start.x), height: abs(end.y - start.y)
+        ).intersection(frame)
+        // A click or a shaky drag should not become an almost invisible attachment.
+        guard clipped.width >= 4, clipped.height >= 4 else { return nil }
+        return CGRect(
+            x: (clipped.minX - frame.minX) / frame.width,
+            y: (clipped.minY - frame.minY) / frame.height,
+            width: clipped.width / frame.width, height: clipped.height / frame.height
+        )
+    }
+
+    public static func rect(_ selection: CGRect, in frame: CGRect) -> CGRect {
+        CGRect(
+            x: frame.minX + selection.minX * frame.width,
+            y: frame.minY + selection.minY * frame.height,
+            width: selection.width * frame.width, height: selection.height * frame.height
+        )
+    }
+
+    public static func pixels(_ selection: CGRect, image: CGSize) -> CGRect? {
+        guard image.width > 0, image.height > 0,
+              [selection.minX, selection.minY, selection.width, selection.height].allSatisfy(\.isFinite),
+              selection.width > 0, selection.height > 0 else { return nil }
+        let bounds = CGRect(origin: .zero, size: image)
+        let crop = rect(selection, in: bounds).integral.intersection(bounds)
+        return crop.isNull || crop.isEmpty ? nil : crop
+    }
+
+    public static func draft(comment: String, address: String, paths: [String]) -> String {
+        let attachments = paths.map(AttachmentDraft.token(for:)).joined(separator: " ")
+        return "\(comment.trimmingCharacters(in: .whitespacesAndNewlines))\nPage: \(address)\n\(attachments)"
+    }
+}

--- a/Sources/BloomCore/System/BrowserRegion.swift
+++ b/Sources/BloomCore/System/BrowserRegion.swift
@@ -31,15 +31,14 @@ public enum BrowserRegion {
         return CGRect(x: left, y: top, width: right - left, height: bottom - top)
     }
 
-    public static func imageFrame(image: CGSize, canvas: CGSize) -> CGRect {
-        guard image.width > 0, image.height > 0, canvas.width > 0, canvas.height > 0 else {
-            return .zero
-        }
-        let scale = min(canvas.width / image.width, canvas.height / image.height)
-        let size = CGSize(width: image.width * scale, height: image.height * scale)
+    /// WebKit can share its native container with an inspector. Only the content's rectangle is
+    /// replaced by the snapshot, using the same top-left coordinates as the selection overlay.
+    public static func pageFrame(content: CGRect, viewport: CGRect, originAtTop: Bool) -> CGRect {
+        guard viewport.width > 0, viewport.height > 0 else { return .zero }
         return CGRect(
-            x: (canvas.width - size.width) / 2, y: (canvas.height - size.height) / 2,
-            width: size.width, height: size.height
+            x: (content.minX - viewport.minX) / viewport.width,
+            y: (originAtTop ? content.minY - viewport.minY : viewport.maxY - content.maxY) / viewport.height,
+            width: content.width / viewport.width, height: content.height / viewport.height
         )
     }
 

--- a/Sources/BloomCore/System/BrowserRegion.swift
+++ b/Sources/BloomCore/System/BrowserRegion.swift
@@ -3,6 +3,32 @@ import Foundation
 /// A selection uses top-left, unit coordinates so resizing the pane never changes the crop.
 /// Pixel rounding happens only at export, retaining the retina detail in the original snapshot.
 public enum BrowserRegion {
+    /// The editor is drawn over the page. Prefer space beside the selection, then the smallest
+    /// overlap available, without changing the viewport or placing controls beyond the pane.
+    public static func commentFrame(near selection: CGRect, in bounds: CGRect, size: CGSize) -> CGRect {
+        let margin: CGFloat = 8
+        let width = min(size.width, max(0, bounds.width - margin * 2))
+        let height = min(size.height, max(0, bounds.height - margin * 2))
+        let origins = [
+            CGPoint(x: selection.minX, y: selection.maxY + margin),
+            CGPoint(x: selection.minX, y: selection.minY - height - margin),
+            CGPoint(x: selection.maxX + margin, y: selection.minY),
+            CGPoint(x: selection.minX - width - margin, y: selection.minY),
+        ]
+        let candidates = origins.map { origin in
+            CGRect(
+                x: max(bounds.minX + margin, min(origin.x, bounds.maxX - margin - width)),
+                y: max(bounds.minY + margin, min(origin.y, bounds.maxY - margin - height)),
+                width: width, height: height
+            )
+        }
+        return candidates.min { first, second in
+            let firstOverlap = first.intersection(selection)
+            let secondOverlap = second.intersection(selection)
+            return firstOverlap.width * firstOverlap.height < secondOverlap.width * secondOverlap.height
+        } ?? .zero
+    }
+
     public enum Corner: String, CaseIterable, Sendable {
         case topLeft, topRight, bottomLeft, bottomRight
 

--- a/Sources/BloomCore/System/BrowserRegionComment.swift
+++ b/Sources/BloomCore/System/BrowserRegionComment.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// A saved annotation on this snapshot. Its attachment carries the durable comment and URL;
+/// the rectangle belongs to the review currently being shown in this browser tab.
+public struct BrowserRegionComment: Identifiable, Sendable, Equatable {
+    public var id: String { path }
+    public let path: String
+    public let selection: CGRect
+    public let address: String
+    public var body: String
+
+    public init(path: String, selection: CGRect, address: String, body: String) {
+        self.path = path
+        self.selection = selection
+        self.address = address
+        self.body = body
+    }
+
+}

--- a/Sources/BloomCore/System/BrowserToolbar.swift
+++ b/Sources/BloomCore/System/BrowserToolbar.swift
@@ -155,6 +155,15 @@ public struct BrowserToolbar: Equatable, Sendable {
         )
     }
 
+    public var regionCapture: Control {
+        Control(
+            symbol: "crop",
+            name: "Comment on an Area",
+            help: "Select part of this page and add a comment to the draft",
+            isEnabled: destination != nil && !isCapturing
+        )
+    }
+
     // MARK: - Sharing
 
     /// What the system's share sheet is handed, or nil when the pane has not been anywhere yet.

--- a/Sources/BloomCore/Transcript/SubmittedDraft.swift
+++ b/Sources/BloomCore/Transcript/SubmittedDraft.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// A composed review differs from its compact draft. Clearing still compares against the
+/// original draft, so words typed while that review was prepared survive the submission.
+public enum SubmittedDraft {
+    public static func matching(current: String, message: String, source: String? = nil) -> String? {
+        let expected = (source ?? message).trimmingCharacters(in: .whitespacesAndNewlines)
+        return current.trimmingCharacters(in: .whitespacesAndNewlines) == expected ? current : nil
+    }
+}

--- a/Tests/BloomCoreTests/BrowserImageCommentTests.swift
+++ b/Tests/BloomCoreTests/BrowserImageCommentTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Browser image comments")
+struct BrowserImageCommentTests {
+    private let path = ".bloom/attachments/ABC/area.png"
+
+    @Test("The compact chip expands to its comment, URL and screenshot when sent")
+    func expandsComment() {
+        let note = BrowserImageComment(body: "More space here", address: "http://localhost:3100/settings")
+        let chip = AttachmentDraft.token(for: path)
+        let sent = BrowserImageComment.expand("Please fix this.\n\(chip)", comments: [path: note])
+        #expect(sent == "Please fix this.\nMore space here\nPage: http://localhost:3100/settings\n\(chip)")
+        #expect(AttachmentDraft.parse(sent).paths == [path])
+    }
+
+    @Test("Removed chips do not send their comments, and ordinary attachments remain unchanged")
+    func respectsDraft() {
+        let note = BrowserImageComment(body: "Do not send", address: "http://localhost")
+        let other = AttachmentDraft.token(for: ".bloom/attachments/DEF/other.png")
+        #expect(BrowserImageComment.expand("Only \(other)", comments: [path: note]) == "Only \(other)")
+        #expect(BrowserImageComment.expand("", comments: [path: note]).isEmpty)
+    }
+
+    @Test("Comment metadata round trips with the attachment")
+    func persistsComment() throws {
+        let note = BrowserImageComment(body: "First line\nSecond line", address: "https://example.com/?a=b#part")
+        let data = try JSONEncoder().encode(note)
+        #expect(try JSONDecoder().decode(BrowserImageComment.self, from: data) == note)
+    }
+
+    @Test("The comment editor stays inside the pane and avoids the selected area when possible")
+    func placesEditor() {
+        let bounds = CGRect(x: 0, y: 0, width: 520, height: 600)
+        for selection in [CGRect(x: 20, y: 20, width: 100, height: 40), CGRect(x: 40, y: 540, width: 100, height: 40)] {
+            let frame = BrowserRegion.commentFrame(near: selection, in: bounds, size: CGSize(width: 380, height: 80))
+            #expect(bounds.contains(frame))
+            #expect(!frame.intersects(selection))
+        }
+        let narrow = CGRect(x: 0, y: 0, width: 240, height: 200)
+        let frame = BrowserRegion.commentFrame(near: narrow, in: narrow, size: CGSize(width: 380, height: 250))
+        #expect(narrow.contains(frame))
+        #expect(frame.width == 224 && frame.height == 184)
+    }
+}

--- a/Tests/BloomCoreTests/BrowserRegionTests.swift
+++ b/Tests/BloomCoreTests/BrowserRegionTests.swift
@@ -4,6 +4,41 @@ import Testing
 
 @Suite("Browser region feedback")
 struct BrowserRegionTests {
+    @Test("Moving a selection preserves its size and stops at each image edge")
+    func moveSelection() {
+        let selection = CGRect(x: 0.2, y: 0.3, width: 0.4, height: 0.5)
+        #expect(BrowserRegion.moved(selection, by: CGSize(width: -1, height: -1))
+            == CGRect(x: 0, y: 0, width: 0.4, height: 0.5))
+        #expect(BrowserRegion.moved(selection, by: CGSize(width: 1, height: 1))
+            == CGRect(x: 0.6, y: 0.5, width: 0.4, height: 0.5))
+        #expect(BrowserRegion.moved(CGRect(x: 0, y: 0, width: 1, height: 1), by: CGSize(width: 1, height: -1))
+            == CGRect(x: 0, y: 0, width: 1, height: 1))
+    }
+
+    @Test("Each resize handle keeps its opposite corner fixed", arguments: BrowserRegion.Corner.allCases)
+    func resizeSelection(corner: BrowserRegion.Corner) {
+        let selection = CGRect(x: 0.25, y: 0.25, width: 0.5, height: 0.5)
+        let point = CGPoint(x: corner.isLeft ? 0 : 1, y: corner.isTop ? 0 : 1)
+        let resized = BrowserRegion.resized(selection, corner: corner, to: point)
+        #expect(resized.width == 0.75)
+        #expect(resized.height == 0.75)
+        #expect(corner.isLeft ? resized.maxX == selection.maxX : resized.minX == selection.minX)
+        #expect(corner.isTop ? resized.maxY == selection.maxY : resized.minY == selection.minY)
+    }
+
+    @Test("Handles cannot cross the opposite corner or escape the screenshot")
+    func clampsResize() {
+        let selection = CGRect(x: 0.25, y: 0.25, width: 0.5, height: 0.5)
+        let crossed = BrowserRegion.resized(selection, corner: .topLeft, to: CGPoint(x: 2, y: 2))
+        #expect(abs(crossed.width - 0.01) < 0.0001)
+        #expect(abs(crossed.height - 0.01) < 0.0001)
+        #expect(crossed.maxX == selection.maxX && crossed.maxY == selection.maxY)
+        let expanded = BrowserRegion.resized(selection, corner: .bottomRight, to: CGPoint(x: 2, y: 2))
+        #expect(expanded.maxX == 1 && expanded.maxY == 1)
+        let tiny = BrowserRegion.resized(CGRect(x: 0, y: 0, width: 0.005, height: 0.005), corner: .topLeft, to: .zero)
+        #expect(tiny.origin == .zero && tiny.width > 0 && tiny.height > 0)
+    }
+
     @Test("Letterboxing keeps the screenshot's aspect ratio")
     func fitsImage() {
         let frame = BrowserRegion.imageFrame(

--- a/Tests/BloomCoreTests/BrowserRegionTests.swift
+++ b/Tests/BloomCoreTests/BrowserRegionTests.swift
@@ -39,13 +39,20 @@ struct BrowserRegionTests {
         #expect(tiny.origin == .zero && tiny.width > 0 && tiny.height > 0)
     }
 
-    @Test("Letterboxing keeps the screenshot's aspect ratio")
-    func fitsImage() {
-        let frame = BrowserRegion.imageFrame(
-            image: CGSize(width: 1600, height: 900), canvas: CGSize(width: 800, height: 600)
-        )
-        #expect(frame == CGRect(x: 0, y: 75, width: 800, height: 450))
-        #expect(BrowserRegion.imageFrame(image: .zero, canvas: CGSize(width: 800, height: 600)) == .zero)
+    @Test("Capturing a page keeps its exact viewport frame")
+    func preservesPageFrame() {
+        let viewport = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let placement = BrowserRegion.pageFrame(content: viewport, viewport: viewport, originAtTop: false)
+        #expect(BrowserRegion.rect(placement, in: viewport) == viewport)
+        #expect(BrowserRegion.pageFrame(content: .zero, viewport: .zero, originAtTop: false) == .zero)
+    }
+
+    @Test("An attached inspector does not stretch the captured web content", arguments: [false, true])
+    func excludesInspector(originAtTop: Bool) {
+        let viewport = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let content = CGRect(x: 0, y: originAtTop ? 0 : 200, width: 800, height: 400)
+        let placement = BrowserRegion.pageFrame(content: content, viewport: viewport, originAtTop: originAtTop)
+        #expect(BrowserRegion.rect(placement, in: viewport) == CGRect(x: 0, y: 0, width: 800, height: 400))
     }
 
     @Test("Dragging in either direction selects the same pixels", arguments: [false, true])
@@ -69,7 +76,7 @@ struct BrowserRegionTests {
         #expect(selection == CGRect(x: 0, y: 0.5, width: 0.5, height: 0.5))
     }
 
-    @Test("Clicks, thin slivers and drags starting in the letterbox do not make attachments")
+    @Test("Clicks, thin slivers and drags outside the page do not make attachments")
     func rejectsEmptySelections() {
         let frame = CGRect(x: 0, y: 75, width: 800, height: 450)
         #expect(BrowserRegion.selection(from: CGPoint(x: 10, y: 10), to: CGPoint(x: 200, y: 200), in: frame) == nil)
@@ -81,9 +88,9 @@ struct BrowserRegionTests {
     func resizePreservesCrop() throws {
         let image = CGSize(width: 1200, height: 800)
         let selection = CGRect(x: 0.25, y: 0.25, width: 0.5, height: 0.5)
-        let frame = BrowserRegion.imageFrame(image: image, canvas: CGSize(width: 300, height: 300))
+        let frame = CGRect(x: 0, y: 0, width: 300, height: 200)
         let outline = BrowserRegion.rect(selection, in: frame)
-        #expect(outline == CGRect(x: 75, y: 100, width: 150, height: 100))
+        #expect(outline == CGRect(x: 75, y: 50, width: 150, height: 100))
         let redrawn = try #require(BrowserRegion.selection(
             from: outline.origin, to: CGPoint(x: outline.maxX, y: outline.maxY), in: frame
         ))

--- a/Tests/BloomCoreTests/BrowserRegionTests.swift
+++ b/Tests/BloomCoreTests/BrowserRegionTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Browser region feedback")
+struct BrowserRegionTests {
+    @Test("Letterboxing keeps the screenshot's aspect ratio")
+    func fitsImage() {
+        let frame = BrowserRegion.imageFrame(
+            image: CGSize(width: 1600, height: 900), canvas: CGSize(width: 800, height: 600)
+        )
+        #expect(frame == CGRect(x: 0, y: 75, width: 800, height: 450))
+        #expect(BrowserRegion.imageFrame(image: .zero, canvas: CGSize(width: 800, height: 600)) == .zero)
+    }
+
+    @Test("Dragging in either direction selects the same pixels", arguments: [false, true])
+    func reverseDrag(reversed: Bool) throws {
+        let first = CGPoint(x: 100, y: 100)
+        let second = CGPoint(x: 300, y: 250)
+        let frame = CGRect(x: 0, y: 75, width: 800, height: 450)
+        let selection = try #require(BrowserRegion.selection(
+            from: reversed ? second : first, to: reversed ? first : second, in: frame
+        ))
+        #expect(BrowserRegion.pixels(selection, image: CGSize(width: 1600, height: 900))
+            == CGRect(x: 200, y: 50, width: 400, height: 300))
+    }
+
+    @Test("Dragging past the screenshot stops at its edges")
+    func clipsDrag() throws {
+        let selection = try #require(BrowserRegion.selection(
+            from: CGPoint(x: 50, y: 50), to: CGPoint(x: -100, y: 200),
+            in: CGRect(x: 0, y: 0, width: 100, height: 100)
+        ))
+        #expect(selection == CGRect(x: 0, y: 0.5, width: 0.5, height: 0.5))
+    }
+
+    @Test("Clicks, thin slivers and drags starting in the letterbox do not make attachments")
+    func rejectsEmptySelections() {
+        let frame = CGRect(x: 0, y: 75, width: 800, height: 450)
+        #expect(BrowserRegion.selection(from: CGPoint(x: 10, y: 10), to: CGPoint(x: 200, y: 200), in: frame) == nil)
+        #expect(BrowserRegion.selection(from: CGPoint(x: 100, y: 100), to: CGPoint(x: 100, y: 100), in: frame) == nil)
+        #expect(BrowserRegion.selection(from: CGPoint(x: 100, y: 100), to: CGPoint(x: 102, y: 200), in: frame) == nil)
+    }
+
+    @Test("Resizing moves the selection outline without changing which source pixels are attached")
+    func resizePreservesCrop() throws {
+        let image = CGSize(width: 1200, height: 800)
+        let selection = CGRect(x: 0.25, y: 0.25, width: 0.5, height: 0.5)
+        let frame = BrowserRegion.imageFrame(image: image, canvas: CGSize(width: 300, height: 300))
+        let outline = BrowserRegion.rect(selection, in: frame)
+        #expect(outline == CGRect(x: 75, y: 100, width: 150, height: 100))
+        let redrawn = try #require(BrowserRegion.selection(
+            from: outline.origin, to: CGPoint(x: outline.maxX, y: outline.maxY), in: frame
+        ))
+        #expect(BrowserRegion.pixels(redrawn, image: image) == CGRect(x: 300, y: 200, width: 600, height: 400))
+    }
+
+    @Test("Crop rounding includes edge pixels and stays inside the image")
+    func roundsPixels() {
+        let image = CGSize(width: 100, height: 100)
+        #expect(BrowserRegion.pixels(CGRect(x: 0.105, y: 0.205, width: 0.2, height: 0.3), image: image)
+            == CGRect(x: 10, y: 20, width: 21, height: 31))
+        #expect(BrowserRegion.pixels(CGRect(x: 0.9, y: 0.9, width: 0.5, height: 0.5), image: image)
+            == CGRect(x: 90, y: 90, width: 10, height: 10))
+        #expect(BrowserRegion.pixels(CGRect(x: 2, y: 2, width: 1, height: 1), image: image) == nil)
+        #expect(BrowserRegion.pixels(.zero, image: image) == nil)
+    }
+
+    @Test("The draft keeps the comment, exact page URL and a recognised attachment together")
+    func draftCarriesContext() {
+        let path = ".bloom/attachments/ABC/Selected area.png"
+        let address = "http://localhost:3100/settings?tab=profile#avatar"
+        let draft = BrowserRegion.draft(comment: "  Give this more space.\nKeep it aligned. \n", address: address, paths: [path])
+        #expect(draft == "Give this more space.\nKeep it aligned.\nPage: \(address)\n`\(path)`")
+        #expect(AttachmentDraft.parse(draft).paths == [path])
+    }
+
+    @Test("Region capture needs a page and waits for other captures")
+    func toolbarAvailability() {
+        let page = BrowserTabTitle.BrowserPage(address: "http://localhost:3100", title: "Preview")
+        #expect(!BrowserToolbar().regionCapture.isEnabled)
+        #expect(BrowserToolbar(page: page).regionCapture.isEnabled)
+        #expect(!BrowserToolbar(page: page, isCapturing: true).regionCapture.isEnabled)
+    }
+}

--- a/Tests/BloomCoreTests/SubmittedDraftTests.swift
+++ b/Tests/BloomCoreTests/SubmittedDraftTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import BloomCore
+
+@Suite("Submitted drafts")
+struct SubmittedDraftTests {
+    @Test("Expanded review payloads clear the compact source draft")
+    func clearsSource() {
+        let draft = "`.bloom/attachments/ABC/area.png` "
+        #expect(SubmittedDraft.matching(current: draft, message: "Expanded image comment", source: draft) == draft)
+    }
+
+    @Test("Typing while a review is prepared prevents the new draft from being cleared")
+    func protectsNewText() {
+        #expect(SubmittedDraft.matching(current: "Original plus new words", message: "Expanded review", source: "Original") == nil)
+    }
+
+    @Test("Ordinary submissions still clear only a matching draft")
+    func normalSubmission() {
+        #expect(SubmittedDraft.matching(current: " Hello \n", message: "Hello") == " Hello \n")
+        #expect(SubmittedDraft.matching(current: "Other words", message: "Hello") == nil)
+    }
+}

--- a/docs/MENUS.md
+++ b/docs/MENUS.md
@@ -226,6 +226,8 @@ loud somewhere a user can read it.
 | Comment on an Area | crop button in the toolbar, and the page menu | **no** | none |
 | Add selected area and comment to the draft | region capture controls | **no** | `⌘Return` |
 | Cancel region capture | region capture controls | **no** | `Escape` |
+| Select All / Clear Selection | region capture's Selection menu | **no** | none |
+| View Draft after capture | confirmation above the browser page | **no** | none |
 | Share | toolbar | **no** | none |
 | Open in External Browser | page context menu | **no** | none |
 | Find in page, next, previous | find bar | yes, Edit > Find | `⌘F` `⌘G` `⇧⌘G` |

--- a/docs/MENUS.md
+++ b/docs/MENUS.md
@@ -224,7 +224,7 @@ loud somewhere a user can read it.
 | Reload / Stop | toolbar | **no** | none |
 | Send a Screenshot to the Agent | toolbar, and the page menu | **no** | none |
 | Comment on an Area | crop button in the toolbar, and the page menu | **no** | none |
-| Add selected area and comment to the draft | region capture controls | **no** | `⌘Return` |
+| Add selected area and comment to the draft | review-comment popover | **no** | `Return` or `⌘Return` |
 | Cancel region capture | region capture controls | **no** | `Escape` |
 | Select All / Clear Selection | region capture's Selection menu | **no** | none |
 | View Draft after capture | confirmation above the browser page | **no** | none |

--- a/docs/MENUS.md
+++ b/docs/MENUS.md
@@ -224,6 +224,9 @@ loud somewhere a user can read it.
 | Jump back or forward several pages | right click on an arrow | **no** | none |
 | Reload / Stop | toolbar | **no** | none |
 | Send a Screenshot to the Agent | toolbar, and the page menu | **no** | none |
+| Comment on an Area | crop button in the toolbar, and the page menu | **no** | none |
+| Add selected area and comment to the draft | region capture controls | **no** | `⌘Return` |
+| Cancel region capture | region capture controls | **no** | `Escape` |
 | Share | toolbar | **no** | none |
 | Open in External Browser | page context menu | **no** | none |
 | Find in page, next, previous | find bar | yes, Edit > Find | `⌘F` `⌘G` `⇧⌘G` |

--- a/docs/MENUS.md
+++ b/docs/MENUS.md
@@ -223,11 +223,12 @@ loud somewhere a user can read it.
 | Jump back or forward several pages | right click on an arrow | **no** | none |
 | Reload / Stop | toolbar | **no** | none |
 | Send a Screenshot to the Agent | toolbar, and the page menu | **no** | none |
-| Comment on an Area | crop button in the toolbar, and the page menu | **no** | none |
-| Add selected area and comment to the draft | review-comment popover | **no** | `Return` or `⌘Return` |
-| Cancel region capture | region capture controls | **no** | `Escape` |
+| Comment on an Area | labelled Comment button in the toolbar, and the page menu | **no** | none |
+| Add selected area and comment to the draft | inline review-comment editor | **no** | `Return` or `⌘Return` |
+| Finish reviewing the page | Done in the toolbar or selection controls | **no** | `Escape` outside the editor |
 | Select All / Clear Selection | region capture's Selection menu | **no** | none |
-| View Draft after capture | confirmation above the browser page | **no** | none |
+| Edit / Remove image comment | saved comment band on the page | **no** | none |
+| Send image comments | composer below the browser, or the adjacent conversation | **no** | `Return` or `⌘Return` |
 | Share | toolbar | **no** | none |
 | Open in External Browser | page context menu | **no** | none |
 | Find in page, next, previous | find bar | yes, Edit > Find | `⌘F` `⌘G` `⇧⌘G` |


### PR DESCRIPTION
Adds a labelled Comment action for browser pages. Select an area, leave a comment in the shared diff-review editor, and collect editable annotations while staying on the page. The shared review composer below the browser sends the screenshot comments without switching tabs.

Selection dragging works immediately with the inline editor open. Captures retain the page dimensions and scroll position, and image comments stay compact in the draft while preserving their text and source URL for sending. Toolbar actions are grouped by purpose. Hovering an image-comment chip previews both its screenshot and saved comment.

Verified with 52 focused tests, both linters, a warning-free build, and isolated native checks of layout, annotations, edit/remove, persistence and message composition.
