### PR TITLE
Fix Install and Restart Now with running agents

### DIFF
--- a/Sources/Bloom/System/SoftwareUpdater.swift
+++ b/Sources/Bloom/System/SoftwareUpdater.swift
@@ -41,6 +41,11 @@ final class SoftwareUpdater: NSObject, SPUUpdaterDelegate {
     /// the app and not the other way round.
     @ObservationIgnored private weak var app: AppModel?
 
+    /// SwiftUI owns `NSApp.delegate` and forwards callbacks to its adapted delegate. Casting that
+    /// proxy to `BloomAppDelegate` silently fails, leaving the quit confirmation enabled during
+    /// an immediate install. Keep the actual delegate supplied at startup instead.
+    @ObservationIgnored private weak var appDelegate: BloomAppDelegate?
+
     @ObservationIgnored private var canCheckObservation: NSKeyValueObservation?
     @ObservationIgnored private var automaticChecksObservation: NSKeyValueObservation?
 
@@ -56,8 +61,9 @@ final class SoftwareUpdater: NSObject, SPUUpdaterDelegate {
     /// Called once, from the app delegate, after launching has finished. Sparkle schedules its
     /// first background check off the back of `startUpdater`, so starting it any earlier would put
     /// a network request in the middle of the launch it is supposed to stay out of.
-    func start(app: AppModel) {
+    func start(app: AppModel, appDelegate: BloomAppDelegate) {
         self.app = app
+        self.appDelegate = appDelegate
         guard controller == nil else { return }
 
         availability = SoftwareUpdate.availability(in: .main)
@@ -238,6 +244,6 @@ final class SoftwareUpdater: NSObject, SPUUpdaterDelegate {
     /// in more detail, so asking it again would only be a way to leave Sparkle's installer waiting
     /// on an answer the user thought they had given.
     private func allowTerminationWithoutAsking() {
-        (NSApp.delegate as? BloomAppDelegate)?.isInstallingUpdate = true
+        appDelegate?.isInstallingUpdate = true
     }
 }

--- a/Sources/Bloom/Views/Chrome/App/BloomAppDelegate.swift
+++ b/Sources/Bloom/Views/Chrome/App/BloomAppDelegate.swift
@@ -55,7 +55,7 @@ final class BloomAppDelegate: NSObject, NSApplicationDelegate, UNUserNotificatio
         // The updater needs the same state, for one question: how many agents are mid turn. This
         // is also the first moment there is any, and it is deliberately after launching rather
         // than during it, so Sparkle's first scheduled check cannot land inside the launch.
-        SoftwareUpdater.shared.start(app: model)
+        SoftwareUpdater.shared.start(app: model, appDelegate: self)
     }
 
     /// Claiming the URL Apple Event has to happen before launching finishes. If SwiftUI's own


### PR DESCRIPTION
Fix "Install and Restart Now" getting stuck while agents are running. Pass Bloom's actual app delegate to the updater so the existing confirmation bypass is set. Casting SwiftUI's `NSApp.delegate` proxy silently failed, leaving a second quit confirmation in the update flow.

Verified the failed cast with a headless SwiftUI probe. App build with warnings as errors, 12 updater tests, house rules and SwiftLint pass. Full update relaunch has not been exercised.
