### PR TITLE
Improve code navigation and add Laravel view definitions

### DIFF
--- a/Sources/Bloom/Views/Center/Panes/FileReview.swift
+++ b/Sources/Bloom/Views/Center/Panes/FileReview.swift
@@ -29,8 +29,7 @@ enum FileReview {
 
     static func open(location: CodeLocation, in model: WorkspaceModel, recording: Bool = true) {
         var location = location
-        let root = model.workspace.path + "/"
-        if location.path.hasPrefix(root) { location.path = String(location.path.dropFirst(root.count)) }
+        location.path = location.displayPath(relativeTo: model.workspace.path)
         if recording { SourceNavigation.shared.visit(location, in: model) }
         let absolute = (location.path as NSString).isAbsolutePath ? location.path
             : (model.workspace.path as NSString).appendingPathComponent(location.path)

--- a/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
+++ b/Sources/Bloom/Views/Chrome/App/BloomCommands.swift
@@ -360,6 +360,18 @@ struct BloomCommands: Commands {
             // hidden button and on a menu item is not a tie, the button wins and the item never
             // fires, so it has to be one or the other. Here it is the menu, which greys itself out
             // when there is nothing to step through and says the keys out loud.
+            MenuCommand(.fileBack) {
+                guard let workspace = model.selectedModel else { return }
+                SourceNavigation.shared.move(-1, in: workspace)
+            }
+            .disabled(fileHistory?.canGoBack != true)
+
+            MenuCommand(.fileForward) {
+                guard let workspace = model.selectedModel else { return }
+                SourceNavigation.shared.move(1, in: workspace)
+            }
+            .disabled(fileHistory?.canGoForward != true)
+
             MenuCommand(.nextChangedFile) { stepChangedFile(1) }
                 .disabled(!canStepChangedFiles)
 
@@ -917,6 +929,16 @@ struct BloomCommands: Commands {
     }
 
     // MARK: - Walking a review
+
+    private var fileHistory: SourceHistory? {
+        guard let workspace = model.selectedModel,
+              let tab = WorkspaceTabsStore.shared.selectedTab(in: workspace),
+              case let .tool(id) = WorkspaceTabsStore.shared.content(
+                of: WorkspaceTabsStore.shared.focusedPane(of: tab), in: tab),
+              CenterTabStore.shared.tabs(for: workspace.workspace.id).contains(where: { $0.id == id && $0.kind == .review })
+        else { return nil }
+        return SourceNavigation.shared.histories[workspace.workspace.id]
+    }
 
     /// Greyed when there is no review open or nothing changed in the worktree, which is the state
     /// the two hidden buttons expressed by not existing.

--- a/Sources/Bloom/Views/Code/CodeTextView+Editing.swift
+++ b/Sources/Bloom/Views/Code/CodeTextView+Editing.swift
@@ -20,11 +20,18 @@ extension CodeTextView {
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
         let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         // Key-equivalent lookup can visit sibling views. Only the editor holding the caret acts.
+        if window?.firstResponder === self, modifiers == [.command, .option], isEditable {
+            switch event.charactersIgnoringModifiers {
+            case "[": editLines(.outdent); return true
+            case "]": editLines(.indent); return true
+            default: break
+            }
+        }
         if window?.firstResponder === self, modifiers == .command, isEditable {
             switch event.charactersIgnoringModifiers {
             case "/": editLines(.comment); return true
-            case "]": editLines(.indent); return true
-            case "[": editLines(.outdent); return true
+            case "]" where editorState == nil: editLines(.indent); return true
+            case "[" where editorState == nil: editLines(.outdent); return true
             default: break
             }
         }
@@ -35,13 +42,21 @@ extension CodeTextView {
         if event.modifierFlags.contains(.command), onOpenReference != nil {
             let point = convert(event.locationInWindow, from: nil)
             let index = characterIndexForInsertion(at: point)
-            if let reference = reference(at: index) { onOpenReference?(reference) } else { onDefinition?(index) }
+            let newTab = event.modifierFlags.contains(.shift)
+            if let reference = reference(at: index) {
+                onOpenReference?(reference, index, newTab)
+            } else if let onNavigateSymbol {
+                onNavigateSymbol(index, newTab)
+            } else {
+                onDefinition?(index)
+            }
             return
         }
         super.mouseDown(with: event)
     }
 
     override func menu(for event: NSEvent) -> NSMenu? {
+        contextOffset = characterIndexForInsertion(at: convert(event.locationInWindow, from: nil))
         let menu = super.menu(for: event) ?? NSMenu()
         menu.addItem(.separator())
         if onAsk != nil, selectedRange().length > 0 {
@@ -54,6 +69,11 @@ extension CodeTextView {
             definition.target = self
             menu.addItem(definition)
         }
+        if onReferences != nil {
+            let references = NSMenuItem(title: "Find Usages", action: #selector(findUsages), keyEquivalent: "")
+            references.target = self
+            menu.addItem(references)
+        }
         if isEditable {
             let comment = NSMenuItem(title: "Toggle Comment", action: #selector(toggleComment), keyEquivalent: "/")
             comment.target = self
@@ -63,8 +83,87 @@ extension CodeTextView {
     }
 
     @objc private func askAboutSelection() { onAsk?() }
-    @objc private func goToDefinition() { onDefinition?(selectedRange().location) }
+    @objc private func goToDefinition() { onDefinition?(contextOffset) }
+    @objc private func findUsages() { onReferences?(contextOffset) }
     @objc private func toggleComment() { editLines(.comment) }
+
+    func showDefinitions(_ locations: [CodeLocation], root: String, offset: Int, title: String = "Definitions", open: @escaping (CodeLocation) -> Void) {
+        guard let layoutManager, let textContainer, window != nil else { return }
+        let menu = NSMenu(title: title)
+        for location in locations {
+            let title = "\(location.displayPath(relativeTo: root)):\(location.line):\(location.column)"
+            let item = NSMenuItem(title: title, action: #selector(openDefinitionChoice(_:)), keyEquivalent: "")
+            item.target = self
+            item.representedObject = location
+            item.toolTip = location.path
+            menu.addItem(item)
+        }
+        let start = min(offset, string.utf16.count)
+        let range = NSRange(location: start, length: start < string.utf16.count ? 1 : 0)
+        let glyphs = layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
+        let rect = layoutManager.boundingRect(forGlyphRange: glyphs, in: textContainer)
+        let point = NSPoint(x: rect.minX + textContainerOrigin.x, y: rect.maxY + textContainerOrigin.y)
+        definitionChoice = open
+        menu.popUp(positioning: nil, at: point, in: self)
+        definitionChoice = nil
+    }
+
+    @objc private func openDefinitionChoice(_ sender: NSMenuItem) {
+        guard let location = sender.representedObject as? CodeLocation else { return }
+        definitionChoice?(location)
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        for area in trackingAreas where area.owner === self { removeTrackingArea(area) }
+        addTrackingArea(NSTrackingArea(rect: .zero, options: [.mouseMoved, .mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect], owner: self))
+    }
+
+    override func flagsChanged(with event: NSEvent) {
+        super.flagsChanged(with: event)
+        updateNavigationHint(command: event.modifierFlags.contains(.command))
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        super.mouseMoved(with: event)
+        updateNavigationHint(command: event.modifierFlags.contains(.command))
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        super.mouseEntered(with: event)
+        updateNavigationHint(command: event.modifierFlags.contains(.command))
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        updateNavigationHint(command: false)
+    }
+
+    func updateNavigationHint(command: Bool) {
+        if let navigationRange {
+            layoutManager?.removeTemporaryAttribute(.underlineStyle, forCharacterRange: NSIntersectionRange(navigationRange, NSRange(location: 0, length: string.utf16.count)))
+            self.navigationRange = nil
+            NSCursor.iBeam.set()
+        }
+        guard command, onDefinition != nil, let window else { return }
+        let point = convert(window.mouseLocationOutsideOfEventStream, from: nil)
+        guard visibleRect.contains(point), let layoutManager, let textContainer else { return }
+        let index = characterIndexForInsertion(at: point)
+        let source = string as NSString
+        guard index < source.length, navigationSource == string else { return }
+        if let token = navigationTokens.first(where: { index >= $0.start && index < $0.start + $0.length }),
+           [.keyword, .comment, .number, .operator, .punctuation, .regex, .constant].contains(token.kind) { return }
+        let range = selectionRange(forProposedRange: NSRange(location: index, length: 0), granularity: .selectByWord)
+        guard range.length > 0, NSMaxRange(range) <= source.length,
+              source.substring(with: range).rangeOfCharacter(from: .letters) != nil else { return }
+        let glyphs = layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
+        let rect = layoutManager.boundingRect(forGlyphRange: glyphs, in: textContainer)
+            .offsetBy(dx: textContainerOrigin.x, dy: textContainerOrigin.y)
+        guard rect.contains(point) else { return }
+        navigationRange = range
+        layoutManager.addTemporaryAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, forCharacterRange: range)
+        NSCursor.pointingHand.set()
+    }
 
     func editLines(_ command: SourceEditing.Command) {
         guard isEditable, let edit = SourceEditing.lines(in: string, selection: selectedRange(),

--- a/Sources/Bloom/Views/Code/SourceActions.swift
+++ b/Sources/Bloom/Views/Code/SourceActions.swift
@@ -3,38 +3,98 @@ import BloomCore
 
 @MainActor
 enum SourceActions {
-    static func open(_ reference: String, path: String, model: WorkspaceModel, state: SourceEditorState) {
+    static func open(_ reference: String, at offset: Int, path: String, model: WorkspaceModel, state: SourceEditorState, newTab: Bool = false) {
+        let language = state.languageOverride ?? Language.detect(path: path)
+        if language == .php || language == .blade {
+            lookup(at: offset, path: path, model: model, state: state, references: false, newTab: newTab, fallbackReference: reference)
+            return
+        }
         state.navigationTask?.cancel()
         state.navigationTask = Task {
             let paths = await FileIndex.shared.files(workspacePath: model.workspace.path)
             guard !Task.isCancelled else { return }
             if let location = SourceSearch.resolve(reference, from: path, root: model.workspace.path, paths: paths) {
                 state.message = nil
-                FileReview.open(location: location, in: model)
+                open(location, model: model, newTab: newTab)
             } else { state.message = "No workspace file matches \(reference)." }
         }
     }
 
     static func definition(at offset: Int, path: String, model: WorkspaceModel, state: SourceEditorState) {
+        lookup(at: offset, path: path, model: model, state: state, references: false)
+    }
+
+    static func references(at offset: Int, path: String, model: WorkspaceModel, state: SourceEditorState) {
+        lookup(at: offset, path: path, model: model, state: state, references: true)
+    }
+
+    static func navigate(at offset: Int, path: String, model: WorkspaceModel, state: SourceEditorState, newTab: Bool = false) {
+        lookup(at: offset, path: path, model: model, state: state, references: false, findUsagesAtDefinition: true, newTab: newTab)
+    }
+
+    private static func lookup(at offset: Int, path: String, model: WorkspaceModel, state: SourceEditorState, references: Bool, findUsagesAtDefinition: Bool = false, newTab: Bool = false, fallbackReference: String? = nil) {
         guard let source = state.textView?.string else { return }
         state.navigationTask?.cancel()
-        state.message = "Finding definition…"
+        state.message = references ? "Finding usages…" : "Finding definition…"
         state.navigationTask = Task {
             do {
                 let language = state.languageOverride ?? Language.detect(path: path)
                 let server = await SourceLanguageServers.shared.server(root: model.workspace.path, language: language)
-                let locations = try await server.definition(root: model.workspace.path,
-                    path: path, text: source, offset: offset, language: language)
+                var showsUsages = references
+                var found: [CodeLocation]
+                if references {
+                    found = try await server.references(root: model.workspace.path,
+                        path: path, text: source, offset: offset, language: language)
+                } else {
+                    do {
+                        found = try await SourceLanguageServers.shared.definition(root: model.workspace.path,
+                            path: path, text: source, offset: offset, language: language)
+                    } catch is CancellationError {
+                        throw CancellationError()
+                    } catch {
+                        guard let fallbackReference else { throw error }
+                        let paths = await FileIndex.shared.files(workspacePath: model.workspace.path)
+                        guard let location = SourceSearch.resolve(fallbackReference, from: path, root: model.workspace.path, paths: paths) else { throw error }
+                        found = [location]
+                    }
+                    if found.isEmpty, let fallbackReference {
+                        let paths = await FileIndex.shared.files(workspacePath: model.workspace.path)
+                        if let location = SourceSearch.resolve(fallbackReference, from: path, root: model.workspace.path, paths: paths) { found = [location] }
+                    }
+                }
+                try Task.checkCancellation()
+                if findUsagesAtDefinition, found.contains(where: {
+                    $0.matchesSymbol(path: path, root: model.workspace.path, text: source, offset: offset)
+                }) {
+                    showsUsages = true
+                    state.message = "Finding usages…"
+                    found = try await server.references(root: model.workspace.path,
+                        path: path, text: source, offset: offset, language: language)
+                }
+                let locations = await CodeLocation.suggestions(found, root: model.workspace.path)
                 try Task.checkCancellation()
                 guard state.textView?.string == source else {
-                    state.message = "The file changed during the lookup. Try Go to Definition again."
+                    state.message = "The file changed during the lookup. Try again."
                     return
                 }
-                state.message = locations.isEmpty ? "No definition found at this position." : nil
-                if locations.count == 1, let location = locations.first { FileReview.open(location: location, in: model) } else { state.definitions = locations }
+                state.message = locations.isEmpty ? (showsUsages ? "No usages found at this position." : "No definition found at this position.") : nil
+                if locations.count == 1, let location = locations.first { open(location, model: model, newTab: newTab) } else if !locations.isEmpty {
+                    state.textView?.showDefinitions(locations, root: model.workspace.path, offset: offset, title: showsUsages ? "Usages" : "Definitions") { location in
+                        open(location, model: model, newTab: newTab)
+                    }
+                }
             } catch is CancellationError {
                 // A newer navigation request owns the result now.
             } catch { state.message = error.localizedDescription }
+        }
+    }
+
+    private static func open(_ location: CodeLocation, model: WorkspaceModel, newTab: Bool) {
+        if newTab {
+            let reference = "\(location.displayPath(relativeTo: model.workspace.path)):\(location.line):\(location.column)"
+            FileReview.openInNewTab(path: reference, in: model)
+        } else {
+            FileReview.open(location: location, in: model)
         }
     }
 

--- a/Sources/Bloom/Views/Code/SourceEditor.swift
+++ b/Sources/Bloom/Views/Code/SourceEditor.swift
@@ -33,8 +33,10 @@ struct SourceEditor: NSViewRepresentable {
     /// otherwise an unexplained empty box.
     var placeholder = ""
     var editorState: SourceEditorState?
-    var onOpenReference: ((String) -> Void)?
+    var onOpenReference: ((String, Int, Bool) -> Void)?
     var onDefinition: ((Int) -> Void)?
+    var onReferences: ((Int) -> Void)?
+    var onNavigateSymbol: ((Int, Bool) -> Void)?
     var onAsk: (() -> Void)?
 
     /// Past this the colour pass costs more than it is worth on every keystroke, and a file this
@@ -162,6 +164,8 @@ struct SourceEditor: NSViewRepresentable {
         view.codeLanguage = language
         view.onOpenReference = onOpenReference
         view.onDefinition = onDefinition
+        view.onReferences = onReferences
+        view.onNavigateSymbol = onNavigateSymbol
         view.onAsk = onAsk
         let wraps = editorState?.wraps ?? false
         view.isHorizontallyResizable = !wraps
@@ -221,6 +225,7 @@ struct SourceEditor: NSViewRepresentable {
                 state.scrollOrigin = view.enclosingScrollView?.contentView.bounds.origin ?? .zero
                 if state.textView === view { state.textView = nil }
             }
+            (textView as? CodeTextView)?.updateNavigationHint(command: false)
             (textView as? CodeTextView)?.bracketTask?.cancel()
             highlightTask?.cancel()
         }
@@ -254,6 +259,7 @@ struct SourceEditor: NSViewRepresentable {
 
         func textDidChange(_ notification: Notification) {
             guard let textView else { return }
+            (textView as? CodeTextView)?.updateNavigationHint(command: false)
             text.wrappedValue = textView.string
             ruler?.refresh()
             highlight(immediately: false)
@@ -314,6 +320,8 @@ struct SourceEditor: NSViewRepresentable {
         }
 
         private func applyPlain() {
+            (textView as? CodeTextView)?.navigationSource = nil
+            (textView as? CodeTextView)?.navigationTokens = []
             guard let storage = textView?.textStorage else { return }
             storage.beginEditing()
             storage.setAttributes(Self.base, range: NSRange(location: 0, length: storage.length))
@@ -323,6 +331,8 @@ struct SourceEditor: NSViewRepresentable {
         private func apply(_ runs: [ColorRun], matching source: String) {
             guard let storage = textView?.textStorage, storage.string == source else { return }
 
+            (textView as? CodeTextView)?.navigationSource = source
+            (textView as? CodeTextView)?.navigationTokens = runs
             var colors: [TokenKind: NSColor] = [:]
             for kind in TokenKind.allCases { colors[kind] = NSColor(CodeText.color(for: kind)) }
 
@@ -381,9 +391,16 @@ struct SourceEditor: NSViewRepresentable {
 final class CodeTextView: NSTextView {
     weak var editorState: SourceEditorState?
     var codeLanguage: Language = .plainText
-    var onOpenReference: ((String) -> Void)?
+    var onOpenReference: ((String, Int, Bool) -> Void)?
     var onDefinition: ((Int) -> Void)?
+    var onReferences: ((Int) -> Void)?
+    var onNavigateSymbol: ((Int, Bool) -> Void)?
     var onAsk: (() -> Void)?
+    var navigationRange: NSRange?
+    var navigationTokens: [SourceEditor.ColorRun] = []
+    var navigationSource: String?
+    var definitionChoice: ((CodeLocation) -> Void)?
+    var contextOffset = 0
     var bracketRange: NSRange?
     var bracketTask: Task<Void, Never>?
 

--- a/Sources/Bloom/Views/Code/SourceEditorState.swift
+++ b/Sources/Bloom/Views/Code/SourceEditorState.swift
@@ -26,7 +26,6 @@ final class SourceEditorState {
     var request: CodeLocation?
     var revision = 0
     @ObservationIgnored var navigationTask: Task<Void, Never>?
-    var definitions: [CodeLocation] = []
     var message: String?
     var prefersEditing = false
     @ObservationIgnored weak var textView: CodeTextView?

--- a/Sources/Bloom/Views/Code/SourceTools.swift
+++ b/Sources/Bloom/Views/Code/SourceTools.swift
@@ -15,10 +15,10 @@ struct SourceTools: View {
         HStack(spacing: InspectorLayout.gap) {
             Button { navigation.move(-1, in: model) } label: { Image(systemName: "chevron.left") }
                 .disabled(navigation.histories[model.workspace.id]?.canGoBack != true)
-                .help("Go back")
+                .help("Go back (Command-[)")
             Button { navigation.move(1, in: model) } label: { Image(systemName: "chevron.right") }
                 .disabled(navigation.histories[model.workspace.id]?.canGoForward != true)
-                .help("Go forward")
+                .help("Go forward (Command-])")
             Button("Find") { state.find() }
                 .help("Find in this file (Command-F)")
             Menu("Navigate") {
@@ -27,6 +27,9 @@ struct SourceTools: View {
                 Button("Go to line…") { line = ""; showsLine = true }
                 Button("Go to Definition") {
                     SourceActions.definition(at: state.selection.location, path: path, model: model, state: state)
+                }
+                Button("Find Usages") {
+                    SourceActions.references(at: state.selection.location, path: path, model: model, state: state)
                 }
                 Divider()
                 Button("Ask about selected code") { SourceActions.ask(path: path, model: model, state: state) }

--- a/Sources/Bloom/Views/Inspector/FileEditPane.swift
+++ b/Sources/Bloom/Views/Inspector/FileEditPane.swift
@@ -76,25 +76,7 @@ struct FileEditPane: View {
                 await session.refresh(path: absolutePath)
             }
         }
-        .sheet(isPresented: Binding(
-            get: { comparing || !state.definitions.isEmpty },
-            set: { if !$0 { comparing = false; state.definitions = [] } }
-        )) {
-            if comparing { comparison } else { definitionChoices }
-        }
-    }
-
-    private var definitionChoices: some View {
-        VStack(alignment: .leading, spacing: Metrics.spacing) {
-            Text("Choose a definition").font(Typo.bodyEmphasis)
-            ForEach(state.definitions, id: \.self) { location in
-                Button("\(location.path):\(location.line)") {
-                    state.definitions = []
-                    FileReview.open(location: location, in: model)
-                }
-            }
-            Button("Cancel") { state.definitions = [] }.keyboardShortcut(.cancelAction)
-        }.padding(Metrics.inset)
+        .sheet(isPresented: $comparing) { comparison }
     }
 
     @ViewBuilder
@@ -109,8 +91,10 @@ struct FileEditPane: View {
                     colorScheme: colorScheme,
                     isEditable: isEditable,
                     editorState: state,
-                    onOpenReference: { SourceActions.open($0, path: path, model: model, state: state) },
+                    onOpenReference: { SourceActions.open($0, at: $1, path: path, model: model, state: state, newTab: $2) },
                     onDefinition: { SourceActions.definition(at: $0, path: path, model: model, state: state) },
+                    onReferences: { SourceActions.references(at: $0, path: path, model: model, state: state) },
+                    onNavigateSymbol: { SourceActions.navigate(at: $0, path: path, model: model, state: state, newTab: $1) },
                     onAsk: { SourceActions.ask(path: path, model: model, state: state) }
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/BloomCore/Presentation/CodeLocation.swift
+++ b/Sources/BloomCore/Presentation/CodeLocation.swift
@@ -12,6 +12,49 @@ public struct CodeLocation: Sendable, Hashable {
         self.column = max(1, column)
     }
 
+    public func displayPath(relativeTo root: String) -> String {
+        let prefix = URL(fileURLWithPath: root).standardizedFileURL.path + "/"
+        let normalised = (path as NSString).isAbsolutePath
+            ? URL(fileURLWithPath: path).standardizedFileURL.path : path
+        return normalised.hasPrefix(prefix) ? String(normalised.dropFirst(prefix.count)) : normalised
+    }
+
+    public static func suggestions(_ locations: [CodeLocation], root: String, ignored: Set<String>) -> [CodeLocation] {
+        var seen: Set<CodeLocation> = []
+        let unique = locations.filter { seen.insert($0).inserted }
+        func priority(_ location: CodeLocation) -> Int {
+            let path = location.displayPath(relativeTo: root)
+            let components = path.split(separator: "/")
+            if zip(components, components.dropFirst()).contains(where: { $0 == "vendor" && $1 == "_laravel_idea" }) { return 2 }
+            return ignored.contains(path) ? 1 : 0
+        }
+        return unique.enumerated().sorted {
+            let lhs = priority($0.element)
+            let rhs = priority($1.element)
+            return lhs == rhs ? $0.offset < $1.offset : lhs < rhs
+        }.map(\.element)
+    }
+
+    public static func suggestions(_ locations: [CodeLocation], root: String) async -> [CodeLocation] {
+        let paths = locations.map { $0.displayPath(relativeTo: root) }.filter { !($0 as NSString).isAbsolutePath }
+        let ignored = await Git.ignoredPaths(among: paths, in: root)
+        return suggestions(locations, root: root, ignored: ignored)
+    }
+
+    public func matchesSymbol(path: String, root: String, text: String, offset: Int) -> Bool {
+        guard displayPath(relativeTo: root) == CodeLocation(path: path).displayPath(relativeTo: root) else { return false }
+        let source = text as NSString
+        guard offset >= 0, offset < source.length else { return false }
+        let position = Self.position(in: text, offset: offset)
+        guard position.line == line else { return false }
+        let lineRange = source.lineRange(for: NSRange(location: offset, length: 0))
+        guard let regex = try? NSRegularExpression(pattern: #"[$\p{L}_][\p{L}\p{N}_]*"#) else { return false }
+        return regex.matches(in: text, range: lineRange).contains { match in
+            NSLocationInRange(offset, match.range)
+                && NSLocationInRange(lineRange.location + column - 1, match.range)
+        }
+    }
+
     public static func parse(_ reference: String) -> CodeLocation {
         let value = reference.trimmingCharacters(in: .whitespacesAndNewlines)
         let pattern = #"^(.*?)(?::(\d+)(?::(\d+))?|#L(\d+)(?:C(\d+))?(?:-L?\d+)?)$"#

--- a/Sources/BloomCore/Presentation/MenuBarCatalogue.swift
+++ b/Sources/BloomCore/Presentation/MenuBarCatalogue.swift
@@ -124,6 +124,8 @@ public enum MenuBarCatalogue {
         MenuBarItem(.previousTab, in: .view, "Previous Tab", key: .init("[", .command, .shift), availability: .needsSeveralTabs),
         MenuBarItem(.nextTab, in: .view, "Next Tab", key: .init("]", .command, .shift), availability: .needsSeveralTabs),
         MenuBarItem(.goToTab, in: .view, "Go to Tab", availability: .needsTab),
+        MenuBarItem(.fileBack, in: .view, "Go Back in Files", key: .init("[", .command), availability: .needsReview),
+        MenuBarItem(.fileForward, in: .view, "Go Forward in Files", key: .init("]", .command), availability: .needsReview),
         MenuBarItem(.nextChangedFile, in: .view, "Next Changed File", key: .init("j", .command, .option), availability: .needsReview),
         MenuBarItem(.previousChangedFile, in: .view, "Previous Changed File", key: .init("k", .command, .option), availability: .needsReview),
         MenuBarItem(.toggleSidebar, in: .view, "Toggle Sidebar", key: .init("s", .command, .control)),
@@ -231,6 +233,8 @@ public enum MenuBarAction: String, CaseIterable, Sendable {
     case previousTab
     case nextTab
     case goToTab
+    case fileBack
+    case fileForward
     case nextChangedFile
     case previousChangedFile
     case toggleSidebar

--- a/Sources/BloomCore/System/SourceLanguageServer.swift
+++ b/Sources/BloomCore/System/SourceLanguageServer.swift
@@ -5,7 +5,7 @@ public enum SourceLanguageServerError: LocalizedError, Sendable {
     case failed(String)
     public var errorDescription: String? {
         switch self {
-        case let .unavailable(name): "Go to Definition needs \(name) installed on your PATH."
+        case let .unavailable(name): "Code navigation needs \(name) installed on your PATH."
         case let .failed(message): message
         }
     }
@@ -13,6 +13,9 @@ public enum SourceLanguageServerError: LocalizedError, Sendable {
 
 /// A reusable LSP connection. A short idle lifetime lets background indexing finish between clicks.
 public actor SourceLanguageServer {
+    private let laravel: Bool
+    private var root: String?
+    private var fileRegistrations: Set<String> = []
     private let process = Process()
     private let input = Pipe()
     private let output = Pipe()
@@ -32,9 +35,17 @@ public actor SourceLanguageServer {
     public var isStopped: Bool { stopped }
     public func close() { stop() }
 
-    public init() {}
+    public init(laravel: Bool = false) { self.laravel = laravel }
 
     public func definition(root: String, path: String, text: String, offset: Int, language: Language) async throws -> [CodeLocation] {
+        try await lookup(root: root, path: path, text: text, offset: offset, language: language, references: false)
+    }
+
+    public func references(root: String, path: String, text: String, offset: Int, language: Language) async throws -> [CodeLocation] {
+        try await lookup(root: root, path: path, text: text, offset: offset, language: language, references: true)
+    }
+
+    private func lookup(root: String, path: String, text: String, offset: Int, language: Language, references: Bool) async throws -> [CodeLocation] {
         idleStop?.cancel()
         let firstRequest = initialisation == nil
         activeRequests += 1
@@ -55,7 +66,7 @@ public actor SourceLanguageServer {
         documentVersion += 1
         if documents[uri] == nil {
             try send(method: "textDocument/didOpen", params: .object(["textDocument": .object([
-                "uri": .string(uri), "languageId": .string(Self.languageID(language, path: path)),
+                "uri": .string(uri), "languageId": .string(languageID(language, path: path)),
                 "version": .integer(documentVersion), "text": .string(text),
             ])]))
         } else if documents[uri] != text {
@@ -76,32 +87,40 @@ public actor SourceLanguageServer {
             }
         }
         let position = CodeLocation.position(in: text, offset: offset)
-        let params = JSONValue.object([
+        var parameters: [String: JSONValue] = [
             "textDocument": .object(["uri": .string(uri)]),
             "position": .object(["line": .integer(position.line - 1), "character": .integer(position.column - 1)]),
-        ])
-        var locations = Self.locations(try await request("textDocument/definition", params))
+        ]
+        if references { parameters["context"] = .object(["includeDeclaration": .bool(false)]) }
+        let params = JSONValue.object(parameters)
+        let method = references ? "textDocument/references" : "textDocument/definition"
+        var locations = Self.locations(try await request(method, params))
         // A fresh server can answer before SwiftPM's background build settings and index arrive.
         // Keep the connection alive, and give the first lookup a bounded chance to become useful.
-        if firstRequest, locations.isEmpty {
+        if firstRequest, !laravel, locations.isEmpty {
             for delay in [1, 2, 3] where locations.isEmpty {
                 try await Task.sleep(for: .seconds(delay))
-                locations = Self.locations(try await request("textDocument/definition", params))
+                locations = Self.locations(try await request(method, params))
             }
         }
         return locations
     }
 
     private func initialise(root: String, language: Language) async throws {
-        let command = Self.command(for: language)
+        self.root = root
+        let command = laravel ? ("laravel-lsp", [String]()) : Self.command(for: language)
         guard let executable = Shell.which(command.0) else { throw SourceLanguageServerError.unavailable(command.0) }
         try Task.checkCancellation()
         try start(executable: executable, arguments: command.1, root: root)
         let rootURI = URL(fileURLWithPath: root).absoluteString
         // The TypeScript syntax server can stop at an import alias while its semantic server
         // starts. Definition-only clients need the semantic answer on the first click.
-        let options: JSONValue = language == .typescript || language == .javascript
-            ? .object(["tsserver": .object(["useSyntaxServer": .string("never")])]) : .object([:])
+        let options: JSONValue
+        if laravel {
+            options = .object(["pestGenerateDocBlocks": .bool(false)])
+        } else if language == .typescript || language == .javascript {
+            options = .object(["tsserver": .object(["useSyntaxServer": .string("never")])])
+        } else { options = .object([:]) }
         let response = try await request("initialize", .object([
             "processId": .integer(Int(ProcessInfo.processInfo.processIdentifier)),
             "rootUri": .string(rootURI),
@@ -109,7 +128,10 @@ public actor SourceLanguageServer {
             "workspaceFolders": .array([.object(["uri": .string(rootURI), "name": .string((root as NSString).lastPathComponent)])]),
             "capabilities": .object([
                 "general": .object(["positionEncodings": .array([.string("utf-16")])]),
-                "textDocument": .object(["definition": .object(["linkSupport": .bool(true)])]),
+                "workspace": .object(["didChangeWatchedFiles": .object([
+                    "dynamicRegistration": .bool(laravel), "relativePatternSupport": .bool(laravel),
+                ])]),
+                "textDocument": .object(["definition": .object(["linkSupport": .bool(true)]), "references": .object([:])]),
             ]),
         ]))
         if let encoding = response["capabilities"]?["positionEncoding"]?.stringValue, encoding != "utf-16" {
@@ -141,7 +163,8 @@ public actor SourceLanguageServer {
         }
     }
 
-    private static func languageID(_ language: Language, path: String) -> String {
+    private func languageID(_ language: Language, path: String) -> String {
+        if language == .blade, !laravel { return "php" }
         if path.hasSuffix(".tsx") { return "typescriptreact" }
         if path.hasSuffix(".jsx") { return "javascriptreact" }
         return language == .shell ? "shellscript" : language.rawValue
@@ -155,7 +178,7 @@ public actor SourceLanguageServer {
                   let position = (value["targetSelectionRange"] ?? value["range"])?["start"],
                   let line = position["line"]?.intValue, let column = position["character"]?.intValue,
                   line >= 0, column >= 0, line < Int.max, column < Int.max else { return nil }
-            return CodeLocation(path: url.path, line: line + 1, column: column + 1)
+            return CodeLocation(path: url.standardizedFileURL.path, line: line + 1, column: column + 1)
         }
     }
 
@@ -234,10 +257,25 @@ public actor SourceLanguageServer {
             for message in try frames.append(data) {
                 if let method = message["method"]?.stringValue {
                     if let id = message["id"] {
-                        // Navigation never applies workspace edits requested by a server.
-                        let result: JSONValue = method == "workspace/configuration"
-                            ? .array((message["params"]?["items"]?.arrayValue ?? []).map { _ in .null }) : .null
-                        try? write(.object(["jsonrpc": .string("2.0"), "id": id, "result": result]))
+                        if method == "client/registerCapability", laravel {
+                            for registration in message["params"]?["registrations"]?.arrayValue ?? [] {
+                                if registration["method"]?.stringValue == "workspace/didChangeWatchedFiles",
+                                   let name = registration["id"]?.stringValue { fileRegistrations.insert(name) }
+                            }
+                            try? write(.object(["jsonrpc": .string("2.0"), "id": id, "result": .null]))
+                        } else if method == "client/unregisterCapability", laravel {
+                            for registration in message["params"]?["unregisterations"]?.arrayValue ?? [] {
+                                if let name = registration["id"]?.stringValue { fileRegistrations.remove(name) }
+                            }
+                            try? write(.object(["jsonrpc": .string("2.0"), "id": id, "result": .null]))
+                        } else if method == "workspace/configuration" {
+                            let result = JSONValue.array((message["params"]?["items"]?.arrayValue ?? []).map { _ in .null })
+                            try? write(.object(["jsonrpc": .string("2.0"), "id": id, "result": result]))
+                        } else {
+                            try? write(.object(["jsonrpc": .string("2.0"), "id": id, "error": .object([
+                                "code": .integer(-32601), "message": .string("Client method not supported."),
+                            ])]))
+                        }
                     }
                     continue
                 }
@@ -250,6 +288,15 @@ public actor SourceLanguageServer {
                 }
             }
         } catch { stop() }
+    }
+
+    public func filesChanged(_ changes: [(path: String, type: Int)]) {
+        guard !stopped, !fileRegistrations.isEmpty, let root else { return }
+        let events = changes.filter { $0.path.hasPrefix(root + "/") }.map { change in
+            JSONValue.object(["uri": .string(URL(fileURLWithPath: change.path).absoluteString), "type": .integer(change.type)])
+        }
+        guard !events.isEmpty else { return }
+        do { try send(method: "workspace/didChangeWatchedFiles", params: .object(["changes": .array(events)])) } catch { stop() }
     }
 
     private func stop() {

--- a/Sources/BloomCore/System/SourceLanguageServers.swift
+++ b/Sources/BloomCore/System/SourceLanguageServers.swift
@@ -3,12 +3,13 @@ import Foundation
 /// At most four recent workspace/language pairs, each with its own short idle timeout.
 public actor SourceLanguageServers {
     public static let shared = SourceLanguageServers()
-    private struct Key: Hashable { var root: String; var language: Language }
+    private struct Key: Hashable { var root: String; var language: Language; var laravel: Bool }
     private struct Entry { var server: SourceLanguageServer; var used: Date }
     private var entries: [Key: Entry] = [:]
+    private var watcher: WorktreeWatcher?
 
-    public func server(root: String, language: Language) async -> SourceLanguageServer {
-        let key = Key(root: root, language: language)
+    public func server(root: String, language: Language, laravel: Bool = false) async -> SourceLanguageServer {
+        let key = Key(root: root, language: language == .blade ? .php : language, laravel: laravel)
         if let entry = entries[key], await !entry.server.isStopped {
             entries[key]?.used = .now
             return entry.server
@@ -17,8 +18,72 @@ public actor SourceLanguageServers {
            let old = entries.removeValue(forKey: oldest) {
             await old.server.close()
         }
-        let server = SourceLanguageServer()
+        let server = SourceLanguageServer(laravel: laravel)
         entries[key] = Entry(server: server, used: .now)
+        if watcher == nil, laravel {
+            watcher = WorktreeWatcher(onFilesChanged: { [weak self] changes in
+                Task { await self?.filesChanged(changes) }
+            }, onChange: { _ in })
+        }
+        watcher?.watch(roots: entries.keys.filter(\.laravel).map(\.root))
         return server
     }
+
+    public func definition(root: String, path: String, text: String, offset: Int, language: Language) async throws -> [CodeLocation] {
+        var connections = [(await server(root: root, language: language), root)]
+        if language == .php || language == .blade, let application = Self.laravelRoot(path: path, root: root) {
+            connections.append((await server(root: application, language: language, laravel: true), application))
+        }
+        let absolute = (path as NSString).isAbsolutePath ? path : (root as NSString).appendingPathComponent(path)
+        let results = await withTaskGroup(of: (Int, Result<[CodeLocation], Error>).self) { group in
+            for (index, connection) in connections.enumerated() {
+                group.addTask {
+                    do {
+                        return (index, .success(try await connection.0.definition(root: connection.1,
+                            path: absolute, text: text, offset: offset, language: language)))
+                    } catch { return (index, .failure(error)) }
+                }
+            }
+            var results: [(Int, Result<[CodeLocation], Error>)] = []
+            for await result in group { results.append(result) }
+            return results.sorted { $0.0 < $1.0 }.map(\.1)
+        }
+        try Task.checkCancellation()
+        var locations: [CodeLocation] = []
+        var failure: Error?
+        for result in results {
+            switch result {
+            case let .success(found): locations += found
+            case let .failure(error): failure = error
+            }
+        }
+        if locations.isEmpty, let failure { throw failure }
+        return locations
+    }
+
+    public static func laravelRoot(path: String, root: String) -> String? {
+        let root = URL(fileURLWithPath: root).standardizedFileURL.path
+        let file = (path as NSString).isAbsolutePath ? path : (root as NSString).appendingPathComponent(path)
+        var directory = URL(fileURLWithPath: file).standardizedFileURL.deletingLastPathComponent()
+        while directory.path == root || directory.path.hasPrefix(root + "/") {
+            if FileManager.default.fileExists(atPath: directory.appendingPathComponent("artisan").path),
+               FileManager.default.fileExists(atPath: directory.appendingPathComponent("composer.json").path) { return directory.path }
+            if directory.path == root { break }
+            directory.deleteLastPathComponent()
+        }
+        return nil
+    }
+
+    private func filesChanged(_ changes: [(path: String, type: Int)]) async {
+        for entry in entries.filter({ $0.key.laravel }).values { await entry.server.filesChanged(changes) }
+    }
+
+    public func close() async {
+        let servers = entries.values.map(\.server)
+        entries = [:]
+        watcher?.stop()
+        watcher = nil
+        for server in servers { await server.close() }
+    }
+
 }

--- a/Sources/BloomCore/System/WorktreeWatcher.swift
+++ b/Sources/BloomCore/System/WorktreeWatcher.swift
@@ -22,10 +22,8 @@ import Synchronization
 ///
 /// # What it reports, and what it deliberately does not
 ///
-/// The root that changed, and nothing else. Not the file, not the kind of change: everything the
-/// app does with this is "ask git about that worktree", and git is the only thing here that can
-/// say what a change means. Reporting less is also what makes the coalescing safe, because two
-/// hundred writes inside one directory are one answer.
+/// By default, reports only the changed roots for git refreshes. Language-server clients can
+/// also request individual file events with `onFilesChanged`.
 ///
 /// `.git` is deliberately NOT excluded. A commit, a checkout, a stash and an index update all move
 /// what `git diff` says and all of them land in there, and a watcher that ignored it would leave
@@ -40,6 +38,7 @@ import Synchronization
 public final class WorktreeWatcher: Sendable {
     /// What a batch of file system events becomes: the worktree roots that changed.
     private let onChange: @Sendable (Set<String>) -> Void
+    private let onFilesChanged: (@Sendable ([(path: String, type: Int)]) -> Void)?
 
     /// How long FSEvents holds events back to coalesce them.
     ///
@@ -65,8 +64,10 @@ public final class WorktreeWatcher: Sendable {
     private let watched = Mutex(Watched())
     private let queue = DispatchQueue(label: "be.spatie.bloom.worktree-watcher", qos: .utility)
 
-    public init(onChange: @escaping @Sendable (Set<String>) -> Void) {
+    public init(onFilesChanged: (@Sendable ([(path: String, type: Int)]) -> Void)? = nil,
+                onChange: @escaping @Sendable (Set<String>) -> Void) {
         self.onChange = onChange
+        self.onFilesChanged = onFilesChanged
     }
 
     deinit {
@@ -121,8 +122,7 @@ public final class WorktreeWatcher: Sendable {
             copyDescription: nil
         )
 
-        // `.fileEvents` is deliberately absent. Directory level events are what this reports
-        // anyway, and per-file events would be thousands of callbacks for one `npm install`.
+        // Only language-server watchers need individual files; diff refreshes use directories.
         // `.noDefer` makes the first event of a burst arrive at the start of the latency window
         // rather than the end, so a single save is seen a second sooner than a storm is.
         let flags = UInt32(
@@ -131,19 +131,21 @@ public final class WorktreeWatcher: Sendable {
                 | kFSEventStreamCreateFlagWatchRoot
         )
 
+        let fileFlags = onFilesChanged == nil ? UInt32(0) : UInt32(kFSEventStreamCreateFlagFileEvents)
         guard let stream = FSEventStreamCreate(
             kCFAllocatorDefault,
-            { _, info, count, paths, _, _ in
+            { _, info, count, paths, eventFlags, _ in
                 guard let info, count > 0 else { return }
                 let watcher = Unmanaged<WorktreeWatcher>.fromOpaque(info).takeUnretainedValue()
                 let changed = unsafeBitCast(paths, to: NSArray.self) as? [String] ?? []
                 watcher.report(changed)
+                watcher.reportFiles(changed, flags: Array(UnsafeBufferPointer(start: eventFlags, count: count)))
             },
             &context,
             roots as CFArray,
             FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
             Self.latency,
-            flags
+            flags | fileFlags
         ) else { return nil }
 
         FSEventStreamSetDispatchQueue(stream, queue)
@@ -172,6 +174,20 @@ public final class WorktreeWatcher: Sendable {
         let changed = Self.roots(of: paths, in: matching).compactMap { origins[$0] }
         guard !changed.isEmpty else { return }
         onChange(Set(changed))
+    }
+
+    private func reportFiles(_ paths: [String], flags: [FSEventStreamEventFlags]) {
+        guard let onFilesChanged else { return }
+        let (matching, origins) = watched.withLock { ($0.matching, $0.origins) }
+        let changes = zip(paths, flags).compactMap { path, flags -> (path: String, type: Int)? in
+            let actual = Self.standardise(path)
+            guard let root = matching.first(where: { actual.hasPrefix($0 + "/") }), let origin = origins[root] else { return nil }
+            let given = origin + actual.dropFirst(root.count)
+            let exists = FileManager.default.fileExists(atPath: given)
+            let created = flags & UInt32(kFSEventStreamEventFlagItemCreated) != 0
+            return (given, exists ? (created ? 1 : 2) : 3)
+        }
+        if !changes.isEmpty { onFilesChanged(changes) }
     }
 
     // MARK: - The arithmetic, which is the part worth testing

--- a/Tests/BloomCoreTests/EditorExperienceTests.swift
+++ b/Tests/BloomCoreTests/EditorExperienceTests.swift
@@ -11,6 +11,160 @@ struct EditorExperienceTests {
         #expect(CodeLocation.parse("file.swift:0").line == 1)
     }
 
+    @Test func definitionMatchesOnlyTheClickedSymbol() {
+        let source = "<?php\nclass Customer {}\nnew Customer();\n"
+        let definition = CodeLocation(path: "/tmp/project/Customer.php", line: 2, column: 7)
+        let declaration = (source as NSString).range(of: "Customer").location
+        #expect(definition.matchesSymbol(path: "Customer.php", root: "/tmp/project", text: source, offset: declaration + 4))
+        #expect(!definition.matchesSymbol(path: "Other.php", root: "/tmp/project", text: source, offset: declaration))
+        #expect(!definition.matchesSymbol(path: "Customer.php", root: "/tmp/project", text: source, offset: declaration - 2))
+        #expect(!definition.matchesSymbol(path: "Customer.php", root: "/tmp/project", text: source, offset: source.utf16.count - 7))
+        #expect(!definition.matchesSymbol(path: "Customer.php", root: "/tmp/project", text: source, offset: source.utf16.count))
+        let unicode = "class Café {}"
+        #expect(CodeLocation(path: "a.php", column: 7).matchesSymbol(path: "a.php", root: "/tmp/project", text: unicode, offset: 9))
+    }
+
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["BLOOM_LOCAL_LSP"] == "1"))
+    func phpReferencesFindCallersAndExcludeDeclaration() async throws {
+        let root = TestScratch.path("php-references")
+        try FileManager.default.createDirectory(atPath: root, withIntermediateDirectories: true)
+        let declaration = "<?php\nclass NavigationCustomer {}\n"
+        let caller = "<?php\nnew NavigationCustomer();\n"
+        try declaration.write(toFile: root + "/Customer.php", atomically: true, encoding: .utf8)
+        try caller.write(toFile: root + "/Caller.php", atomically: true, encoding: .utf8)
+        let offset = (declaration as NSString).range(of: "NavigationCustomer").location
+        let server = SourceLanguageServer()
+        do {
+            let references = try await server.references(root: root, path: "Customer.php", text: declaration, offset: offset, language: .php)
+            #expect(references.contains { $0.path.hasSuffix("/Caller.php") && $0.line == 2 })
+            #expect(!references.contains { $0.path.hasSuffix("/Customer.php") })
+            let definitions = try await server.definition(root: root, path: "Customer.php", text: declaration, offset: offset, language: .php)
+            #expect(definitions.contains { $0.matchesSymbol(path: "Customer.php", root: root, text: declaration, offset: offset + 3) })
+            await server.close()
+        } catch {
+            await server.close()
+            throw error
+        }
+    }
+
+    @Test func laravelRootsStayInsideTheWorkspace() throws {
+        let root = TestScratch.path("workspace")
+        for directory in [root, root + "/apps/blog", root + "-other"] {
+            try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+            try "".write(toFile: directory + "/artisan", atomically: true, encoding: .utf8)
+            try "{}".write(toFile: directory + "/composer.json", atomically: true, encoding: .utf8)
+        }
+        #expect(SourceLanguageServers.laravelRoot(path: "apps/blog/app/Controller.php", root: root) == root + "/apps/blog")
+        #expect(SourceLanguageServers.laravelRoot(path: "app/Controller.php", root: root) == root)
+        #expect(SourceLanguageServers.laravelRoot(path: root + "-other/Controller.php", root: root) == nil)
+        #expect(SourceLanguageServers.laravelRoot(path: "../Controller.php", root: root) == nil)
+        try FileManager.default.removeItem(atPath: root + "/composer.json")
+        #expect(SourceLanguageServers.laravelRoot(path: "app/Controller.php", root: root) == nil)
+    }
+
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["BLOOM_LARAVEL_LSP_VENDOR"] != nil), .timeLimit(.minutes(2)))
+    func laravelViewsAndPhpDefinitionsWorkTogether() async throws {
+        let vendor = try #require(ProcessInfo.processInfo.environment["BLOOM_LARAVEL_LSP_VENDOR"])
+        let root = TestScratch.path("laravel")
+        for directory in ["bootstrap/cache", "resources/views/front/blog", "storage/framework/views", "storage/logs", "config"] {
+            try FileManager.default.createDirectory(atPath: root + "/" + directory, withIntermediateDirectories: true)
+        }
+        try FileManager.default.createSymbolicLink(atPath: root + "/vendor", withDestinationPath: vendor)
+        let files = [
+            "composer.json": "{}",
+            "artisan": """
+            <?php
+            require __DIR__.'/vendor/autoload.php';
+            $app = require __DIR__.'/bootstrap/app.php';
+            exit($app->handleCommand(new Symfony\\Component\\Console\\Input\\ArgvInput));
+            """,
+            "bootstrap/app.php": """
+            <?php
+            return Illuminate\\Foundation\\Application::configure(basePath: dirname(__DIR__))
+                ->withProviders([Laravel\\Tinker\\TinkerServiceProvider::class])
+                ->withExceptions()
+                ->create();
+            """,
+            "config/view.php": "<?php return ['paths' => [resource_path('views')], 'compiled' => storage_path('framework/views')];",
+            "resources/views/front/blog/index.blade.php": "<h1>Blog</h1>",
+            "Caller.php": "<?php view('missing.on.disk');",
+        ]
+        for (path, contents) in files { try contents.write(toFile: root + "/" + path, atomically: true, encoding: .utf8) }
+        let servers = SourceLanguageServers()
+        do {
+            let source = "<?php class NavigationBlog {} new NavigationBlog(); view('front.blog.index');"
+            let definitions = try await servers.definition(root: root, path: "Caller.php", text: source,
+                offset: (source as NSString).range(of: "front.blog.index").location + 3, language: .php)
+            #expect(definitions == [CodeLocation(path: root + "/resources/views/front/blog/index.blade.php")])
+            let php = try await servers.definition(root: root, path: "Caller.php", text: source,
+                offset: (source as NSString).range(of: "NavigationBlog", options: .backwards).location + 3, language: .php)
+            #expect(php.contains { $0.path.hasSuffix("/Caller.php") && $0.column == 13 })
+
+            try FileManager.default.moveItem(atPath: root + "/resources/views/front/blog/index.blade.php",
+                toPath: root + "/resources/views/front/blog/renamed.blade.php")
+            let blade = "@include('front.blog.renamed')"
+            var renamed: [CodeLocation] = []
+            for _ in 0..<10 where renamed.isEmpty {
+                try await Task.sleep(for: .milliseconds(500))
+                renamed = try await servers.definition(root: root, path: "resources/views/page.blade.php", text: blade,
+                    offset: (blade as NSString).range(of: "front.blog.renamed").location + 3, language: .blade)
+            }
+            #expect(renamed == [CodeLocation(path: root + "/resources/views/front/blog/renamed.blade.php")])
+            let removed = try await servers.definition(root: root, path: "Caller.php", text: source,
+                offset: (source as NSString).range(of: "front.blog.index").location + 3, language: .php)
+            #expect(removed.isEmpty)
+            await servers.close()
+        } catch {
+            await servers.close()
+            throw error
+        }
+    }
+
+    @Test func definitionPathsRespectProjectBoundaries() {
+        #expect(CodeLocation(path: "/tmp/project/src/My File.php").displayPath(relativeTo: "/tmp/project/") == "src/My File.php")
+        #expect(CodeLocation(path: "/tmp/project-other/file.php").displayPath(relativeTo: "/tmp/project") == "/tmp/project-other/file.php")
+        #expect(CodeLocation(path: "src/File.php").displayPath(relativeTo: "/tmp/project") == "src/File.php")
+    }
+
+    @Test func definitionsKeepServerOrderWithinIgnoreGroups() {
+        let dependency = CodeLocation(path: "/tmp/project/vendor/Class.php", line: 9)
+        let first = CodeLocation(path: "/tmp/project/src/B.php", line: 2)
+        let second = CodeLocation(path: "/tmp/project/src/A.php", line: 3)
+        let external = CodeLocation(path: "/tmp/other/Class.php")
+        let results = CodeLocation.suggestions([dependency, first, second, first, external], root: "/tmp/project", ignored: ["vendor/Class.php"])
+        #expect(results == [first, second, external, dependency])
+    }
+
+    @Test func definitionsPutLaravelIdeaHelpersAfterRealVendorCode() {
+        let root = "/tmp/project"
+        let helper = CodeLocation(path: root + "/vendor/_laravel_idea/_ide_helper_macro.php", line: 253)
+        let staticHelper = CodeLocation(path: root + "/vendor/_laravel_idea/_ide_helper_macro_static.php", line: 217)
+        let implementation = CodeLocation(path: root + "/vendor/laravel/framework/src/Illuminate/Collections/Collection.php", line: 24)
+        let application = CodeLocation(path: root + "/app/Collection.php")
+        let ignored = Set([helper, staticHelper, implementation].map { $0.displayPath(relativeTo: root) })
+        let results = CodeLocation.suggestions([helper, staticHelper, implementation, application], root: root, ignored: ignored)
+        #expect(results == [application, implementation, helper, staticHelper])
+        #expect(CodeLocation.suggestions([helper, staticHelper], root: root, ignored: []) == [helper, staticHelper])
+    }
+
+    @Test func helperPriorityRequiresTheExactVendorDirectory() {
+        let ordinary = CodeLocation(path: "/tmp/project/vendor/_laravel_idea_extension/File.php")
+        let helper = CodeLocation(path: "/tmp/project/packages/app/vendor/_laravel_idea/_ide_helper.php")
+        let results = CodeLocation.suggestions([helper, ordinary], root: "/tmp/project", ignored: ["vendor/_laravel_idea_extension/File.php"])
+        #expect(results == [ordinary, helper])
+    }
+
+    @Test func definitionsUseGitIgnoreRules() async throws {
+        let root = TestScratch.path("definitions")
+        try FileManager.default.createDirectory(atPath: root + "/vendor", withIntermediateDirectories: true)
+        _ = try await Git.run(["init"], in: root)
+        try "vendor/\n".write(toFile: root + "/.gitignore", atomically: true, encoding: .utf8)
+        let dependency = CodeLocation(path: root + "/vendor/Class.php")
+        let source = CodeLocation(path: root + "/App.php")
+        let results = await CodeLocation.suggestions([dependency, source], root: root)
+        #expect(results == [source, dependency])
+    }
+
     @Test func unicodeAndLineEndings() {
         let text = "a\r\n😀xyz\r\n"
         #expect(CodeLocation.offset(in: text, line: 2, column: 3) == 5)
@@ -162,6 +316,13 @@ struct EditorExperienceTests {
         let refreshed = draft.acceptDisk(disk)
         #expect(refreshed)
         #expect(draft.text == "agent version")
+    }
+
+    @Test func definitionLinksNormaliseRepeatedPathSeparators() throws {
+        let response = try #require(JSONValue.parse(#"[{"targetUri":"file:///tmp/My%20Project//resources/views/front/blog/index.blade.php","targetSelectionRange":{"start":{"line":0,"character":0}}}]"#))
+        let locations = SourceLanguageServer.locations(response)
+        #expect(locations == [CodeLocation(path: "/tmp/My Project/resources/views/front/blog/index.blade.php")])
+        #expect(locations.first?.displayPath(relativeTo: "/tmp/My Project") == "resources/views/front/blog/index.blade.php")
     }
 
     @Test func definitionLinksUseSelectionRange() throws {

--- a/Tests/BloomCoreTests/MenuBarCatalogueTests.swift
+++ b/Tests/BloomCoreTests/MenuBarCatalogueTests.swift
@@ -17,6 +17,11 @@ struct MenuBarCatalogueTests {
         }
     }
 
+    @Test func fileHistoryShortcuts() {
+        #expect(MenuBarCatalogue[.fileBack].key == MenuShortcut("[", .command))
+        #expect(MenuBarCatalogue[.fileForward].key == MenuShortcut("]", .command))
+    }
+
     @Test("every action has exactly one row, so a lookup cannot trap")
     func everyActionHasARow() {
         for action in MenuBarAction.allCases {

--- a/docs/EDITOR.md
+++ b/docs/EDITOR.md
@@ -18,20 +18,41 @@ The Navigate menu contains:
   This lightweight outline recognises common declaration syntax. It is not a semantic index.
 - **Go to line:** accepts a one-based line and optional column, such as `42:7`.
 - **Go to Definition:** asks an installed language server about the symbol at the caret.
+- **Find Usages:** lists references to the symbol, excluding its declaration.
 - **Ask about selected code:** appends the file, line range and selected text to the chosen
   conversation's draft. It does not send the message.
 
 Command-click a relative import or file path to follow it. Command-click a symbol to request its
-definition. Go to Definition is also available in the editor's contextual menu. Bloom looks for
+definition. When that definition points back to the clicked symbol, Command-click lists its usages
+instead. Command-Shift-click opens the destination in a new tab, including a destination chosen
+from multiple results. A single definition or usage opens directly. Go to Definition and Find
+Usages are both available in the contextual menu. Bloom looks for
 SourceKit-LSP, TypeScript Language Server, Intelephense, Pyright, rust-analyzer, gopls, Ruby LSP or
 Vue Language Server on PATH, according to the file's language. It does not install servers.
 Lookups reuse a connection for up to a minute of inactivity, using the
 [Language Server Protocol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/).
 Project dependencies and the server's available build information determine what it can resolve.
-Multiple definitions offer a chooser; missing servers and failed requests are reported in the pane.
+Multiple definitions open a native menu beside the symbol, with project-relative paths.
+Ignored files follow project files, and Laravel Idea helpers under `vendor/_laravel_idea/` come last; missing servers and failed requests are reported in the pane.
+
+For PHP and Blade files inside a Laravel app, Bloom also queries
+[Laravel LSP](https://github.com/laravel/lsp). Install it with
+`composer global require laravel/lsp` and put Composer's global `vendor/bin` directory on PATH.
+Intelephense handles PHP symbols and usages; Laravel LSP adds framework definitions such as
+`view('front.blog.index')`, which opens `resources/views/front/blog/index.blade.php`.
+Both use the current editor contents, including unsaved changes. Results are combined and deduplicated.
+The nearest directory containing `artisan` and `composer.json` within the workspace is the Laravel
+root. Its dependencies, including Tinker, must be installed so Laravel LSP can boot the app.
+Bloom forwards file changes to refresh Laravel's index and disables Pest helper generation.
+Quoted PHP and Blade references try language servers before the ordinary file-path fallback.
+Command-Shift-click opens the result in a new tab, including Laravel views.
+
+Hold Command over a word to underline the definition lookup target. The underline marks where a
+lookup can be requested; the language server may still return no definition. Command-[ and
+Command-] move backwards and forwards while a file or diff pane has focus.
 
 The editor supports native undo and find, automatic indentation, Tab and Shift-Tab for indenting
-selections, Command-[ and Command-] for indentation, and Command-/ for toggling comments.
+selections, Command-Option-[ and Command-Option-] for indentation, and Command-/ for toggling comments.
 Matching brackets and the current line are highlighted. Syntax colouring includes embedded script
 and style regions in Vue and HTML, Blade expressions, and JSX attributes and expressions.
 Large buffers remain editable with plain text above the highlighting limit of 400,000 UTF-16 units.
@@ -49,3 +70,8 @@ Saving still refuses a disk version that changed after the comparison was loaded
 For development, `Bloom --source-editor-probe` checks the native editor in an unshown window and
 writes light and dark screenshots under `/tmp/editor-*.png`. Add `--language-server` to check a
 real SourceKit-LSP lookup between two temporary Swift files. Use an isolated `BLOOM_DB_PATH`.
+
+`./Tools/test-core.sh EditorExperienceTests WorktreeWatcherTests` covers navigation and file
+watching. Set `BLOOM_LOCAL_LSP=1` for the real Intelephense check. To also test Laravel view links,
+set `BLOOM_LARAVEL_LSP_VENDOR` to the `vendor` directory of a disposable Laravel app with Tinker
+installed; the test creates its own app and checks unsaved content and renamed Blade files.


### PR DESCRIPTION
Improves Cmd-click navigation with usages at declarations, direct jumps for single results, Cmd-Shift-click for new tabs, and back/forward shortcuts. Result menus use project-relative paths and put ignored files and Laravel Idea helpers last.

Adds Laravel LSP alongside Intelephense so view names open their Blade files. File changes refresh Laravel results, and returned paths are normalised before opening.

Validated in Bloom Dev with real PHP and Laravel servers, focused navigation and watcher tests, app builds, and both linters.
