### PR TITLE
Offer ready for review action for draft pull requests

### DIFF
--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -2013,6 +2013,27 @@ final class WorkspaceModel {
         return nil
     }
 
+    /// Uses the same transcript and permission mode as the other pull request actions.
+    func requestMarkReadyForReview(
+        _ pullRequest: PullRequest,
+        overrides: PromptOverrides = PromptOverrides()
+    ) async -> String? {
+        guard pullRequest.isOpen, pullRequest.isDraft else {
+            return "This pull request is no longer an open draft."
+        }
+        guard let session = await sessionForPullRequest(titledIfNew: "Mark ready for review") else {
+            return "Could not open a session in \(workspace.name) to send the request to."
+        }
+
+        let render = PromptTemplate.render(
+            overrides.template(for: .markReadyForReview),
+            values: [PromptRegistry.MarkReadyForReview.url: pullRequest.url]
+        )
+        activeSessionID = session.id
+        await transcript(for: session).submit(render.text)
+        return nil
+    }
+
     /// Asks the workspace's agent to merge the pull request, instead of running `gh` from here.
     ///
     /// The last of the three buttons in the strip to move, and the one with the most riding on it.

--- a/Sources/Bloom/Views/Inspector/PullRequestBar.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestBar.swift
@@ -102,6 +102,7 @@ struct PullRequestBar: View {
                 mergeMethod: model.mergeMethod,
                 onChooseMergeMethod: chooseMergeMethod,
                 onMerge: merge,
+                onMarkReadyForReview: { markReadyForReview(pullRequest) },
                 onPush: push,
                 onFixConflicts: { fixConflicts(on: pullRequest) },
                 onContinue: { carryOn(after: pullRequest) },
@@ -184,6 +185,21 @@ struct PullRequestBar: View {
         Task {
             defer { isWorking = false }
             if let refusal = await model.requestPullRequest() {
+                report = PullRequestNotice(
+                    tone: .info, title: "Nothing was sent", message: refusal
+                )
+            }
+        }
+    }
+
+    private func markReadyForReview(_ pullRequest: PullRequest) {
+        guard !isWorking, branchActions.isAllowed else { return }
+        isWorking = true
+        report = nil
+
+        Task {
+            defer { isWorking = false }
+            if let refusal = await model.requestMarkReadyForReview(pullRequest) {
                 report = PullRequestNotice(
                     tone: .info, title: "Nothing was sent", message: refusal
                 )

--- a/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
+++ b/Sources/Bloom/Views/Inspector/PullRequestSummary.swift
@@ -40,6 +40,7 @@ struct PullRequestSummary: View {
     /// and `onMerge`.
     var onChooseMergeMethod: (GitHub.MergeMethod) -> Void
     var onMerge: (GitHub.MergeMethod) -> Void
+    var onMarkReadyForReview: () -> Void
     /// Hands the outstanding work to the workspace's agent to commit and push.
     var onPush: () -> Void
     /// Asks the workspace's agent to bring the base branch in and resolve the conflicts with it.
@@ -291,7 +292,7 @@ struct PullRequestSummary: View {
         // agreed to throw away.
     }
 
-    /// Which of the three the open state's primary slot holds.
+    /// Which action the open state's primary slot holds.
     ///
     /// A switch rather than a chain of conditions, and the reason is the failure this project has
     /// had four times: the remedy is an enum in the core, and a case added to it has to stop
@@ -302,6 +303,7 @@ struct PullRequestSummary: View {
     private var primaryButton: some View {
         switch status.remedy {
         case .merge: mergeControl
+        case .markReadyForReview: markReadyForReviewButton
         case .fixConflicts: fixConflictsButton
         case .commitAndPush, .push: pushButton
         }
@@ -453,6 +455,19 @@ struct PullRequestSummary: View {
 
     private var pushLabel: String {
         status.remedy == .push ? "Push" : "Commit and push"
+    }
+
+    private var markReadyForReviewButton: some View {
+        Button("Mark ready for review", action: onMarkReadyForReview)
+            .buttonStyle(.borderedProminent)
+            .buttonBorderShape(.roundedRectangle(radius: Metrics.corner))
+            .tint(status.tone.fill)
+            .controlSize(.regular)
+            .fixedSize()
+            .help(
+                branchActions.reason
+                    ?? "Ask this workspace's agent to mark #\(pullRequest.number) ready for review on GitHub."
+            )
     }
 
     /// What stands where Merge stands, when merging is the one thing this state cannot do.

--- a/Sources/BloomCore/Bridge/WorkspaceListTool.swift
+++ b/Sources/BloomCore/Bridge/WorkspaceListTool.swift
@@ -413,6 +413,7 @@ public struct WorkspaceListTool: BridgeToolHandling {
     private func remedy(_ remedy: PullRequestStatus.Remedy) -> String {
         switch remedy {
         case .merge: "merge"
+        case .markReadyForReview: "markReadyForReview"
         case .push: "push"
         case .commitAndPush: "commitAndPush"
         case .fixConflicts: "fixConflicts"

--- a/Sources/BloomCore/GitHub/PullRequestStatus.swift
+++ b/Sources/BloomCore/GitHub/PullRequestStatus.swift
@@ -48,8 +48,10 @@ public struct PullRequestStatus: Sendable, Hashable {
 
     /// What to do about this state, as far as one button can express it.
     public enum Remedy: Sendable, Hashable {
-        /// Land it. What every state GitHub reports on its own offers.
+        /// Land it once the pull request is ready.
         case merge
+        /// A draft must be ready for review before GitHub allows a merge.
+        case markReadyForReview
         /// Get the worktree onto the remote first. Committing is part of it or it is not,
         /// depending on whether anything is uncommitted, and the label follows.
         case commitAndPush
@@ -234,7 +236,8 @@ public extension PullRequest {
                 text: "Draft",
                 detail: checksDetail,
                 canMerge: false,
-                blockedReason: "This pull request is still a draft."
+                blockedReason: "This pull request is still a draft.",
+                remedy: .markReadyForReview
             )
         }
 

--- a/Sources/BloomCore/Transcript/PromptRegistry.swift
+++ b/Sources/BloomCore/Transcript/PromptRegistry.swift
@@ -8,6 +8,7 @@ public enum PromptID: String, Sendable, Hashable, CaseIterable, Codable {
     case createPullRequest
     case pushLocalWork
     case mergePullRequest
+    case markReadyForReview
     case fixConflicts
     case continueAfterMerge
     case carryOnArchived
@@ -62,7 +63,7 @@ public struct PromptDefinition: Sendable, Hashable, Identifiable {
 /// none of that and can only fail.
 public enum PromptRegistry {
     public static let all: [PromptDefinition] = [
-        createPullRequest, pushLocalWork, mergePullRequest, fixConflicts, continueAfterMerge,
+        createPullRequest, pushLocalWork, mergePullRequest, markReadyForReview, fixConflicts, continueAfterMerge,
         carryOnArchived, review, nameWorkspace,
     ]
 
@@ -88,6 +89,24 @@ public enum PromptRegistry {
         public static let baseBranch = "base_branch"
         public static let changes = "changes"
     }
+
+    public enum MarkReadyForReview {
+        public static let url = "url"
+    }
+
+    static let markReadyForReview = PromptDefinition(
+        id: .markReadyForReview,
+        title: "Mark ready for review",
+        summary: "Sent when you press Mark ready for review on a draft pull request.",
+        variables: [
+            PromptVariable(name: MarkReadyForReview.url, summary: "The pull request's URL."),
+        ],
+        defaultTemplate: """
+        Mark pull request {{url}} ready for review on GitHub using `gh pr ready`, then verify its \
+        draft status is cleared. If GitHub refuses, explain why. Do not merge the pull request, \
+        commit or push changes, or start any other work.
+        """
+    )
 
     /// The names the merge prompt may use.
     public enum MergePullRequest {

--- a/Tests/BloomCoreTests/MarkReadyForReviewTests.swift
+++ b/Tests/BloomCoreTests/MarkReadyForReviewTests.swift
@@ -1,0 +1,63 @@
+import Testing
+@testable import BloomCore
+
+@Suite("Mark ready for review")
+struct MarkReadyForReviewTests {
+    @Test("drafts offer ready for review regardless of their checks", arguments: [
+        PullRequest.Checks.none, .pending, .failing, .passing,
+    ])
+    func draftsOfferReady(checks: PullRequest.Checks) {
+        var request = draft()
+        request.checks = checks
+
+        #expect(request.status.remedy == .markReadyForReview)
+        #expect(!request.status.canMerge)
+
+        request.isDraft = false
+        #expect(request.status.remedy == .merge)
+        #expect(request.status.canMerge)
+    }
+
+    @Test("conflicts and local changes keep their existing actions")
+    func precedingActions() {
+        #expect(draft().status(local: LocalWork(modifiedFiles: 1)).remedy == .commitAndPush)
+        #expect(draft().status(local: LocalWork(unpushedCommits: 1)).remedy == .push)
+
+        var request = draft()
+        request.mergeable = "CONFLICTING"
+        #expect(request.status.remedy == .fixConflicts)
+    }
+
+    @Test("closed and merged drafts never offer ready for review", arguments: ["CLOSED", "MERGED"])
+    func finishedRequests(state: String) {
+        var request = draft()
+        request.state = state
+
+        #expect(request.status.remedy != .markReadyForReview)
+        #expect(!request.status.canMerge)
+    }
+
+    @Test("the turn targets the exact pull request and stops after clearing draft status")
+    func readyPrompt() {
+        let request = draft()
+        let render = PromptTemplate.render(
+            PromptRegistry.definition(for: .markReadyForReview).defaultTemplate,
+            values: [PromptRegistry.MarkReadyForReview.url: request.url]
+        )
+
+        #expect(render.unknown.isEmpty)
+        #expect(render.missing.isEmpty)
+        #expect(render.text.contains(request.url))
+        #expect(render.text.contains("gh pr ready"))
+        #expect(render.text.contains("verify its draft status is cleared"))
+        #expect(render.text.contains("Do not merge the pull request, commit or push changes"))
+    }
+
+    private func draft() -> PullRequest {
+        PullRequest(
+            number: 42, title: "Fix the updater", url: "https://github.com/example/bloom/pull/42",
+            state: "OPEN", isDraft: true, mergeable: "MERGEABLE", checks: .passing,
+            checksSummary: "3 checks passed", reviewDecision: nil, branch: "fix-updater"
+        )
+    }
+}


### PR DESCRIPTION
Draft pull requests now show “Mark ready for review” in place of the disabled merge button. The action asks the workspace agent to clear draft status on GitHub, then the strip returns to the merge action. Existing conflict and local-change actions retain priority.

Verified locally with 69 focused tests, an app build with warnings treated as errors, and both linters. CI build and lint pass. The full suite currently fails in the unchanged GrokRunnerTests cancellation test; the new tests passed on both CI attempts.
