### PR TITLE
Draw Bloom's instruction files as the same chip as inline instructions

### DIFF
--- a/Sources/Bloom/Views/Center/Composer/ComposerChipText.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerChipText.swift
@@ -41,11 +41,21 @@ enum InlineChip: Equatable, Sendable {
     /// without asking anything that only the press which composed the turn could answer.
     case instructions(InjectedInstruction)
 
-    /// What the chip reads.
+    /// What the chip reads. Bloom's own instruction files read as the button that sent them, the
+    /// same as the blocks it puts in the message, so a pull request turn and a merge turn draw the
+    /// same kind of chip. See `SentTurn.title(forFile:)`.
     var label: String {
         switch self {
-        case .file(let path): (path as NSString).lastPathComponent
+        case .file(let path): SentTurn.title(forFile: path) ?? (path as NSString).lastPathComponent
         case .instructions(let block): block.title
+        }
+    }
+
+    /// Whether this chip stands for instructions Bloom gave the agent, by either road.
+    var isInstructions: Bool {
+        switch self {
+        case .file(let path): SentTurn.title(forFile: path) != nil
+        case .instructions: true
         }
     }
 
@@ -521,23 +531,22 @@ final class AttachmentChipCell: NSTextAttachmentCell {
 
     /// The mark in the slot before the name.
     ///
-    /// A file gets the icon its kind is drawn with everywhere else in this window. A block of
-    /// instructions has no kind and no file for `FileTypeIcon` to answer about, so it gets a symbol
-    /// in the ground's own ink: the same `doc.text` the button under the bubble used to carry, kept
-    /// so that a reader who knew that chip still recognises this one.
+    /// A file gets the icon its kind is drawn with everywhere else in this window. Instructions
+    /// get a symbol in the ground's own ink, whether they are a block in the message or one of
+    /// Bloom's own files: the same `doc.text` the button under the bubble used to carry, kept so
+    /// that a reader who knew that chip still recognises this one. An instruction file drawn with
+    /// the markdown icon was the half of the inconsistency `SentTurn.title(forFile:)` did not fix.
     ///
     /// Built per draw rather than held, exactly as `close` is. One chip in a turn is one of these,
     /// and it is a glyph.
     private var icon: NSImage? {
-        switch subject {
-        case .file:
-            return FileTypeIcon.icon(for: label)
-        case .instructions:
-            let size = NSImage.SymbolConfiguration(pointSize: iconSize - 3, weight: .regular)
-            let colour = NSImage.SymbolConfiguration(paletteColors: [ground.ink])
-            return NSImage(systemSymbolName: "doc.text", accessibilityDescription: label)?
-                .withSymbolConfiguration(size.applying(colour))
+        if case .file(let path) = subject, !subject.isInstructions {
+            return FileTypeIcon.icon(for: (path as NSString).lastPathComponent)
         }
+        let size = NSImage.SymbolConfiguration(pointSize: iconSize - 3, weight: .regular)
+        let colour = NSImage.SymbolConfiguration(paletteColors: [ground.ink])
+        return NSImage(systemSymbolName: "doc.text", accessibilityDescription: label)?
+            .withSymbolConfiguration(size.applying(colour))
     }
 
     // MARK: - Taking it off

--- a/Sources/BloomCore/Transcript/SentTurn.swift
+++ b/Sources/BloomCore/Transcript/SentTurn.swift
@@ -75,6 +75,32 @@ public enum SentTurn {
     public static let conflictTitle = "Conflict instructions"
     public static let projectTitle = "Project instructions"
 
+    /// The title a file Bloom named in its own turn is drawn under, or nil for any other file.
+    ///
+    /// The same four titles, because the same four kinds arrive by two roads: a pull request's
+    /// instructions are normally a file and a merge's never are, so a chip reading
+    /// `pr-instructions.md` with a markdown icon sat one turn above a chip reading "Merge
+    /// instructions" with a document symbol, and the owner's report was that the two were the same
+    /// thing drawn inconsistently. They were. What the reader pressed was a button, not a file, so
+    /// the button's name is what both say. The chip still stands for the path underneath it, so a
+    /// hover shows the file and a click opens it.
+    ///
+    /// Matched on the exact paths Bloom writes into a turn, and nothing looser, so a file somebody
+    /// attached themselves keeps its own name.
+    public static func title(forFile path: String) -> String? {
+        switch path {
+        case PullRequestInstructions.projectPath, PullRequestInstructions.scratchPath:
+            return pullRequestTitle
+        case ConflictInstructions.scratchPath:
+            return conflictTitle
+        default:
+            let projectPaths = ProjectInstructions.Subject.allCases.flatMap {
+                [ProjectInstructions.projectPath(for: $0), ProjectInstructions.scratchPath(for: $0)]
+            }
+            return projectPaths.contains(path) ? projectTitle : nil
+        }
+    }
+
     public static func segments(in text: String) -> [Segment] {
         var out: [Segment] = []
         var start = text.startIndex

--- a/Tests/BloomCoreTests/SentTurnTests.swift
+++ b/Tests/BloomCoreTests/SentTurnTests.swift
@@ -111,6 +111,30 @@ struct SentTurnTests {
         #expect(titles == [SentTurn.mergeTitle, SentTurn.projectTitle])
     }
 
+    /// A pull request's instructions are a file and a merge's are a block, and both are drawn as a
+    /// chip named after the button, so the two turns read the same way.
+    @Test("Bloom's own instruction files carry the same titles as the blocks", arguments: [
+        (PullRequestInstructions.scratchPath, SentTurn.pullRequestTitle),
+        (PullRequestInstructions.projectPath, SentTurn.pullRequestTitle),
+        (ConflictInstructions.scratchPath, SentTurn.conflictTitle),
+        (ProjectInstructions.projectPath(for: .merge), SentTurn.projectTitle),
+        (ProjectInstructions.scratchPath(for: .merge), SentTurn.projectTitle),
+        (ProjectInstructions.projectPath(for: .fixConflicts), SentTurn.projectTitle),
+        (ProjectInstructions.scratchPath(for: .fixConflicts), SentTurn.projectTitle),
+    ])
+    func instructionFilesAreTitled(path: String, title: String) {
+        #expect(SentTurn.title(forFile: path) == title)
+    }
+
+    @Test("any other file keeps its own name", arguments: [
+        "README.md",
+        "docs/pr-instructions.md",
+        ".bloom/setup.sh",
+    ])
+    func otherFilesAreNotTitled(path: String) {
+        #expect(SentTurn.title(forFile: path) == nil)
+    }
+
     // MARK: - What is left alone
 
     @Test("a file named in the sentence is still a file")


### PR DESCRIPTION
The pull request and conflict turns named their instructions file, drawn as `pr-instructions.md` with a markdown icon, while the merge turn carries its rules inline, drawn as "Merge instructions" with a document symbol. Bloom's own instruction files (`SentTurn.title(forFile:)`, exact paths only) now read as the button that sent them ("Pull request instructions", "Conflict instructions", "Project instructions") with the same symbol. Hover and click still show and open the file. Any other attached file keeps its name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)