### PR TITLE
Make the PR number and arrow read as one button

### DIFF
--- a/Sources/Bloom/Views/Inspector/InspectorLayout.swift
+++ b/Sources/Bloom/Views/Inspector/InspectorLayout.swift
@@ -41,8 +41,8 @@ enum InspectorLayout {
     /// badge it replaces was 17 points tall, 11 point text and filled, which read as a sticker on
     /// the band rather than as something to press, and half of it was not pressable at all.
     ///
-    /// The inset is the horizontal padding of each half, so the seam between them sits at the
-    /// middle of the pair rather than being a third measurement. See `PullRequestBadge`.
+    /// The inset surrounds the number and arrow together so they read as one action.
+    /// See `PullRequestBadge`.
     static let badgeHeight: CGFloat = 24
     static let badgeInset: CGFloat = Metrics.spacingWide
     static let badgeStrokeOpacity: Double = 0.2

--- a/Sources/Bloom/Views/Inspector/PullRequestBadge.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestBadge.swift
@@ -7,9 +7,8 @@ import BloomCore
 /// which did nothing at all when clicked, and a separate borderless arrow button beside it, which
 /// was the only way out to GitHub. The number is the obvious thing to click and it was the half
 /// that was inert, which is the sort of dead control people learn to distrust a whole strip over.
-/// So the two halves became one button. Both of them open the same page, through the same
-/// `GitHubBridge.open` the arrow always used, and the hairline between them is a seam rather than
-/// a boundary: it says the arrow belongs to the number, not that it does something else.
+/// Both now open the same page through `GitHubBridge.open`. A divider still made them look like
+/// separate actions, so the number and arrow share padding inside one uninterrupted outline.
 ///
 /// Outlined rather than filled, and the numbers are measured off the control this is meant to
 /// match rather than chosen: 24 points tall, 12 point text, the outline at twenty percent. Filled
@@ -34,7 +33,7 @@ struct PullRequestBadge: View {
 
     var body: some View {
         Button(action: open) {
-            HStack(spacing: 0) {
+            HStack(spacing: Metrics.spacingSmall) {
                 // `verbatim`, and this is not a style choice. A `Text` built from a
                 // `LocalizedStringKey` formats an interpolated `Int` for the current locale, so on
                 // a machine set to Dutch #2631 came out as "#2.631": a pull request number with a
@@ -45,16 +44,11 @@ struct PullRequestBadge: View {
                     // shape and the badge cannot appear to jitter as a poll comes back.
                     .font(Typo.label)
                     .monospacedDigit()
-                    .padding(.horizontal, InspectorLayout.badgeInset)
-
-                Rectangle()
-                    .fill(ink.opacity(InspectorLayout.badgeStrokeOpacity))
-                    .frame(width: Metrics.hairline)
 
                 Image(systemName: "arrow.up.forward")
                     .font(Typo.caption)
-                    .padding(.horizontal, InspectorLayout.badgeInset)
             }
+            .padding(.horizontal, InspectorLayout.badgeInset)
             .foregroundStyle(ink)
             .frame(height: InspectorLayout.badgeHeight)
             .background {


### PR DESCRIPTION
The PR number and arrow now share padding inside one outline, removing the divider that made them look like separate actions. The GitHub action, hover state and accessibility label remain intact.

Validated with a warnings-as-errors build, house rules and SwiftLint.
