### PR TITLE
Clarify assistant messages and fix copying Codex answers

### DIFF
--- a/Sources/Bloom/Views/Transcript/ProseRowView.swift
+++ b/Sources/Bloom/Views/Transcript/ProseRowView.swift
@@ -1,22 +1,25 @@
 import SwiftUI
 
-/// A finished block of assistant prose, rendered as markdown.
+/// Shared by live and saved messages so their boundaries do not move when streaming finishes.
 struct ProseRowView: View {
     var text: String
+    var isStreaming = false
 
     var body: some View {
-        MarkdownView(text)
-            .font(Typo.body)
-            .proseLeading()
-            .textSelection(.enabled)
-            // Capped, then left aligned in whatever is left. One frame would centre the column
-            // in a wide pane and take the paragraph off the line every other row starts on.
-            .frame(maxWidth: TranscriptLayout.proseMeasure, alignment: .leading)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, TranscriptLayout.inset)
-            // More than a row keeps, and deliberately. An answer is the one thing in this pane
-            // that is read rather than scanned, and what sets it apart from the list of actions
-            // above and below it is the space around it as much as the size it is set in.
-            .padding(.vertical, TranscriptLayout.block)
+        VStack(alignment: .leading, spacing: TranscriptLayout.block) {
+            Hairline()
+                .accessibilityHidden(true)
+
+            MarkdownView(text, isStreaming: isStreaming)
+                .font(Typo.body)
+                .proseLeading()
+                .textSelection(.enabled)
+                // Capped, then left aligned in whatever is left. One frame would centre the column
+                // in a wide pane and take the paragraph off the line every other row starts on.
+                .frame(maxWidth: TranscriptLayout.proseMeasure, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, TranscriptLayout.inset)
+        .padding(.vertical, TranscriptLayout.block)
     }
 }

--- a/Sources/Bloom/Views/Transcript/StreamingRowView.swift
+++ b/Sources/Bloom/Views/Transcript/StreamingRowView.swift
@@ -61,16 +61,7 @@ struct StreamingRowView: View {
             }
 
             if !transcript.streamingText.isEmpty {
-                MarkdownView(transcript.streamingText, isStreaming: true)
-                    .font(Typo.body)
-                    .proseLeading()
-                    .textSelection(.enabled)
-                    // The same measure the stored prose row uses, or the line the user is
-                    // watching rewraps the instant it is replaced by its persisted twin.
-                    .frame(maxWidth: TranscriptLayout.proseMeasure, alignment: .leading)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, TranscriptLayout.inset)
-                    .padding(.vertical, TranscriptLayout.inset)
+                ProseRowView(text: transcript.streamingText, isStreaming: true)
                     // Streamed text arrives many times a second, and every one of those deltas
                     // runs through here. Nothing inside this block may carry an animation: see
                     // the note under `body`.

--- a/Sources/Bloom/Views/Transcript/TurnFooterView.swift
+++ b/Sources/Bloom/Views/Transcript/TurnFooterView.swift
@@ -52,7 +52,16 @@ struct TurnFooterView: View {
             succeeded: result?.succeeded != false,
             denials: result?.permissionDenials ?? 0
         )
-        let summaryText = result?.summary ?? ""
+        let answerText = TurnAnswer.text(
+            summary: result?.summary ?? "",
+            rows: rows.lazy.map {
+                TurnAnswer.Row(
+                    seq: $0.seq, kind: $0.kind, payload: $0.payload,
+                    isNested: $0.parentToolUseID != nil
+                )
+            },
+            endingAt: row.seq
+        )
 
         return VStack(alignment: .leading, spacing: 0) {
             // Inset to the column the footer's own contents start on, rather than to the pane.
@@ -127,7 +136,8 @@ struct TurnFooterView: View {
                     Color.clear.frame(width: 0, height: 0)
                 }
 
-                CopyButton(text: summaryText, title: "Copy this answer")
+                CopyButton(text: answerText, title: "Copy this answer")
+                    .disabled(answerText.isEmpty)
             }
             .foregroundStyle(Palette.textSecondary)
             .padding(.horizontal, TranscriptLayout.inset)

--- a/Sources/BloomCore/Transcript/TurnAnswer.swift
+++ b/Sources/BloomCore/Transcript/TurnAnswer.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Codex's successful result carries no summary. Recover the answer from the saved prose so
+/// the footer can copy it in old conversations as well as newly completed turns.
+public enum TurnAnswer {
+    public struct Row: Sendable {
+        public var seq: Int
+        public var kind: MessageKind
+        public var payload: Data
+        public var isNested: Bool
+
+        public init(seq: Int, kind: MessageKind, payload: Data, isNested: Bool = false) {
+            self.seq = seq
+            self.kind = kind
+            self.payload = payload
+            self.isNested = isNested
+        }
+    }
+
+    /// A lazy projection avoids copying the session. Locate this footer in sequence order, then
+    /// decode only assistant rows in its own turn, ignoring tools and subagent conversations.
+    public static func text<Rows: RandomAccessCollection>(
+        summary: String, rows: Rows, endingAt seq: Int
+    ) -> String where Rows.Element == Row, Rows.Index == Int {
+        if !summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return summary }
+
+        var low = rows.startIndex
+        var high = rows.endIndex
+        while low < high {
+            let middle = low + (high - low) / 2
+            if rows[middle].seq < seq { low = middle + 1 } else { high = middle }
+        }
+
+        var index = low
+        while index > rows.startIndex {
+            index -= 1
+            let row = rows[index]
+            if row.isNested { continue }
+            switch row.kind {
+            case .user, .crew, .result:
+                return ""
+            case .assistantText:
+                guard case .assistantText(let block)? = AgentEvent.decode(
+                    line: String(decoding: row.payload, as: UTF8.self)
+                ), !block.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
+                return block.text
+            default:
+                continue
+            }
+        }
+        return ""
+    }
+}

--- a/Tests/BloomCoreTests/TurnAnswerTests.swift
+++ b/Tests/BloomCoreTests/TurnAnswerTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("The answer copied by a turn footer")
+struct TurnAnswerTests {
+    @Test func preservesTheResultSummary() {
+        let summary = "## Done\n\nThe complete answer.\n"
+        #expect(TurnAnswer.text(summary: summary, rows: [prose(1, "An update")], endingAt: 2) == summary)
+    }
+
+    @Test(arguments: ["", " \n\t"])
+    func fallsBackToTheLastAssistantMessage(summary: String) {
+        let answer = "## Fixed\n\n- Preserves **Markdown**.\n- And line breaks.\n"
+        let rows = [
+            row(10, .user), prose(20, "I'll inspect this."), row(30, .toolUse),
+            prose(40, answer), row(50, .system), row(60, .result),
+            row(70, .user), prose(80, "An answer to a later question"), row(90, .result),
+        ]
+        #expect(TurnAnswer.text(summary: summary, rows: rows.lazy.map { $0 }, endingAt: 60) == answer)
+    }
+
+    @Test func copiesARecordedCodexAnswerAfterTranslationAndPersistence() throws {
+        var translation = CodexTranslation(context: .init(model: "gpt-5.6-sol", cwd: "/tmp/w"))
+        var rows: [TurnAnswer.Row] = []
+        var result: AgentResult?
+        for line in try bloomFixtureLines("codex-turn.ndjson") {
+            guard case .notification(let notification)? = CodexFrame.decode(line: line) else { continue }
+            let event = CodexEvent.decode(notification)
+            for translated in translation.translate(event) where translated.isTranscriptRow {
+                rows.append(TurnAnswer.Row(seq: rows.count, kind: translated.kind, payload: translated.raw))
+                if case .result(let value) = translated { result = value }
+            }
+        }
+        let completed = try #require(result)
+        let footer = try #require(rows.last(where: { $0.kind == .result }))
+        #expect(completed.summary.isEmpty)
+        #expect(TurnAnswer.text(summary: completed.summary, rows: rows, endingAt: footer.seq) == "bloom")
+    }
+
+    @Test(arguments: [MessageKind.user, .crew, .result])
+    func neverCopiesFromAnEarlierTurn(boundary: MessageKind) {
+        let rows = [prose(1, "An earlier answer"), row(2, boundary), row(3, .toolUse), row(4, .result)]
+        #expect(TurnAnswer.text(summary: "", rows: rows, endingAt: 4).isEmpty)
+    }
+
+    @Test func ignoresSubagentRowsIncludingTheirTurnBoundaries() {
+        let rows = [
+            row(1, .user), prose(2, "The parent's answer"),
+            row(3, .user, isNested: true), prose(4, "A subagent's answer", isNested: true),
+            row(5, .result, isNested: true), row(6, .result),
+        ]
+        #expect(TurnAnswer.text(summary: "", rows: rows, endingAt: 6) == "The parent's answer")
+    }
+
+    @Test func skipsEmptyAndMalformedProse() {
+        let rows = [prose(1, "The answer"), prose(2, " \n"), row(3, .assistantText), row(4, .result)]
+        #expect(TurnAnswer.text(summary: "", rows: rows, endingAt: 4) == "The answer")
+    }
+
+    @Test func handlesEmptyAndPartiallyLoadedHistory() {
+        #expect(TurnAnswer.text(summary: "", rows: [TurnAnswer.Row](), endingAt: 4).isEmpty)
+        let rows = [row(0, .user), prose(1, "The answer"), row(2, .system), row(3, .result)]
+        #expect(TurnAnswer.text(summary: "", rows: rows[1...], endingAt: 3) == "The answer")
+        #expect(TurnAnswer.text(summary: "", rows: rows[3...], endingAt: 3).isEmpty)
+    }
+
+    private func row(_ seq: Int, _ kind: MessageKind, isNested: Bool = false) -> TurnAnswer.Row {
+        TurnAnswer.Row(seq: seq, kind: kind, payload: Data(), isNested: isNested)
+    }
+
+    private func prose(_ seq: Int, _ text: String, isNested: Bool = false) -> TurnAnswer.Row {
+        let payload = JSONValue.object([
+            "type": .string("assistant"),
+            "message": .object([
+                "content": .array([.object(["type": .string("text"), "text": .string(text)])]),
+            ]),
+        ])
+        return TurnAnswer.Row(
+            seq: seq, kind: .assistantText, payload: Data(payload.compactJSON.utf8), isNested: isNested
+        )
+    }
+}


### PR DESCRIPTION
Add subtle dividers above assistant messages and share their streamed and saved layout. Fix the footer copy button for Codex turns by falling back to the last saved assistant response when the result has no summary, including existing conversations. Disable copying when no answer is available.

The app builds with warnings treated as errors, both linters pass, and all 7 TurnAnswer regression tests pass, including a recorded Codex turn.