### PR TITLE
Show more rows in the branch picker popover

### DIFF
--- a/Sources/Bloom/Views/Sidebar/WorkspaceSourcePicker.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspaceSourcePicker.swift
@@ -51,6 +51,12 @@ struct WorkspaceSourcePicker: View {
     /// floats over the composer it is filtering. This one hangs off a control at the top of a
     /// sheet with nothing underneath it worth reading, and it is a list people scan rather than a
     /// glance, so it gets about eleven rows instead of eight.
+    ///
+    /// **A fixed height, never a `maxHeight`.** A popover sizes its content to its ideal size, and
+    /// a `ScrollView` capped only from above has almost none, so the list opened a row and a half
+    /// tall over a repository with dozens of branches. Fixed also means the panel keeps its size
+    /// while the query narrows the list and when the tab changes, so the search field never moves
+    /// under the pointer; the empty line sits in the same height for the same reason.
     private static let listHeight: CGFloat = 320
 
     private var matches: WorkspaceSourceMatches {
@@ -135,13 +141,16 @@ struct WorkspaceSourcePicker: View {
             searchRow
             Hairline()
 
-            if matches.isEmpty(in: tab) {
-                MenuEmptyRow(
-                    text: query.isEmpty ? emptyTabText : "Nothing matches \(query)"
-                )
-            } else {
-                list(matches)
+            Group {
+                if matches.isEmpty(in: tab) {
+                    MenuEmptyRow(
+                        text: query.isEmpty ? emptyTabText : "Nothing matches \(query)"
+                    )
+                } else {
+                    list(matches)
+                }
             }
+            .frame(height: Self.listHeight, alignment: .top)
 
             if let unavailable, tab == .existingBranch {
                 Hairline()
@@ -230,7 +239,6 @@ struct WorkspaceSourcePicker: View {
                 }
                 .padding(Metrics.spacingSmall)
             }
-            .frame(maxHeight: Self.listHeight)
             .onChange(of: selected) { _, row in
                 guard let row else { return }
                 proxy.scrollTo(row.id)


### PR DESCRIPTION
The Start from popover's list only showed about a row and a half, because a popover sizes content to its ideal size and a ScrollView capped only by \`maxHeight\` has almost none. The list now has a fixed 320pt height (about eleven rows), with the empty state in the same space, so the panel no longer resizes while typing or switching tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)