### PR TITLE
Open a self-started turn with the background task that woke it

### DIFF
--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -122,7 +122,8 @@ final class TranscriptModel {
                     || TranscriptRowInk.drawsNothing(kind: row.kind, payload: row.payload),
                 settled: settled,
                 toolUseID: row.kind == .toolUse ? row.refID : nil,
-                parentToolUseID: row.parentToolUseID
+                parentToolUseID: row.parentToolUseID,
+                opensTurn: BackgroundWake.isRow(kind: row.kind, payload: row.payload)
             )
         })
     }
@@ -1530,6 +1531,10 @@ final class TranscriptModel {
 
         case .subagent(let signal):
             subagents.apply(signal)
+            // Between turns the runner has just stored this as the line opening the turn the CLI
+            // is about to start, and nothing else would read it in until that turn's first row
+            // arrived. See `BackgroundWake`.
+            if case .reported = signal, !isRunning { await appendLatestMessages() }
 
         case .hook, .unknown:
             break

--- a/Sources/Bloom/Views/Transcript/BackgroundWakeRowView.swift
+++ b/Sources/Bloom/Views/Transcript/BackgroundWakeRowView.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
+import BloomCore
+
+/// The line that opens a turn the CLI started by itself, because a background task finished.
+///
+/// It stands where a prompt would, drawn in the shape of `SessionStartRowView`: a glyph, a label
+/// and chips. Whether the row exists, what it says and why it never folds are all decided in the
+/// core; see `BackgroundWake`.
+struct BackgroundWakeRowView: View {
+    var wake: BackgroundWake
+
+    /// Asked once per row rather than in `body`. The CLI writes the output into its temporary
+    /// directory, which does not outlive the machine's next clean up, so a transcript from last
+    /// week names a file that is gone, and a link that does nothing is worse than no link.
+    @State private var outputExists = false
+
+    var body: some View {
+        HStack(spacing: TranscriptLayout.glyphGap) {
+            TranscriptGlyph(symbol: glyph, tint: glyphTint)
+
+            Text(wake.title)
+                .font(Typo.label)
+                .foregroundStyle(Palette.textSecondary)
+                .fixedSize()
+
+            if let name = wake.name {
+                Chip(text: name)
+            } else if !wake.summary.isEmpty {
+                Text(wake.summary)
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textTertiary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            if let exit = wake.exitLabel {
+                Chip(text: exit, tint: exitTint, monospaced: true)
+                    .fixedSize()
+            }
+
+            Spacer(minLength: 0)
+
+            if outputExists, let file = wake.outputFile {
+                Button("Show output") { Self.open(file) }
+                    .buttonStyle(.link)
+                    .font(Typo.caption)
+                    .help(file)
+                    .fixedSize()
+            }
+        }
+        .transcriptRowFrame()
+        .accessibilityElement(children: .combine)
+        .task(id: wake.outputFile) {
+            outputExists = wake.outputFile.map { FileManager.default.fileExists(atPath: $0) } ?? false
+        }
+    }
+
+    private var glyph: String {
+        wake.source == .command ? "terminal" : "person.2"
+    }
+
+    private var glyphTint: Color {
+        wake.outcome == .failed ? Palette.negative : Palette.textTertiary
+    }
+
+    private var exitTint: Color {
+        switch wake.outcome {
+        case .finished: Palette.positive
+        case .failed: Palette.negative
+        case .stopped: Palette.textSecondary
+        }
+    }
+
+    /// In the Mac's text editor rather than a pane of Bloom's. The file sits in the CLI's temporary
+    /// directory, outside the worktree, and `LocalPage` refuses anything outside it for reasons
+    /// that must not be widened for this. `.output` has no type of its own either, so asking for
+    /// the default application would put up a chooser instead of the text.
+    private static func open(_ path: String) {
+        let url = URL(filePath: path)
+        guard let editor = NSWorkspace.shared.urlForApplication(toOpen: .plainText) else {
+            NSWorkspace.shared.open(url)
+            return
+        }
+        NSWorkspace.shared.open([url], withApplicationAt: editor, configuration: NSWorkspace.OpenConfiguration())
+    }
+}

--- a/Sources/Bloom/Views/Transcript/TranscriptRowView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptRowView.swift
@@ -203,6 +203,8 @@ struct TranscriptRowView: View, Equatable {
         case .system:
             if let info = initInfo {
                 SessionStartRowView(info: info)
+            } else if let wake = backgroundWake {
+                BackgroundWakeRowView(wake: wake)
             }
 
         // A result row is a turn boundary, and the footer that renders it needs the rows around it,
@@ -267,6 +269,12 @@ struct TranscriptRowView: View, Equatable {
     private var initInfo: AgentInit? {
         guard case .initialized(let info)? = event else { return nil }
         return info
+    }
+
+    /// Only ever stored when it opened a turn, so any row that decodes to one is drawn.
+    private var backgroundWake: BackgroundWake? {
+        guard case .subagent(.reported(let report))? = event else { return nil }
+        return BackgroundWake(report)
     }
 
     /// Only decoded once a row is open, because a tool result is the largest payload in the file.

--- a/Sources/BloomCore/Agent/AgentRunner.swift
+++ b/Sources/BloomCore/Agent/AgentRunner.swift
@@ -521,6 +521,16 @@ public actor AgentRunner {
             return
         }
 
+        // A background task finishing between turns is what the CLI starts a turn of its own for,
+        // and this line is the only one saying so. Stored as the row that opens that turn, so the
+        // work under it is not drawn straight after a footer as if the footer had been wrong.
+        // Read before the `init` that follows it, which is what moves the state on. See
+        // `BackgroundWake`.
+        if case .subagent(.reported(let report)) = event, !report.raw.isEmpty,
+           BackgroundWake.opensTurn(during: session.state) {
+            await persist(kind: .system, payload: report.raw)
+        }
+
         if event.isTranscriptRow || persistsStreamDeltas {
             var durationMS: Int?
             if case .result(let result) = event { durationMS = result.durationMS }

--- a/Sources/BloomCore/Transcript/BackgroundWake.swift
+++ b/Sources/BloomCore/Transcript/BackgroundWake.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// The line that opens a turn nobody in Bloom sent: a background task finishing.
+///
+/// **The bug: work carrying on under a footer that said the turn was over.** The owner merged a
+/// pull request, the turn closed with "Completed in 21s", and under that footer came seventeen
+/// actions and a second answer with nothing above them. The agent had put a CI watch in the
+/// background and ended its turn; when the command exited, the CLI told the model and started a
+/// turn of its own. The transcript drew that turn with no opening line, so it read as the footer
+/// having been wrong.
+///
+/// Measured on `claude 2.1.268` on 11 September 2026 with a five second background `sleep`: the
+/// first turn's `result`, then `task_updated`, then this line, then a second `init` and the turn
+/// the CLI started, whose `result` names `origin: task-notification`. The notification is the one
+/// line in that run saying why the turn began, so it is stored and drawn where a prompt would be:
+///
+///     {"type":"system","subtype":"task_notification","task_id":"b1u04xrxg",
+///      "tool_use_id":"toolu_01Bv...","status":"completed","output_file":"/private/tmp/.../b1u04xrxg.output",
+///      "summary":"Background command \"Wait five seconds\" completed (exit code 0)"}
+///
+/// Only a notification arriving between turns is kept. One that lands while a turn is running is
+/// read by the model inside that turn and starts nothing, so a row for it would be a turn's opening
+/// line drawn in the middle of a turn.
+public struct BackgroundWake: Sendable, Equatable {
+    public enum Source: Sendable, Equatable {
+        case command
+        case agent
+    }
+
+    public enum Outcome: Sendable, Equatable {
+        case finished
+        case failed
+        case stopped
+    }
+
+    public var source: Source
+    public var outcome: Outcome
+    /// What the agent called the task when it started it, which for a command is the Bash call's
+    /// `description`. Nil when the summary quotes nothing.
+    public var name: String?
+    public var exitCode: Int?
+    /// The CLI's own sentence, whole, for when there is no name to show.
+    public var summary: String
+    public var outputFile: String?
+
+    /// Read off the CLI's summary, because the notification carries no `task_type` and no
+    /// description of its own. Both are on `task_started`, which may have arrived in a process
+    /// that has since been replaced by a `--resume`, so the summary is the only account that is
+    /// always on the line being drawn. A shape this does not know still draws, as the sentence.
+    public init(_ report: SubagentReport) {
+        let summary = report.summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        let exitCode = Self.exitCode(in: summary)
+        self.summary = summary
+        self.exitCode = exitCode
+        self.name = Self.quotedName(in: summary)
+        self.source = summary.hasPrefix("Background command") ? .command : .agent
+        self.outcome = Self.outcome(status: report.status, exitCode: exitCode)
+        self.outputFile = report.outputFile.flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    /// What the row says before the chips.
+    public var title: String {
+        let noun = source == .command ? "Background command" : "Background agent"
+        return switch outcome {
+        case .finished: "\(noun) finished"
+        case .failed: "\(noun) failed"
+        case .stopped: "\(noun) stopped"
+        }
+    }
+
+    /// `exit 0`, or nothing when the summary named no exit code, which is every agent.
+    public var exitLabel: String? { exitCode.map { "exit \($0)" } }
+
+    // MARK: Which rows
+
+    private static let probeLength = 256
+    private static let marker = Data("\"subtype\":\"task_notification\"".utf8)
+
+    /// Whether a stored row is one of these, by its first bytes. `TranscriptRowInk` and the fold
+    /// both ask it once per row per pass, which is why it is a sniff rather than a decode.
+    public static func isRow(kind: MessageKind, payload: Data) -> Bool {
+        kind == .system && payload.prefix(probeLength).range(of: marker) != nil
+    }
+
+    /// Whether a notification arriving now opens a turn, and so is worth a row.
+    ///
+    /// Between turns it does: the CLI starts one to hand the model the news. A failed or stopped
+    /// turn is still between turns, and the CLI wakes after either. While a turn is running, or
+    /// holding for an answer, the model reads the notification inside it and nothing new begins.
+    public static func opensTurn(during state: SessionState) -> Bool {
+        switch state {
+        case .idle, .failed, .cancelled: true
+        case .running, .waiting: false
+        }
+    }
+
+    // MARK: Reading the summary
+
+    /// The text between the first and the last double quote. The last rather than the next,
+    /// because a description is the agent's own words and may quote something itself.
+    private static func quotedName(in summary: String) -> String? {
+        guard let open = summary.firstIndex(of: "\""),
+              let close = summary.lastIndex(of: "\""),
+              open < close else { return nil }
+        let name = summary[summary.index(after: open)..<close]
+        return name.isEmpty ? nil : String(name)
+    }
+
+    private static func exitCode(in summary: String) -> Int? {
+        guard let match = summary.firstMatch(of: /\(exit code (-?\d+)\)/) else { return nil }
+        return Int(match.1)
+    }
+
+    /// A command the CLI calls `completed` can still have failed: the status says the process
+    /// ended, and the exit code says how.
+    private static func outcome(status: String, exitCode: Int?) -> Outcome {
+        switch status {
+        case "failed": .failed
+        case "killed", "stopped", "cancelled": .stopped
+        default: (exitCode ?? 0) == 0 ? .finished : .failed
+        }
+    }
+}

--- a/Sources/BloomCore/Transcript/Subagent.swift
+++ b/Sources/BloomCore/Transcript/Subagent.swift
@@ -80,7 +80,8 @@ public enum SubagentSignal: Sendable, Hashable {
                     summary: json["summary"]?.stringValue ?? "",
                     // Absent is a real answer and not a failure: it means there is nothing on
                     // disk to open, and the row says so by refusing the click.
-                    outputFile: json["output_file"]?.stringValue
+                    outputFile: json["output_file"]?.stringValue,
+                    raw: raw
                 ))
 
             default:
@@ -190,11 +191,17 @@ public struct SubagentReport: Sendable, Hashable {
     public let status: String
     public let summary: String
     public let outputFile: String?
+    /// The line itself, because it is the one subagent line that is ever stored: a notification
+    /// arriving between turns opens the turn the CLI starts for it. See `BackgroundWake`.
+    public let raw: Data
 
-    public init(id: SubagentID, status: String, summary: String = "", outputFile: String? = nil) {
+    public init(
+        id: SubagentID, status: String, summary: String = "", outputFile: String? = nil, raw: Data = Data()
+    ) {
         self.id = id
         self.status = status
         self.summary = summary
         self.outputFile = outputFile
+        self.raw = raw
     }
 }

--- a/Sources/BloomCore/Transcript/TranscriptFold.swift
+++ b/Sources/BloomCore/Transcript/TranscriptFold.swift
@@ -219,6 +219,11 @@ public enum TranscriptFold {
         /// Only compared, never parsed. It is already on the row for the indent the view draws,
         /// so the fold reads it for nothing.
         public var parentToolUseID: String?
+        /// The row says why a turn the CLI started by itself began, which is a background task
+        /// finishing. It stands where a prompt would, so it is a boundary like one and never
+        /// folds: counted into "17 actions" it would hide the one line explaining them. See
+        /// `BackgroundWake`.
+        public var opensTurn: Bool
 
         public init(
             seq: Int,
@@ -228,7 +233,8 @@ public enum TranscriptFold {
             drawsNothing: Bool = false,
             settled: Bool = true,
             toolUseID: String? = nil,
-            parentToolUseID: String? = nil
+            parentToolUseID: String? = nil,
+            opensTurn: Bool = false
         ) {
             self.seq = seq
             self.kind = kind
@@ -238,6 +244,7 @@ public enum TranscriptFold {
             self.settled = settled
             self.toolUseID = toolUseID
             self.parentToolUseID = parentToolUseID
+            self.opensTurn = opensTurn
         }
 
         /// Whether this is a grey activity row that may belong to a compact group. Black prose and
@@ -462,8 +469,9 @@ public enum TranscriptFold {
             markHeader(of: fact)
             // A message and the footer settle everything above them. Neither belongs to an
             // activity group, and a crew row is a message: it is what another agent said to start
-            // this turn, in the place a user row sits when a person started it.
-            if fact.kind == .user || fact.kind == .crew || fact.kind == .result {
+            // this turn, in the place a user row sits when a person started it. A background
+            // task's notification is the same for a turn nobody started.
+            if fact.kind == .user || fact.kind == .crew || fact.kind == .result || fact.opensTurn {
                 close(hasAnswer: false)
                 resume = offset + 1
                 continue

--- a/Sources/BloomCore/Transcript/TranscriptRowInk.swift
+++ b/Sources/BloomCore/Transcript/TranscriptRowInk.swift
@@ -40,8 +40,12 @@ public enum TranscriptRowInk {
     /// it would be a guess, and a guess here is worth less than the mean it would replace. A tool
     /// result whose call is on the row above draws nothing either, but which rows those are is a
     /// question about the row before it rather than about the row, so it is not answered here.
+    ///
+    /// Two `system` rows draw: an init, and a background task's notification, which is stored only
+    /// when it opens a turn the CLI started by itself. See `BackgroundWake`.
     public static func drawsNothing(kind: MessageKind, payload: Data) -> Bool {
         guard kind == .system else { return false }
         return payload.prefix(probeLength).range(of: initMarker) == nil
+            && !BackgroundWake.isRow(kind: kind, payload: payload)
     }
 }

--- a/Tests/BloomCoreTests/BackgroundWakeTests.swift
+++ b/Tests/BloomCoreTests/BackgroundWakeTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// A turn the CLI started because a background task finished, and the row that says so.
+///
+/// The lines are from a probe of `claude 2.1.268` on 11 September 2026: a five second background
+/// `sleep`, a turn ended straight after it, and the turn the CLI started when the command exited.
+@Suite("A background task opening a turn")
+struct BackgroundWakeTests {
+    /// Verbatim from the probe, minus the uuid and session id.
+    static let commandLine = #"""
+    {"type":"system","subtype":"task_notification","task_id":"b1u04xrxg",\
+    "tool_use_id":"toolu_01Bvp96FxPWLvXFdW1QmRADF","status":"completed",\
+    "output_file":"/private/tmp/claude-501/-private-tmp-bgprobe/9816/tasks/b1u04xrxg.output",\
+    "summary":"Background command \"Wait five seconds\" completed (exit code 0)"}
+    """#.replacingOccurrences(of: "\\\n", with: "")
+
+    private func report(_ line: String) throws -> SubagentReport {
+        let json = try #require(JSONValue.parse(line))
+        guard case .reported(let report)? = SubagentSignal.decode(json, raw: Data(line.utf8)) else {
+            Issue.record("not a notification")
+            throw CancellationError()
+        }
+        return report
+    }
+
+    private func wake(status: String, summary: String) -> BackgroundWake {
+        BackgroundWake(SubagentReport(id: SubagentID("t"), status: status, summary: summary))
+    }
+
+    @Test("a command that exited cleanly is named by its description")
+    func finishedCommand() throws {
+        let wake = BackgroundWake(try report(Self.commandLine))
+        #expect(wake.source == .command)
+        #expect(wake.outcome == .finished)
+        #expect(wake.title == "Background command finished")
+        #expect(wake.name == "Wait five seconds")
+        #expect(wake.exitLabel == "exit 0")
+        #expect(wake.outputFile?.hasSuffix("b1u04xrxg.output") == true)
+    }
+
+    /// The CLI says `completed` for a process that ended, whatever it ended with.
+    @Test("a completed command with a non zero exit code failed")
+    func nonZeroExit() {
+        let wake = wake(status: "completed", summary: #"Background command "Run tests" completed (exit code 1)"#)
+        #expect(wake.outcome == .failed)
+        #expect(wake.title == "Background command failed")
+        #expect(wake.exitLabel == "exit 1")
+    }
+
+    @Test("a killed task was stopped")
+    func killed() {
+        let wake = wake(status: "killed", summary: #"Background command "Serve" was stopped"#)
+        #expect(wake.outcome == .stopped)
+        #expect(wake.name == "Serve")
+    }
+
+    /// The shape in `claude-api-retry.ndjson`: an agent, no quotes, no exit code. It still draws,
+    /// as the sentence.
+    @Test("an agent's summary with nothing quoted falls back to the sentence")
+    func agentWithoutName() {
+        let wake = wake(status: "failed", summary: "Agent terminated early due to an API error: 529 Overloaded.")
+        #expect(wake.source == .agent)
+        #expect(wake.outcome == .failed)
+        #expect(wake.title == "Background agent failed")
+        #expect(wake.name == nil)
+        #expect(wake.exitLabel == nil)
+        #expect(wake.summary.hasPrefix("Agent terminated early"))
+    }
+
+    @Test("a name that quotes something keeps its own quotes")
+    func nestedQuotes() {
+        let wake = wake(status: "completed", summary: #"Background command "grep "todo" src" completed (exit code 0)"#)
+        #expect(wake.name == #"grep "todo" src"#)
+    }
+
+    @Test("only a notification between turns opens one")
+    func onlyBetweenTurns() {
+        #expect(BackgroundWake.opensTurn(during: .idle))
+        #expect(BackgroundWake.opensTurn(during: .failed))
+        #expect(BackgroundWake.opensTurn(during: .cancelled))
+        #expect(!BackgroundWake.opensTurn(during: .running))
+        #expect(!BackgroundWake.opensTurn(during: .waiting))
+    }
+
+    @Test("the row is found by its first bytes, and only as a system row")
+    func sniff() {
+        let payload = Data(Self.commandLine.utf8)
+        #expect(BackgroundWake.isRow(kind: .system, payload: payload))
+        #expect(!BackgroundWake.isRow(kind: .user, payload: payload))
+        let initLine = Data(#"{"type":"system","subtype":"init","cwd":"/tmp"}"#.utf8)
+        #expect(!BackgroundWake.isRow(kind: .system, payload: initLine))
+    }
+
+    @Test("the row draws, unlike every other system row but an init")
+    func draws() {
+        #expect(!TranscriptRowInk.drawsNothing(kind: .system, payload: Data(Self.commandLine.utf8)))
+    }
+}
+
+/// The row must stay on screen: folded into "17 actions" it would hide the one line explaining them.
+@Suite("A background task's row and the fold")
+struct BackgroundWakeFoldTests {
+    private func tool(_ seq: Int) -> TranscriptFold.Fact {
+        TranscriptFold.Fact(seq: seq, kind: .toolUse)
+    }
+
+    private func wake(_ seq: Int) -> TranscriptFold.Fact {
+        TranscriptFold.Fact(seq: seq, kind: .system, opensTurn: true)
+    }
+
+    private func footer(_ seq: Int) -> TranscriptFold.Fact {
+        TranscriptFold.Fact(seq: seq, kind: .result)
+    }
+
+    /// The shape from the owner's transcript: a footer, the notification, and a turn of work.
+    @Test("the row opens the turn and is never part of its fold")
+    func neverFolded() throws {
+        let facts = [footer(0), wake(1), tool(2), tool(3), tool(4), tool(5)]
+        let folds = TranscriptFold.folds(in: facts)
+        let work = try #require(folds.all.first)
+        #expect(folds.all.count == 1)
+        #expect(work.firstSeq == 2)
+        #expect(!work.rows.contains { $0.seq == 1 })
+        #expect(TranscriptFold.hiddenIndices(work, revealed: [], drawn: 0..<100) == [2, 3, 4, 5])
+    }
+
+    /// Without it, the activity either side would join up into one fold spanning two turns.
+    @Test("it divides activity like a prompt does")
+    func divides() {
+        let facts = [tool(0), tool(1), tool(2), wake(3), tool(4), tool(5), tool(6)]
+        let folds = TranscriptFold.folds(in: facts)
+        #expect(folds.all.map(\.firstSeq) == [0, 4])
+    }
+}
+
+@Suite("Storing a background task's notification")
+struct BackgroundWakeStorageTests {
+    private func makeSession(_ store: Store) async throws -> Session {
+        let repo = try await store.upsert(Repo(name: "r", path: "/tmp/r-\(UUID().uuidString)"))
+        let workspace = try await store.upsert(Workspace(
+            repoID: repo.id, name: "w", branch: "b", path: "/tmp/w", baseBranch: "main"
+        ))
+        return try await store.upsert(Session(workspaceID: workspace.id, model: "opus"))
+    }
+
+    private var line: AgentEvent {
+        get throws { try #require(AgentEvent.decode(line: BackgroundWakeTests.commandLine)) }
+    }
+
+    @Test("between turns it is stored, as the line itself")
+    func storedWhenIdle() async throws {
+        let store = try makeTestStore("wake-idle")
+        let session = try await makeSession(store)
+        let runner = AgentRunner(workspacePath: "/tmp/w", session: session, store: store)
+
+        await runner.ingest(try line)
+
+        let stored = try await store.messages(sessionID: session.id)
+        #expect(stored.map(\.kind) == [.system])
+        let payload = try #require(stored.first?.payload)
+        #expect(BackgroundWake.isRow(kind: .system, payload: payload))
+    }
+
+    /// Mid turn the model reads it inside the turn and nothing new begins, so there is nothing
+    /// for a row to open.
+    @Test("during a turn it is not stored")
+    func notStoredMidTurn() async throws {
+        let store = try makeTestStore("wake-running")
+        let session = try await makeSession(store)
+        let runner = AgentRunner(
+            workspacePath: "/tmp/w", session: session.with { $0.apply(.turnStarted) }, store: store
+        )
+
+        await runner.ingest(try line)
+
+        #expect(try await store.messages(sessionID: session.id).isEmpty)
+    }
+}

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -193,6 +193,14 @@ before it read anything from stdin: `init`, this line, then a second `init` for 
 had actually sent. A result answering a prompt names no origin at all. See `StrayResult`, which is
 the bug that cost.
 
+The same thing happens mid process, and there the turn does real work. Measured on `claude
+2.1.268` on 11 September 2026: a turn put `sleep 5` in the background and ended; five seconds later
+the CLI wrote `task_updated`, then `system/task_notification` for the command, then a second `init`,
+then a whole turn, closed by a `result` with `origin: task-notification`. The notification is the
+only line saying why that turn began, and its `summary` reads `Background command "<description>"
+completed (exit code 0)`. Bloom stores it when it arrives between turns and draws it as the turn's
+opening line. See `BackgroundWake`.
+
 ### `rate_limit_event`
 
 One per turn, and it carries **one window**, never a set:


### PR DESCRIPTION
When a background command or agent finishes between turns, Claude Code starts a turn by itself, and the transcript drew that work straight under the previous "Completed" footer with nothing explaining it. The runner now stores the `task_notification` line when it arrives between turns, and the transcript draws it as the turn's opening row: "Background command finished", the command's description, its exit code and a link to the output. The fold treats that row as a turn boundary like a prompt, so it never disappears into "N actions". The stream order was measured against `claude 2.1.268` and is written down in `docs/PROTOCOL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)