### PR TITLE
Fix Unicode highlighting cache collisions in diffs

### DIFF
--- a/Sources/Bloom/Design/ReviewWrappingProbe.swift
+++ b/Sources/Bloom/Design/ReviewWrappingProbe.swift
@@ -25,7 +25,8 @@ enum ReviewWrappingProbe {
                     let lines = view.string.components(separatedBy: "\n")
                     let expected = Fixture.texts.map { $0 ?? "" }.joined(separator: "\n")
                     let opposite = Fixture.opposite.map { $0 ?? "" }.joined(separator: "\n")
-                    check(view.string == expected || view.string == opposite, "wrapping changed the source text")
+                    check(view.string.utf8.elementsEqual(expected.utf8) || view.string.utf8.elementsEqual(opposite.utf8),
+                          "wrapping changed the source text")
                     guard let manager = view.layoutManager, let container = view.textContainer else {
                         check(false, "wrapped code has no text layout")
                         continue
@@ -106,10 +107,13 @@ enum ReviewWrappingProbe {
             "let unicode = \"café 👩🏽‍💻 漢字\"",
             "\tlet values = [" + String(repeating: "12345, ", count: 16) + "]",
             "return result",
+            // Cache the longer encoding first to catch attributes extending past the shorter one.
+            "// cafe\u{301}",
+            "// caf\u{e9}",
         ]
         static let opposite: [String?] = [
             "let message = input", "// The other half contains a line here.",
-            String(repeating: "// another longer comment ", count: 12), nil, "return newResult",
+            String(repeating: "// another longer comment ", count: 12), nil, "return newResult", nil, nil,
         ]
 
         var body: some View {

--- a/Sources/Bloom/Views/Code/SyntaxCache.swift
+++ b/Sources/Bloom/Views/Code/SyntaxCache.swift
@@ -2,34 +2,6 @@ import SwiftUI
 import AppKit
 import BloomCore
 
-private final class SyntaxKey: NSObject {
-    let line: String
-    let language: Language
-    let carry: LexState
-    private let cachedHash: Int
-
-    init(line: String, language: Language, carry: LexState) {
-        self.line = line
-        self.language = language
-        self.carry = carry
-        var hasher = Hasher()
-        hasher.combine(line)
-        hasher.combine(language)
-        hasher.combine(carry)
-        self.cachedHash = hasher.finalize()
-    }
-
-    override var hash: Int { cachedHash }
-
-    override func isEqual(_ object: Any?) -> Bool {
-        guard let other = object as? SyntaxKey else { return false }
-        return cachedHash == other.cachedHash
-            && line == other.line
-            && language == other.language
-            && carry == other.carry
-    }
-}
-
 private final class SyntaxBox {
     let value: AttributedString
 
@@ -47,14 +19,14 @@ enum SyntaxCache {
     private static let limit = 4_000
 
     // NSCache is documented as thread safe, which is the whole reason it is used here.
-    nonisolated(unsafe) private static let storage: NSCache<SyntaxKey, SyntaxBox> = {
-        let cache = NSCache<SyntaxKey, SyntaxBox>()
+    nonisolated(unsafe) private static let storage: NSCache<SyntaxCacheKey, SyntaxBox> = {
+        let cache = NSCache<SyntaxCacheKey, SyntaxBox>()
         cache.countLimit = limit
         return cache
     }()
 
     static func attributed(line: String, language: Language, carry: LexState) -> AttributedString {
-        let key = SyntaxKey(line: line, language: language, carry: carry)
+        let key = SyntaxCacheKey(line: line, language: language, carry: carry)
         if let hit = storage.object(forKey: key) { return hit.value }
 
         let value = build(line: line, language: language, carry: carry)

--- a/Sources/Bloom/Views/Code/WrappedCodeText.swift
+++ b/Sources/Bloom/Views/Code/WrappedCodeText.swift
@@ -133,7 +133,8 @@ struct WrappedCodeText: NSViewRepresentable {
             value.append(paragraph)
         }
         let selection = view.selectedRanges
-        let sameText = view.string == value.string
+        // Canonically equal text can be shorter in UTF-16, invalidating the old selection.
+        let sameText = view.string.utf8.elementsEqual(value.string.utf8)
         view.textContainer?.containerSize = NSSize(width: width, height: .greatestFiniteMagnitude)
         view.textStorage?.setAttributedString(value)
         if sameText { view.selectedRanges = selection }

--- a/Sources/BloomCore/Transcript/SyntaxCacheKey.swift
+++ b/Sources/BloomCore/Transcript/SyntaxCacheKey.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Cached highlighting must contain the exact source bytes. Swift string equality treats
+/// composed and decomposed accents as equal, but their UTF-16 lengths differ. Reusing the
+/// longer cached text for the shorter source made the wrapped diff apply attributes past its
+/// end, raising an NSRangeException as the line scrolled into view.
+public final class SyntaxCacheKey: NSObject {
+    private let line: String
+    private let language: Language
+    private let carry: LexState
+    private let cachedHash: Int
+
+    public init(line: String, language: Language, carry: LexState) {
+        self.line = line
+        self.language = language
+        self.carry = carry
+        var hasher = Hasher()
+        hasher.combine(line)
+        hasher.combine(language)
+        hasher.combine(carry)
+        self.cachedHash = hasher.finalize()
+    }
+
+    public override var hash: Int { cachedHash }
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? SyntaxCacheKey else { return false }
+        return cachedHash == other.cachedHash
+            && line.utf8.elementsEqual(other.line.utf8)
+            && language == other.language
+            && carry == other.carry
+    }
+}

--- a/Tests/BloomCoreTests/SyntaxCacheKeyTests.swift
+++ b/Tests/BloomCoreTests/SyntaxCacheKeyTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+struct SyntaxCacheKeyTests {
+    @Test("highlighting keeps canonically equal source text separate", arguments: [false, true])
+    func unicodeCacheEntries(reverse: Bool) throws {
+        let composed = "// caf\u{e9}"
+        let decomposed = "// cafe\u{301}"
+        #expect(composed == decomposed)
+        #expect(composed.utf16.count != decomposed.utf16.count)
+
+        let cache = NSCache<SyntaxCacheKey, NSAttributedString>()
+        let lines = reverse ? [decomposed, composed] : [composed, decomposed]
+        for line in lines {
+            let key = SyntaxCacheKey(line: line, language: .swift, carry: LexState())
+            #expect(cache.object(forKey: key) == nil)
+            cache.setObject(NSAttributedString(string: line), forKey: key)
+        }
+
+        for line in lines {
+            let key = SyntaxCacheKey(line: line, language: .swift, carry: LexState())
+            let cached = try #require(cache.object(forKey: key))
+            #expect(cached.string.utf8.elementsEqual(line.utf8))
+            #expect(cached.length == line.utf16.count)
+        }
+    }
+
+    @Test("identical source reuses highlighting but language and lexer state stay separate")
+    func highlightingContext() {
+        let cache = NSCache<SyntaxCacheKey, NSAttributedString>()
+        let value = NSAttributedString(string: "return value")
+        cache.setObject(value, forKey: SyntaxCacheKey(line: value.string, language: .swift, carry: LexState()))
+
+        let same = SyntaxCacheKey(line: value.string, language: .swift, carry: LexState())
+        #expect(cache.object(forKey: same) === value)
+        let otherLanguage = SyntaxCacheKey(line: value.string, language: .php, carry: LexState())
+        #expect(cache.object(forKey: otherLanguage) == nil)
+
+        var comment = LexState()
+        _ = SyntaxHighlighter.tokenize(line: "/*", language: .swift, carry: &comment)
+        let otherState = SyntaxCacheKey(line: value.string, language: .swift, carry: comment)
+        #expect(cache.object(forKey: otherState) == nil)
+    }
+}


### PR DESCRIPTION
Prevent a diff rendering crash when composed and decomposed Unicode text share a highlighting cache entry. Cache keys now compare exact bytes, and wrapped text only restores selection when the source bytes are unchanged.

Adds cache regression tests and the Unicode case to the wrapped renderer probe. Focused tests, app build, both linters and all 159 renderer probe checks pass locally.
