### PR TITLE
Fix file clicks landing on the wrong diff

### DIFF
--- a/Sources/Bloom/Design/ReviewNavigationProbe.swift
+++ b/Sources/Bloom/Design/ReviewNavigationProbe.swift
@@ -1,0 +1,124 @@
+import AppKit
+import BloomCore
+import SwiftUI
+
+#if DEBUG
+/// Checks the landing position, not just whether a lazy diff loaded somewhere in the document.
+/// All windows stay offscreen and navigation goes through the inspector's normal entry point.
+@MainActor
+enum ReviewNavigationProbe {
+    static func run(directory: String, check: (Bool, String) -> Void) async {
+        let app = AppModel()
+        let model = WorkspaceModel(
+            workspace: Workspace(repoID: .new(), name: "Navigation", branch: "main",
+                                 path: directory + "/navigation", baseBranch: "main"),
+            app: app
+        )
+        await model.refreshChanges()
+        check(model.reviewFiles.count == 8, "navigation fixture did not load its eight files")
+        FileReview.open(path: "File00.swift", in: model)
+        let host = NSHostingView(rootView: Fixture(model: model))
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 900, height: 600),
+                              styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = host
+
+        // Cold jumps, backward jumps, repeated destinations and previously prepared files.
+        for index in [6, 2, 7, 0, 6, 6, 3] {
+            let path = String(format: "File%02d.swift", index)
+            FileReview.open(path: path, in: model)
+            await settle(window)
+            check(model.selectedFilePath == path,
+                  "requested \(path), but the inspector selected \(model.selectedFilePath ?? "nil")")
+            checkLanding(index: index, host: host, check: check)
+        }
+        // Rewrapping changes the heights above a destination which already finished loading.
+        for width: CGFloat in [420, 1100, 600] {
+            window.setContentSize(NSSize(width: width, height: 600))
+            await settle(window)
+            checkLanding(index: 3, host: host, check: check)
+        }
+        await checkKeyboardScrolling(host: host, window: window, check: check)
+        FileReview.open(path: "File03.swift", in: model)
+        await settle(window)
+        checkLanding(index: 3, host: host, check: check)
+        check(!window.isVisible && !window.isKeyWindow, "navigation probe activated its window")
+        window.contentView = nil
+        withExtendedLifetime(app) {}
+    }
+
+    private static func checkLanding(index: Int, host: NSView, check: (Bool, String) -> Void) {
+        guard let scroll = scrollView(in: host),
+              let text = firstLine(index: index, in: host) else {
+            let details = textViews(in: host).map { String($0.string.prefix(24)) }
+            let offset = scrollView(in: host)?.contentView.bounds.origin.y ?? -1
+            check(false, "file \(index) did not render its first line at offset \(offset): \(details), prepared \(ReviewRunProbe.preparedLayouts)")
+            return
+        }
+        let top = text.convert(text.bounds, to: scroll.contentView).minY - scroll.contentView.bounds.minY
+        let header = InspectorLayout.reviewHeaderHeight
+        check(top >= header - 1 && top <= header + 2 * CodeMetrics.rowHeight,
+              "file \(index) landed with its first line at \(top), expected just below header \(header)")
+    }
+
+    private static func firstLine(index: Int, in view: NSView) -> WrappedCodeText.TextView? {
+        if let text = view as? WrappedCodeText.TextView, text.string.hasPrefix("let file\(index)Line0 =") {
+            return text
+        }
+        return view.subviews.lazy.compactMap { firstLine(index: index, in: $0) }.first
+    }
+
+    private static func textViews(in view: NSView) -> [WrappedCodeText.TextView] {
+        if let text = view as? WrappedCodeText.TextView { return [text] }
+        return view.subviews.flatMap { textViews(in: $0) }
+    }
+
+    private static func checkKeyboardScrolling(host: NSView, window: NSWindow, check: (Bool, String) -> Void) async {
+        guard let input = inputView(in: host), let scroll = scrollView(in: host),
+              let text = firstLine(index: 3, in: host),
+              let event = NSEvent.keyEvent(with: .keyDown, location: .zero, modifierFlags: [],
+                                          timestamp: 0, windowNumber: window.windowNumber, context: nil,
+                                          characters: "", charactersIgnoringModifiers: "", isARepeat: false,
+                                          keyCode: 125) else {
+            check(false, "keyboard navigation fixture is missing its views")
+            return
+        }
+        check(input.enclosingScrollView === scroll, "input observer is outside the review scroll view")
+        check(window.makeFirstResponder(text), "could not focus the offscreen code view")
+        // Call the observer directly. No event is posted to the app or the window server.
+        input.handle(event)
+        await settle(window)
+        let before = scroll.contentView.bounds.origin.y
+        text.scrollToVisible(NSRect(x: 0, y: 900, width: 10, height: 18))
+        await settle(window)
+        check(scroll.contentView.bounds.origin.y > before + 100, "navigation anchor undid keyboard scrolling")
+    }
+
+    private static func inputView(in view: NSView) -> ReviewNavigationInput.InputView? {
+        if let input = view as? ReviewNavigationInput.InputView { return input }
+        return view.subviews.lazy.compactMap { inputView(in: $0) }.first
+    }
+
+    private static func scrollView(in view: NSView) -> NSScrollView? {
+        if let scroll = view as? NSScrollView { return scroll }
+        return view.subviews.lazy.compactMap { scrollView(in: $0) }.first
+    }
+
+    private static func settle(_ window: NSWindow) async {
+        for _ in 0..<30 {
+            window.contentView?.layoutSubtreeIfNeeded()
+            try? await Task.sleep(for: .milliseconds(30))
+        }
+    }
+
+    private struct Fixture: View {
+        let model: WorkspaceModel
+
+        var body: some View {
+            if let tab = CenterTabStore.shared.review(for: model.workspace.id) {
+                AllFilesReviewView(model: model, selectedPath: tab.path,
+                                   navigationRevision: tab.reviewNavigationRevision)
+            }
+        }
+    }
+}
+#endif

--- a/Sources/Bloom/Design/ReviewRunProbe.swift
+++ b/Sources/Bloom/Design/ReviewRunProbe.swift
@@ -27,6 +27,18 @@ enum ReviewRunProbe {
             if !condition { failures.append(message) }
         }
 
+        if let directory = ProbeHarness.value(for: "--review-run-probe") {
+            progress("Checking file navigation alignment")
+            await ReviewNavigationProbe.run(directory: directory, check: check)
+        }
+        if CommandLine.arguments.contains("--review-navigation-only") {
+            let result: JSONValue = .object([
+                "checks": .integer(checks), "passed": .bool(failures.isEmpty), "failures": .strings(failures),
+            ])
+            if let data = try? JSONEncoder().encode(result) { FileHandle.standardOutput.write(data) }
+            exit(failures.isEmpty ? 0 : 1)
+        }
+
         progress("Checking comment scrolling and focus")
         for numbers in [DiffGutter.Numbers.both, .old, .new] {
             let fixture = ReviewRunFixture()

--- a/Sources/Bloom/Views/Center/Panes/AllFilesReviewView.swift
+++ b/Sources/Bloom/Views/Center/Panes/AllFilesReviewView.swift
@@ -7,10 +7,10 @@ struct AllFilesReviewView: View {
     let model: WorkspaceModel
     let selectedPath: String
     let navigationRevision: Int
-    /// Keep the destination anchored while loading replaces short placeholders with full diffs.
+    /// A prepared file can still move when neighbouring diffs load or the lazy stack lays out.
+    /// Hold the clicked destination until the reader scrolls or collapses a section.
     @State private var pendingDestination: String?
     @State private var layoutRevision = 0
-    @State private var preparedPaths: Set<String> = []
     @State private var collapsedPaths: Set<String> = []
     @State private var hasNavigated = false
 
@@ -32,10 +32,15 @@ struct AllFilesReviewView: View {
                                     embeddedViewportHeight: geometry.size.height,
                                     isCollapsed: collapsedPaths.contains(file.path),
                                     onScrollFocus: {
+                                        guard hasNavigated, pendingDestination == nil else { return }
                                         if model.selectedFilePath != file.path { model.selectedFilePath = file.path }
                                     },
+                                    navigationTarget: pendingDestination == file.path,
+                                    onNavigationLayout: {
+                                        guard pendingDestination == file.path else { return }
+                                        reader.scrollTo(file.path, anchor: .top)
+                                    },
                                     onPrepared: {
-                                        preparedPaths.insert(file.path)
                                         layoutRevision += 1
                                     },
                                     onToggleCollapsed: {
@@ -48,6 +53,11 @@ struct AllFilesReviewView: View {
                                 .id(file.path)
                             }
                         }
+                        .background {
+                            ReviewNavigationInput(armed: pendingDestination != nil) {
+                                pendingDestination = nil
+                            }
+                        }
                     }
                     .defaultScrollAnchor(.topLeading)
                     .onScrollPhaseChange { _, phase in
@@ -58,7 +68,7 @@ struct AllFilesReviewView: View {
                     .onScrollGeometryChange(for: Bool.self) { geometry in
                         geometry.contentOffset.y <= geometry.contentInsets.top
                     } action: { _, atTop in
-                        if atTop, let path = model.reviewFiles.first?.path,
+                        if hasNavigated, pendingDestination == nil, atTop, let path = model.reviewFiles.first?.path,
                            model.selectedFilePath != path {
                             model.selectedFilePath = path
                         }
@@ -69,18 +79,22 @@ struct AllFilesReviewView: View {
                         let path = requested.isEmpty ? model.reviewFiles.first?.path : requested
                         guard let path, model.reviewFiles.contains(where: { $0.path == path }) else { return }
                         collapsedPaths.remove(path)
-                        pendingDestination = preparedPaths.contains(path) ? nil : path
+                        pendingDestination = path
+                        model.selectedFilePath = path
                         reader.scrollTo(path, anchor: .top)
+                    }
+                    .onScrollGeometryChange(for: CGSize.self) { geometry in
+                        geometry.contentSize
+                    } action: { _, _ in
+                        if let path = pendingDestination { reader.scrollTo(path, anchor: .top) }
                     }
                     .onChange(of: layoutRevision) { _, _ in
                         if let path = pendingDestination {
                             reader.scrollTo(path, anchor: .top)
-                            if preparedPaths.contains(path) { pendingDestination = nil }
                         }
                     }
                     .onChange(of: model.reviewFiles.map(\.path)) { _, paths in
                         collapsedPaths.formIntersection(paths)
-                        preparedPaths.formIntersection(paths)
                         if let pendingDestination, !paths.contains(pendingDestination) { self.pendingDestination = nil }
                     }
                 }

--- a/Sources/Bloom/Views/Center/Panes/ReviewNavigationInput.swift
+++ b/Sources/Bloom/Views/Center/Panes/ReviewNavigationInput.swift
@@ -1,0 +1,61 @@
+import AppKit
+import SwiftUI
+
+/// Gutter keys use scrollToVisible, which does not emit a SwiftUI scroll phase. Release the
+/// navigation anchor before input reaches a control, including legacy mouse wheels and editors.
+struct ReviewNavigationInput: NSViewRepresentable {
+    var armed: Bool
+    var onInteraction: () -> Void
+
+    func makeNSView(context: Context) -> InputView { InputView() }
+
+    func updateNSView(_ view: InputView, context: Context) {
+        view.onInteraction = onInteraction
+        view.armed = armed
+    }
+
+    static func dismantleNSView(_ view: InputView, coordinator: Void) {
+        view.armed = false
+        view.onInteraction = nil
+    }
+
+    final class InputView: NSView {
+        var onInteraction: (() -> Void)?
+        var armed = false { didSet { updateMonitor() } }
+        private var monitor: Any?
+
+        override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            updateMonitor()
+        }
+
+        func handle(_ event: NSEvent) {
+            guard armed, let window, event.window === window, let scroll = enclosingScrollView else { return }
+            if event.type == .keyDown {
+                guard let responder = window.firstResponder as? NSView,
+                      responder.isDescendant(of: scroll) else { return }
+            } else {
+                let point = scroll.convert(event.locationInWindow, from: nil)
+                guard scroll.bounds.contains(point) else { return }
+            }
+            onInteraction?()
+        }
+
+        private func updateMonitor() {
+            guard armed, window != nil else {
+                if let monitor { NSEvent.removeMonitor(monitor) }
+                monitor = nil
+                return
+            }
+            guard monitor == nil else { return }
+            monitor = NSEvent.addLocalMonitorForEvents(
+                matching: [.keyDown, .scrollWheel, .leftMouseDown, .rightMouseDown, .otherMouseDown]
+            ) { [weak self] event in
+                MainActor.assumeIsolated { self?.handle(event) }
+                return event
+            }
+        }
+    }
+}

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -15,6 +15,10 @@ struct DiffView: View {
     let embeddedViewportHeight: CGFloat?
     let isCollapsed: Bool
     var onScrollFocus: (() -> Void)?
+    /// Only the clicked section reports its frame. Prepared rows have not necessarily been
+    /// laid out yet, and lazy height estimates can move this section after its own load ends.
+    let navigationTarget: Bool
+    var onNavigationLayout: (() -> Void)?
     var onPrepared: (() -> Void)?
     var onToggleCollapsed: (() -> Void)?
 
@@ -150,7 +154,8 @@ struct DiffView: View {
     init(
         model: WorkspaceModel, file: ChangedFile, embeddedWidth: CGFloat? = nil,
         embeddedViewportHeight: CGFloat? = nil, isCollapsed: Bool = false,
-        onScrollFocus: (() -> Void)? = nil, onPrepared: (() -> Void)? = nil,
+        onScrollFocus: (() -> Void)? = nil, navigationTarget: Bool = false,
+        onNavigationLayout: (() -> Void)? = nil, onPrepared: (() -> Void)? = nil,
         onToggleCollapsed: (() -> Void)? = nil
     ) {
         self.model = model
@@ -159,6 +164,8 @@ struct DiffView: View {
         self.embeddedViewportHeight = embeddedViewportHeight
         self.isCollapsed = isCollapsed
         self.onScrollFocus = onScrollFocus
+        self.navigationTarget = navigationTarget
+        self.onNavigationLayout = onNavigationLayout
         self.onPrepared = onPrepared
         self.onToggleCollapsed = onToggleCollapsed
         let absolute = (model.workspace.path as NSString).appendingPathComponent(file.path)
@@ -217,6 +224,13 @@ struct DiffView: View {
                 Section {
                     if !isCollapsed {
                         fileContent
+                            .onGeometryChange(for: CGRect?.self) { proxy in
+                                navigationTarget ? proxy.frame(in: .scrollView(axis: .vertical)) : nil
+                            } action: { frame in
+                                if let frame, abs(frame.minY - InspectorLayout.reviewHeaderHeight) > 1 {
+                                    onNavigationLayout?()
+                                }
+                            }
                             .onGeometryChange(for: Bool.self) { proxy in
                                 let frame = proxy.frame(in: .scrollView(axis: .vertical))
                                 let edge = InspectorLayout.reviewHeaderHeight

--- a/Tools/review-run-probe.sh
+++ b/Tools/review-run-probe.sh
@@ -1,6 +1,7 @@
 #!/bin/zsh
 # Runs the diff comment regression in an invisible, isolated bundle after swift build.
 # Pass --review-compare-eager to also measure the previous 5,000-line renderer.
+# Pass --review-navigation-only to check file jumps without sending any input events.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -66,6 +67,17 @@ git('-c', 'commit.gpgsign=false', '-c', 'user.name=Review Probe',
 (fixture / 'Sources/LongReview.swift').write_text(
     ''.join(f'let reviewLine{line} = {line}\n' for line in range(1800 if '--review-scroll-profile' in arguments else 120))
 )
+navigation = pathlib.Path(root, 'navigation')
+navigation.mkdir()
+subprocess.run(['git', '-C', str(navigation), 'init', '-b', 'main'], check=True, capture_output=True)
+subprocess.run(['git', '-C', str(navigation), '-c', 'commit.gpgsign=false',
+                '-c', 'user.name=Review Probe', '-c', 'user.email=probe@example.test',
+                'commit', '--allow-empty', '-m', 'Fixture'], check=True, capture_output=True)
+for index in range(8):
+    (navigation / f'File{index:02}.swift').write_text(''.join(
+        f'let file{index}Line{line} = "' + ('wrapped text ' * (index + 4)) + '"\n'
+        for line in range(30 + index * 7)
+    ))
 try:
     subprocess.run(
         ['open', '-g', '-n', '-W', '-a', str(pathlib.Path(binary).parents[2]),


### PR DESCRIPTION
Keep inspector file clicks anchored to the requested diff while lazy sections load and change height. Release the anchor on keyboard or pointer input so manual scrolling remains free. Add offscreen regression checks for cold and repeated jumps, resizing and keyboard scrolling; the navigation checks fail on the original code and pass with the fix.
