### PR TITLE
Add Quick Look and file icons to source links

### DIFF
--- a/Sources/Bloom/Views/Markdown/MarkdownView.swift
+++ b/Sources/Bloom/Views/Markdown/MarkdownView.swift
@@ -434,6 +434,7 @@ enum InlineNSAttributes {
 
         let output = NSMutableAttributedString()
         render(inline, font: font, code: code, color: color, traits: [], into: output)
+        TranscriptLink.addSourceIcons(to: output)
         output.addAttribute(
             .paragraphStyle, value: paragraph, range: NSRange(location: 0, length: output.length)
         )

--- a/Sources/Bloom/Views/Transcript/TranscriptLink.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptLink.swift
@@ -161,6 +161,8 @@ enum TranscriptLink {
             }
         }
 
+        addSourceIcons(to: output)
+
         // Said once over the whole turn, so the line a chip sits on is led like every other line.
         output.addAttribute(
             .paragraphStyle, value: paragraph, range: NSRange(location: 0, length: output.length)
@@ -184,6 +186,40 @@ enum TranscriptLink {
             run.addAttribute(.link, value: url, range: range)
         }
         return run
+    }
+
+    @MainActor
+    static func addSourceIcons(to text: NSMutableAttributedString) {
+        var links: [(NSRange, CodeLocation)] = []
+        text.enumerateAttribute(.link, in: NSRange(location: 0, length: text.length)) { value, range, _ in
+            guard let url = value as? URL, let location = SourceReference.location(url) else { return }
+            links.append((range, location))
+        }
+        for (range, location) in links.reversed() {
+            let attributes = text.attributes(at: range.location, effectiveRange: nil)
+            let font = attributes[.font] as? NSFont ?? .systemFont(ofSize: NSFont.systemFontSize)
+            let size = ceil(font.pointSize)
+            let attachment = NSTextAttachment()
+            attachment.image = FileTypeIcon.icon(for: location.path)
+            attachment.bounds = CGRect(x: 0, y: (font.capHeight - size) / 2, width: size, height: size)
+            let icon = NSMutableAttributedString(attachment: attachment)
+            icon.addAttributes(attributes, range: NSRange(location: 0, length: icon.length))
+            text.insert(icon, at: range.location)
+        }
+    }
+
+    @MainActor
+    static func selectedText(in storage: NSAttributedString, range: NSRange) -> String {
+        let selection = NSMutableAttributedString(attributedString: storage.attributedSubstring(from: range))
+        var icons: [NSRange] = []
+        selection.enumerateAttribute(.attachment, in: NSRange(location: 0, length: selection.length)) { value, range, _ in
+            guard value is NSTextAttachment,
+                  let url = selection.attribute(.link, at: range.location, effectiveRange: nil) as? URL,
+                  SourceReference.location(url) != nil else { return }
+            icons.append(range)
+        }
+        for range in icons.reversed() { selection.deleteCharacters(in: range) }
+        return ComposerChipText.draft(of: selection)
     }
 
     /// What a transcript row does with an address, in one place so every row does the same.
@@ -225,6 +261,11 @@ enum TranscriptLink {
                 TranscriptLinkMenu.items(
                     for: url, placement: BrowserTab.placement(of: pane, in: model)
                 )
+            },
+            previewSource: { url in
+                guard let location = SourceReference.location(url), let model else { return nil }
+                let target = FileChipTarget.resolve(location.path, in: model.workspace.path)
+                return PromptAttachment.sent(path: target.path).url(in: target.worktree)
             }
         )
     }

--- a/Sources/Bloom/Views/Transcript/TranscriptTextView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptTextView.swift
@@ -56,6 +56,8 @@ struct TranscriptLinkActions: Sendable, Equatable {
     var hoverFile: @MainActor @Sendable (FileChipHover?) -> Void = { _ in }
     var previewFile: @MainActor @Sendable (String) -> URL? = { _ in nil }
 
+    var previewSource: @MainActor @Sendable (URL) -> URL? = { _ in nil }
+
     static func == (lhs: Self, rhs: Self) -> Bool { lhs.identity == rhs.identity }
 }
 
@@ -305,8 +307,9 @@ final class LinkTextView: NSTextView, HoverQuickLookSource {
     }
 
     func quickLookURL(at point: NSPoint) -> URL? {
-        guard let path = fileChip(at: point)?.subject.path else { return nil }
-        return actions.previewFile(path)
+        if let path = fileChip(at: point)?.subject.path { return actions.previewFile(path) }
+        guard let url = link(at: point) else { return nil }
+        return actions.previewSource(url)
     }
 
     var bubbleAlignmentWidth: CGFloat?
@@ -463,6 +466,7 @@ final class LinkTextView: NSTextView, HoverQuickLookSource {
         guard let layout = layoutManager, let container = textContainer,
               let storage = textStorage, storage.length > 0 else { return nil }
 
+        let point = NSPoint(x: point.x - textContainerOrigin.x, y: point.y - textContainerOrigin.y)
         let index = layout.characterIndex(
             for: point, in: container, fractionOfDistanceBetweenInsertionPoints: nil
         )
@@ -491,6 +495,7 @@ final class LinkTextView: NSTextView, HoverQuickLookSource {
         guard let layout = layoutManager, let container = textContainer,
               let storage = textStorage, storage.length > 0 else { return nil }
 
+        let point = NSPoint(x: point.x - textContainerOrigin.x, y: point.y - textContainerOrigin.y)
         let index = layout.characterIndex(
             for: point, in: container, fractionOfDistanceBetweenInsertionPoints: nil
         )
@@ -526,7 +531,7 @@ final class LinkTextView: NSTextView, HoverQuickLookSource {
             return super.writeSelection(to: pasteboard, type: type)
         }
         let text = selectedRanges
-            .map { ComposerChipText.draft(of: storage, in: $0.rangeValue) }
+            .map { TranscriptLink.selectedText(in: storage, range: $0.rangeValue) }
             .joined(separator: "\n")
         pasteboard.setString(text, forType: .string)
         return true
@@ -548,6 +553,12 @@ final class LinkTextView: NSTextView, HoverQuickLookSource {
         let menu = NSMenu()
         for offered in actions.items(url) {
             menu.addItem(item(offered.title, url: url, target: offered.target))
+        }
+        if let file = actions.previewSource(url), QuickLookTarget.url(for: file.path) != nil {
+            let preview = NSMenuItem(title: "Quick Look", action: #selector(previewSource(_:)), keyEquivalent: "")
+            preview.target = self
+            preview.represent(file)
+            menu.addItem(preview)
         }
         menu.addItem(.separator())
         let copy = NSMenuItem(title: "Copy Link", action: #selector(copyLink(_:)), keyEquivalent: "")
@@ -572,6 +583,11 @@ final class LinkTextView: NSTextView, HoverQuickLookSource {
     @objc private func openLink(_ sender: NSMenuItem) {
         guard let choice = sender.represented(LinkChoice.self) else { return }
         actions.open(choice.url, choice.target)
+    }
+
+    @objc private func previewSource(_ sender: NSMenuItem) {
+        guard let url = sender.represented(URL.self) else { return }
+        HoverQuickLookController.shared.show(url, in: window)
     }
 
     @objc private func copyLink(_ sender: NSMenuItem) {


### PR DESCRIPTION
Adds file type icons and Quick Look to `bloom-source` links in chat messages, available by pressing Space while hovering or through the context menu. Copied text excludes the decorative icons, and link hit testing accounts for the text container offset.

Validated with a full app build, house rules, SwiftLint, and headless checks for icon layout and copying; the isolated Bloom Dev build was also installed and launched.
