### PR TITLE
Sort Home's project menu alphabetically, hidden projects last

### DIFF
--- a/Sources/Bloom/Views/Home/HomeBar.swift
+++ b/Sources/Bloom/Views/Home/HomeBar.swift
@@ -175,16 +175,31 @@ struct HomeBar: View {
     /// what the list shows, and a status bar is a place for reading rather than pressing: Finder's
     /// says how many items there are and offers nothing to click.
     ///
+    /// The order of the rows, and why hidden projects are here at all, is `HomeProjectMenu`.
+    ///
     /// `.menuStyle(.button)` because a borderless `Menu` on macOS throws a custom label away and
     /// draws only the chevron, which is what the sidebar's account row used to look like.
     private var projectMenu: some View {
-        Menu {
-            Toggle("All projects", isOn: allProjects)
+        let menu = HomeProjectMenu(repos)
 
-            if !repos.isEmpty {
-                Divider()
-                ForEach(repos) { repo in
-                    Toggle(repo.name, isOn: binding(for: repo))
+        return Menu {
+            Section {
+                Toggle("All projects", isOn: allProjects)
+            }
+
+            if !menu.visible.isEmpty {
+                Section {
+                    ForEach(menu.visible) { repo in
+                        Toggle(repo.name, isOn: binding(for: repo))
+                    }
+                }
+            }
+
+            if !menu.hidden.isEmpty {
+                Section("Hidden") {
+                    ForEach(menu.hidden) { repo in
+                        Toggle(repo.name, isOn: binding(for: repo))
+                    }
                 }
             }
         } label: {

--- a/Sources/BloomCore/Presentation/HomeProjectMenu.swift
+++ b/Sources/BloomCore/Presentation/HomeProjectMenu.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// The rows of Home's project menu, and the order they come in.
+///
+/// **Alphabetical, not the sidebar's stored order.** The sidebar is arranged by hand and read by
+/// position, so its order means something there. This menu is a list somebody scans for a name,
+/// and at thirty projects the stored order reads as no order at all: the owner's copy put
+/// `monizze` first and `laravel-honeypot` last, with five `laravel-` packages scattered between.
+/// `localizedStandardCompare` is Finder's rule, so case does not split `VicGames` off from the rest
+/// and a `2` sorts before a `10`.
+///
+/// **Visible projects first, hidden ones after.** A hidden project still needs a row here, because
+/// its workspaces keep turning up on Home (see `ProjectVisibility`, which is emphatic that hiding
+/// loses nothing), and a filter that cannot reach rows the list is showing is a filter with a hole
+/// in it. But the owner has said those projects are not worth the room, so they go below the ones
+/// he works in rather than interleaved with them.
+public struct HomeProjectMenu: Equatable, Sendable {
+    public var visible: [Repo]
+    public var hidden: [Repo]
+
+    public init(_ repos: [Repo]) {
+        let sorted = repos.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+        visible = sorted.filter { !$0.hidden }
+        hidden = sorted.filter(\.hidden)
+    }
+}

--- a/Tests/BloomCoreTests/HomeProjectMenuTests.swift
+++ b/Tests/BloomCoreTests/HomeProjectMenuTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+/// Home's project menu, which is scanned for a name rather than read by position.
+@Suite("Home project menu")
+struct HomeProjectMenuTests {
+    private func repo(_ name: String, order: Int, hidden: Bool = false) -> Repo {
+        Repo(name: name, path: "/Users/me/dev/\(name)", sortOrder: order, hidden: hidden)
+    }
+
+    @Test("projects are alphabetical, not in the sidebar's stored order")
+    func alphabetical() {
+        let menu = HomeProjectMenu([
+            repo("monizze", order: 0),
+            repo("invade", order: 1),
+            repo("laravel-pdf", order: 2),
+            repo("flareapp.io", order: 3),
+        ])
+
+        #expect(menu.visible.map(\.name) == ["flareapp.io", "invade", "laravel-pdf", "monizze"])
+    }
+
+    /// A plain `<` puts every capitalised name before every lowercase one, which would sink
+    /// `VicGames` to the top of a list that is otherwise all lowercase.
+    @Test("case does not decide the order, and numbers sort as numbers")
+    func finderOrder() {
+        let menu = HomeProjectMenu([
+            repo("www", order: 0),
+            repo("VicGames", order: 1),
+            repo("there-there", order: 2),
+            repo("site10", order: 3),
+            repo("site2", order: 4),
+        ])
+
+        #expect(menu.visible.map(\.name) == ["site2", "site10", "there-there", "VicGames", "www"])
+    }
+
+    @Test("hidden projects come after the visible ones, each group alphabetical")
+    func hiddenLast() {
+        let menu = HomeProjectMenu([
+            repo("scotty", order: 0),
+            repo("bloom", order: 1, hidden: true),
+            repo("alix-backend", order: 2),
+            repo("ohdear", order: 3, hidden: true),
+            repo("card-service", order: 4, hidden: true),
+        ])
+
+        #expect(menu.visible.map(\.name) == ["alix-backend", "scotty"])
+        #expect(menu.hidden.map(\.name) == ["bloom", "card-service", "ohdear"])
+    }
+
+    @Test("nothing hidden leaves the second group empty")
+    func noneHidden() {
+        let menu = HomeProjectMenu([repo("b", order: 0), repo("a", order: 1)])
+
+        #expect(menu.visible.map(\.name) == ["a", "b"])
+        #expect(menu.hidden.isEmpty)
+    }
+}


### PR DESCRIPTION
Home's project filter menu listed projects in the sidebar's stored order, which reads as no order at all at thirty projects. It now lists visible projects alphabetically (Finder's rule, so case is ignored and numbers sort numerically), followed by a "Hidden" section with the hidden projects, also alphabetical. The rule is `HomeProjectMenu` in BloomCore, with tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)