### PR TITLE
Match confirmation button colour to the strip's button

### DIFF
--- a/Sources/Bloom/Design/Theme.swift
+++ b/Sources/Bloom/Design/Theme.swift
@@ -475,8 +475,8 @@ enum Palette {
     /// It is NOT the merge confirmation's button label, which is what it was first spent on. The
     /// owner reported that from a screenshot: this colour says a pull request HAS merged, so on
     /// the button that has not merged anything yet it named the state rather than the action, and
-    /// the dialog was wearing its own answer. That button is `positive` now, and
-    /// `ConfirmationTone.completing` carries the rest of the reasoning.
+    /// the dialog was wearing its own answer. That button now takes the fill of the merge control
+    /// it is attached to, `PullRequestStatus.Tone.fill`, so it matches the band's button.
     ///
     /// So it is the colour of merged and of nothing else. `PullRequestStatus.Tone` has a `merged`
     /// case, `PullRequestTint` resolves it here, and `WorkspaceStatusGlyph` draws the merge mark

--- a/Sources/Bloom/Views/Archive/ArchiveConfirmationPopover.swift
+++ b/Sources/Bloom/Views/Archive/ArchiveConfirmationPopover.swift
@@ -4,6 +4,7 @@ import BloomCore
 struct ArchiveConfirmationPopover: View {
     let request: ArchiveRequest
     var canConfirm = true
+    var tint: Color = Palette.controlAccent
     let onConfirm: () -> Void
     let onCancel: () -> Void
 
@@ -11,7 +12,7 @@ struct ArchiveConfirmationPopover: View {
         ConfirmationPopover(
             title: "Archive this workspace?",
             confirmLabel: request.confirmLabel,
-            tint: Palette.controlAccent,
+            tint: tint,
             canConfirm: canConfirm,
             onConfirm: onConfirm,
             onCancel: onCancel,
@@ -32,16 +33,22 @@ struct ArchiveConfirmationPopover: View {
 
 extension View {
     /// Attach this to the initiating control, which stays in the hierarchy until dismissal.
+    ///
+    /// `tint` is the initiating control's own colour where it has one, so the confirm button
+    /// matches the button that opened it. The pull request strip's Archive is the merged band's
+    /// purple; a sidebar row has no coloured control and keeps the accent.
     func archiveConfirmation(
         _ request: Binding<ArchiveRequest?>,
         arrowEdge: Edge = .top,
         canConfirm: Bool = true,
+        tint: Color = Palette.controlAccent,
         onConfirm: @escaping (ArchiveRequest) -> Void
     ) -> some View {
         popover(item: request, arrowEdge: arrowEdge) { value in
             ArchiveConfirmationPopover(
                 request: value,
                 canConfirm: canConfirm,
+                tint: tint,
                 onConfirm: {
                     request.wrappedValue = nil
                     onConfirm(value)

--- a/Sources/Bloom/Views/Inspector/MergeConfirmationPopover.swift
+++ b/Sources/Bloom/Views/Inspector/MergeConfirmationPopover.swift
@@ -9,6 +9,10 @@ struct MergeConfirmationPopover: View {
     let method: GitHub.MergeMethod
     let deletesBranch: Bool
     let canMerge: Bool
+    /// The fill of the merge control this is attached to, so the press that asks and the press
+    /// that answers are one colour. It was `Palette.positive` for every state, which put a green
+    /// button under an amber "Checks running" one and made the popover read as a second decision.
+    let tint: Color
     let onConfirm: () -> Void
     let onCancel: () -> Void
 
@@ -16,7 +20,7 @@ struct MergeConfirmationPopover: View {
         ConfirmationPopover(
             title: pullRequest.mergeConfirmationTitle(base: baseBranch),
             confirmLabel: method.label,
-            tint: Palette.positive,
+            tint: tint,
             canConfirm: canMerge,
             onConfirm: onConfirm,
             onCancel: onCancel

--- a/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
@@ -253,6 +253,7 @@ struct PullRequestSummary: View {
                         method: method,
                         deletesBranch: Self.deletesBranch,
                         canMerge: canConfirmMerge,
+                        tint: status.tone.fill,
                         onConfirm: {
                             pendingMerge = nil
                             onMerge(method)
@@ -403,6 +404,7 @@ struct PullRequestSummary: View {
             .archiveConfirmation(
                 $archiveRequest,
                 canConfirm: branchActions.isAllowed && !isWorking,
+                tint: status.tone.fill,
                 onConfirm: onConfirmArchive
             )
             .buttonStyle(.borderedProminent)


### PR DESCRIPTION
The merge confirmation's button was always green, so under an amber "Checks running" or red "Checks failing" band it disagreed with the merge button that opened it. It now uses `status.tone.fill`, the same colour as the merge control, in every state. The strip's Archive confirmation follows its purple Archive button the same way, while sidebar archive confirmations keep the accent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)