### PR TITLE
Read Claude Code extra usage amounts as minor units

### DIFF
--- a/Sources/BloomCore/Agent/AgentQuotaAdapter.swift
+++ b/Sources/BloomCore/Agent/AgentQuotaAdapter.swift
@@ -280,13 +280,18 @@ public enum ClaudeCodeUsageAdapter: AgentQuotaAdapter {
     /// against a monthly ceiling and the provider states neither a turnover instant nor a window.
     /// `QuotaBoard` sorts a window of unknown length last and `QuotaPace` declines to pace it, both
     /// of which are the right answers for a row that is money.
+    ///
+    /// **Both amounts arrive in minor units.** The CLI's own names for them are `usedCents` and
+    /// `spendLimitCents`, and they were read as whole pounds until a user on a £20.00 ceiling who
+    /// had spent £18.56 was told "£1,856.00 of £2,000.00". `utilization` agreed either way, which is
+    /// why the fraction looked right and nothing caught it.
     static func extraUsage(in limits: JSONValue, at now: Date) -> [AgentQuota] {
         guard let extra = limits["extra_usage"], extra["is_enabled"]?.boolValue == true else {
             return []
         }
-        let used = extra["used_credits"]?.doubleValue
-        let limit = extra["monthly_limit"]?.doubleValue
-        let currency = extra["currency"]?.stringValue ?? "USD"
+        let currency = (extra["currency"]?.stringValue ?? "USD").uppercased()
+        let used = extra["used_credits"]?.doubleValue.map { majorUnits($0, currency: currency) }
+        let limit = extra["monthly_limit"]?.doubleValue.map { majorUnits($0, currency: currency) }
         let measure: QuotaMeasure
         if let used {
             // The amounts when they are there, because "$17.20 of $50.00" is a thing somebody can
@@ -304,6 +309,15 @@ public enum ClaudeCodeUsageAdapter: AgentQuotaAdapter {
             resetsAt: nil,
             observedAt: now
         )]
+    }
+
+    /// The currencies the CLI prints without dividing, because they have no minor unit. The list
+    /// is the CLI's own rather than `NumberFormatter`'s fraction digits, so Bloom and `/usage`
+    /// cannot disagree about one amount.
+    static let zeroDecimalCurrencies: Set<String> = ["JPY", "KRW", "VND"]
+
+    static func majorUnits(_ minor: Double, currency: String) -> Double {
+        zeroDecimalCurrencies.contains(currency) ? minor : minor / 100
     }
 
     /// ISO 8601, with and without fractional seconds, because a timestamp that gains milliseconds

--- a/Tests/BloomCoreTests/QuotaAskTests.swift
+++ b/Tests/BloomCoreTests/QuotaAskTests.swift
@@ -348,18 +348,46 @@ struct RequestedQuotaPayloadTests {
     @Test func readsExtraUsageAsMoneyOnceItIsSwitchedOn() throws {
         let enabled = """
         {"rate_limits_available":true,"rate_limits":{\
-        "extra_usage":{"is_enabled":true,"monthly_limit":50,"used_credits":17.2,\
+        "extra_usage":{"is_enabled":true,"monthly_limit":5000,"used_credits":1720,\
         "utilization":34.4,"currency":"USD"}}}
         """
         let quotas = AgentQuotaAdapters.quotas(fromRateLimitEvent: Data(enabled.utf8), at: now)
         let extra = try #require(quotas.first { $0.window.key == "extra_usage" })
 
+        // Cents on the wire, dollars in the row.
         #expect(extra.measure == .counted(used: 17.2, limit: 50, unit: "USD"))
         #expect(extra.fraction == 0.344)
         // No reset time and no length, which is true rather than missing: it is a balance against
         // a monthly ceiling and the provider states neither a turnover instant nor a window.
         #expect(extra.resetsAt == nil)
         #expect(extra.window.duration == nil)
+    }
+
+    /// **The report that found it**: £18.56 of £20.00 spent, shown as £1,856.00 of £2,000.00,
+    /// because pence were read as pounds.
+    @Test func readsExtraUsageInPenceAsPounds() throws {
+        let enabled = """
+        {"rate_limits_available":true,"rate_limits":{\
+        "extra_usage":{"is_enabled":true,"monthly_limit":2000,"used_credits":1856,\
+        "utilization":92.8,"currency":"gbp"}}}
+        """
+        let quotas = AgentQuotaAdapters.quotas(fromRateLimitEvent: Data(enabled.utf8), at: now)
+        let extra = try #require(quotas.first { $0.window.key == "extra_usage" })
+
+        #expect(extra.measure == .counted(used: 18.56, limit: 20, unit: "GBP"))
+    }
+
+    /// A currency with no minor unit is not divided, exactly as the CLI prints it.
+    @Test func leavesAZeroDecimalCurrencyUndivided() throws {
+        let enabled = """
+        {"rate_limits_available":true,"rate_limits":{\
+        "extra_usage":{"is_enabled":true,"monthly_limit":3000,"used_credits":1200,\
+        "utilization":40,"currency":"JPY"}}}
+        """
+        let quotas = AgentQuotaAdapters.quotas(fromRateLimitEvent: Data(enabled.utf8), at: now)
+        let extra = try #require(quotas.first { $0.window.key == "extra_usage" })
+
+        #expect(extra.measure == .counted(used: 1200, limit: 3000, unit: "JPY"))
     }
 
     /// A display name is not a key. Two spellings of one model must not become two rows for one


### PR DESCRIPTION
Claude Code reports \`used_credits\` and \`monthly_limit\` in cents or pence (the CLI calls them \`usedCents\` and \`spendLimitCents\`), so a user who had spent £18.56 of £20.00 saw £1,856.00 of £2,000.00. The adapter now divides both by 100, except for JPY, KRW and VND, matching the CLI's own formatter. Tests cover the reported GBP case and a zero-decimal currency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)