### PR TITLE
Include Mac names in installation reports

### DIFF
--- a/Sources/Bloom/System/InstallPingService.swift
+++ b/Sources/Bloom/System/InstallPingService.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import SystemConfiguration
 import BloomCore
 
 /// Sends the install ping, and does nothing else.
@@ -138,6 +139,7 @@ final class InstallPingService {
             agent: InstallPing.agentName(installed: installed),
             theme: InstallPing.Theme(),
             appBuild: Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String,
+            computerName: SCDynamicStoreCopyComputerName(nil, nil) as String?,
             architecture: FeedbackEnvironment.architecture(),
             translated: FeedbackEnvironment.isTranslated(),
             screenWidth: screen.map { Double($0.frame.width) },

--- a/Sources/BloomCore/System/InstallPing.swift
+++ b/Sources/BloomCore/System/InstallPing.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Reports distinct installations and coarse setup metrics about once a day.
+/// Includes the computer name, which may contain a person's name.
 /// No paths, prompts, account details, serial numbers or hardware identifiers are collected.
 /// The random token identifies an installation, not a person or a physical Mac.
 public enum InstallPing {
@@ -153,7 +154,7 @@ public enum InstallPing {
     /// The defaults domain survives what this has to survive: quitting, updating in place, and
     /// Sparkle replacing the bundle, because none of those touch
     /// `~/Library/Preferences/be.spatie.bloom.plist`. It does not survive somebody deleting Bloom's
-    /// data, and that is the right way round for an anonymous counter: removing the app should
+    /// data, and that is the right way round for an installation counter: removing the app should
     /// mean the app forgets you, and a reinstall afterwards is honestly a new install. A keychain
     /// item would outlive the uninstall, which makes the number very slightly more accurate and
     /// leaves a thing behind on the user's disk that they did not ask for and cannot easily find.
@@ -303,6 +304,7 @@ public enum InstallPing {
         /// The appearance setting.
         public let theme: Theme
         public let appBuild: String?
+        public let computerName: String?
         public let architecture: String?
         public let translated: Bool?
         public let screenWidth: Int?
@@ -318,6 +320,7 @@ public enum InstallPing {
             agent: String,
             theme: Theme,
             appBuild: String? = nil,
+            computerName: String? = nil,
             architecture: Feedback.Architecture = .unknown,
             translated: Bool? = nil,
             screenWidth: Double? = nil,
@@ -332,6 +335,7 @@ public enum InstallPing {
             self.agent = InstallPing.checked(agent, InstallPing.namePattern, or: InstallPing.unknownName)
             self.theme = theme
             self.appBuild = appBuild.flatMap { InstallPing.matches($0, #"^[A-Za-z0-9.]{1,16}$"#) ? $0 : nil }
+            self.computerName = InstallPing.checkedComputerName(computerName)
             self.architecture = architecture.wireName
             self.translated = architecture == .unknown ? nil : translated
             let width = InstallPing.roundedScreenDimension(screenWidth)
@@ -352,6 +356,7 @@ public enum InstallPing {
             case agent
             case theme
             case appBuild = "app_build"
+            case computerName = "computer_name"
             case architecture
             case translated
             case screenWidth = "screen_width"
@@ -360,6 +365,14 @@ public enum InstallPing {
             case displayCount = "display_count"
             case memoryBucket = "memory_bucket"
         }
+    }
+
+    public static func checkedComputerName(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty, value.unicodeScalars.count <= 255,
+              value.rangeOfCharacter(from: .controlCharacters) == nil
+        else { return nil }
+        return value
     }
 
     public enum MemoryBucket: String, Sendable, Equatable, Encodable, CaseIterable {
@@ -529,8 +542,8 @@ public enum InstallPing {
     public static let settingTitle = "Share daily usage reports"
 
     public static let settingDetail =
-        "Help improve Bloom by sharing a random install token, app version and build, macOS version, installed agents, theme, processor architecture, Rosetta status, rounded display dimensions, display scale and count, and memory range."
+        "Help improve Bloom by sharing a random install token, computer name, app version and build, macOS version, installed agents, theme, processor architecture, Rosetta status, rounded display dimensions, display scale and count, and memory range."
 
     public static let settingFooter =
-        "Reports start a day after first launch and count installations. Display dimensions are rounded to 100 points and memory is grouped into broad ranges. Reports contain no names, account details, hardware identifiers, project paths or prompts. Feedback uses the same token, so an email you include with feedback can identify that installation."
+        "Reports start a day after first launch and count installations. Your computer name may include your name and identify you. Display dimensions are rounded to 100 points and memory is grouped into broad ranges. Reports contain no account details, hardware identifiers, project paths or prompts. Feedback uses the same token, so an email you include with feedback can identify that installation."
 }

--- a/Tests/BloomCoreTests/InstallPingTests.swift
+++ b/Tests/BloomCoreTests/InstallPingTests.swift
@@ -59,7 +59,7 @@ struct InstallPingTests {
         #expect(json["theme"] as? String == "dark")
     }
 
-    @Test("cannot carry anything about the user or their work")
+    @Test("omits personal details when no computer name is supplied")
     func bodyCarriesNothingElse() throws {
         let data = try InstallPing.body(payload(theme: .light))
         let text = try #require(String(data: data, encoding: .utf8))
@@ -82,7 +82,7 @@ struct InstallPingTests {
         let value = InstallPing.Payload(
             token: "3F2504E0-4F89-11D3-9A0C-0305E82C3301",
             appVersion: "0.4.0", macOSVersion: "26.1.0", agent: "claude", theme: .dark,
-            appBuild: "42", architecture: .arm64, translated: false,
+            appBuild: "42", computerName: "Zoë's MacBook Pro", architecture: .arm64, translated: false,
             screenWidth: 1512, screenHeight: 982, displayScale: 2, displayCount: 2,
             memoryBucket: .upTo32GiB
         )
@@ -90,9 +90,10 @@ struct InstallPingTests {
         #expect(Set(json.keys) == [
             "token", "app_version", "macos_version", "agent", "theme", "app_build",
             "architecture", "translated", "screen_width", "screen_height", "display_scale",
-            "display_count", "memory_bucket",
+            "display_count", "memory_bucket", "computer_name",
         ])
         #expect(json["app_build"] as? String == "42")
+        #expect(json["computer_name"] as? String == "Zoë's MacBook Pro")
         #expect(json["architecture"] as? String == "arm64")
         #expect(json["translated"] as? Bool == false)
         #expect(json["screen_width"] as? Int == 1500)
@@ -115,6 +116,24 @@ struct InstallPingTests {
         #expect(InstallPing.roundedScreenDimension(-1) == nil)
         #expect(InstallPing.roundedScreenDimension(20_001) == nil)
         #expect(InstallPing.roundedScreenDimension(20_000) == 20_000)
+    }
+
+    @Test("trims computer names and omits unavailable or invalid names", arguments: [
+        (nil, nil), ("", nil), ("   ", nil),
+        ("  Zoë's MacBook Pro  ", "Zoë's MacBook Pro"),
+        ("開発用 💻", "開発用 💻"),
+        ("Mac\nBook", nil), ("Mac\u{0000}Book", nil),
+        (String(repeating: "é", count: 255), String(repeating: "é", count: 255)),
+        (String(repeating: "é", count: 256), nil),
+    ] as [(String?, String?)])
+    func computerNames(value: String?, expected: String?) throws {
+        let payload = InstallPing.Payload(
+            token: "3F2504E0-4F89-11D3-9A0C-0305E82C3301",
+            appVersion: "0.4.0", macOSVersion: "26.1.0", agent: "claude", theme: .dark,
+            computerName: value
+        )
+        #expect(try object(payload)["computer_name"] as? String == expected)
+        #expect(try InstallPing.body(payload).count < InstallPing.maximumBodyBytes)
     }
 
     @Test("groups memory at the documented boundaries")
@@ -488,6 +507,8 @@ struct InstallPingTests {
             #expect(InstallPing.settingDetail.localizedCaseInsensitiveContains(word))
         }
         #expect(InstallPing.settingDetail.contains("random"))
+        #expect(InstallPing.settingDetail.contains("computer name"))
+        #expect(InstallPing.settingFooter.contains("Your computer name may include your name"))
         #expect(InstallPing.settingFooter.contains("100 points"))
         #expect(InstallPing.settingFooter.contains("account details"))
         #expect(InstallPing.settingFooter.contains("email"))


### PR DESCRIPTION
Include the Mac's computer name in daily install reports, omit unavailable or invalid names, and disclose this field in Settings. The existing reporting switch and schedule still apply.

Website support: https://github.com/spatie/runbloom.app/pull/16. Deploy that migration before releasing this app change.

The app builds with warnings treated as errors, and both linters pass. Payload tests cover Unicode names, invalid values and omitted fields.
