### PR TITLE
Offer to open a branch when a new one is about to be cut from it

### DIFF
--- a/Sources/Bloom/Views/CreateWorkspace/CreateWorkspaceView.swift
+++ b/Sources/Bloom/Views/CreateWorkspace/CreateWorkspaceView.swift
@@ -470,6 +470,17 @@ struct CreateWorkspaceView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
+            if let carryOn {
+                HStack(spacing: Metrics.spacingSmall) {
+                    Text(carryOn.sentence)
+                        .font(Typo.caption)
+                        .foregroundStyle(Palette.textSecondary)
+                    Button(carryOn.action) { pick(carryOn.source) }
+                        .linkButton()
+                        .font(Typo.caption)
+                }
+            }
+
             // A rung below the title in the band, which is what makes the band the anchor. Both
             // were `Typo.heading` for one build and the sheet had two things the same size
             // competing to be read first, which is most of what "janky" was: "New workspace" and
@@ -835,6 +846,13 @@ struct CreateWorkspaceView: View {
             branches: checkoutOptions.branches,
             baseBranches: branchOptions
         )
+    }
+
+    /// The other verb, offered when a new branch is about to be cut from a branch that could have
+    /// been opened. See `WorkspaceSourceOffering.carryOn`.
+    private var carryOn: WorkspaceCarryOnOffer? {
+        guard checkout == nil else { return nil }
+        return offering.carryOn(from: baseBranch, holders: checkoutOptions.holders)
     }
 
     /// The same question `AppModel` will ask a moment from now, so the hint and what happens cannot

--- a/Sources/BloomCore/Workspace/WorkspaceSource.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceSource.swift
@@ -230,6 +230,39 @@ public struct WorkspaceSourceOffering: Sendable, Hashable {
         )
     }
 
+    /// What to offer when a new branch is being cut from a branch that could have been opened.
+    ///
+    /// **The report this exists for.** "When I have an existing branch and I click + and create
+    /// the conversation on top of this branch it makes a new worktree and branch instead of using
+    /// the existing one." The picker opens on the New branch tab, the branch is right there in it,
+    /// and "New branch from" does exactly what it says. Both tabs are correct and the person still
+    /// ended up on the wrong one, so the window says what is about to happen and offers the other
+    /// verb in one click, rather than guessing which of the two was meant.
+    ///
+    /// Nothing is offered for the default branch, which is what a new branch is ordinarily cut
+    /// from and is not in `branches`, nor for a branch git would refuse: one held by the project's
+    /// own checkout or by a worktree Bloom did not make. A branch one of Bloom's own workspaces
+    /// holds is offered, because picking it goes to that workspace, which is exactly "use the
+    /// existing one".
+    ///
+    /// A pull request whose head is `base` answers before the bare branch, for the reason
+    /// `WorkspaceCheckoutPlan.offeredBranches` drops the branch: the pull request knows what the
+    /// Changes tab should be measured against. `holders` is `WorkspaceCheckoutOptions.holders`,
+    /// because a pull request row carries no holder of its own.
+    public func carryOn(
+        from base: String, holders: [String: BranchHolder] = [:]
+    ) -> WorkspaceCarryOnOffer? {
+        if let request = pullRequests.first(where: { !$0.isCrossRepository && $0.headRefName == base }) {
+            return WorkspaceCarryOnOffer(
+                source: .pullRequest(.listed(request)), branch: base, holder: holders[base]
+            )
+        }
+        guard let branch = branches.first(where: { $0.name == base }) else { return nil }
+        return WorkspaceCarryOnOffer(
+            source: .existingBranch(branch), branch: base, holder: branch.inUseBy
+        )
+    }
+
     /// The row for a number or a URL that was typed rather than picked.
     ///
     /// Nothing is offered when the list already answers the number, because the listed row knows
@@ -264,6 +297,32 @@ public struct WorkspaceSourceOffering: Sendable, Hashable {
             return lhs.position < rhs.position
         }
         return scored.prefix(limit).map(\.row)
+    }
+}
+
+/// The line the create window draws under a new branch cut from a branch it could have opened.
+/// See `WorkspaceSourceOffering.carryOn`.
+public struct WorkspaceCarryOnOffer: Sendable, Hashable {
+    /// What picking the button hands to the window's own `pick`, which already knows how to open
+    /// a branch, open a pull request and go to the workspace holding either.
+    public let source: WorkspaceSource
+    /// Says what Create is about to do, because "from" on the button is one word and is the only
+    /// place the window said it.
+    public let sentence: String
+    public let action: String
+
+    /// Nil for a holder git would refuse, so a refusal is never what the button offers.
+    init?(source: WorkspaceSource, branch: String, holder: BranchHolder?) {
+        switch holder {
+        case .none:
+            action = "Open \(branch) instead"
+        case .workspace(let name):
+            action = "Go to \(name)"
+        case .projectCheckout, .otherWorktree:
+            return nil
+        }
+        self.source = source
+        sentence = "This cuts a new branch from \(branch)."
     }
 }
 

--- a/Tests/BloomCoreTests/WorkspaceSourceTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceSourceTests.swift
@@ -282,6 +282,57 @@ struct WorkspaceSourceTests {
         #expect(offered.search(query: "").settled(after: held, in: .newBranch)?.name == "main")
     }
 
+    // MARK: - Cutting from a branch that could have been opened
+
+    @Test("Cutting from a free branch offers to open that branch instead")
+    func offersToOpenAFreeBranch() {
+        let branch = ExistingBranch(name: "wip", isLocal: true)
+        let offer = offering(branches: [branch], baseBranches: ["main", "wip"]).carryOn(from: "wip")
+        #expect(offer?.source == .existingBranch(branch))
+        #expect(offer?.action == "Open wip instead")
+        #expect(offer?.sentence == "This cuts a new branch from wip.")
+    }
+
+    @Test("Cutting from the default branch, or from one nobody can open, offers nothing")
+    func offersNothingForTheOrdinaryCase() {
+        let offered = offering(
+            branches: [
+                ExistingBranch(name: "mine", isLocal: true, inUseBy: .projectCheckout(path: "/p")),
+                ExistingBranch(name: "theirs", isLocal: true, inUseBy: .otherWorktree(path: "/c")),
+            ],
+            baseBranches: ["main", "mine", "theirs"]
+        )
+        // `branches` never holds the default branch, so cutting from it is never second-guessed.
+        #expect(offered.carryOn(from: "main") == nil)
+        #expect(offered.carryOn(from: "") == nil)
+        // Git would refuse both, so offering them would be offering a refusal.
+        #expect(offered.carryOn(from: "mine") == nil)
+        #expect(offered.carryOn(from: "theirs") == nil)
+    }
+
+    @Test("A branch one of Bloom's workspaces holds offers to go there")
+    func offersTheWorkspaceHoldingTheBranch() {
+        let branch = ExistingBranch(name: "wip", isLocal: true, inUseBy: .workspace("Quiet Harbour"))
+        let offer = offering(branches: [branch], baseBranches: ["wip"]).carryOn(from: "wip")
+        #expect(offer?.source == .existingBranch(branch))
+        #expect(offer?.action == "Go to Quiet Harbour")
+    }
+
+    @Test("A pull request on the branch answers before the bare branch, and forks do not count")
+    func prefersThePullRequestOnTheBranch() {
+        let request = listing(number: 5, head: "fix-parser")
+        let offered = offering(pullRequests: [request], baseBranches: ["fix-parser"])
+        #expect(offered.carryOn(from: "fix-parser")?.source == .pullRequest(.listed(request)))
+        let checkedOut: [String: BranchHolder] = ["fix-parser": .projectCheckout(path: "/p")]
+        #expect(offered.carryOn(from: "fix-parser", holders: checkedOut) == nil)
+
+        let fork = PullRequestListing(
+            number: 6, title: "Patch", headRefName: "patch-1", baseRefName: "main",
+            isCrossRepository: true, headRepositoryOwner: "stranger"
+        )
+        #expect(offering(pullRequests: [fork], baseBranches: ["patch-1"]).carryOn(from: "patch-1") == nil)
+    }
+
     // MARK: - What the button says
 
     @Test("The button says 'on' for a checkout and 'from' for a new branch")


### PR DESCRIPTION
From feedback: picking an existing branch after clicking + cut a new worktree and branch off it instead of using it. The create window opens on the New branch tab, so "New branch from X" was the row people picked.

When a new branch is about to be cut from a branch that could be opened, the window now says so and offers "Open X instead", or "Go to <workspace>" when one of Bloom's workspaces already holds it. Nothing is offered for the default branch or for a branch git would refuse (the project's own checkout, another tool's worktree).

The decision is `WorkspaceSourceOffering.carryOn` in the core, with tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)