### PR TITLE
Bind run script rows by identity and probe rapid review navigation

### DIFF
--- a/Sources/Bloom/Design/ReviewRunProbe.swift
+++ b/Sources/Bloom/Design/ReviewRunProbe.swift
@@ -262,6 +262,8 @@ enum ReviewRunProbe {
                     }
                 }
             }
+            await rapidNavigation(model: model, fixture: directory + "/fixture", host: host, window: window,
+                                  check: check)
             check(!hoverViews(in: host).isEmpty, "review did not render code after jumping to a file")
             check(!window.isVisible && !window.isKeyWindow, "review probe activated its window")
             window.contentView = nil
@@ -311,6 +313,55 @@ enum ReviewRunProbe {
 
     private static func progress(_ message: String) {
         FileHandle.standardError.write(Data((message + "\n").utf8))
+    }
+
+    /// A reader clicking through the inspector faster than sections lay out. Reported on
+    /// 2026-09-11 as Bloom crashing "sometimes when I change the file I want to review", on a
+    /// side-by-side review of 45 files, most of them sections still on "Laying out the diff". No
+    /// crash report came with it, so this puts the review in that state and navigates through it:
+    /// each click lands while the previous destination is on its placeholder, so `scrollTo`, the
+    /// prepared callbacks and scroll-follow all run into each other. A crash here ends the process,
+    /// which the script reports as a missing result.
+    private static func rapidNavigation(
+        model: WorkspaceModel, fixture: String, host: NSView, window: NSWindow,
+        check: (Bool, String) -> Void
+    ) async {
+        progress("Checking rapid navigation between files")
+        let root = URL(fileURLWithPath: fixture)
+        for index in 0..<40 {
+            let url = root.appendingPathComponent("Tests/Feature/Rapid/Generated\(index)Test.php")
+            try? FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            let body = (0..<(20 + index * 7)).map { "    public function test\($0)(): void {}" }
+            try? ("<?php\n\nclass Generated\(index)Test\n{\n" + body.joined(separator: "\n") + "\n}\n")
+                .write(to: url, atomically: true, encoding: .utf8)
+        }
+        // Refreshed with the review on screen, which is what the six second poll does to a reader.
+        await model.refreshChanges()
+        UserDefaults.standard.set(true, forKey: DiffLayoutSetting.storageKey)
+        await settle(window)
+
+        let paths = model.reviewFiles.map(\.path)
+        check(paths.count >= 46, "rapid navigation fixture loaded \(paths.count) files")
+        for round in 0..<3 {
+            for (step, path) in (round.isMultiple(of: 2) ? paths : paths.reversed()).enumerated() {
+                model.selectedFilePath = path
+                FileReview.open(path: path, in: model)
+                host.layoutSubtreeIfNeeded()
+                // Mostly no pause at all: the point is to arrive before layout does.
+                if step.isMultiple(of: 4) { try? await Task.sleep(for: .milliseconds(8)) }
+            }
+        }
+        // Three rounds, forwards, backwards, forwards, so the last click was the last file.
+        let last = paths.last ?? ""
+        for _ in 0..<20 {
+            await settle(window)
+            if preparedLayouts[last] != nil { break }
+        }
+        save(host, name: "all-files-rapid")
+        check(preparedLayouts[last] != nil, "rapid navigation left \(last) on its placeholder")
+        UserDefaults.standard.set(false, forKey: DiffLayoutSetting.storageKey)
     }
 
     private static func loadedLongReview(in view: NSView) -> Bool {

--- a/Sources/Bloom/Views/RepoSettings/RepoScriptsSection.swift
+++ b/Sources/Bloom/Views/RepoSettings/RepoScriptsSection.swift
@@ -88,9 +88,17 @@ struct RepoScriptsSection: View {
 
     private var runSection: some View {
         Section {
-            ForEach($model.draft.runScripts) { $script in
-                RepoRunScriptRow(model: model, script: $script) {
-                    model.draft.runScripts.removeAll { $0.id == script.id }
+            // Values, and a binding by identity, never `ForEach($model.draft.runScripts)`. See
+            // `RepoSettingsDraft.runScript(id:)` for the crash that binding by index caused.
+            ForEach(model.draft.runScripts) { script in
+                RepoRunScriptRow(
+                    model: model,
+                    script: Binding(
+                        get: { model.draft.runScript(id: script.id) ?? script },
+                        set: { model.draft.updateRunScript($0) }
+                    )
+                ) {
+                    model.draft.removeRunScript(id: script.id)
                 }
             }
 

--- a/Sources/BloomCore/Workspace/RepoSettingsDraft.swift
+++ b/Sources/BloomCore/Workspace/RepoSettingsDraft.swift
@@ -64,6 +64,30 @@ public struct RepoSettingsDraft: Sendable, Hashable {
         browserURL = settings.browserURL ?? ""
     }
 
+    // MARK: - One run script, by identity
+
+    /// A run script's row reads and writes through these rather than through a position in the
+    /// array. `ForEach($model.draft.runScripts)` hands each row a binding that subscripts by index,
+    /// and a row removed from under it (its own minus button, a Revert, the files changing on
+    /// disk) could still be asked for its value once more, at an index that no longer existed.
+    /// That is `Index out of range` inside SwiftUI, and it was two SIGABRT reports in Flare, on
+    /// 1.6.0 and 1.9.1, both stopping in the key path getter for `RepoSettingsModel.draft`. By
+    /// identity, a stale row reads nothing and writes nothing.
+    public func runScript(id: DraftRunScript.ID) -> DraftRunScript? {
+        runScripts.first { $0.id == id }
+    }
+
+    /// Writes a row back in place. A row that has already gone is left gone rather than appended,
+    /// because a late keystroke from a removed row must not bring it back.
+    public mutating func updateRunScript(_ script: DraftRunScript) {
+        guard let index = runScripts.firstIndex(where: { $0.id == script.id }) else { return }
+        runScripts[index] = script
+    }
+
+    public mutating func removeRunScript(id: DraftRunScript.ID) {
+        runScripts.removeAll { $0.id == id }
+    }
+
     /// The patterns, one per line. A blank line is not a pattern, and an empty field means "copy
     /// nothing", which is a different answer from "say nothing" and is written as such.
     public var globs: [String] {

--- a/Tests/BloomCoreTests/RepoSettingsDraftTests.swift
+++ b/Tests/BloomCoreTests/RepoSettingsDraftTests.swift
@@ -163,4 +163,36 @@ struct RepoSettingsDraftTests {
         // And reopening the window on the saved state offers nothing more to save.
         #expect(RepoSettingsDraft(reloaded).edits(comparedTo: reloaded).isEmpty)
     }
+
+    /// The crash `runScript(id:)` exists for: a row removed while SwiftUI still held its binding.
+    @Test("a removed run script row reads nothing and writes nothing")
+    func removedRunScriptRowIsInert() {
+        let dev = DraftRunScript(key: "dev", name: "Dev", command: "pnpm dev")
+        let test = DraftRunScript(key: "test", name: "Test", command: "pnpm test")
+        var draft = RepoSettingsDraft()
+        draft.runScripts = [dev, test]
+
+        draft.removeRunScript(id: test.id)
+        var late = test
+        late.command = "pnpm test --watch"
+        draft.updateRunScript(late)
+
+        #expect(draft.runScript(id: test.id) == nil)
+        #expect(draft.runScripts == [dev])
+    }
+
+    @Test("a run script row writes back in place")
+    func runScriptRowWritesInPlace() {
+        let dev = DraftRunScript(key: "dev", name: "Dev", command: "pnpm dev")
+        let test = DraftRunScript(key: "test", name: "Test", command: "pnpm test")
+        var draft = RepoSettingsDraft()
+        draft.runScripts = [dev, test]
+
+        var renamed = dev
+        renamed.name = "Serve"
+        draft.updateRunScript(renamed)
+
+        #expect(draft.runScripts == [renamed, test])
+        #expect(draft.runScript(id: dev.id)?.name == "Serve")
+    }
 }


### PR DESCRIPTION
Fixes a crash in the repository settings window. Run script rows were bound by array index (`ForEach($model.draft.runScripts)`), so a removed row could be read past the end of the array. Two SIGABRTs in Flare (1.6.0, 1.9.1) symbolicate to the key path getter for `RepoSettingsModel.draft` in `RepoScriptsSection.runSection`. Rows now read and write by id through `RepoSettingsDraft`, with core tests.

Also adds a rapid navigation block to the review probe: 46 files, side by side, clicked through faster than sections lay out. This is for a user report of a crash when changing the reviewed file, which came without a crash report. It passes, so that crash is not reproduced or fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)