### PR TITLE
Name background work still running under the last turn's footer

### DIFF
--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -200,8 +200,17 @@ final class TranscriptModel {
         didSet {
             if let id = workspace?.id { app.noteSubagentsChanged(workspaceID: id) }
             if oldValue.isWorking != subagents.isWorking { app.noteAgentTurnsChanged() }
+            let note = BackgroundWork.note(for: subagents)
+            if note != backgroundWork { backgroundWork = note }
         }
     }
+
+    /// What the agent left running when its turn ended, named, for the last turn's footer.
+    ///
+    /// Stored rather than read off `subagents` by the transcript, because the roster moves on every
+    /// `tool_progress` tick, about once a second per subagent, and the transcript's table reading
+    /// it would rebuild on each one. This moves only when the sentence does. See `BackgroundWork`.
+    private(set) var backgroundWork: String?
 
     var draft = ""
 

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -436,6 +436,9 @@ struct TranscriptListView: View {
         let agentKind = transcript.session.agentKind
         let recoveredRuns = transcript.recoveredRuns
         let stoppedTurnSeq = transcript.stoppedTurnSeq
+        // Only while nothing is running: a turn the CLI started for itself has its own footer
+        // coming, and the sentence belongs under whichever turn ended last.
+        let backgroundWork = transcript.isRunning ? nil : transcript.backgroundWork
         let paneHeight = geometry.paneHeight
         let arrivals = self.arrivals
         // The fold's three inputs, read once for the pass for the reason the eight above are: each
@@ -548,6 +551,7 @@ struct TranscriptListView: View {
             let wasStopped = row.seq == stoppedTurnSeq
             let recovered = recoveredRuns[row.seq]
             let closesTranscript = row.kind == .result && row.seq == lastVisibleSeq
+            let stillRunning = closesTranscript ? backgroundWork : nil
             // The same fields `TranscriptRowView.==` compared, and for the same reason: the
             // payload is never read, because comparing it is 1.6MB of `Data` per pass.
             //
@@ -569,6 +573,7 @@ struct TranscriptListView: View {
                 $0.combine(wasStopped)
                 $0.combine(recovered != nil)
                 $0.combine(closesTranscript)
+                $0.combine(stillRunning)
             }
             // Free, and no for the two kinds that make up most of a long session, so it is asked
             // here rather than inside the closure that runs per cell.
@@ -597,7 +602,8 @@ struct TranscriptListView: View {
                                 permissionMode: permissionMode,
                                 agentKind: agentKind,
                                 wasStopped: wasStopped,
-                                recovered: recovered
+                                recovered: recovered,
+                                stillRunning: stillRunning
                             )
                             .arrivingRow(settles && arrivals.isArriving(row.seq))
                             .padding(.horizontal, TranscriptLayout.inset)

--- a/Sources/Bloom/Views/Transcript/TurnFooterView.swift
+++ b/Sources/Bloom/Views/Transcript/TurnFooterView.swift
@@ -30,6 +30,13 @@ struct TurnFooterView: View {
     ///
     /// A turn that failed carries none of this. See `TranscriptModel.abandonRetryRun`.
     var recovered: RetryRun?
+    /// What the agent left running in the background, named, or nothing.
+    ///
+    /// Only ever handed to the footer that closes the transcript. A turn that ends while a
+    /// backgrounded command is still going is not the agent being finished, and "Completed" on its
+    /// own, under a tab that is still breathing, is what made that look like a stuck turn. See
+    /// `BackgroundWork`.
+    var stillRunning: String?
 
     /// More chips than this and the footer stops being a footer.
     private static let visibleFileLimit = 6
@@ -165,6 +172,17 @@ struct TurnFooterView: View {
                 .frame(maxWidth: TranscriptLayout.proseMeasure, alignment: .leading)
                 .padding(.horizontal, TranscriptLayout.inset)
                 .padding(.bottom, TranscriptLayout.inset)
+            }
+
+            // Secondary rather than tertiary: unlike the retry note below, this is news now, and it
+            // is the answer to why the tab is still busy.
+            if let stillRunning {
+                Text(stillRunning)
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, TranscriptLayout.inset)
+                    .padding(.bottom, TranscriptLayout.inset)
             }
 
             // Tertiary rather than secondary, and under everything else: it explains a duration

--- a/Sources/BloomCore/Presentation/BackgroundWork.swift
+++ b/Sources/BloomCore/Presentation/BackgroundWork.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// The sentence under a finished turn that says the agent is not finished.
+///
+/// **The bug: "Completed in 5m 44s" with the tab still breathing.** The agent put a
+/// `gh run watch` in the background, ended its turn with "#212 is still in CI, once it's green
+/// I'll merge it", and the footer said Completed. The tab's activity mark stayed on, because
+/// `SubagentRoster.isWorking` counts a backgrounded shell command as work in flight, which it is.
+/// Seven minutes later the command finished and the CLI started a turn of its own. Nothing was
+/// wrong, and nothing on screen said so: the only trace of the command was a truncated row forty
+/// lines up. The owner took a screenshot and asked what was still going on.
+///
+/// Named rather than counted, because "1 background command" answers the question with another
+/// one. `description` is the phrase the agent wrote for the Bash call, "Wait for the PR's Test run
+/// to finish", which is exactly the sentence somebody wants here.
+public enum BackgroundWork {
+    /// More names than this and the sentence is a list, so the rest are counted.
+    static let namedLimit = 3
+
+    /// What is still running, or nil when nothing is.
+    public static func note(for roster: SubagentRoster) -> String? {
+        note(for: roster.subagents)
+    }
+
+    static func note(for subagents: [Subagent]) -> String? {
+        let running = subagents.filter { $0.state == .running }
+        guard let first = running.first else { return nil }
+
+        let noun = running.allSatisfy { $0.kind == first.kind } ? first.kind.noun : "background task"
+        let subject = running.count == 1
+            ? "\(article(for: noun)) \(noun) is"
+            : "\(running.count) \(plural(noun)) are"
+
+        let titles = running.map(SubagentRow.title(of:))
+        let named = Array(titles.prefix(namedLimit))
+        let rest = titles.count - named.count
+        let names = rest > 0
+            ? named.joined(separator: ", ") + " and \(rest) more"
+            : list(named)
+
+        return "\(subject) still running: \(names)."
+    }
+
+    /// "A background command is" rather than "1 background command is", which reads as a count
+    /// of something the sentence is about to name anyway.
+    private static func article(for noun: String) -> String {
+        noun.first.map { "aeiou".contains($0) } == true ? "An" : "A"
+    }
+
+    private static func plural(_ noun: String) -> String { noun + "s" }
+
+    private static func list(_ items: [String]) -> String {
+        guard items.count > 1, let last = items.last else { return items.first ?? "" }
+        return items.dropLast().joined(separator: ", ") + " and " + last
+    }
+}

--- a/Tests/BloomCoreTests/BackgroundWorkTests.swift
+++ b/Tests/BloomCoreTests/BackgroundWorkTests.swift
@@ -1,0 +1,56 @@
+import Testing
+import Foundation
+@testable import BloomCore
+
+/// The sentence under a finished turn naming what the agent left running. See `BackgroundWork`.
+@Suite struct BackgroundWorkTests {
+    private func command(_ description: String, state: SubagentState = .running) -> Subagent {
+        Subagent(
+            id: SubagentID(UUID().uuidString), description: description,
+            taskType: "local_bash", state: state
+        )
+    }
+
+    private func agent(_ description: String) -> Subagent {
+        Subagent(id: SubagentID(UUID().uuidString), description: description, taskType: "local_agent")
+    }
+
+    @Test func nothingRunningSaysNothing() {
+        #expect(BackgroundWork.note(for: SubagentRoster()) == nil)
+        #expect(BackgroundWork.note(for: [command("Done already", state: .completed)]) == nil)
+    }
+
+    /// The case the screenshot was of.
+    @Test func oneCommandIsNamed() {
+        let note = BackgroundWork.note(for: [command("Wait for the PR's Test run to finish")])
+        #expect(note == "A background command is still running: Wait for the PR's Test run to finish.")
+    }
+
+    @Test func finishedOnesAreLeftOut() {
+        let note = BackgroundWork.note(for: [
+            command("Wait for main head's Test run to finish", state: .completed),
+            command("Wait for the PR's Test run to finish"),
+        ])
+        #expect(note == "A background command is still running: Wait for the PR's Test run to finish.")
+    }
+
+    @Test func severalOfOneKindAreCountedAndNamed() {
+        let note = BackgroundWork.note(for: [command("Build"), command("Test")])
+        #expect(note == "2 background commands are still running: Build and Test.")
+    }
+
+    @Test func aSubagentTakesAnArticleThatReads() {
+        #expect(BackgroundWork.note(for: [agent("Audit the parser")])
+            == "A subagent is still running: Audit the parser.")
+    }
+
+    @Test func mixedKindsShareOneNoun() {
+        let note = BackgroundWork.note(for: [command("Build"), agent("Audit the parser")])
+        #expect(note == "2 background tasks are still running: Build and Audit the parser.")
+    }
+
+    @Test func aLongListIsCut() {
+        let note = BackgroundWork.note(for: ["A", "B", "C", "D", "E"].map { command($0) })
+        #expect(note == "5 background commands are still running: A, B, C and 2 more.")
+    }
+}


### PR DESCRIPTION
A turn could end with "Completed" while a backgrounded shell command or subagent was still going, which kept the tab's activity mark on with nothing explaining it. The footer that closes the transcript now names what is still running, for example "A background command is still running: Wait for the PR's Test run to finish." The sentence is built by a new `BackgroundWork` type in BloomCore, with tests, and `TranscriptModel` stores it so progress ticks do not rebuild the transcript table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)