### PR TITLE
Fix project reordering when projects are hidden

### DIFF
--- a/Sources/Bloom/State/AppModel.swift
+++ b/Sources/Bloom/State/AppModel.swift
@@ -1559,10 +1559,9 @@ final class AppModel {
 
     /// What a drag on a project header ends in.
     ///
-    /// The projects are a flat list with one number ordering them, so there is none of the
-    /// translation a workspace drag needs: no filter hides a project and nothing sorts ahead of
-    /// anything. `to` is already an offset into this list, worked out by `SidebarReorder` from the
-    /// flattened rows the pane actually draws.
+    /// `to` indexes the visible projects from the pane that produced the drag. Hidden projects
+    /// still exist in `repos`, so applying that offset directly to it can leave the dragged
+    /// project where it started. `SidebarReorder` translates it while preserving hidden slots.
     ///
     /// The new order is put on screen before it is written, for the reason `reorderWorkspaces`
     /// gives: a drop is the end of a movement the table has already animated, and waiting for the
@@ -1574,9 +1573,9 @@ final class AppModel {
     /// or an icon that landed while the drag was happening. See e47a3b7. It is one transaction for
     /// the same reason `reorderWorkspaces` gives: one commit, one announcement, and no moment at
     /// which the observer can reload a half written order.
-    func reorderProjects(id: RepoID, to: Int) async {
+    func reorderProjects(id: RepoID, visible: [RepoID], to: Int) async {
         guard let store else { return }
-        let changes = SidebarReorder.move(projects: repos, id: id, to: to)
+        let changes = SidebarReorder.move(projects: repos, visible: visible, id: id, to: to)
         guard !changes.isEmpty else { return }
 
         let byID = Dictionary(changes.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })

--- a/Sources/Bloom/Views/Sidebar/SidebarView.swift
+++ b/Sources/Bloom/Views/Sidebar/SidebarView.swift
@@ -542,7 +542,8 @@ struct SidebarView: View {
             break
 
         case .project(let id, let offset):
-            Task { await app.reorderProjects(id: id, to: offset) }
+            let visible = groups.map(\.id)
+            Task { await app.reorderProjects(id: id, visible: visible, to: offset) }
 
         case .workspace(let projectID, let offsets, let offset, let landedOutside):
             guard let group = groups.first(where: { $0.id == projectID }) else { return }

--- a/Sources/BloomCore/Presentation/SidebarReorder.swift
+++ b/Sources/BloomCore/Presentation/SidebarReorder.swift
@@ -293,8 +293,25 @@ extension SidebarReorder {
     /// right is not written. Every remaining project ends up holding its own index, which is what
     /// keeps the numbers from drifting into ties over a long series of drags.
     public static func move(projects: [Repo], id: RepoID, to: Int) -> [ProjectChange] {
-        guard let index = projects.firstIndex(where: { $0.id == id }) else { return [] }
-        let ordered = moving(projects, from: IndexSet(integer: index), to: to)
+        move(projects: projects, visible: projects.map(\.id), id: id, to: to)
+    }
+
+    /// The drop offset counts visible projects only. Reorder their slots in the full list so
+    /// hidden projects keep their places when they are shown again.
+    public static func move(
+        projects: [Repo], visible: [RepoID], id: RepoID, to: Int
+    ) -> [ProjectChange] {
+        guard let index = visible.firstIndex(of: id), (0...visible.count).contains(to) else { return [] }
+        let moved = moving(visible, from: IndexSet(integer: index), to: to)
+
+        let visibleIDs = Set(visible)
+        let stored = Dictionary(projects.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        guard visibleIDs.count == visible.count, visible.allSatisfy({ stored[$0] != nil }) else { return [] }
+        var replacements = moved.makeIterator()
+        let ordered = projects.map { repo in
+            guard visibleIDs.contains(repo.id), let next = replacements.next() else { return repo }
+            return stored[next] ?? repo
+        }
         return ordered.enumerated().compactMap { offset, repo in
             guard repo.sortOrder != offset else { return nil }
             return ProjectChange(id: repo.id, sortOrder: offset)

--- a/Tests/BloomCoreTests/SidebarReorderTests.swift
+++ b/Tests/BloomCoreTests/SidebarReorderTests.swift
@@ -399,6 +399,54 @@ struct SidebarReorderTests {
         #expect(SidebarReorder.move(projects: repos, id: RepoID("b"), to: 2).isEmpty)
     }
 
+    @Test("Project drops count visible projects and preserve hidden places", arguments: [false, true])
+    func projectMoveWithHiddenProjects(movingDown: Bool) {
+        var repos = [
+            repo("hidden-first", order: 0), repo("a", order: 1),
+            repo("hidden-middle", order: 2), repo("b", order: 3),
+            repo("hidden-last", order: 4),
+        ]
+        for index in [0, 2, 4] { repos[index].hidden = true }
+        let visible = ProjectVisibility.listed(repos, showingHidden: false).map(\.id)
+        let changes = SidebarReorder.move(
+            projects: repos, visible: visible,
+            id: RepoID(movingDown ? "a" : "b"), to: movingDown ? 2 : 0
+        )
+        #expect(changes == [
+            SidebarReorder.ProjectChange(id: RepoID("b"), sortOrder: 1),
+            SidebarReorder.ProjectChange(id: RepoID("a"), sortOrder: 3),
+        ])
+    }
+
+    @Test("A drop beside the same visible project does not move it past hidden projects")
+    func projectMoveBesideItselfWithHiddenProjects() {
+        let repos = [repo("hidden", order: 0), repo("a", order: 1), repo("b", order: 2)]
+        for destination in [0, 1] {
+            let changes = SidebarReorder.move(
+                projects: repos, visible: [RepoID("a"), RepoID("b")],
+                id: RepoID("a"), to: destination
+            )
+            #expect(changes.isEmpty)
+        }
+    }
+
+    @Test("Showing hidden projects includes them in the drag order")
+    func projectMoveWhileShowingHiddenProjects() {
+        var hidden = repo("hidden", order: 0)
+        hidden.hidden = true
+        let repos = [hidden, repo("a", order: 1), repo("b", order: 2)]
+        let changes = SidebarReorder.move(
+            projects: repos,
+            visible: ProjectVisibility.listed(repos, showingHidden: true).map(\.id),
+            id: hidden.id, to: 3
+        )
+        #expect(changes == [
+            SidebarReorder.ProjectChange(id: RepoID("a"), sortOrder: 0),
+            SidebarReorder.ProjectChange(id: RepoID("b"), sortOrder: 1),
+            SidebarReorder.ProjectChange(id: hidden.id, sortOrder: 2),
+        ])
+    }
+
     /// Every project added before the sidebar could be reordered carries the column's default, so
     /// the first drag in a project list is a drag over a list of zeroes. What comes out of it has
     /// to be an order, not a tie.


### PR DESCRIPTION
Fix project drags using a visible drop position against the full project list, which could leave a project in place or move it to the wrong position when other projects were hidden. Reorder visible projects while preserving hidden positions.

Adds regression coverage for both drag directions, unchanged drops, and showing hidden projects. The 36 sidebar reorder tests, app build with warnings as errors, and both linters pass locally.
