### PR TITLE
Land all-files review jumps on the file that was asked for

### DIFF
--- a/Sources/Bloom/Design/ReviewRunProbe.swift
+++ b/Sources/Bloom/Design/ReviewRunProbe.swift
@@ -124,7 +124,7 @@ enum ReviewRunProbe {
                 app: app
             )
             await model.refreshChanges()
-            check(model.changedFiles.count == 6, "review fixture did not load its six changed files")
+            check(model.changedFiles.count == 11, "review fixture did not load its eleven changed files")
             check(model.reviewFiles.last?.path == "README.md", "review order did not put root files after folders")
             let fresh = CenterTab(workspaceID: model.workspace.id, kind: .review, title: CenterTab.reviewTitle)
             check(fresh.showsAllFiles, "a new review did not default to all files")
@@ -261,6 +261,26 @@ enum ReviewRunProbe {
                         scrollSteps.append(ProcessInfo.processInfo.systemUptime - start)
                     }
                 }
+                // Down, up, next door and back to a file already laid out once. A destination is
+                // reached when its first line sits under its own header, and it has to still be
+                // there once every file around it has finished loading.
+                for part in [3, 1, 5, 2, 4, 3] {
+                    let path = "Tests/Part\(part).swift"
+                    let marker = "let part\(part)Line0 = 0"
+                    model.selectedFilePath = path
+                    FileReview.open(path: path, in: model)
+                    for _ in 0..<40 {
+                        await settle(window)
+                        if topCode(in: scroll)?.text.hasPrefix(marker) == true { break }
+                    }
+                    for _ in 0..<10 { await settle(window) }
+                    let top = topCode(in: scroll)
+                    let offset = top?.offset ?? -1
+                    check(top?.text.hasPrefix(marker) == true
+                            && (0...(InspectorLayout.reviewHeaderHeight + 80)).contains(offset),
+                          "jumping to \(path) showed \(top.map { String($0.text.prefix(24)) } ?? "nothing") at \(offset)")
+                    save(host, name: "all-files-part\(part)")
+                }
             }
             check(!hoverViews(in: host).isEmpty, "review did not render code after jumping to a file")
             check(!window.isVisible && !window.isKeyWindow, "review probe activated its window")
@@ -316,6 +336,24 @@ enum ReviewRunProbe {
     private static func loadedLongReview(in view: NSView) -> Bool {
         if let text = view as? WrappedCodeText.TextView, text.string.contains("let reviewLine0 = 0") { return true }
         return view.subviews.contains { loadedLongReview(in: $0) }
+    }
+
+    /// The first run of code below the pinned file header, and how far below the top it starts.
+    private static func topCode(in scroll: NSScrollView) -> (text: String, offset: CGFloat)? {
+        let visible = scroll.contentView.bounds
+        let edge = visible.minY + InspectorLayout.reviewHeaderHeight
+        // A lazy stack keeps some views it has stopped drawing, hidden or clipped away.
+        return codeViews(in: scroll.documentView ?? scroll)
+            .filter { !$0.isHiddenOrHasHiddenAncestor && !$0.visibleRect.isEmpty }
+            .map { (text: $0.string, frame: $0.convert($0.bounds, to: scroll.contentView)) }
+            .filter { $0.frame.maxY > edge && $0.frame.minY < visible.maxY }
+            .min { $0.frame.minY < $1.frame.minY }
+            .map { (text: $0.text, offset: $0.frame.minY - visible.minY) }
+    }
+
+    private static func codeViews(in view: NSView) -> [WrappedCodeText.TextView] {
+        if let text = view as? WrappedCodeText.TextView { return [text] }
+        return view.subviews.flatMap { codeViews(in: $0) }
     }
 
     private static func scroll(to target: CGFloat, in scroll: NSScrollView, window: NSWindow) async {

--- a/Sources/Bloom/Views/Center/Panes/AllFilesReviewView.swift
+++ b/Sources/Bloom/Views/Center/Panes/AllFilesReviewView.swift
@@ -3,14 +3,26 @@ import BloomCore
 
 /// File sections share one vertical scroller. Each diff keeps its wrapped code,
 /// comments and viewed control, and loads only as its section approaches the viewport.
+///
+/// A jump to a file is not one `scrollTo`. The lazy stack places a file it has not drawn from
+/// estimated heights, and diffs here run from a header to thousands of points, so a jump across
+/// long files it had dropped landed wherever the estimate said: asked for the fifth of five long
+/// files, it showed the end of the second, and asking again went back to the same place. So a jump
+/// holds its destination until it arrives or the reader scrolls, and a landing in the wrong file
+/// steps to that file's neighbour, whose position is exact because it touches something drawn.
 struct AllFilesReviewView: View {
     let model: WorkspaceModel
     let selectedPath: String
     let navigationRevision: Int
-    /// Keep the destination anchored while loading replaces short placeholders with full diffs.
+    /// The file a jump is taking the reader to, until it arrives or they scroll for themselves.
+    ///
+    /// Not released when the destination has been laid out, which is what it used to do: files
+    /// around it still load and grow afterwards, and one that grows above it pushes it down.
     @State private var pendingDestination: String?
-    @State private var layoutRevision = 0
-    @State private var preparedPaths: Set<String> = []
+    /// The file the last scroll of ours put at the top, which is the destination or a step on
+    /// the way to it. A change in the stack's height anchors this again, rather than the
+    /// destination, because asking for the destination from part way is asking the estimate.
+    @State private var anchoredPath: String?
     @State private var collapsedPaths: Set<String> = []
     @State private var hasNavigated = false
 
@@ -31,15 +43,9 @@ struct AllFilesReviewView: View {
                                     model: model, file: file, embeddedWidth: geometry.size.width,
                                     embeddedViewportHeight: geometry.size.height,
                                     isCollapsed: collapsedPaths.contains(file.path),
-                                    onScrollFocus: {
-                                        if model.selectedFilePath != file.path { model.selectedFilePath = file.path }
-                                    },
-                                    onPrepared: {
-                                        preparedPaths.insert(file.path)
-                                        layoutRevision += 1
-                                    },
+                                    onScrollFocus: { reached(file.path, reader: reader) },
                                     onToggleCollapsed: {
-                                        pendingDestination = nil
+                                        release()
                                         if !collapsedPaths.insert(file.path).inserted {
                                             collapsedPaths.remove(file.path)
                                         }
@@ -50,10 +56,11 @@ struct AllFilesReviewView: View {
                         }
                     }
                     .defaultScrollAnchor(.topLeading)
+                    // Any scroll that is not the reader's stays idle: `scrollTo` here is not
+                    // animated. So a wheel, a scroller drag or a keyboard page all let go of the
+                    // jump, and a file finishing its layout later cannot drag the reader back.
                     .onScrollPhaseChange { _, phase in
-                        if phase == .tracking || phase == .interacting || phase == .decelerating {
-                            pendingDestination = nil
-                        }
+                        if phase != .idle { release() }
                     }
                     .onScrollGeometryChange(for: Bool.self) { geometry in
                         geometry.contentOffset.y <= geometry.contentInsets.top
@@ -69,22 +76,51 @@ struct AllFilesReviewView: View {
                         let path = requested.isEmpty ? model.reviewFiles.first?.path : requested
                         guard let path, model.reviewFiles.contains(where: { $0.path == path }) else { return }
                         collapsedPaths.remove(path)
-                        pendingDestination = preparedPaths.contains(path) ? nil : path
-                        reader.scrollTo(path, anchor: .top)
+                        pendingDestination = path
+                        anchor(path, reader: reader)
                     }
-                    .onChange(of: layoutRevision) { _, _ in
-                        if let path = pendingDestination {
-                            reader.scrollTo(path, anchor: .top)
-                            if preparedPaths.contains(path) { pendingDestination = nil }
+                    // After layout, not when a file says it has been laid out. That report arrives
+                    // before its new height is applied, so a scroll taken then measured the stack
+                    // with the file still at its loading height, and the file grew over the
+                    // destination anyway.
+                    .onScrollGeometryChange(for: CGFloat.self) { $0.contentSize.height } action: { _, _ in
+                        if pendingDestination != nil, let anchoredPath {
+                            reader.scrollTo(anchoredPath, anchor: .top)
                         }
                     }
                     .onChange(of: model.reviewFiles.map(\.path)) { _, paths in
                         collapsedPaths.formIntersection(paths)
-                        preparedPaths.formIntersection(paths)
-                        if let pendingDestination, !paths.contains(pendingDestination) { self.pendingDestination = nil }
+                        if let pendingDestination, !paths.contains(pendingDestination) { release() }
+                        if let anchoredPath, !paths.contains(anchoredPath) { self.anchoredPath = pendingDestination }
                     }
                 }
             }
         }
+    }
+
+    /// A file's code reached the top. Selected when it is where the reader is, and otherwise a
+    /// jump in progress that has landed short or long of its destination, which moves one file on.
+    ///
+    /// Only called when a file newly reaches the top, so a destination that cannot get there (a
+    /// last file shorter than the pane) ends the walk on its neighbour rather than looping.
+    private func reached(_ path: String, reader: ScrollViewProxy) {
+        guard let destination = pendingDestination, destination != path else {
+            if model.selectedFilePath != path { model.selectedFilePath = path }
+            return
+        }
+        let files = model.reviewFiles
+        guard let here = files.firstIndex(where: { $0.path == path }),
+              let there = files.firstIndex(where: { $0.path == destination }) else { return }
+        anchor(files[here < there ? here + 1 : here - 1].path, reader: reader)
+    }
+
+    private func anchor(_ path: String, reader: ScrollViewProxy) {
+        anchoredPath = path
+        reader.scrollTo(path, anchor: .top)
+    }
+
+    private func release() {
+        pendingDestination = nil
+        anchoredPath = nil
     }
 }

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -15,7 +15,6 @@ struct DiffView: View {
     let embeddedViewportHeight: CGFloat?
     let isCollapsed: Bool
     var onScrollFocus: (() -> Void)?
-    var onPrepared: (() -> Void)?
     var onToggleCollapsed: (() -> Void)?
 
     /// Above this many changed lines the diff is gated behind a tap. Rendering is lazy and would
@@ -150,8 +149,7 @@ struct DiffView: View {
     init(
         model: WorkspaceModel, file: ChangedFile, embeddedWidth: CGFloat? = nil,
         embeddedViewportHeight: CGFloat? = nil, isCollapsed: Bool = false,
-        onScrollFocus: (() -> Void)? = nil, onPrepared: (() -> Void)? = nil,
-        onToggleCollapsed: (() -> Void)? = nil
+        onScrollFocus: (() -> Void)? = nil, onToggleCollapsed: (() -> Void)? = nil
     ) {
         self.model = model
         self.file = file
@@ -159,7 +157,6 @@ struct DiffView: View {
         self.embeddedViewportHeight = embeddedViewportHeight
         self.isCollapsed = isCollapsed
         self.onScrollFocus = onScrollFocus
-        self.onPrepared = onPrepared
         self.onToggleCollapsed = onToggleCollapsed
         let absolute = (model.workspace.path as NSString).appendingPathComponent(file.path)
         _mode = State(initialValue: FileEditSession.shared.isDirty(absolute) ? .edit : .diff)
@@ -853,7 +850,6 @@ struct DiffView: View {
             revision: revision, document: document, rows: currentRows, width: width, heights: heights,
             codeHeight: heights.values.reduce(0) { $0 + $1.reduce(0, +) }
         )
-        onPrepared?()
         #if DEBUG
         if CommandLine.arguments.contains("--review-run-probe") {
             ReviewRunProbe.preparedLayouts[file.path] = "rows=\(currentRows.count), blocks=\(heights.count), height=\(heights.values.flatMap { $0 }.reduce(0, +)), width=\(width), viewport=\(embeddedViewportHeight ?? -1)"

--- a/Tools/review-run-probe.sh
+++ b/Tools/review-run-probe.sh
@@ -66,6 +66,13 @@ git('-c', 'commit.gpgsign=false', '-c', 'user.name=Review Probe',
 (fixture / 'Sources/LongReview.swift').write_text(
     ''.join(f'let reviewLine{line} = {line}\n' for line in range(1800 if '--review-scroll-profile' in arguments else 120))
 )
+# Several screens each, so a jump crosses files that load and grow around its destination.
+# After Sources in review order, so the offsets measured around LongReview.swift stay put.
+(fixture / 'Tests').mkdir()
+for part in range(1, 6):
+    (fixture / f'Tests/Part{part}.swift').write_text(
+        ''.join(f'let part{part}Line{line} = {line}\n' for line in range(160))
+    )
 try:
     subprocess.run(
         ['open', '-g', '-n', '-W', '-a', str(pathlib.Path(binary).parents[2]),


### PR DESCRIPTION
Clicking a file in the all-files review could land in a different one, typically the end of an earlier long diff. The lazy stack places files it has not drawn from estimated heights, and rows it dropped come back at their loading height and grow, so a single \`scrollTo\` landed wherever the estimate said and nothing corrected it. A jump now stays pending until it arrives or the reader scrolls, re-anchors after every height change, and steps file by file from a wrong landing, since the neighbour of a drawn file has an exact position. The review probe gained five long files and checks six jumps down, up and back to a file already laid out.