### PR TITLE
Draw at most 2,000 characters of a diff line

### DIFF
--- a/Sources/Bloom/Views/Inspector/DiffLineView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffLineView.swift
@@ -204,7 +204,7 @@ struct DiffLineView: View, Equatable {
                 // the tint says the line changed, the emphasis says which part of it did.
                 HStack(spacing: 0) {
                     DiffMarker(line: line)
-                    CodeText(line: line.text, language: language, carry: carry)
+                    CodeText(line: DiffLineDisplay.text(line.text), language: language, carry: carry)
                         .emphasizing(emphasis, color: DiffWash.emphasis(of: line))
                     Spacer(minLength: 0)
                 }

--- a/Sources/Bloom/Views/Inspector/DiffRunView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffRunView.swift
@@ -292,8 +292,9 @@ struct DiffRunView: View, Equatable {
         lines.map { entry in
             CodeRunLine(
                 // A row with nothing opposite it still occupies a line in the run, or every line
-                // below it in the split layout would sit one row too high.
-                text: entry.line?.text ?? "",
+                // below it in the split layout would sit one row too high. Shortened for drawing
+                // only: see `DiffLineDisplay`.
+                text: DiffLineDisplay.text(entry.line?.text ?? ""),
                 carry: entry.carry,
                 emphasis: entry.emphasis,
                 emphasisColor: DiffWash.emphasis(of: entry.line)

--- a/Sources/Bloom/Views/Inspector/DiffView.swift
+++ b/Sources/Bloom/Views/Inspector/DiffView.swift
@@ -662,7 +662,7 @@ struct DiffView: View {
         priming = Task.detached(priority: .utility) {
             for line in lines {
                 guard !Task.isCancelled else { return }
-                _ = SyntaxCache.attributed(line: line.text, language: language, carry: line.carry)
+                _ = SyntaxCache.attributed(line: DiffLineDisplay.text(line.text), language: language, carry: line.carry)
             }
         }
     }
@@ -1022,7 +1022,7 @@ struct DiffView: View {
         func height(_ line: DiffLine?, numbers: DiffGutter.Numbers, width: CGFloat) -> CGFloat {
             let codeWidth = floor(max(1, width - DiffGutter.width(for: numbers)
                 - CodeMetrics.markerWidth - CodeMetrics.gutterPadding))
-            return WrappedCodeLayout.height(of: line?.text ?? "", width: codeWidth)
+            return WrappedCodeLayout.height(of: DiffLineDisplay.text(line?.text ?? ""), width: codeWidth)
         }
         func pairHeight(_ pair: SideBySideRow) -> CGFloat {
             let half = (width - Metrics.hairline) / 2

--- a/Sources/BloomCore/Presentation/DiffLineDisplay.swift
+++ b/Sources/BloomCore/Presentation/DiffLineDisplay.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// How much of one diff line is drawn, which for nearly every line is all of it.
+///
+/// **This exists because one line of a minified bundle froze the whole app.** Feedback #25 was a
+/// worktree with thirty uncommitted files that "crashed every five minutes" while the diff was
+/// being built. Recreated with a 3.5 MB single line `app.min.js` among them, Bloom beachballed at
+/// 100% CPU for minutes and did not come back: both stack samples were entirely inside
+/// `-[NSTextView setFrameSize:]`, with TextKit typesetting the one paragraph on the main thread.
+/// The 5,000 line gate did not stop it because it counts lines, and this file was one.
+///
+/// The cost is not linear, which is why nothing smaller than a cap will do. Measured headless with
+/// the diff's own font and wrapping, one line with a colour run every six characters (which is
+/// what highlighting makes of minified code) took 0.35 s at 303 KB and 1.22 s at 614 KB. Plain
+/// text with no runs wrapped 5 MB in 0.69 s, so it is the runs, and a highlighted line cannot be
+/// drawn without them.
+///
+/// Only what is DRAWN is shortened. `DiffLine.text` keeps the whole line, because editing a line
+/// in place and reverting it both write that text back to disk, and a line cut here and saved
+/// there would be a file quietly truncated. Every view that draws, highlights or measures a diff
+/// line goes through `text(_:)`, so the three agree on what the line is.
+public enum DiffLineDisplay {
+    /// The most characters of one line that are drawn.
+    ///
+    /// Two thousand is wider than any line a person wrote to be read, costs nothing measurable to
+    /// lay out, and is deliberately not below `DiffParser.intraLineLimit`: a shortened line is
+    /// then always one the word diff already declined, so it has no emphasis ranges pointing past
+    /// the cut.
+    public static let limit = 2_000
+
+    /// The line as drawn: the whole of it, or its first `limit` characters and a note of how much
+    /// was left out.
+    ///
+    /// Cheap on a line of any length. The byte count is constant time, and a line within the
+    /// limit in bytes is within it in characters, so almost every call returns at once; the rest
+    /// walk `limit` characters and no further.
+    public static func text(_ line: String) -> String {
+        guard line.utf8.count > limit else { return line }
+        let shown = line.prefix(limit)
+        // Over the limit in bytes and not in characters: a line of CJK or emoji, drawn whole.
+        guard shown.endIndex < line.endIndex else { return line }
+        return String(shown) + omission(bytes: line.utf8.count - shown.utf8.count)
+    }
+
+    /// Said in bytes rather than characters, because counting the characters of a 3.5 MB line is
+    /// the walk this type exists to avoid, and a size is what the reader wants to know anyway.
+    static func omission(bytes: Int) -> String {
+        " … " + ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+            + " more on this line, not shown"
+    }
+}

--- a/Tests/BloomCoreTests/DiffLineDisplayTests.swift
+++ b/Tests/BloomCoreTests/DiffLineDisplayTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// How much of a diff line is drawn, pinned for the line that froze the app in feedback #25: one
+/// line of a minified bundle, several megabytes long, which the 5,000 line gate let through
+/// because it counts lines.
+struct DiffLineDisplayTests {
+    @Test func anOrdinaryLineIsDrawnWhole() {
+        let line = "    return $result->map(fn ($item) => ['invoice' => $item])->all();"
+        #expect(DiffLineDisplay.text(line) == line)
+    }
+
+    @Test func aLineOfExactlyTheLimitIsDrawnWhole() {
+        let line = String(repeating: "a", count: DiffLineDisplay.limit)
+        #expect(DiffLineDisplay.text(line) == line)
+    }
+
+    @Test func aMinifiedLineIsCutAtTheLimitAndSaysHowMuchIsMissing() {
+        let line = String(repeating: "var a=function(b){return b.x};", count: 120_000)
+        let shown = DiffLineDisplay.text(line)
+
+        #expect(shown.hasPrefix(String(line.prefix(DiffLineDisplay.limit))))
+        #expect(shown.hasSuffix("more on this line, not shown"))
+        #expect(shown.count < DiffLineDisplay.limit + 60)
+    }
+
+    /// Over the limit in bytes, within it in characters. Cutting by bytes would have split a line
+    /// somebody can read.
+    @Test func aLineOfWideCharactersWithinTheLimitIsDrawnWhole() {
+        let line = String(repeating: "日本語", count: 600)
+        #expect(line.utf8.count > DiffLineDisplay.limit)
+        #expect(DiffLineDisplay.text(line) == line)
+    }
+
+    /// The cut is by character, so a flag or a skin toned emoji straddling it is kept or dropped
+    /// whole rather than drawn as half of one.
+    @Test func theCutNeverSplitsACharacter() {
+        let line = String(repeating: "🇦🇹👍🏽", count: DiffLineDisplay.limit)
+        let kept = DiffLineDisplay.text(line).prefix(DiffLineDisplay.limit)
+
+        #expect(kept.allSatisfy { $0 == "🇦🇹" || $0 == "👍🏽" })
+    }
+
+    /// A shortened line has to be one the word diff already declined, or its emphasis ranges
+    /// would point past the end of the text that is drawn.
+    @Test func noShortenedLineCanCarryWordEmphasis() {
+        #expect(DiffLineDisplay.limit >= DiffParser.intraLineLimit)
+    }
+}


### PR DESCRIPTION
A single-line minified file froze the app in the review: the 5,000 line gate counts lines, so a 3.5 MB \`app.min.js\` passed as one and TextKit typeset the whole highlighted line on the main thread. Recreating feedback #25 left Bloom Dev at 100% CPU for minutes, and the cost grows faster than the line (0.35 s at 303 KB, 1.22 s at 614 KB).

\`DiffLineDisplay\` now shortens what is drawn, highlighted and measured to 2,000 characters and says how much was left out, for example "… 3.5 MB more on this line, not shown". \`DiffLine.text\` stays whole, so editing and reverting still write the full line.