### PR TITLE
Add a way to stop a running setup script

### DIFF
--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -329,6 +329,12 @@ final class WorkspaceModel {
     /// A setup script can run for minutes (`composer install`, `npm ci`). Without a handle,
     /// archiving mid-setup cannot stop it and it outlives the app.
     private var setupTask: Task<Void, Never>?
+    /// The script alone, where `setupTask` is the script and whatever follows it. Stop cancels
+    /// this one, so the queue behind the run still drains; archiving and quitting cancel the
+    /// outer task, which reaches this through `stream`'s cancellation handler.
+    @ObservationIgnored private var setupRunTask: Task<Bool, Never>?
+    /// Set by `stopSetup`, so a run the reader stopped is not announced as a failed setup.
+    @ObservationIgnored private var setupWasStopped = false
 
     init(workspace: Workspace, app: AppModel) {
         self.workspace = workspace
@@ -1038,7 +1044,7 @@ final class WorkspaceModel {
             // its way out is the one thing that must not happen here.
             guard !Task.isCancelled else { return }
 
-            if !succeeded {
+            if !succeeded, !setupWasStopped {
                 // The one sentence every route says about a failed setup, rather than a second
                 // one written here that would drift from it. It names no tab, which is what makes
                 // it survive the tab it used to name. See `SetupFailure`.
@@ -1136,6 +1142,7 @@ final class WorkspaceModel {
     @discardableResult
     private func stream(setupIn repo: Repo, through manager: WorkspaceManager) async -> Bool {
         isRunningSetup = true
+        setupWasStopped = false
         setupStartedAt = .now
         setupDurationMS = nil
         setupExitStatus = nil
@@ -1158,14 +1165,25 @@ final class WorkspaceModel {
             }
         }
 
-        let succeeded = await manager.runSetup(
-            workspace: workspace, repo: repo, port: port,
-            onExit: { [weak self] status in
-                Task { @MainActor in self?.setupExitStatus = status }
+        let workspace = workspace
+        let port = port
+        let run = Task {
+            await manager.runSetup(
+                workspace: workspace, repo: repo, port: port,
+                onExit: { [weak self] status in
+                    Task { @MainActor in self?.setupExitStatus = status }
+                }
+            ) { line in
+                buffer.append(line)
             }
-        ) { line in
-            buffer.append(line)
         }
+        setupRunTask = run
+        let succeeded = await withTaskCancellationHandler {
+            await run.value
+        } onCancel: {
+            run.cancel()
+        }
+        if setupRunTask == run { setupRunTask = nil }
 
         flusher.cancel()
         appendSetupOutput(buffer.drain())
@@ -1231,6 +1249,18 @@ final class WorkspaceModel {
             guard let self, self.setupGeneration == generation else { return }
             self.setupTask = nil
         }
+    }
+
+    /// Stops the setup script that is running in this worktree.
+    ///
+    /// Only the script: whatever was waiting for setup to finish goes on as it would after a
+    /// failure, so a prompt queued behind a seeder that hangs reaches the agent rather than
+    /// sitting there until the workspace is archived. The run is filed as failed, which is what
+    /// puts "Run setup again" on its row. See `WorkspaceManager.setupStoppedNote`.
+    func stopSetup() {
+        guard isRunningSetup, let run = setupRunTask else { return }
+        setupWasStopped = true
+        run.cancel()
     }
 
     /// Re-reads what setup ended up as.

--- a/Sources/Bloom/Views/Transcript/WorkspaceEventsView.swift
+++ b/Sources/Bloom/Views/Transcript/WorkspaceEventsView.swift
@@ -457,7 +457,7 @@ struct WorkspaceEventRow: View {
             // behind a condition of its own instead of being an `HStack` that is sometimes empty:
             // an empty stack is still a view, and the gap above it would be drawn under every
             // finished run.
-            if showsExpandLink || showsRunSetupAgain {
+            if showsExpandLink || showsRunSetupAgain || showsStopSetup {
                 // Wider than the `spacing` rung most pairs use. The gap was the only thing
                 // saying these were two controls back when both were plain words, and at six
                 // points "Show more of the log Run setup again" read as one sentence somebody had
@@ -496,6 +496,16 @@ struct WorkspaceEventRow: View {
                             .font(Typo.caption)
                             .help("Asks, then runs this repository's setup script in this workspace again")
                     }
+
+                    // No confirmation, unlike the run: stopping costs nothing that "Run setup
+                    // again" on the failed row it leaves behind cannot give back.
+                    if showsStopSetup, let model {
+                        Button("Stop setup") { model.stopSetup() }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .font(Typo.caption)
+                            .help("Stops the setup script. Anything waiting for it goes to the agent")
+                    }
                 }
                 .padding(.leading, TranscriptLayout.block)
             }
@@ -528,6 +538,11 @@ struct WorkspaceEventRow: View {
     /// a wrong answer.
     private var showsRunSetupAgain: Bool {
         event.kind == .setup && event.outcome == .failed && model?.canRunSetup == true
+    }
+
+    /// Whether this row offers to stop the run, which is for as long as the script is going.
+    private var showsStopSetup: Bool {
+        event.kind == .setup && event.isRunning && model?.isRunningSetup == true
     }
 
     /// Whether unfolding this row would actually show anything the reader cannot already see.

--- a/Sources/BloomCore/Workspace/WorkspaceManager.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceManager.swift
@@ -450,7 +450,17 @@ public struct WorkspaceManager: Sendable {
         return env
     }
 
+    /// What the setup log says when a run was stopped before the script exited.
+    public static let setupStoppedNote = "[bloom] Setup was stopped before it finished. "
+        + "Run setup again to finish it."
+
+    /// How long a stopped setup script has to exit after SIGTERM before it is killed.
+    static let setupStopGrace: Duration = .seconds(5)
+
     /// Runs the setup script, streaming output line by line. Returns whether it succeeded.
+    ///
+    /// Cancelling the calling task stops the script, and the run is filed as failed with
+    /// `setupStoppedNote` at the end of its log.
     ///
     /// - Parameter onExit: the status the script ended on, reported once and only when one
     ///   exists. A run that never started a process has no status, and reporting a made up zero
@@ -507,6 +517,20 @@ public struct WorkspaceManager: Sendable {
         } catch {
             log += "\n\(error)\n"
             onOutput("\(error)")
+        }
+
+        // Stopped rather than finished: the reader pressed Stop, or the workspace is being archived
+        // or the app is quitting. Cancelling ends `lines`, and its termination handler sends
+        // SIGTERM to the script's process group. A seeder or a watcher that ignores it would hold
+        // `exitStatus` for ever and leave the row `running`, so it gets SIGKILL after a grace
+        // period. The line in the log is what tells a reader later that nobody's script failed.
+        if Task.isCancelled {
+            Task.detached {
+                try? await Task.sleep(for: Self.setupStopGrace)
+                runner.kill()
+            }
+            log += Self.setupStoppedNote + "\n"
+            onOutput(Self.setupStoppedNote)
         }
 
         let status = await runner.exitStatus

--- a/Tests/BloomCoreTests/WorkspaceManagerTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceManagerTests.swift
@@ -287,6 +287,48 @@ struct WorkspaceManagerTests {
     }
 
     @Test(
+        "cancelling a setup run stops the script and files it as stopped",
+        .tags(.subprocess), .timeLimit(.minutes(1))
+    )
+    func cancellingSetupStopsTheScript() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        // Ignores SIGTERM, which is what a Stop has to get past as well as the ordinary case.
+        try repo.write(".conductor/settings.toml", """
+        [scripts]
+        setup = '''
+        trap '' TERM
+        echo "seeding"
+        for _ in $(seq 1 600); do sleep 0.05; done
+        touch finished.txt
+        '''
+        """)
+
+        let store = try makeTestStore("wm")
+        let manager = WorkspaceManager(store: store)
+        let registered = try await manager.addRepository(at: repo.path)
+        let workspace = try await manager.createWorkspace(repo: registered, prompt: "Stop setup")
+
+        let collector = LineCollector()
+        let run = Task {
+            await manager.runSetup(workspace: workspace, repo: registered, port: 0) { collector.append($0) }
+        }
+        await waitUntil("the script has printed its first line") {
+            collector.joined.contains("seeding")
+        }
+
+        run.cancel()
+        let succeeded = await run.value
+        #expect(succeeded == false)
+
+        let stored = try #require(try await store.workspace(id: workspace.id))
+        #expect(stored.setupState == .failed)
+        #expect(stored.setupLog.contains("seeding"))
+        #expect(stored.setupLog.contains(WorkspaceManager.setupStoppedNote))
+        #expect(!TempRepo(existing: workspace.path).exists("finished.txt"))
+    }
+
+    @Test(
         "a finishing setup run does not undo edits made while it ran",
         .tags(.subprocess), .timeLimit(.minutes(1))
     )


### PR DESCRIPTION
The running setup row in the transcript gets a Stop setup button, so a hung seeder or install no longer holds the workspace until it is archived. It stops only the script (SIGTERM to its process group, SIGKILL after five seconds if ignored) and files the run as failed with a note saying it was stopped, which brings up Run setup again. Anything queued behind setup still goes to the agent, without the setup failed alert. Covered by a new test in `WorkspaceManagerTests` with a script that traps SIGTERM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)