### PR TITLE
Improve Git safety and agent workflows

### DIFF
--- a/Sources/Bloom/State/AppModel+Projects.swift
+++ b/Sources/Bloom/State/AppModel+Projects.swift
@@ -121,6 +121,12 @@ extension AppModel {
     /// workspace whose row no longer exists is a second writer with nothing to write to.
     func removeRepository(_ repo: Repo) async {
         guard let store else { return }
+        do {
+            try await store.requireRepoCanBeRemoved(id: repo.id)
+        } catch {
+            alert = BloomAlert(title: "Could not remove the project", message: error.readableMessage)
+            return
+        }
 
         // Every model this project has, not only the rows the sidebar is drawing: `workspaces`
         // holds active ones, and an archived workspace that is still open in a tab has a model too.

--- a/Sources/Bloom/State/AppModel.swift
+++ b/Sources/Bloom/State/AppModel.swift
@@ -340,7 +340,7 @@ final class AppModel {
     ///
     /// Outside observation for the same reason `lastDiffRefresh` is: nothing draws from it, and it
     /// is written by a background queue's hop onto this actor whenever an agent touches a file.
-    @ObservationIgnored private var changedWorkspaceIDs: Set<WorkspaceID> = []
+    @ObservationIgnored private var diffInvalidations = DiffRefreshInvalidations()
 
     /// The one watcher, over every active worktree. Built lazily so that a model made by a test or
     /// a probe with no workspaces at all never subscribes to anything.
@@ -390,6 +390,7 @@ final class AppModel {
             ComposerModelCatalog.shared.configure(store: store)
             self.manager = WorkspaceManager(store: store)
             try await store.resetRunningSessions()
+            try await store.recoverDeliveryClaims()
             // The questions those sessions were blocked on. A pending ask whose agent is gone is
             // not a question, it is a row with four live buttons that answer nothing, so they are
             // closed here and the rows that asked them say what happened instead. Bloom denies
@@ -856,7 +857,7 @@ final class AppModel {
     private func noteWorktreesChanged(_ paths: Set<String>) {
         let changed = workspaces.filter { paths.contains($0.path) }.map(\.id)
         guard !changed.isEmpty else { return }
-        changedWorkspaceIDs.formUnion(changed)
+        diffInvalidations.record(Set(changed))
     }
 
     /// - Returns: the workspaces this pass actually asked git about.
@@ -872,7 +873,7 @@ final class AppModel {
         // the backstop rotation comes round, which is what lets that rotation be slow. See
         // `WorktreeWatcher`.
         var busy = runningWorkspaceIDs
-        busy.formUnion(changedWorkspaceIDs)
+        busy.formUnion(diffInvalidations.pending)
         let due = Set(DiffRefreshSchedule.due(
             workspaces: workspaces.map(\.id),
             busy: busy,
@@ -889,6 +890,7 @@ final class AppModel {
         // remembered rather than pinning a path that no longer exists.
         let present = Set(workspaces.map(\.id))
         lastDiffRefresh = lastDiffRefresh.filter { present.contains($0.key) }
+        diffInvalidations.retain(present)
 
         let pending = workspaces.filter {
             // A worktree that has been removed outside Bloom would make git walk up to the parent
@@ -897,33 +899,33 @@ final class AppModel {
         }
 
         var refreshed: Set<WorkspaceID> = []
-        await withTaskGroup(of: WorkspaceID.self) { group in
+        await withTaskGroup(of: (WorkspaceID, UInt64, Bool).self) { group in
             var next = pending.startIndex
             var running = 0
             while next < pending.endIndex || running > 0 {
                 while running < DiffRefreshSchedule.width, next < pending.endIndex {
                     let workspace = pending[next]
+                    let generation = diffInvalidations.generation(for: workspace.id)
                     next = pending.index(after: next)
                     running += 1
                     // The deadline stays around each worktree rather than around the group, so one
                     // git blocked on an `index.lock` costs its own slot and nobody else's.
                     group.addTask {
-                        await Self.withTimeLimit(.seconds(5)) {
+                        let succeeded = await Self.withTimeLimit(.seconds(5)) {
                             await manager.refreshDiffStat(workspace: workspace)
                         }
-                        return workspace.id
+                        return (workspace.id, generation, succeeded)
                     }
                 }
-                guard let id = await group.next() else { break }
+                guard let (id, generation, succeeded) = await group.next() else { break }
                 running -= 1
+                diffInvalidations.finish(id, generation: generation, succeeded: succeeded)
                 // After the pass rather than before it, so a workspace whose git call took four
                 // seconds is not immediately due again on the next tick.
-                lastDiffRefresh[id] = Date()
-                // And it has now been asked about, so the watcher's report is spent. Anything that
-                // happened WHILE the pass ran is a fresh event and lands back in here behind us,
-                // which is the right answer: the numbers this pass read are already a moment old.
-                changedWorkspaceIDs.remove(id)
-                refreshed.insert(id)
+                if succeeded {
+                    lastDiffRefresh[id] = Date()
+                    refreshed.insert(id)
+                }
                 if Task.isCancelled {
                     group.cancelAll()
                     break
@@ -947,13 +949,14 @@ final class AppModel {
     /// actor it would hop back for the group's own bookkeeping, once per worktree, for nothing.
     private nonisolated static func withTimeLimit(
         _ limit: Duration,
-        _ work: @escaping @Sendable () async -> Void
-    ) async {
-        await withTaskGroup(of: Void.self) { group in
+        _ work: @escaping @Sendable () async -> Bool
+    ) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
             group.addTask { await work() }
-            group.addTask { try? await Task.sleep(for: limit) }
-            await group.next()
+            group.addTask { try? await Task.sleep(for: limit); return false }
+            let succeeded = await group.next() ?? false
             group.cancelAll()
+            return succeeded
         }
     }
 

--- a/Sources/Bloom/State/Bridges.swift
+++ b/Sources/Bloom/State/Bridges.swift
@@ -9,6 +9,17 @@ import BloomCore
 /// are all turns sent to the workspace's agent now, so the only `gh` this app runs is the reading
 /// half.
 enum GitHubBridge {
+    static func readPullRequest(for workspace: Workspace, maxAge: Duration = .zero) async -> PullRequestRead {
+        let availability = await GitHubAvailability.shared.check()
+        if availability == .notInstalled {
+            return .unavailable(GitHubReadFailure(reason: .unavailable, message: "Install the GitHub CLI to refresh pull requests."))
+        }
+        guard availability == .ready else {
+            return .unavailable(GitHubReadFailure(reason: .authentication, message: "Connect GitHub to refresh pull requests."))
+        }
+        return await GitHub.readPullRequest(for: workspace, maxAge: maxAge)
+    }
+
     /// - Parameter maxAge: how old an answer from the last `gh pr view` may be and still be used.
     ///   Zero always asks GitHub.
     ///
@@ -24,8 +35,8 @@ enum GitHubBridge {
     static func pullRequest(
         for workspace: Workspace, maxAge: Duration = .zero
     ) async -> PullRequest? {
-        guard await GitHubAvailability.shared.isReady() else { return nil }
-        return try? await GitHub.pullRequest(for: workspace, maxAge: maxAge)
+        guard case .current(let pullRequest) = await readPullRequest(for: workspace, maxAge: maxAge) else { return nil }
+        return pullRequest
     }
 
     static func checks(for workspace: Workspace) async -> [CheckRun] {

--- a/Sources/Bloom/State/TranscriptHistory.swift
+++ b/Sources/Bloom/State/TranscriptHistory.swift
@@ -1,0 +1,258 @@
+import Foundation
+import Observation
+import BloomCore
+
+/// A worktree may hold several conversations. An unresolved file/history operation blocks
+/// all of their send paths, including a conversation opened after the operation started.
+@MainActor
+@Observable
+final class HistoryWorkspaceGate {
+    static let shared = HistoryWorkspaceGate()
+    private(set) var held: Set<WorkspaceID> = []
+    private(set) var unresolved: Set<WorkspaceID> = []
+    @ObservationIgnored private var leases: [WorkspaceID: WorkspaceOperationLease] = [:]
+
+    func holds(_ id: WorkspaceID) -> Bool { held.contains(id) || unresolved.contains(id) }
+    func begin(_ id: WorkspaceID, worktree: String) -> Bool {
+        guard !held.contains(id), let lease = WorkspaceOperationLease.acquire(in: worktree, operation: .rewind) else { return false }
+        leases[id] = lease
+        held.insert(id)
+        return true
+    }
+    func lease(for id: WorkspaceID) -> WorkspaceOperationLease? { leases[id] }
+    func end(_ id: WorkspaceID) {
+        leases.removeValue(forKey: id)?.release()
+        held.remove(id)
+    }
+    func mark(_ id: WorkspaceID, unresolved value: Bool) {
+        if value { unresolved.insert(id) } else { unresolved.remove(id) }
+    }
+}
+
+@MainActor
+@Observable
+final class TranscriptHistory {
+    var checkpoints: [TurnCheckpoint] = []
+    var pendingRewind: CheckpointRewind?
+    var failure: String?
+    var blockingSessionID: SessionID?
+    private(set) var isCapturing = false
+    var isFinalisingTurn = false
+    private(set) var isRewinding = false
+    var hasActiveTurn: Bool { active != nil }
+    @ObservationIgnored private var active: TurnCheckpoint?
+    @ObservationIgnored private var activeDeliveryID: DeliveryID?
+
+    func load(store: Store, sessionID: SessionID, workspaceID: WorkspaceID?) async {
+        do {
+            checkpoints = try await store.turnCheckpoints(sessionID: sessionID)
+            let journal = try await store.checkpointRewind(sessionID: sessionID)
+            pendingRewind = journal?.stage == .complete ? nil : journal
+            if let workspaceID, pendingRewind != nil {
+                HistoryWorkspaceGate.shared.mark(workspaceID, unresolved: true)
+            }
+        } catch { failure = "Could not load turn history: \(error.localizedDescription)" }
+    }
+
+    func cleanupRetired(store: Store, sessionID: SessionID, cwd: String) async {
+        do { try await TurnCheckpointStore(store: store).cleanupRetired(sessionID: sessionID, cwd: cwd) } catch { failure = "Could not finish cleaning up old snapshots: \(error)" }
+    }
+
+    func begin(delivery: Delivery, store: Store, cwd: String) async {
+        isCapturing = true
+        defer { isCapturing = false }
+        do {
+            guard let saved = try await store.delivery(id: delivery.id), let seq = saved.deliveredSeq else {
+                throw SnapshotFailure("The sent message has no stored sequence.")
+            }
+            active = try await TurnCheckpointStore(store: store).begin(
+                sessionID: delivery.targetSessionID, cwd: cwd, startSeq: seq
+            )
+            activeDeliveryID = delivery.id
+            failure = nil
+        } catch { failure = "Could not capture this turn's starting state: \(error)" }
+    }
+
+    func sent(delivery: Delivery, store: Store) async {
+        do {
+            guard let saved = try await store.delivery(id: delivery.id), let provider = saved.providerTurnID,
+                  let seq = saved.deliveredSeq else { return }
+            // Steering messages and chats without a worktree have no starting snapshot. The
+            // association lives in Store; a reused sequence after rewind has no cached identity.
+            guard try await store.linkTurnCheckpoint(
+                sessionID: saved.targetSessionID, startSeq: seq, providerTurnID: provider
+            ) else { return }
+            if var current = active, current.startSeq == seq {
+                current.providerTurnID = provider
+                active = current
+            }
+            merge(try await store.turnCheckpoints(sessionID: saved.targetSessionID))
+        } catch { failure = "Could not link the turn to its snapshot: \(error)" }
+    }
+
+    func finish(store: Store, cwd: String, endSeq: Int, captureFiles: Bool = true) async {
+        guard let checkpoint = active else { return }
+        active = nil
+        isCapturing = true
+        defer { isCapturing = false; activeDeliveryID = nil }
+        do {
+            if !captureFiles {
+                var closed = checkpoint
+                closed.endSeq = max(endSeq, checkpoint.startSeq)
+                try await store.saveTurnCheckpoint(closed)
+                merge(try await store.turnCheckpoints(sessionID: checkpoint.sessionID))
+                failure = "This turn's final file snapshot is unavailable because another turn had already started."
+                return
+            }
+            var providerTurnID = checkpoint.providerTurnID
+            if let id = activeDeliveryID, let delivery = try await store.delivery(id: id) {
+                providerTurnID = delivery.providerTurnID ?? providerTurnID
+            }
+            _ = try await TurnCheckpointStore(store: store).finish(
+                id: checkpoint.id, sessionID: checkpoint.sessionID, cwd: cwd, endSeq: max(endSeq, checkpoint.startSeq),
+                providerTurnID: providerTurnID
+            )
+            merge(try await store.turnCheckpoints(sessionID: checkpoint.sessionID))
+        } catch { failure = "Could not capture this turn's final state: \(error)" }
+    }
+
+    private func merge(_ records: [TurnCheckpoint]) {
+        let previous = Dictionary(checkpoints.map { ($0.id, $0) }, uniquingKeysWith: { _, last in last })
+        checkpoints = records.map { record in
+            var merged = record
+            if merged.after == nil, let completed = previous[record.id], completed.after != nil {
+                merged.after = completed.after
+                merged.endSeq = completed.endSeq
+            }
+            merged.providerTurnID = merged.providerTurnID ?? previous[record.id]?.providerTurnID
+            return merged
+        }
+    }
+
+    func diff(_ checkpoint: TurnCheckpoint, store: Store, cwd: String, path: String? = nil) async throws -> String {
+        try await TurnCheckpointStore(store: store).diff(checkpoint, cwd: cwd, path: path)
+    }
+
+    func files(_ checkpoint: TurnCheckpoint, cwd: String) async throws -> [ChangedFile] {
+        guard let after = checkpoint.after else { throw SnapshotFailure("This turn has no completed snapshot.") }
+        return try await Git.snapshotFiles(from: checkpoint.before, to: after, in: cwd)
+    }
+
+    func rewind(_ checkpoint: TurnCheckpoint, restoringFiles: Bool, transcript: TranscriptModel, app: AppModel) async {
+        guard let workspace = transcript.workspace, let store = app.store,
+              let turnID = checkpoint.providerTurnID, transcript.session.agentKind == .codex,
+              !isRewinding, !HistoryWorkspaceGate.shared.holds(workspace.id),
+              HistoryWorkspaceGate.shared.begin(workspace.id, worktree: transcript.cwd) else { return }
+        isRewinding = true
+        defer { isRewinding = false; HistoryWorkspaceGate.shared.end(workspace.id) }
+        let service = TurnCheckpointStore(store: store)
+        do {
+            try await requireIdleWorkspace(transcript: transcript, app: app, store: store)
+            guard try await store.pendingCheckpointRewind(workspaceID: workspace.id) == nil else {
+                throw SnapshotFailure("Resolve the previous interrupted rewind first.")
+            }
+            let backup = try await store.prepareTranscriptRewind(checkpoint)
+            try requireAttachments(backup.prompt, cwd: transcript.cwd)
+            // Validate the provider boundary before changing files. A stale local checkpoint
+            // cannot become a file restore followed by a predictable missing-turn failure.
+            guard try await transcript.providerContainsTurn(turnID) else { throw ConversationRewindError.missingTurn }
+            try await requireIdleWorkspace(transcript: transcript, app: app, store: store)
+            var journal = try await service.prepareRewind(
+                checkpoint: checkpoint, cwd: transcript.cwd, restoringFiles: restoringFiles,
+                operationLease: HistoryWorkspaceGate.shared.lease(for: workspace.id)
+            )
+            pendingRewind = journal
+            HistoryWorkspaceGate.shared.mark(workspace.id, unresolved: true)
+            if restoringFiles {
+                try await Git.restoreSnapshot(checkpoint.before, in: transcript.cwd)
+                journal.stage = .filesRestored
+                try await service.markRewind(journal)
+                pendingRewind = journal
+            }
+            try await transcript.rewindProvider(beforeTurnID: turnID)
+            journal.stage = .providerReverted
+            try await service.markRewind(journal)
+            pendingRewind = journal
+            try await finishRewind(journal, transcript: transcript, app: app, store: store)
+        } catch {
+            failure = "Rewind could not finish: \(error)"
+            if var journal = pendingRewind {
+                journal.failure = failure
+                pendingRewind = journal
+                try? await service.markRewind(journal)
+            }
+        }
+    }
+
+    /// An unanswered request is not proof of failure. Reconcile the exact boundary before
+    /// truncating local history or allowing another send, including after an app restart.
+    func recover(transcript: TranscriptModel, app: AppModel) async {
+        guard let journal = pendingRewind, let workspace = transcript.workspace, let store = app.store,
+              let turnID = journal.checkpoint.providerTurnID,
+              !isRewinding, HistoryWorkspaceGate.shared.begin(workspace.id, worktree: transcript.cwd) else { return }
+        isRewinding = true
+        defer { isRewinding = false; HistoryWorkspaceGate.shared.end(workspace.id) }
+        do {
+            try await requireIdleWorkspace(transcript: transcript, app: app, store: store)
+            let reverted: Bool
+            if journal.stage == .providerReverted { reverted = true } else {
+                let retained = try await transcript.providerContainsTurn(turnID)
+                reverted = !retained
+            }
+            if reverted {
+                var confirmed = journal
+                confirmed.stage = .providerReverted
+                try await store.saveCheckpointRewind(confirmed)
+                try await finishRewind(confirmed, transcript: transcript, app: app, store: store)
+            } else {
+                // Provider retained the turn. Put files and staging back, keeping the transcript
+                // and draft intact. A provider lookup error never reaches this branch.
+                if let recovery = journal.recovery { try await Git.restoreSnapshot(recovery, in: transcript.cwd) }
+                var resolved = journal
+                resolved.stage = .complete
+                resolved.failure = nil
+                try await store.saveCheckpointRewind(resolved)
+                pendingRewind = nil
+                failure = nil
+                HistoryWorkspaceGate.shared.mark(workspace.id, unresolved: false)
+            }
+        } catch { failure = "Could not resolve the interrupted rewind: \(error)" }
+    }
+
+    private func finishRewind(_ journal: CheckpointRewind, transcript: TranscriptModel, app: AppModel, store: Store) async throws {
+        _ = try await store.completeTranscriptRewind(sessionID: transcript.session.id)
+        try await TurnCheckpointStore(store: store).removeAfter(
+            sessionID: transcript.session.id, seq: journal.checkpoint.startSeq, cwd: transcript.cwd
+        )
+        await transcript.reloadAfterRewind()
+        pendingRewind = nil
+        failure = nil
+        if let workspace = transcript.workspace {
+            HistoryWorkspaceGate.shared.mark(workspace.id, unresolved: false)
+        }
+    }
+
+    private func requireIdleWorkspace(transcript: TranscriptModel, app: AppModel, store: Store) async throws {
+        guard let workspace = transcript.workspace, !app.isArchiving(workspace.id) else { throw ConversationRewindError.busy }
+        let sessions = try await store.sessions(workspaceID: workspace.id)
+        let model = app.existingModel(for: workspace.id)
+        guard model?.isRunningSetup != true else { throw ConversationRewindError.busy }
+        for session in sessions {
+            let live = model?.existingTranscript(for: session.id)
+            guard !session.state.isMidTurn, live?.isRunning != true, live?.isAwaitingPermission != true, live?.sending == nil,
+                  live?.backgroundWork == nil, live?.subagents.isWorking != true,
+                  live?.history.isCapturing != true, live?.history.isFinalisingTurn != true, live?.history.hasActiveTurn != true,
+                  try await store.pendingDeliveries(sessionID: session.id).isEmpty else {
+                throw ConversationRewindError.busy
+            }
+        }
+    }
+
+    private func requireAttachments(_ prompt: String, cwd: String) throws {
+        for path in AttachmentDraft.parse(prompt).paths {
+            guard FileManager.default.fileExists(atPath: PromptAttachment.sent(path: path).url(in: cwd).path) else {
+                throw SnapshotFailure("An attachment from this message is missing: \(path)")
+            }
+        }
+    }
+}

--- a/Sources/Bloom/State/TranscriptModel.swift
+++ b/Sources/Bloom/State/TranscriptModel.swift
@@ -69,6 +69,7 @@ final class TranscriptModel {
     }
 
     var session: Session
+    let history = TranscriptHistory()
     /// The workspace as it was when this model was made, or nil for a chat that is in none.
     ///
     /// **Nil is Ask Bloom and nothing else today.** Its id and path are stable and are what most
@@ -305,7 +306,13 @@ final class TranscriptModel {
 
     func focusComposer() { composerFocusRequests += 1 }
 
+    private var isReconcilingPresentation = false
+    private var isReplayingPastTurn = false
+    private var presentationMessageSeq: Int?
+    private var dispatchingDeliveryID: DeliveryID?
+    private var activeInteractionMode: InteractionMode?
     private var runner: (any SessionRunner)?
+    @ObservationIgnored private var idleEvictionTask: Task<Void, Never>?
 
     func codexSubagentTranscript(for id: SubagentID) async -> SubagentTranscript? {
         guard let codex = runner as? CodexRunner else { return nil }
@@ -354,6 +361,48 @@ final class TranscriptModel {
     }
 
     private var store: Store? { app.store }
+
+    private var historyWorkspaceHeld: Bool {
+        workspace.map { HistoryWorkspaceGate.shared.holds($0.id) } ?? false
+    }
+
+    private func historyBlocksSending() async -> Bool {
+        if historyWorkspaceHeld { return true }
+        guard let store, let workspace else { return false }
+        do {
+            guard let journal = try await store.pendingCheckpointRewind(workspaceID: workspace.id) else { return false }
+            HistoryWorkspaceGate.shared.mark(workspace.id, unresolved: true)
+            history.blockingSessionID = journal.checkpoint.sessionID
+            history.failure = "Resolve the interrupted rewind in its conversation before sending more messages."
+            if journal.checkpoint.sessionID == session.id { history.pendingRewind = journal }
+            return true
+        } catch {
+            history.failure = "Could not check the workspace's rewind state: \(error)"
+            return true
+        }
+    }
+
+    func providerContainsTurn(_ turnID: String) async throws -> Bool {
+        guard let runner = ensureRunner(), runner.supportsConversationRewind else { throw ConversationRewindError.unsupported }
+        return try await runner.containsTurn(turnID)
+    }
+
+    func rewindProvider(beforeTurnID: String) async throws {
+        guard let runner = ensureRunner(), runner.supportsConversationRewind else { throw ConversationRewindError.unsupported }
+        try await runner.rewind(beforeTurnID: beforeTurnID)
+    }
+
+    func reloadAfterRewind() async {
+        guard let store else { return }
+        wasStoppedByHand = true
+        sending = nil
+        steering = nil
+        clearStreaming()
+        await read(from: store)
+        await refreshSession()
+        PromptAttachmentStore.shared.restoreDraftAttachments(draft, sessionID: session.id.rawValue)
+        composerFocusRequests += 1
+    }
 
     // MARK: - Loading
 
@@ -440,6 +489,8 @@ final class TranscriptModel {
         // start a paid turn on a Mac nobody is sitting at, so it is shown as pending and goes with
         // the owner's next message. See `DeliveryHold.none`.
         await refreshQueue()
+        await history.load(store: store, sessionID: session.id, workspaceID: workspace?.id)
+        if workspace != nil { await history.cleanupRetired(store: store, sessionID: session.id, cwd: cwd) }
         isLoaded = true
     }
 
@@ -566,6 +617,7 @@ final class TranscriptModel {
         model: String? = nil,
         effort: String? = nil,
         permissionMode: PermissionMode? = nil,
+        interactionMode: InteractionMode? = nil,
         implementationMode: PermissionMode? = nil,
         agentKind: AgentKind? = nil
     ) async {
@@ -576,6 +628,7 @@ final class TranscriptModel {
             model: model,
             effort: effort,
             permissionMode: permissionMode,
+            interactionMode: interactionMode,
             implementationMode: implementationMode,
             agentKind: agentKind
         )
@@ -615,10 +668,12 @@ final class TranscriptModel {
     /// screen from the frame the key went down, in the state `Delivery.goesImmediately` says it is
     /// in: as a sent bubble if nothing is holding the queue, as a pending one if something is. See
     /// `sending`.
-    func submit(_ text: String, clearingDraft sourceDraft: String? = nil) async {
-        guard !isWorkspaceArchiving else { return }
+    @discardableResult
+    func submit(_ text: String, clearingDraft sourceDraft: String? = nil,
+                interactionMode: InteractionMode? = nil, sourcePlan: PlanArtefact? = nil) async -> Bool {
+        guard !isWorkspaceArchiving else { return false }
         let body = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !body.isEmpty, let store else { return }
+        guard !body.isEmpty, let store else { return false }
 
         // Review payloads expand compact chips into comments. Clear the source draft, while
         // retaining anything the reader typed after that payload began being prepared.
@@ -628,9 +683,9 @@ final class TranscriptModel {
         // Built here rather than inside the enqueue, so the row that goes in the table and the
         // bubble that goes on screen are one object with one id. Drawn twice under two ids is the
         // duplicate that would appear the moment the queue was read back.
-        let delivery = Delivery(targetSessionID: session.id, body: body)
+        let delivery = Delivery(targetSessionID: session.id, body: body, interactionMode: interactionMode ?? session.interactionMode)
         messageArrivals.sent(delivery.id)
-        if queuesNextMessage {
+        if queuesNextMessage || (isRunning && delivery.interactionMode != activeInteractionMode) {
             pendingDeliveries.append(delivery)
         } else {
             sending = delivery
@@ -654,7 +709,7 @@ final class TranscriptModel {
         jumpToLiveEnd()
 
         do {
-            _ = try await store.enqueueDelivery(delivery, clearingDraftMatching: submittedDraft)
+            _ = try await store.enqueueDelivery(delivery, clearingDraftMatching: submittedDraft, sourcePlan: sourcePlan)
         } catch {
             // The bubble was drawn on the promise that this would be queued. It was not, so the
             // promise is taken back rather than left on screen next to a message that is never
@@ -671,7 +726,7 @@ final class TranscriptModel {
                 title: "Could not queue the message",
                 message: TranscriptStanding.complaint(about: error)
             )
-            return
+            return false
         }
 
         // Not from `drain`, and not before the enqueue. The owner saying something is the moment a
@@ -679,6 +734,7 @@ final class TranscriptModel {
         // moves from the front rather than from what was just typed.
         wasStoppedByHand = false
         await drain()
+        return true
     }
 
     /// Why the queue in front of this chat is not moving, which is both the drain's condition and
@@ -707,7 +763,9 @@ final class TranscriptModel {
     /// question the moment a running turn stopped holding the queue on two of the four backends:
     /// the tooltip went on offering to queue a message that was about to go straight out.
     var queuesNextMessage: Bool {
-        !Delivery.goesImmediately(
+        if history.isCapturing || history.isFinalisingTurn || (history.hasActiveTurn && !isRunning) || historyWorkspaceHeld { return true }
+        if isRunning, session.interactionMode != activeInteractionMode { return true }
+        return !Delivery.goesImmediately(
             behind: pendingDeliveries, hold: deliveryHold, on: session.agentKind
         )
     }
@@ -717,7 +775,17 @@ final class TranscriptModel {
     /// Here rather than in the row because it needs the chat's backend, which the row has no
     /// business knowing, and because a caption that disagrees with the drain is the one thing this
     /// queue may not do: both read `DeliveryHold`. See `DeliveryHold.sentence(on:)`.
-    var holdSentence: String? { deliveryHold.sentence(on: session.agentKind) }
+    var holdSentence: String? {
+        if historyWorkspaceHeld { return "Resolve the interrupted rewind before sending more messages." }
+        if history.isCapturing || history.isFinalisingTurn { return "Saving this turn's file changes." }
+        if pendingDeliveries.first?.state == .uncertain {
+            return "Bloom could not confirm delivery. Check the conversation before sending again."
+        }
+        if isRunning, let mode = pendingDeliveries.first?.interactionMode, mode != activeInteractionMode {
+            return "Goes when this turn ends."
+        }
+        return deliveryHold.sentence(on: session.agentKind)
+    }
 
     /// Hands the queue to the agent, from the front, for as long as it is allowed to go.
     ///
@@ -737,6 +805,8 @@ final class TranscriptModel {
     /// for at that moment, and both are covered by the queue simply sitting there, visibly, until
     /// somebody says something.
     func drain() async {
+        guard !isReconcilingPresentation else { return }
+        guard !history.isCapturing, !history.isFinalisingTurn, !(history.hasActiveTurn && !isRunning), !(await historyBlocksSending()) else { return }
         guard !isWorkspaceArchiving, !wasStoppedByHand, store != nil else { return }
         guard drainState.begin() else { return }
         var allowRepeat = true
@@ -751,6 +821,7 @@ final class TranscriptModel {
         ) {
             guard !isWorkspaceArchiving, !wasStoppedByHand,
                   deliveryHold.allowsDelivery(on: session.agentKind) else { return }
+            if isRunning, let mode = next.interactionMode, mode != activeInteractionMode { return }
             // Deleted, or steered out, since the list was taken.
             guard pendingDeliveries.contains(where: { $0.id == next.id }) else { continue }
 
@@ -789,7 +860,7 @@ final class TranscriptModel {
     private func claimForDelivery(_ delivery: Delivery) async -> Bool {
         guard let store else { return false }
         do {
-            let claimed = try await store.markDelivered(id: delivery.id)
+            let claimed = try await store.claimDelivery(id: delivery.id)
             guard claimed else {
                 if sending?.id == delivery.id { sending = nil }
                 await refreshQueue()
@@ -815,13 +886,18 @@ final class TranscriptModel {
 
     /// Whether this delivery is at the front of an idle queue and can be attempted now.
     func canRetry(_ delivery: Delivery) -> Bool {
-        Delivery.next(
-            from: pendingDeliveries, hold: deliveryHold, on: session.agentKind
-        )?.id == delivery.id
+        pendingDeliveries.first?.id == delivery.id
+            && dispatchingDeliveryID != delivery.id && drainState == .idle
+            && deliveryHold.allowsDelivery(on: session.agentKind)
     }
 
     /// Attempts the front of the queue again without changing its order or duplicating its text.
     func retryPending() async {
+        guard let candidate = pendingDeliveries.first, canRetry(candidate) else { return }
+        if let first = pendingDeliveries.first, first.state == .uncertain {
+            do { try await store?.restoreDelivery(id: first.id) } catch { return }
+            await refreshQueue()
+        }
         wasStoppedByHand = false
         await drain()
     }
@@ -839,7 +915,7 @@ final class TranscriptModel {
     /// The words are `PendingMessageDiscard`'s, including the promise about where the sentence
     /// ends up, so the dialog cannot promise something this object then does not do.
     func askToDiscard(_ delivery: Delivery) {
-        guard PendingMessageDiscard.canDiscard(delivery) else { return }
+        guard dispatchingDeliveryID != delivery.id, PendingMessageDiscard.canDiscard(delivery) else { return }
         discarding = delivery
     }
 
@@ -850,6 +926,7 @@ final class TranscriptModel {
     /// whether the sentence can go back into it.
     func confirmDiscard(_ delivery: Delivery) async {
         discarding = nil
+        guard dispatchingDeliveryID != delivery.id else { return }
         guard let store else { return }
         let recovery = PendingMessageDiscard.recovery(of: delivery, composerDraft: draft)
         let removed = (try? await store.cancelDelivery(id: delivery.id)) ?? false
@@ -877,7 +954,7 @@ final class TranscriptModel {
     /// The join is worked out after the row is gone rather than before, so the words go in front
     /// of whatever the box holds by then rather than in front of what it held a round trip ago.
     func editPending(_ delivery: Delivery) async {
-        guard PendingMessageEdit.canEdit(delivery), let store else { return }
+        guard dispatchingDeliveryID != delivery.id, PendingMessageEdit.canEdit(delivery), let store else { return }
         let removed = (try? await store.cancelDelivery(id: delivery.id)) ?? false
         await refreshQueue()
 
@@ -1009,6 +1086,8 @@ final class TranscriptModel {
     /// on a backend that takes a message mid turn and must stop at the first that did not.
     @discardableResult
     private func deliver(_ delivery: Delivery) async -> Bool {
+        dispatchingDeliveryID = delivery.id
+        defer { if dispatchingDeliveryID == delivery.id { dispatchingDeliveryID = nil } }
         guard !isWorkspaceArchiving else {
             await abandon(delivery, saying: "The workspace is being archived.")
             return false
@@ -1020,6 +1099,10 @@ final class TranscriptModel {
         // disappearing without a word is not a thing to leave resting on that.
         guard let runner = ensureRunner() else {
             await abandon(delivery, saying: "Bloom could not open an agent for this chat.")
+            return false
+        }
+        guard !historyWorkspaceHeld else {
+            await abandon(delivery, saying: "Resolve the interrupted rewind before sending more messages.")
             return false
         }
         // The queue is moving, whether or not that begins a turn.
@@ -1034,6 +1117,7 @@ final class TranscriptModel {
         // `Delivery.deliverable(from:hold:on:)` for why a send arrives here at all.
         let startsATurn = !isRunning
         if startsATurn {
+            activeInteractionMode = delivery.interactionMode ?? session.interactionMode
             turnStartedAt = Date()
             hasReportedTurnEnded = false
             // **The clearing rule.** The last turn's FINISHED subagents go here, at the one place
@@ -1047,6 +1131,12 @@ final class TranscriptModel {
             subagents.turnStarted()
             setRunning(true)
             statusLabel = "Starting"
+            if let store, workspace != nil { await history.begin(delivery: delivery, store: store, cwd: cwd) }
+            guard !wasStoppedByHand else {
+                await abandon(delivery, saying: "Stopped before the message was sent.")
+                if let store { await history.finish(store: store, cwd: cwd, endSeq: highestSeenMessageSeq) }
+                return false
+            }
         }
 
         do {
@@ -1054,7 +1144,8 @@ final class TranscriptModel {
             // anything the owner typed and two different strings for a crew message: what the
             // model is handed is the envelope, and what the transcript draws is the words. See
             // `Delivery.sent` and `SessionRunner.send(_:recording:)`.
-            try await runner.send(delivery.sent, recording: delivery.crewPayload)
+            try await runner.sendDelivery(delivery)
+            if startsATurn, let store { await history.sent(delivery: delivery, store: store) }
             // The runner writes the user row as part of the send, and until this line nothing read
             // it back: the transcript only pulled rows on an agent event, so the owner's own
             // message did not appear until the answer did. Reading it here is what retires the
@@ -1062,10 +1153,19 @@ final class TranscriptModel {
             // of the sentence swap inside one synchronous pass and nothing on screen moves.
             await appendLatestMessages()
             return true
+        } catch ProviderIdleError.retired {
+            if self.runner === runner {
+                pumpTask?.cancel()
+                pumpTask = nil
+                self.runner = nil
+                runnerPreferences = nil
+            }
+            return await deliver(delivery)
         } catch {
             // Only what this call turned on. A send that failed into a turn somebody else started
             // must not report that turn as over: it is still running and still writing rows.
             if startsATurn {
+                if let store { await history.finish(store: store, cwd: cwd, endSeq: highestSeenMessageSeq) }
                 setRunning(false)
                 statusLabel = nil
             }
@@ -1105,7 +1205,7 @@ final class TranscriptModel {
             return
         }
 
-        try? await store.restoreDelivery(id: delivery.id)
+        try? await store.releaseDeliveryClaim(id: delivery.id)
         await refreshQueue()
 
         let row = AgentError.notStarted(message: complaint)
@@ -1232,6 +1332,8 @@ final class TranscriptModel {
     /// The session itself is going away, so the pump goes with it. The event stream never ends on
     /// its own, and a pump left iterating one holds its runner alive for the rest of the launch.
     func teardown() {
+        idleEvictionTask?.cancel()
+        idleEvictionTask = nil
         terminateNow()
         pumpTask?.cancel()
         pumpTask = nil
@@ -1244,6 +1346,8 @@ final class TranscriptModel {
     /// return happily on a Codex chat whose server was still very much alive: the interrupt landed,
     /// the turn closed, and nothing had ever been signalled.
     func shutdown() async {
+        idleEvictionTask?.cancel()
+        idleEvictionTask = nil
         guard let runner else { return }
         terminateNow()
 
@@ -1306,6 +1410,7 @@ final class TranscriptModel {
         )
         self.runner = runner
         runnerPreferences = preferences
+        startIdleEviction()
         if pumpTask == nil { startPump(on: runner) }
         return runner
     }
@@ -1353,13 +1458,159 @@ final class TranscriptModel {
         }
     }
 
+    private func startIdleEviction() {
+        guard idleEvictionTask == nil else { return }
+        idleEvictionTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do { try await Task.sleep(for: .seconds(60)) } catch { return }
+                guard let self else { return }
+                await evictIdleProvider()
+            }
+        }
+    }
+
+    private func evictIdleProvider() async {
+        guard let store, let current = runner, !isRunning, !isAwaitingPermission,
+              sending == nil, pendingDeliveries.isEmpty, !subagents.isWorking else { return }
+        let stored = try? await store.setting(ProviderIdlePolicy.settingKey)
+        guard let duration = ProviderIdlePolicy.duration(stored: stored),
+              let waiting = try? await store.pendingDeliveries(sessionID: session.id), waiting.isEmpty,
+              !isRunning, sending == nil else { return }
+        guard await current.evictIfIdle(for: duration), runner === current else { return }
+        pumpTask?.cancel()
+        pumpTask = nil
+        runner = nil
+        runnerPreferences = nil
+    }
+
     private func startPump(on runner: any SessionRunner) {
+        if let feed = runner.presentationFeed {
+            let baseline = feed.snapshot()
+            let subscriber = UUID()
+            let notifications = feed.notifications(id: subscriber, after: baseline.revision)
+            pumpTask = Task { [weak self] in
+                defer { feed.unsubscribe(subscriber) }
+                var cursor = baseline.revision
+                var pendingResult: AgentResult?
+                if baseline.revision > 0, let recovery = baseline.recovery, let self {
+                    await recoverPresentation(recovery, after: baseline.revision)
+                    setRunning(session.state.isMidTurn)
+                }
+                for await _ in notifications {
+                    guard let self, !Task.isCancelled else { return }
+                    let batch = feed.read(after: cursor)
+                    do {
+                        if let failure = batch.failure { throw PresentationFailure(message: failure) }
+                        let result = try await consumePresentation(batch, from: feed, after: cursor)
+                        pendingResult = result ?? pendingResult
+                        cursor = batch.revision
+                        await feed.acknowledgePage(subscriber: subscriber, through: cursor)
+                        // New lifecycle events may have arrived while checkpoints were saved.
+                        // Catch up before allowing any queued message to cross a turn boundary.
+                        let latest = feed.snapshot()
+                        guard latest.revision == cursor else { continue }
+                        if let event = latest.recovery?.stateEvent, case .error = event { pendingResult = nil }
+                        if AgentPresentationReconciliation.permitsAutomaticDrain(
+                            isCatchingUp: isReconcilingPresentation, isTurnRunning: isRunning || feed.isTurnRunning
+                        ), let result = pendingResult {
+                            pendingResult = nil
+                            await finishPresentationTurn(result)
+                        }
+                    } catch {
+                        runner.terminateNow()
+                        await handle(.error(AgentError(message: error.localizedDescription)))
+                        return
+                    }
+                }
+            }
+            return
+        }
         pumpTask = Task { [weak self] in
             for await event in runner.events {
                 guard let self else { return }
                 await self.handle(event)
             }
         }
+    }
+
+    private struct PresentationFailure: LocalizedError {
+        let message: String
+        var errorDescription: String? { message }
+    }
+
+    private func consumePresentation(
+        _ batch: AgentPresentationBatch, from feed: AgentPresentationFeed, after cursor: UInt64
+    ) async throws -> AgentResult? {
+        isReconcilingPresentation = true
+        defer {
+            isReconcilingPresentation = false
+            isReplayingPastTurn = false
+            presentationMessageSeq = nil
+        }
+        var result: AgentResult?
+        if let recovery = batch.recovery {
+            var lifecycleCursor = cursor
+            while true {
+                let page = try await feed.lifecyclePage(after: lifecycleCursor, through: batch.revision)
+                guard !page.isEmpty else { break }
+                for entry in page {
+                    isReplayingPastTurn = feed.hasLaterTurn(than: entry.revision)
+                    presentationMessageSeq = entry.messageSeq
+                    await handle(entry.event)
+                    if case .result(let terminal) = entry.event { result = terminal }
+                    lifecycleCursor = entry.revision
+                }
+            }
+            // Boundaries were replayed independently; never apply the latest boundary twice.
+            await recoverPresentation(recovery, after: batch.revision)
+        } else {
+            for index in batch.events.indices {
+                isReplayingPastTurn = feed.hasLaterTurn(than: batch.eventRevisions[index])
+                presentationMessageSeq = batch.messageSequences[index]
+                let event = batch.events[index]
+                await handle(event)
+                if case .result(let terminal) = event { result = terminal }
+            }
+        }
+        return result
+    }
+
+    private func finishPresentationTurn(_ result: AgentResult) async {
+        if let steered = steering {
+            steering = nil
+            wasStoppedByHand = false
+            await sendSteered(steered)
+        } else if !wasStoppedByHand { await drain() }
+        if !isRunning {
+            await reportToOrchestrator(CrewMessage.stopped(name: session.title, lastMessage: result.summary))
+        }
+    }
+
+    private func recoverPresentation(_ recovery: AgentPresentationRecovery, after cursor: UInt64) async {
+        // Rows and permission decisions are durable. Reload those first; the current live tail
+        // is a snapshot, so assigning it never loses or repeats individual text chunks.
+        await appendLatestMessages()
+        await refreshSession()
+        if let store {
+            let decisions = (try? await store.permissionAskDecisions(sessionID: session.id)) ?? [:]
+            for (id, decision) in decisions {
+                settle(PermissionResolution(requestID: id, decision: decision))
+            }
+        }
+        refreshAwaitingPermission()
+        subagents = recovery.subagents
+        if recovery.stateRevision > cursor, let event = recovery.stateEvent {
+            await handle(event)
+        }
+        clearStreaming()
+        streamingText = recovery.text
+        streamingThinking = recovery.thinking
+        streamingToolName = recovery.toolName
+        thinkingTokens = recovery.thinkingTokens
+        if let status = recovery.status { await handle(.status(status)) }
+        if let retry = recovery.retry { absorb(retry) }
+        if let quota = recovery.quota { await app.recordQuotas(AgentQuotaAdapters.quotas(fromRateLimitEvent: quota)) }
+        if isAwaitingPermission { statusLabel = "Waiting on you" }
     }
 
     // MARK: - Event handling
@@ -1430,6 +1681,7 @@ final class TranscriptModel {
             clearStreaming()
 
         case .error(let failure):
+            history.isFinalisingTurn = true
             // The agent died without ever producing a result: a model it does not know, expired
             // credentials, a crash. Nothing else will arrive, so the turn ends here or the composer
             // stays locked for the rest of the launch.
@@ -1445,6 +1697,7 @@ final class TranscriptModel {
             abandonRetryRun()
             clearStreaming()
             await appendLatestMessages()
+            if let store { await history.finish(store: store, cwd: cwd, endSeq: presentationMessageSeq ?? highestSeenMessageSeq, captureFiles: !isReplayingPastTurn) }
             setRunning(false)
             statusLabel = nil
             // The process is gone, so every subagent under it went with it and nothing is left to
@@ -1476,7 +1729,10 @@ final class TranscriptModel {
                 )
             }
 
+            history.isFinalisingTurn = false
+
         case .result(let result):
+            history.isFinalisingTurn = true
             // A turn that recovered leaves its sentence on the row that closes it; one that failed
             // leaves nothing, for the same reason as `.error` above.
             if result.succeeded { settleRetryRun() } else { abandonRetryRun() }
@@ -1485,6 +1741,7 @@ final class TranscriptModel {
             // After the append, deliberately: the row the sentence hangs under is the result row,
             // and it is not in `rows` until the read above has brought it back from the store.
             fileRecoveredRun()
+            if let store { await history.finish(store: store, cwd: cwd, endSeq: presentationMessageSeq ?? highestSeenMessageSeq, captureFiles: !isReplayingPastTurn) }
             setRunning(false)
             statusLabel = nil
             // **A result is not news about a subagent, and assuming it was is what hid them.**
@@ -1509,11 +1766,12 @@ final class TranscriptModel {
             // stopped in order to say this, so this is what goes, and the rest of the queue waits
             // as it was. Stop's own answer is not here at all, because it has already run: the
             // queue was handed back to the composer on the frame the button was pressed.
-            if let steered = steering {
+            history.isFinalisingTurn = false
+            if !isReconcilingPresentation, let steered = steering {
                 steering = nil
                 wasStoppedByHand = false
                 await sendSteered(steered)
-            } else if !wasStoppedByHand {
+            } else if !isReconcilingPresentation, !wasStoppedByHand {
                 await drain()
             }
             // After the drain, and only if nothing moved: a crew member whose orchestrator said
@@ -1522,7 +1780,7 @@ final class TranscriptModel {
             // is about to be superseded. `drain` is awaited to completion above, `runner.send` and
             // all, and `deliver` sets `isRunning` before that send, so by this line the flag is
             // already describing the turn that has just begun rather than the one that ended.
-            if !isRunning {
+            if !isReconcilingPresentation, !isRunning {
                 await reportToOrchestrator(
                     CrewMessage.stopped(name: session.title, lastMessage: result.summary)
                 )

--- a/Sources/Bloom/State/WorkspaceModel.swift
+++ b/Sources/Bloom/State/WorkspaceModel.swift
@@ -154,6 +154,10 @@ final class WorkspaceModel {
         set { WorkspacePullRequests.shared.set(newValue, for: workspace.id) }
     }
 
+    var pullRequestRefreshFailure: GitHubReadFailure? {
+        WorkspacePullRequests.shared.failure(for: workspace.id)
+    }
+
     var isLoadingPullRequest = false
     /// Whether any refresh has come back for this workspace this launch, whatever it said.
     ///
@@ -322,7 +326,7 @@ final class WorkspaceModel {
     private var arrivalTask: Task<Void, Never>?
 
     private var changesTask: Task<Result<ChangesAnswer, GitFailure>, Never>?
-    private var pullRequestTask: Task<PullRequest?, Never>?
+    private var pullRequestTask: Task<PullRequestRead, Never>?
     /// One repository settings read at a time. A request that arrives during a read is remembered,
     /// so the burst ends with one fresh read rather than silently keeping the older answer.
     @ObservationIgnored private var settingsRefresh = RefreshDemand()
@@ -451,6 +455,7 @@ final class WorkspaceModel {
             session.effort = controls.effort
             session.agentKind = controls.agentKind
             session.permissionMode = controls.permissionMode
+            session.interactionMode = controls.interactionMode
         }
         guard let stored = try? await store.upsert(session) else { return nil }
         if let controls { await controls.store(sessionID: stored.id, in: store) }
@@ -505,6 +510,10 @@ final class WorkspaceModel {
     /// Persist the replacement before stopping the old agent so a failed write leaves it usable.
     func replaceSession(_ session: Session, controls: ComposerControls) async -> Session? {
         guard !app.isArchiving(workspace.id), let store else { return nil }
+        guard !HistoryWorkspaceGate.shared.holds(workspace.id) else {
+            app.notice = BloomNotice(message: "Resolve the workspace's interrupted rewind before replacing a conversation.")
+            return nil
+        }
         do {
             let next = try await store.replaceWorkspaceConversation(id: session.id, controls: controls)
             transcripts.removeValue(forKey: session.id)?.teardown()
@@ -520,12 +529,21 @@ final class WorkspaceModel {
 
     func closeSession(_ session: Session) async {
         guard let store else { return }
+        guard !HistoryWorkspaceGate.shared.holds(workspace.id) else {
+            app.notice = BloomNotice(message: "Resolve the workspace's interrupted rewind before closing a conversation.")
+            return
+        }
+        do {
+            _ = try await store.update(sessionID: session.id) { $0.archivedAt = Date() }
+        } catch {
+            app.notice = BloomNotice(message: "Could not close the conversation: \(error.readableMessage)")
+            return
+        }
         transcripts[session.id]?.teardown()
         transcripts[session.id] = nil
         // Closing is one column. The strip's copy of this row can be a whole turn old, and the
         // runner has been writing the state, the counters and the agent session id into it all
         // the while.
-        _ = try? await store.update(sessionID: session.id) { $0.archivedAt = Date() }
         // The chat is over, so its bridge token is a token nothing may use again and the config
         // file carrying it is a dead letter. Nothing used to remove either, and the files are one
         // per session rather than one per instance, so they only ever grew.
@@ -1041,7 +1059,7 @@ final class WorkspaceModel {
             SettingsLoader.load(repo: repoPath)
         }.value
 
-        if workspace.setupState == .pending, settings.setupScript != nil {
+        if workspace.setupState == .pending, settings.setupScript != nil || Git.hasSubmodules(in: workspace.path) {
             let succeeded = await stream(setupIn: repo, through: manager)
 
             // Archiving or quitting cancels this task. Starting an agent in a worktree that is on
@@ -1144,8 +1162,29 @@ final class WorkspaceModel {
     /// Setup tab, and the two had already drifted: only one of them cleared the exit status, so a
     /// re-run after a failure drew a red cross over a log that was still being written.
     @discardableResult
-    private func stream(setupIn repo: Repo, through manager: WorkspaceManager) async -> Bool {
+    private func stream(
+        setupIn repo: Repo, through manager: WorkspaceManager, operationLease: WorkspaceOperationLease? = nil
+    ) async -> Bool {
+        guard !HistoryWorkspaceGate.shared.holds(workspace.id),
+              let lease = operationLease ?? WorkspaceOperationLease.acquire(in: workspace.path, operation: .setup),
+              lease.isValid(in: workspace.path, operation: .setup) else {
+            operationLease?.release()
+            if operationLease != nil { isRunningSetup = false }
+            app.notice = BloomNotice(message: "Resolve the workspace's rewind before running setup.")
+            return false
+        }
         isRunningSetup = true
+        defer { isRunningSetup = false; lease.release() }
+        do {
+            guard let store = app.store,
+                  try await store.pendingCheckpointRewind(workspaceID: workspace.id) == nil else {
+                app.notice = BloomNotice(message: "Resolve the interrupted rewind before running setup.")
+                return false
+            }
+        } catch {
+            if !Task.isCancelled { app.notice = BloomNotice(message: "Bloom could not check this workspace's rewind state. Setup did not start.") }
+            return false
+        }
         setupWasStopped = false
         setupStartedAt = .now
         setupDurationMS = nil
@@ -1173,7 +1212,7 @@ final class WorkspaceModel {
         let port = port
         let run = Task {
             await manager.runSetup(
-                workspace: workspace, repo: repo, port: port,
+                workspace: workspace, repo: repo, port: port, operationLease: lease,
                 onExit: { [weak self] status in
                     Task { @MainActor in self?.setupExitStatus = status }
                 }
@@ -1208,7 +1247,7 @@ final class WorkspaceModel {
     /// that there is no script here to run.
     var setupRunOffer: SetupRunOffer? {
         SetupRunOffer.offer(
-            hasSetupScript: repo != nil && settings.setupScript != nil,
+            hasSetupScript: repo != nil && (settings.setupScript != nil || Git.hasSubmodules(in: workspace.path)),
             hasRunSetup: hasRunSetup,
             isRunning: isRunningSetup
         )
@@ -1244,13 +1283,19 @@ final class WorkspaceModel {
     /// Through the same `setupTask` the first run uses, so archiving or quitting stops a
     /// `composer install` started from here exactly as it stops one started at creation.
     func runSetupAgain() {
-        guard !app.isArchiving(workspace.id), canRunSetup, let repo, let manager = app.manager else { return }
+        guard !app.isArchiving(workspace.id), !HistoryWorkspaceGate.shared.holds(workspace.id),
+              canRunSetup, let repo, let manager = app.manager,
+              let lease = WorkspaceOperationLease.acquire(in: workspace.path, operation: .setup) else { return }
+        // The scheduled task has not run yet. Reserve now so a rewind cannot pass its idle
+        // check in the interval between this button action and the task's first instruction.
+        isRunningSetup = true
         setupTask?.cancel()
         setupGeneration += 1
         let generation = setupGeneration
         setupTask = Task { [weak self] in
-            await self?.stream(setupIn: repo, through: manager)
-            guard let self, self.setupGeneration == generation else { return }
+            guard let self else { lease.release(); return }
+            await self.stream(setupIn: repo, through: manager, operationLease: lease)
+            guard self.setupGeneration == generation else { return }
             self.setupTask = nil
         }
     }
@@ -1920,7 +1965,7 @@ final class WorkspaceModel {
         let asked = workspace
 
         let task = Task.detached(priority: .utility) {
-            await GitHubBridge.pullRequest(for: asked, maxAge: maxAge)
+            await GitHubBridge.readPullRequest(for: asked, maxAge: maxAge)
         }
         pullRequestTask = task
         // Only before there has been any answer at all, for the same reason the changed file list
@@ -1932,7 +1977,7 @@ final class WorkspaceModel {
             isLoadingPullRequest = true
         }
 
-        let fresh = await task.value
+        let read = await task.value
 
         guard pullRequestTask == task, !task.isCancelled else { return }
         pullRequestTask = nil
@@ -1940,16 +1985,14 @@ final class WorkspaceModel {
         // workspace having been looked at, and the next refresh has an answer on screen to leave
         // alone. Only a superseded or cancelled refresh, which returns above, says nothing.
         hasReadPullRequest = true
-        // A nil is not written, and that is the rule the shared cache has always had: nil is "gh
-        // could not answer" at least as often as it is "there is no pull request", so a slow
-        // network or a rate limit would otherwise drop the mark back to a plain branch.
-        //
-        // It matters more now than it did. This used to write into a copy only the inspector
-        // read; it writes into the one cache the sidebar glyph, the Home rail and the title bar
-        // strip all read, so a nil from this poll would clear the mark in four places at once.
-        // The deliberate clear is `WorkspacePullRequests.forget`, which `adopt` calls when a
-        // merge moves the worktree to a fresh branch.
-        if let fresh, pullRequest != fresh { pullRequest = fresh }
+        // Failed refreshes retain the last good content. An explicit no-PR answer can now
+        // clear it, because the read result distinguishes absence from an unavailable service.
+        WorkspacePullRequests.shared.record(read, for: workspace.id)
+        guard case .current(let current) = read else {
+            isLoadingPullRequest = false
+            return
+        }
+        let fresh = current
         // The number, written where a deleted branch cannot take it. This is the path the band
         // polls on, so it is the one that fills the column in for a workspace whose pull request
         // an agent opened rather than the create sheet. See `Workspace.pullRequestNumber`.

--- a/Sources/Bloom/Views/Center/Attachments/PromptAttachmentStore.swift
+++ b/Sources/Bloom/Views/Center/Attachments/PromptAttachmentStore.swift
@@ -69,6 +69,16 @@ final class PromptAttachmentStore {
 
     // MARK: - Writing
 
+    func restoreDraftAttachments(_ draft: String, sessionID: String) {
+        load(sessionID: sessionID)
+        var restored = attachments(for: sessionID)
+        var paths = Set(restored.map(\.path))
+        for path in AttachmentDraft.parse(draft).paths where paths.insert(path).inserted {
+            restored.append(.sent(path: path))
+        }
+        apply(restored, to: sessionID)
+    }
+
     /// What one batch of attaching came to: the records it made, the paths to write into the
     /// sentence, and the sentences for the ones it could not.
     struct Added: Sendable {

--- a/Sources/Bloom/Views/Center/Composer/ComposerFooterView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerFooterView.swift
@@ -223,8 +223,24 @@ struct ComposerFooterView: View {
                     onOutputStyle: { id in edit { $0.outputStyle = id } },
                     onPermissionMode: selectPermissionMode,
                     onFastMode: { value in edit { $0.isFastMode = value } },
-                    onContextWindow: { tokens in edit { $0.codexContextWindow = tokens } }
+                    onContextWindow: { tokens in edit { $0.codexContextWindow = tokens } },
+                    onInteractionMode: { mode in edit { $0.interactionMode = mode } }
                 )
+            }
+
+            if showsAgentControls, controls.offersInteractionMode {
+                Button {
+                    edit { $0.interactionMode = controls.interactionMode == .plan ? .build : .plan }
+                } label: {
+                    Text(controls.interactionMode.label).font(Typo.label)
+                }
+                .buttonStyle(.plain)
+                .disabled(!ComposerPlanningSupport.shared.isAvailable && controls.interactionMode == .build)
+                .help(ComposerPlanningSupport.shared.isAvailable
+                    ? (controls.interactionMode == .plan ? "Switch to building" : "Plan before implementing")
+                    : CodexPlanningCapability.explanation)
+                .accessibilityLabel("Interaction mode")
+                .accessibilityValue(controls.interactionMode.label)
             }
 
             if intent != .create {

--- a/Sources/Bloom/Views/Center/Composer/ComposerModelCatalog.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerModelCatalog.swift
@@ -30,6 +30,7 @@ final class ComposerModelCatalog {
     }
 
     func configure(store: Store) {
+        Task { await ComposerPlanningSupport.shared.refresh(from: store) }
         sources = AgentModelSource.live(store: store)
         refresh()
     }

--- a/Sources/Bloom/Views/Center/Composer/ComposerPlanningSupport.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerPlanningSupport.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Observation
+import BloomCore
+
+@MainActor
+@Observable
+final class ComposerPlanningSupport {
+    static let shared = ComposerPlanningSupport()
+    private(set) var isAvailable = true
+    private(set) var isChecking = false
+    @ObservationIgnored private var store: Store?
+    @ObservationIgnored private var revision = 0
+
+    func refresh(from store: Store) async {
+        self.store = store
+        guard !isChecking else { return }
+        let revision = self.revision
+        do {
+            let available = try await store.setting(CodexPlanningCapability.unavailableKey) != "1"
+            guard revision == self.revision, !isChecking else { return }
+            if isAvailable != available { isAvailable = available }
+        } catch {
+            // A failed preference read is not evidence about the provider's capabilities.
+            // Retain the last known answer until the next transcript-driven refresh.
+        }
+    }
+
+    /// A retry is explicit and only resets discovery. It never sends a prompt or starts a turn.
+    func checkAgain() async {
+        guard let store, !isChecking else { return }
+        isChecking = true
+        revision += 1
+        defer { isChecking = false }
+        do {
+            try await store.setSetting(CodexPlanningCapability.rescanKey, UUID().uuidString)
+            try await store.setSetting(CodexPlanningCapability.unavailableKey, nil)
+            isAvailable = true
+        } catch { isAvailable = false }
+    }
+}

--- a/Sources/Bloom/Views/Center/Composer/ComposerPlansView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerPlansView.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+import BloomCore
+
+/// The saved revision is the handoff, so later refinements cannot rewrite an implementation's
+/// source. Loading follows persisted transcript arrivals rather than individual streaming tokens.
+struct ComposerPlansView: View {
+    @Bindable var transcript: TranscriptModel
+    var model: WorkspaceModel?
+    var controls: ComposerControls
+    @Environment(AppModel.self) private var app
+    @State private var plans: [PlanArtefact] = []
+    @State private var source: PlanArtefact?
+    @State private var selectedID: PlanArtefactID?
+    @State private var preview: PlanArtefact?
+    @State private var isSubmitting = false
+
+    private var selected: PlanArtefact? {
+        plans.first { $0.id == selectedID } ?? plans.last
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
+            if let source {
+                Button("From plan revision \(source.version)") { preview = source }
+                    .buttonStyle(.plain)
+                    .font(Typo.caption)
+            }
+            if let plan = selected {
+                HStack(spacing: Metrics.spacing) {
+                    Button { preview = plan } label: {
+                        Text(plan.title).lineLimit(1).truncationMode(.tail)
+                    }
+                    .buttonStyle(.plain)
+                    Picker("Plan revision", selection: Binding(
+                        get: { plan.id }, set: { selectedID = $0 }
+                    )) {
+                        ForEach(plans) { item in
+                            Text("Revision \(item.version)").tag(item.id)
+                        }
+                    }
+                    .labelsHidden()
+                    .fixedSize()
+                }
+                .font(Typo.label)
+
+                if !transcript.isRunning && !transcript.isAwaitingPermission {
+                    HStack(spacing: Metrics.spacing) {
+                        Button("Refine") { refine() }
+                            .disabled(!transcript.draft.contains { !$0.isWhitespace } || isSubmitting
+                                || (transcript.session.agentKind == .codex && !ComposerPlanningSupport.shared.isAvailable))
+                            .help("Send the draft as a refinement of this plan")
+                        Button("Implement") { implement(plan, inNewConversation: false) }
+                            .disabled(isSubmitting)
+                        if model != nil {
+                            Button("Implement in New Chat") { implement(plan, inNewConversation: true) }
+                                .disabled(isSubmitting)
+                        }
+                    }
+                    .font(Typo.label)
+                }
+            }
+        }
+        .padding(plans.isEmpty && source == nil ? 0 : Metrics.spacingSmall)
+        .task(id: "\(transcript.session.id):\(transcript.rows.last?.seq ?? -1):\(transcript.isRunning):\(transcript.pendingDeliveries.last?.id.rawValue ?? "")") {
+            await load()
+        }
+        .sheet(item: $preview) { plan in
+            VStack(alignment: .leading, spacing: Metrics.spacing) {
+                HStack {
+                    Text("Plan revision \(plan.version)").font(Typo.label)
+                    Spacer()
+                    if let model, model.sessions.contains(where: { $0.id == plan.sessionID }) {
+                        Button("Open Source Chat") {
+                            WorkspaceTabsStore.shared.reveal(.chat(plan.sessionID), in: model)
+                            preview = nil
+                        }
+                    }
+                    Button("Done") { preview = nil }.keyboardShortcut(.cancelAction)
+                }
+                ScrollView { MarkdownView(plan.markdown).frame(maxWidth: .infinity, alignment: .leading) }
+                    .textSelection(.enabled)
+            }
+            .padding(Metrics.gutter)
+            .frame(width: 640, height: 520)
+        }
+    }
+
+    private func load() async {
+        guard let store = app.store else { return }
+        let sessionID = transcript.session.id
+        do {
+            let loaded = try await store.planArtefacts(sessionID: sessionID)
+            let origin = try await store.sourcePlan(sessionID: sessionID)
+            guard !Task.isCancelled, transcript.session.id == sessionID else { return }
+            plans = loaded
+            source = origin
+        } catch {
+            guard !Task.isCancelled else { return }
+            app.notice = BloomNotice(message: "Could not load saved plans: \(error.localizedDescription)")
+        }
+    }
+
+    private func refine() {
+        guard let plan = selected else { return }
+        let draft = transcript.draft
+        guard draft.contains(where: { !$0.isWhitespace }) else { return }
+        isSubmitting = true
+        Task { @MainActor in
+            defer { isSubmitting = false }
+            if !InteractionMode.supports(transcript.session.agentKind) {
+                await transcript.updatePreferences(permissionMode: .plan)
+            }
+            let text = "Refine this plan without implementing it:\n\n\(plan.markdown)\n\nRequested changes:\n\(draft)"
+            _ = await transcript.submit(text, clearingDraft: draft, interactionMode: .plan)
+        }
+    }
+
+    private func implement(_ plan: PlanArtefact, inNewConversation: Bool) {
+        guard !isSubmitting, !transcript.isRunning, !transcript.isAwaitingPermission else { return }
+        isSubmitting = true
+        let origin = transcript
+        var chosen = controls
+        chosen.interactionMode = .build
+        Task { @MainActor in
+            defer { isSubmitting = false }
+            guard let store = app.store else { return }
+            // Claude's legacy Plan permission must become the user's chosen implementation
+            // permission. Codex's independent permission value passes through unchanged.
+            if chosen.permissionMode == .plan {
+                chosen.permissionMode = (try? await store.planImplementationMode(
+                    sessionID: origin.session.id, hasWorktree: origin.session.workspaceID != nil
+                )) ?? .acceptEdits
+            }
+            let destination: TranscriptModel
+            if inNewConversation {
+                guard let model, let session = await model.createSession(
+                    title: "Implement \(plan.title)", controls: chosen
+                ) else {
+                    app.notice = BloomNotice(message: "Could not create the implementation conversation.")
+                    return
+                }
+                destination = model.transcript(for: session)
+                await destination.load()
+                WorkspaceTabsStore.shared.reveal(.chat(session.id), in: model)
+            } else {
+                destination = origin
+            }
+            await destination.updatePreferences(
+                permissionMode: chosen.permissionMode, interactionMode: .build
+            )
+            guard await destination.submit(plan.implementationPrompt, interactionMode: .build, sourcePlan: plan) else { return }
+            await load()
+        }
+    }
+}

--- a/Sources/Bloom/Views/Center/Composer/ComposerSessionEditor.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerSessionEditor.swift
@@ -31,6 +31,7 @@ struct ComposerSessionEditor {
                 model: session.model,
                 effort: session.effort,
                 permissionMode: session.permissionMode,
+                interactionMode: session.interactionMode,
                 implementationMode: implementationMode,
                 agentKind: session.agentKind
             )

--- a/Sources/Bloom/Views/Center/Composer/ComposerSettingsPicker.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerSettingsPicker.swift
@@ -19,6 +19,7 @@ struct ComposerSettingsPicker: View {
     var onPermissionMode: @MainActor (String) -> Void
     var onFastMode: @MainActor (Bool) -> Void
     var onContextWindow: @MainActor (Int) -> Void
+    var onInteractionMode: @MainActor (InteractionMode) -> Void = { _ in }
 
     @State private var isOpen = false
 
@@ -49,7 +50,8 @@ struct ComposerSettingsPicker: View {
                 onOutputStyle: onOutputStyle,
                 onPermissionMode: onPermissionMode,
                 onFastMode: onFastMode,
-                onContextWindow: onContextWindow
+                onContextWindow: onContextWindow,
+                onInteractionMode: onInteractionMode
             )
             .environment(\.fontScale, 1)
         }
@@ -79,6 +81,7 @@ private struct ComposerSettingsPanel: View {
     var onPermissionMode: @MainActor (String) -> Void
     var onFastMode: @MainActor (Bool) -> Void
     var onContextWindow: @MainActor (Int) -> Void
+    var onInteractionMode: @MainActor (InteractionMode) -> Void = { _ in }
 
     private static let width: CGFloat = 300
 
@@ -98,6 +101,29 @@ private struct ComposerSettingsPanel: View {
                             options: outputStyles,
                             onSelect: onOutputStyle
                         )
+                    }
+                }
+
+                if controls.offersInteractionMode {
+                    settingRow("Work mode") {
+                        if ComposerPlanningSupport.shared.isAvailable {
+                            optionPicker(
+                                "Work mode", selection: controls.interactionMode.rawValue,
+                                options: InteractionMode.allCases.map { ComposerOption(id: $0.rawValue, label: $0.label) },
+                                onSelect: { value in
+                                    if let mode = InteractionMode(rawValue: value) { onInteractionMode(mode) }
+                                }
+                            )
+                        } else if controls.interactionMode == .plan {
+                            Button("Use Build") { onInteractionMode(.build) }
+                        } else {
+                            Text("Build")
+                        }
+                    }
+                    if !ComposerPlanningSupport.shared.isAvailable {
+                        Text(CodexPlanningCapability.explanation).font(Typo.caption)
+                        Button("Check Again") { Task { await ComposerPlanningSupport.shared.checkAgain() } }
+                            .disabled(ComposerPlanningSupport.shared.isChecking)
                     }
                 }
 

--- a/Sources/Bloom/Views/Center/Composer/ComposerView.swift
+++ b/Sources/Bloom/Views/Center/Composer/ComposerView.swift
@@ -87,6 +87,8 @@ struct ComposerView: View {
             )
             .help("Drag to resize. Double-click to fit the text.")
 
+            TurnHistoryNotice(transcript: transcript)
+            ComposerPlansView(transcript: transcript, model: model, controls: controls)
             composer
         }
         // The chrome is whatever is left once the editor's share is taken off, so this settles on
@@ -153,6 +155,9 @@ struct ComposerView: View {
             )
         }
         .task(id: transcript.session.id) { await prepare() }
+        .task(id: "planning:\(transcript.session.id):\(transcript.rows.last?.seq ?? -1)") {
+            if let store = app.store { await ComposerPlanningSupport.shared.refresh(from: store) }
+        }
         .onChange(of: transcript.draft) { _, _ in scheduleDraftSave() }
         // Something put words in the box for the owner to carry on writing, which today is Edit on
         // a queued message. The caret goes to the start rather than the end, because the words that
@@ -308,6 +313,7 @@ struct ComposerView: View {
             || new.effort != session.effort
             || new.agentKind != session.agentKind
             || new.permissionMode != session.permissionMode
+            || new.interactionMode != session.interactionMode
         else { return }
 
         sessionEditor.apply {
@@ -315,6 +321,7 @@ struct ComposerView: View {
             $0.effort = new.effort
             $0.agentKind = new.agentKind
             $0.permissionMode = new.permissionMode
+            $0.interactionMode = new.interactionMode
         }
     }
 
@@ -771,7 +778,8 @@ struct ComposerView: View {
         if session.model != resolved.model
             || session.effort != resolved.effort
             || session.agentKind != resolved.backend
-            || session.permissionMode != resolved.permissionMode {
+            || session.permissionMode != resolved.permissionMode
+            || session.interactionMode != resolved.interactionMode {
             // The backend moves with the model, and it can only move here: this runs once, before
             // the chat has said anything, so there is no transcript in the old backend's
             // vocabulary and no thread on its server to strand. A chat that has spoken forks
@@ -781,6 +789,7 @@ struct ComposerView: View {
                 $0.effort = resolved.effort
                 $0.agentKind = resolved.backend
                 $0.permissionMode = resolved.permissionMode
+                $0.interactionMode = resolved.interactionMode
             }
         }
 

--- a/Sources/Bloom/Views/Center/Composer/TurnHistoryNotice.swift
+++ b/Sources/Bloom/Views/Center/Composer/TurnHistoryNotice.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import BloomCore
+
+struct TurnHistoryNotice: View {
+    var transcript: TranscriptModel
+    @Environment(AppModel.self) private var app
+    @State private var confirmsRecovery = false
+
+    var body: some View {
+        if transcript.history.pendingRewind != nil {
+            VStack(alignment: .leading, spacing: Metrics.spacingSmall) {
+                Text("A rewind needs recovery before this workspace can continue.")
+                    .font(Typo.label)
+                if let failure = transcript.history.failure { Text(failure).font(Typo.caption).textSelection(.enabled) }
+                Button("Resolve Rewind") { confirmsRecovery = true }
+                    .disabled(transcript.history.isRewinding)
+            }
+            .padding(Metrics.spacingSmall)
+            .alert("Resolve the interrupted rewind?", isPresented: $confirmsRecovery) {
+                Button("Cancel", role: .cancel) {}
+                Button("Resolve Rewind") {
+                    Task { await transcript.history.recover(transcript: transcript, app: app) }
+                }
+            } message: {
+                Text("Bloom checks the agent's history, then completes the rewind or restores the saved files and staging. Later file edits may be replaced. Stop terminal commands first.")
+            }
+        } else if let failure = transcript.history.failure {
+            HStack(alignment: .top, spacing: Metrics.spacing) {
+                Text(failure).font(Typo.caption).textSelection(.enabled)
+                Spacer(minLength: 0)
+                if let id = transcript.history.blockingSessionID, let workspace = transcript.workspace,
+                   let model = app.existingModel(for: workspace.id) {
+                    Button("Open Recovery Chat") { WorkspaceTabsStore.shared.reveal(.chat(id), in: model) }
+                } else {
+                    Button("Dismiss") { transcript.history.failure = nil }
+                }
+            }
+            .padding(Metrics.spacingSmall)
+        }
+    }
+}

--- a/Sources/Bloom/Views/Center/Panes/ToolPaneView.swift
+++ b/Sources/Bloom/Views/Center/Panes/ToolPaneView.swift
@@ -35,6 +35,7 @@ struct ToolPaneView: View {
 
     /// Read for the setup strip's slide. See the `.animation` in `body`.
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(AppModel.self) private var app
 
     var body: some View {
         switch tab.kind {
@@ -54,7 +55,9 @@ struct ToolPaneView: View {
                             port: model.port,
                             directory: tab.directory,
                             onCloseTab: { Task { await CenterTabStore.shared.close(tab) } },
-                            splitColumn: splitColumn
+                            splitColumn: splitColumn,
+                            terminalLabel: tab.title,
+                            onAddToChat: terminalHandoff
                         )
                         .id(tab.id)
                     } else {
@@ -104,6 +107,18 @@ struct ToolPaneView: View {
             isRunningSetup: model.isRunningSetup,
             setupState: model.workspace.setupState
         )
+    }
+
+    private var terminalHandoff: (@MainActor (TerminalExcerpt) -> Void)? {
+        guard let sessionID = model.activeSession?.id else { return nil }
+        let destination = model
+        return { excerpt in
+            Task { @MainActor in
+                if let failure = await TerminalExcerptHandoff.attach(excerpt, to: destination, sessionID: sessionID) {
+                    app.notice = BloomNotice(message: failure)
+                }
+            }
+        }
     }
 
     /// The store a shell's environment is built from, and the workspace's port, which is the one

--- a/Sources/Bloom/Views/Chrome/Settings/AgentsSettingsView.swift
+++ b/Sources/Bloom/Views/Chrome/Settings/AgentsSettingsView.swift
@@ -29,6 +29,7 @@ struct AgentsSettingsView: View {
 
     var body: some View {
         Form {
+            ProviderIdleSettingsSection()
             Section {
                 // Plain labels. A segmented control paints its own text colour and takes either a
                 // title or an image per segment, so a coloured state dot cannot ride along inside

--- a/Sources/Bloom/Views/Chrome/Settings/ProviderIdleSettingsSection.swift
+++ b/Sources/Bloom/Views/Chrome/Settings/ProviderIdleSettingsSection.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+import BloomCore
+
+struct ProviderIdleSettingsSection: View {
+    @Environment(AppModel.self) private var app
+    @State private var minutes = 0
+    @State private var loaded = false
+    @State private var failure: String?
+
+    var body: some View {
+        Section("Idle agents") {
+            Picker("Release idle processes", selection: $minutes) {
+                Text("Never").tag(0)
+                ForEach(ProviderIdlePolicy.choices.filter { $0 > 0 }, id: \.self) { value in
+                    Text("After \(value) minutes").tag(value)
+                }
+            }
+            Text("Conversations resume when you send again. Active work and waiting questions keep their processes. Codex may ask again for permissions granted only for the previous process.")
+                .font(Typo.caption)
+                .foregroundStyle(Palette.textSecondary)
+            if let failure { Text(failure).foregroundStyle(.red) }
+        }
+        .task {
+            let stored = try? await app.store?.setting(ProviderIdlePolicy.settingKey)
+            let value = stored.flatMap(Int.init) ?? 0
+            minutes = ProviderIdlePolicy.choices.contains(value) ? value : 0
+            loaded = true
+        }
+        .onChange(of: minutes) { _, value in
+            guard loaded else { return }
+            Task {
+                do {
+                    try await app.store?.setSetting(ProviderIdlePolicy.settingKey, String(value))
+                    failure = nil
+                } catch { failure = error.localizedDescription }
+            }
+        }
+    }
+}

--- a/Sources/Bloom/Views/Inspector/FileRevert.swift
+++ b/Sources/Bloom/Views/Inspector/FileRevert.swift
@@ -56,28 +56,8 @@ enum FileRevert {
         }
 
         do {
-            // The same divergence point the diff was drawn from. Reverting to a different one
-            // would restore a version of the file the user was never shown.
-            let base = try await Git.baseline(workspace.baseBranch, in: worktree)
-
-            // A rename is two paths: the old one has to come back and the new one has to go, and
-            // doing only half of it leaves the file present under both names.
-            if file.change == .renamed, let oldPath = file.oldPath {
-                try await git(["checkout", base, "--", oldPath], in: worktree)
-                try await git(["rm", "-f", "--", file.path], in: worktree)
-                return nil
-            }
-
-            if try await exists(file.path, at: base, in: worktree) {
-                try await git(["checkout", base, "--", file.path], in: worktree)
-            } else {
-                // Added since the base, so there is nothing to restore and the file itself is
-                // the change.
-                try await git(["rm", "-f", "--", file.path], in: worktree)
-            }
+            try await Git.revertTrackedFile(file, worktree: worktree, base: workspace.baseBranch)
             return nil
-        } catch let failure as Failure {
-            return "Could not revert \(file.filename): \(failure.message)"
         } catch let error as ShellError {
             return "Could not revert \(file.filename): \(error.stderr)"
         } catch {
@@ -85,33 +65,4 @@ enum FileRevert {
         }
     }
 
-    private static func exists(
-        _ path: String, at ref: String, in worktree: String
-    ) async throws -> Bool {
-        let result = try await Shell.run(
-            "git", ["cat-file", "-e", "\(ref):\(path)"], cwd: worktree, env: environment
-        )
-        return result.ok
-    }
-
-    /// `ShellError`'s memberwise initialiser is internal to BloomCore, and a failed revert only
-    /// needs the one sentence anyway.
-    private struct Failure: Error {
-        var message: String
-    }
-
-    private static func git(_ arguments: [String], in worktree: String) async throws {
-        let result = try await Shell.run("git", arguments, cwd: worktree, env: environment)
-        guard result.ok else {
-            let detail = result.stderr.isEmpty ? result.stdout : result.stderr
-            throw Failure(message: detail.trimmingCharacters(in: .whitespacesAndNewlines))
-        }
-    }
-
-    /// The same two variables `Git` sets, so a revert cannot be the one command that stops to ask
-    /// for a password or fights the index lock the refresh loop is holding.
-    private static let environment = [
-        "GIT_TERMINAL_PROMPT": "0",
-        "GIT_OPTIONAL_LOCKS": "0",
-    ]
 }

--- a/Sources/Bloom/Views/Inspector/InspectorView.swift
+++ b/Sources/Bloom/Views/Inspector/InspectorView.swift
@@ -31,6 +31,25 @@ struct InspectorView: View {
                 InspectorNotice(notice: notice) { model.pullRequestNotice = nil }
                 Hairline()
             }
+            if let failure = model.pullRequestRefreshFailure {
+                VStack(alignment: .leading, spacing: InspectorLayout.tight) {
+                    Text(model.pullRequest == nil ? "GitHub could not refresh" : "Showing the last GitHub update")
+                        .font(Typo.captionEmphasis)
+                        .foregroundStyle(Palette.textPrimary)
+                    Text(failure.message).font(Typo.micro).foregroundStyle(Palette.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .textSelection(.enabled)
+                    if let retryAt = failure.retryAt {
+                        Text("Next refresh after \(retryAt.formatted(date: .omitted, time: .shortened))")
+                            .font(Typo.micro).foregroundStyle(Palette.textSecondary)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, InspectorLayout.inset)
+                .padding(.vertical, Metrics.spacing)
+                .accessibilityElement(children: .contain)
+                Hairline()
+            }
 
             // The tab row, and the boundary between it and the pane, as one band.
             //

--- a/Sources/Bloom/Views/Sidebar/WorkspacePullRequests.swift
+++ b/Sources/Bloom/Views/Sidebar/WorkspacePullRequests.swift
@@ -10,8 +10,8 @@ import BloomCore
 /// has produced no changes at all is never asked about, because a branch with nothing on it
 /// cannot have a pull request.
 ///
-/// Nothing here throws or reports. A sidebar mark is not the place to learn that gh is signed
-/// out: the row simply falls back to what git alone knows.
+/// Failed reads preserve the last good mark. The inspector reads the accompanying failure
+/// from this same state, so the explanation and the content cannot disagree.
 @MainActor
 @Observable
 final class WorkspacePullRequests {
@@ -25,7 +25,17 @@ final class WorkspacePullRequests {
     /// genuine poll a full interval later is never served from the cache.
     private static let maxAge = Duration.seconds(110)
 
-    private var pullRequests: [WorkspaceID: PullRequest] = [:]
+    private var states: [WorkspaceID: PullRequestRefreshState] = [:]
+    @ObservationIgnored private var generations: [WorkspaceID: UInt64] = [:]
+
+    func failure(for workspaceID: WorkspaceID) -> GitHubReadFailure? { states[workspaceID]?.failure }
+
+    func record(_ read: PullRequestRead, for workspaceID: WorkspaceID) {
+        generations[workspaceID, default: 0] &+= 1
+        var state = states[workspaceID] ?? PullRequestRefreshState()
+        state.record(read)
+        if states[workspaceID] != state { states[workspaceID] = state }
+    }
 
     /// The tail of the lookup queue. Each new lookup waits for the previous one, which is what
     /// turns twelve rows appearing at once into twelve sequential `gh` calls instead of twelve
@@ -33,7 +43,7 @@ final class WorkspacePullRequests {
     private var queue: Task<Void, Never> = Task {}
 
     func pullRequest(for workspaceID: WorkspaceID) -> PullRequest? {
-        pullRequests[workspaceID]
+        states[workspaceID]?.pullRequest
     }
 
     /// Records an answer somebody else went and got, including nil.
@@ -46,27 +56,19 @@ final class WorkspacePullRequests {
     /// This is the two-blues bug one layer down: not two places deciding a colour, but two places
     /// holding the fact the colour comes from.
     ///
-    /// Nil is written here where `refresh` below refuses to write it, and the difference is the
-    /// whole reason both exist. `refresh` is a poll behind a row nobody is looking at, where nil
-    /// means "gh did not answer" at least as often as it means "there is no pull request", and
-    /// making the mark flicker on a slow network is worse than showing a stale one. This is a
-    /// deliberate read for the workspace somebody is looking at, and there nil is an answer.
+    /// Only a successful read calls this. Failed reads go through record and retain content.
     func set(_ pullRequest: PullRequest?, for workspaceID: WorkspaceID) {
-        // Writing an equal value still invalidates every row reading this dictionary.
-        guard pullRequests[workspaceID] != pullRequest else { return }
-        pullRequests[workspaceID] = pullRequest
+        record(.current(pullRequest), for: workspaceID)
     }
 
     /// Drops what is remembered about one workspace, for a caller that knows the answer is now
     /// about a branch this workspace is no longer on.
     ///
-    /// Needed because `refresh` deliberately never clears: it treats nil as "gh could not answer"
-    /// rather than "there is no pull request", so a stale entry outlives every poll. That is the
-    /// right trade for a slow network and the wrong one after `AppModel.continueAfterMerge` moves
-    /// the worktree to a fresh branch, where the merged pull request in here would keep marking
-    /// the row for the rest of the session.
+    /// Also invalidates a queued read of the old branch, which must not repopulate this entry
+    /// after the workspace has continued onto a new branch.
     func forget(_ workspaceID: WorkspaceID) {
-        pullRequests[workspaceID] = nil
+        generations[workspaceID, default: 0] &+= 1
+        states[workspaceID] = nil
     }
 
     /// Keeps one workspace's answer fresh for as long as its row is on screen.
@@ -93,27 +95,24 @@ final class WorkspacePullRequests {
         // workspace and the band asked on its own.
         guard workspace.hasDiff
             || workspace.pullRequestNumber != nil
-            || pullRequests[workspace.id] != nil else { return }
-        guard await GitHubAvailability.shared.isReady() else { return }
+            || states[workspace.id]?.pullRequest != nil else { return }
 
         let id = workspace.id
         let asked = workspace
+        let generation = generations[id, default: 0]
 
         let previous = queue
         let lookup = Task { @MainActor in
             await previous.value
-            let fresh = await GitHubBridge.pullRequest(for: asked, maxAge: Self.maxAge)
-            // Nil is both "there is no pull request" and "gh could not answer", so the last known
-            // answer is kept rather than making the mark flicker back to a plain branch whenever
-            // the network is slow.
+            guard !Task.isCancelled, self.generations[id, default: 0] == generation else { return }
+            let read = await GitHubBridge.readPullRequest(for: asked, maxAge: Self.maxAge)
+            guard !Task.isCancelled, self.generations[id, default: 0] == generation else { return }
+            self.record(read, for: id)
+            guard case .current(let fresh) = read else { return }
             guard let fresh else { return }
             await PullRequestNumber.record(fresh, for: asked, in: store)
-            // Writing an equal value still invalidates every row reading this dictionary, and a
-            // poll that changed nothing is the common case.
-            guard self.pullRequests[id] != fresh else { return }
-            self.pullRequests[id] = fresh
         }
         queue = lookup
-        await lookup.value
+        await withTaskCancellationHandler { await lookup.value } onCancel: { lookup.cancel() }
     }
 }

--- a/Sources/Bloom/Views/Terminal/TerminalExcerptHandoff.swift
+++ b/Sources/Bloom/Views/Terminal/TerminalExcerptHandoff.swift
@@ -1,0 +1,30 @@
+import Foundation
+import BloomCore
+
+@MainActor
+enum TerminalExcerptHandoff {
+    static func attach(_ excerpt: TerminalExcerpt, to model: WorkspaceModel, sessionID: SessionID) async -> String? {
+        guard excerpt.workspaceID == model.workspace.id else {
+            return "This terminal belongs to another workspace."
+        }
+        model.prepareTranscript(for: sessionID)
+        guard let transcript = model.existingTranscript(for: sessionID) else {
+            return "The conversation for this selection has been closed."
+        }
+        await transcript.load()
+        do {
+            let outcome = await ComposerHandoff.attach(
+                [.text(try excerpt.attachmentText(), named: excerpt.filename)],
+                to: model, sessionID: sessionID
+            )
+            // The conversation may not have had a composer on screen to schedule its usual
+            // debounced save. Persist before reporting success to the terminal action.
+            if outcome.failure == nil, let transcript = model.existingTranscript(for: sessionID) {
+                await transcript.saveDraft()
+            }
+            return outcome.failure
+        } catch {
+            return "Could not attach the terminal selection: \(error.localizedDescription)"
+        }
+    }
+}

--- a/Sources/Bloom/Views/Terminal/TerminalPaneMenu.swift
+++ b/Sources/Bloom/Views/Terminal/TerminalPaneMenu.swift
@@ -19,12 +19,20 @@ enum TerminalPaneMenu {
     static func make(
         canClose: Bool,
         isZoomed: Bool,
+        onAddToChat: (@MainActor () -> Void)? = nil,
         perform: @escaping @MainActor (TerminalPaneCommand) -> Void
     ) -> NSMenu {
-        let target = ActionTarget(perform: perform)
+        let target = ActionTarget(perform: perform, onAddToChat: onAddToChat)
         // A menu that owns its target, because `NSMenuItem.target` is weak and nothing else here
         // would hold it: without this the closures are gone before the user picks anything.
         let menu = OwningMenu(target: target)
+        menu.autoenablesItems = false
+
+        let addToChat = NSMenuItem(title: "Add to Chat", action: #selector(ActionTarget.addToChat), keyEquivalent: "")
+        addToChat.target = target
+        addToChat.isEnabled = onAddToChat != nil
+        menu.addItem(addToChat)
+        menu.addItem(.separator())
 
         menu.addItem(splitItem(
             "Split Right", symbol: PaneSymbol.splitRight, axis: .horizontal,
@@ -122,10 +130,14 @@ enum TerminalPaneMenu {
     @MainActor
     final class ActionTarget: NSObject {
         private let perform: @MainActor (TerminalPaneCommand) -> Void
+        private let onAddToChat: (@MainActor () -> Void)?
 
-        init(perform: @escaping @MainActor (TerminalPaneCommand) -> Void) {
+        init(perform: @escaping @MainActor (TerminalPaneCommand) -> Void, onAddToChat: (@MainActor () -> Void)?) {
             self.perform = perform
+            self.onAddToChat = onAddToChat
         }
+
+        @objc func addToChat() { onAddToChat?() }
 
         @objc func fire(_ sender: NSMenuItem) {
             guard let command = sender.represented(TerminalPaneCommand.self) else { return }

--- a/Sources/Bloom/Views/Terminal/TerminalSessionStore.swift
+++ b/Sources/Bloom/Views/Terminal/TerminalSessionStore.swift
@@ -44,6 +44,16 @@ final class TerminalSessionStore {
 
     // MARK: - Terminals
 
+    func excerpt(inPaneID paneID: String, workspaceID: WorkspaceID, label: String) -> TerminalExcerpt? {
+        guard paneOwner[paneID] == workspaceID,
+              let selection = terminals[paneID]?.selection, selection.active else { return nil }
+        return TerminalExcerpt(
+            terminalID: TerminalTabID(paneID), workspaceID: workspaceID, label: label,
+            firstLine: selection.start.row + 1, lastLine: selection.end.row + 1,
+            text: selection.getSelectedText()
+        )
+    }
+
     /// Queues a command for the pane that has not been drawn yet, so the shell runs it the moment
     /// it is forked. Nothing happens if the pane's shell already exists: a run script opens a tab
     /// of its own, and the tab is new every time.

--- a/Sources/Bloom/Views/Terminal/TerminalSplitView.swift
+++ b/Sources/Bloom/Views/Terminal/TerminalSplitView.swift
@@ -26,6 +26,8 @@ struct TerminalSplitView: View {
     var onCloseTab: @MainActor () -> Void
     /// Called when a split asks for something a shell tree cannot hold. See `handle`.
     var splitColumn: @MainActor (SplitAxis, PaneKind) -> Void
+    var terminalLabel: String = "Terminal"
+    var onAddToChat: (@MainActor (TerminalExcerpt) -> Void)?
 
     /// The same switch the terminal itself reads, so turning the Ghostty theme off also turns off
     /// Ghostty's way of fading the panes that do not have the keyboard.
@@ -124,9 +126,16 @@ struct TerminalSplitView: View {
                 onCommand: { handle($0, from: id) },
                 onExit: { finished($0, in: id) },
                 onContextMenu: {
-                    TerminalPaneMenu.make(
+                    let excerpt = TerminalSessionStore.shared.excerpt(
+                        inPaneID: id, workspaceID: workspace.id, label: terminalLabel
+                    )
+                    let add: (@MainActor () -> Void)? = if let excerpt, let onAddToChat {
+                        { onAddToChat(excerpt) }
+                    } else { nil }
+                    return TerminalPaneMenu.make(
                         canClose: layout.paneCount > 1,
-                        isZoomed: layout.zoomed == id
+                        isZoomed: layout.zoomed == id,
+                        onAddToChat: add
                     ) { _ = handle($0, from: id) }
                 }
             )

--- a/Sources/Bloom/Views/Transcript/PendingTurnRowView.swift
+++ b/Sources/Bloom/Views/Transcript/PendingTurnRowView.swift
@@ -91,7 +91,7 @@ struct PendingTurnRowView: View {
             Spacer(minLength: Self.inset)
 
             VStack(alignment: .trailing, spacing: TranscriptLayout.tight) {
-                bubble
+                if delivery.deliveredSeq == nil { bubble }
                 caption
             }
         }
@@ -277,11 +277,13 @@ struct PendingTurnRowView: View {
             }
 
             if canRetry {
-                Button("Try Again", action: onRetry)
+                Button(delivery.state == .uncertain ? "Send Again" : "Try Again", action: onRetry)
                     .buttonStyle(.plain)
                     .foregroundStyle(Palette.link)
                     .pointerStyle(.link)
-                    .help("Try to send this message again.")
+                    .help(delivery.state == .uncertain
+                        ? "The agent may already have received this message. Send another attempt only after checking."
+                        : "Try to send this message again.")
             }
 
             moreMenu

--- a/Sources/Bloom/Views/Transcript/TranscriptListView.swift
+++ b/Sources/Bloom/Views/Transcript/TranscriptListView.swift
@@ -603,7 +603,8 @@ struct TranscriptListView: View {
                                 agentKind: agentKind,
                                 wasStopped: wasStopped,
                                 recovered: recovered,
-                                stillRunning: stillRunning
+                                stillRunning: stillRunning,
+                                transcript: transcript
                             )
                             .arrivingRow(settles && arrivals.isArriving(row.seq))
                             .padding(.horizontal, TranscriptLayout.inset)
@@ -1105,11 +1106,7 @@ struct TranscriptListView: View {
         // than on the row, so the question survives its row leaving, which is exactly what happens
         // when the queue moves while it is open.
         .confirmation($transcript.discarding) { delivery in
-            let question = PendingMessageDiscard.question(
-                for: PendingMessageDiscard.recovery(
-                    of: delivery, composerDraft: transcript.draft
-                )
-            )
+            let question = PendingMessageDiscard.question(for: delivery, composerDraft: transcript.draft)
             return Confirmation(
                 title: question.title,
                 message: question.message,

--- a/Sources/Bloom/Views/Transcript/TurnFile.swift
+++ b/Sources/Bloom/Views/Transcript/TurnFile.swift
@@ -1,10 +1,9 @@
 import Foundation
 import BloomCore
 
-/// A file a turn touched, with the line counts taken from the tool calls themselves.
+/// A file changed during a turn. Recorded snapshots supply net counts; old turns use tool calls.
 struct TurnFile: Identifiable, Hashable, Sendable {
-    /// Absolute, because that is what the agent wrote: Claude Code requires an absolute
-    /// `file_path` on every call. Nothing shows this to a reader; see `display(in:)`.
+    /// Snapshot paths are repository-relative; older tool events can carry absolute paths.
     var path: String
     var additions: Int
     var deletions: Int

--- a/Sources/Bloom/Views/Transcript/TurnFileChip.swift
+++ b/Sources/Bloom/Views/Transcript/TurnFileChip.swift
@@ -5,6 +5,7 @@ struct TurnFileChip: View {
     var file: TurnFile
     /// The worktree the path is shown relative to. See `TurnFile.display(in:)`.
     var worktree: String
+    var previewsCurrentFile = true
 
     var body: some View {
         HStack(spacing: TranscriptLayout.tight * 2) {
@@ -26,7 +27,11 @@ struct TurnFileChip: View {
         // `TurnFooterView` decides how many chips there is room for; a chip that is drawn is drawn
         // whole.
         .fixedSize()
-        .background(HoverQuickLook(url: PromptAttachment.sent(path: file.path).url(in: worktree)))
+        .background {
+            if previewsCurrentFile {
+                HoverQuickLook(url: PromptAttachment.sent(path: file.path).url(in: worktree))
+            }
+        }
         // Said once, in the form the rest of the window says it in.
         //
         // It was said three times: `.help` gives a tooltip AND an accessibility help string, and

--- a/Sources/Bloom/Views/Transcript/TurnFooterView.swift
+++ b/Sources/Bloom/Views/Transcript/TurnFooterView.swift
@@ -37,11 +37,18 @@ struct TurnFooterView: View {
     /// own, under a tab that is still breathing, is what made that look like a stuck turn. See
     /// `BackgroundWork`.
     var stillRunning: String?
+    var transcript: TranscriptModel?
 
     /// More chips than this and the footer stops being a footer.
     private static let visibleFileLimit = 6
 
     @State private var files: [TurnFile] = []
+    @State private var snapshotFailure: String?
+    @State private var historicalFile: TurnFile?
+
+    private var checkpoint: TurnCheckpoint? {
+        transcript?.history.checkpoints.first { $0.endSeq == row.seq && $0.after != nil }
+    }
 
     var body: some View {
         // Read once for the pass, and handed down.
@@ -143,6 +150,7 @@ struct TurnFooterView: View {
                     Color.clear.frame(width: 0, height: 0)
                 }
 
+                if let transcript { TurnHistoryActions(transcript: transcript, endingAt: row.seq) }
                 CopyButton(text: answerText, title: "Copy this answer")
                     .disabled(answerText.isEmpty)
             }
@@ -184,6 +192,15 @@ struct TurnFooterView: View {
                 .padding(.bottom, TranscriptLayout.inset)
             }
 
+            if let snapshotFailure {
+                Text("Saved file summary unavailable")
+                    .font(Typo.caption)
+                    .foregroundStyle(Palette.textSecondary)
+                    .help(snapshotFailure)
+                    .padding(.horizontal, TranscriptLayout.inset)
+                    .padding(.bottom, TranscriptLayout.inset)
+            }
+
             // Secondary rather than tertiary: unlike the retry note below, this is news now, and it
             // is the answer to why the tab is still busy.
             if let stillRunning {
@@ -206,7 +223,12 @@ struct TurnFooterView: View {
                     .padding(.bottom, TranscriptLayout.inset)
             }
         }
-        .task(id: row.seq) { await scanFiles() }
+        .task(id: "\(row.seq):\(checkpoint?.after?.id.rawValue ?? "legacy")") { await scanFiles() }
+        .sheet(item: $historicalFile) { file in
+            if let transcript, let checkpoint {
+                TurnSnapshotView(transcript: transcript, checkpoint: checkpoint, initialPath: file.path)
+            }
+        }
     }
 
     private static func durationLabel(outcome: TurnEnding, milliseconds: Int) -> String {
@@ -268,6 +290,24 @@ struct TurnFooterView: View {
     /// was a walk back over up to four hundred rows, decoding every one of them. See
     /// `TurnScanCache` for why the answer can be kept.
     private func scanFiles() async {
+        snapshotFailure = nil
+        if let transcript, let checkpoint, let snapshotID = checkpoint.after?.id {
+            if let known = TurnScanCache.files(snapshotID: snapshotID) {
+                files = known
+                return
+            }
+            do {
+                let changed = try await transcript.history.files(checkpoint, cwd: worktree)
+                guard !Task.isCancelled else { return }
+                files = changed.map { TurnFile(path: $0.path, additions: $0.additions, deletions: $0.deletions) }
+                TurnScanCache.remember(files, snapshotID: snapshotID)
+            } catch {
+                guard !Task.isCancelled else { return }
+                files = []
+                snapshotFailure = "Could not load the saved file summary: \(error)"
+            }
+            return
+        }
         if let known = TurnScanCache.files(rowID: row.id) {
             files = known
             return
@@ -275,6 +315,7 @@ struct TurnFooterView: View {
         let scanned = await Task.detached(priority: .utility) { [rows, seq = row.seq] in
             TurnScan.files(rows: rows, endingAt: seq)
         }.value
+        guard !Task.isCancelled else { return }
         TurnScanCache.remember(scanned, rowID: row.id)
         files = scanned
     }
@@ -284,7 +325,14 @@ struct TurnFooterView: View {
     private func fileChips(limit: Int) -> some View {
         HStack(spacing: TranscriptLayout.block) {
             ForEach(files.prefix(limit)) { file in
-                TurnFileChip(file: file, worktree: worktree)
+                if checkpoint != nil {
+                    Button { historicalFile = file } label: {
+                        TurnFileChip(file: file, worktree: worktree, previewsCurrentFile: false)
+                    }
+                    .buttonStyle(.plain)
+                } else {
+                    TurnFileChip(file: file, worktree: worktree)
+                }
             }
             if files.count > limit {
                 Chip(text: "+\(files.count - limit) more")

--- a/Sources/Bloom/Views/Transcript/TurnHistoryActions.swift
+++ b/Sources/Bloom/Views/Transcript/TurnHistoryActions.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+import BloomCore
+
+struct TurnHistoryActions: View {
+    var transcript: TranscriptModel
+    var endingAt: Int
+    @State private var isOpen = false
+
+    private var checkpoint: TurnCheckpoint? {
+        transcript.history.checkpoints.first { $0.endSeq == endingAt && $0.after != nil }
+    }
+
+    var body: some View {
+        if let checkpoint {
+            Button { isOpen = true } label: {
+                Image(systemName: "doc.text.magnifyingglass")
+            }
+            .buttonStyle(.plain)
+            .help("Review the file changes during this turn")
+            .accessibilityLabel("Review turn changes")
+            .sheet(isPresented: $isOpen) {
+                TurnSnapshotView(transcript: transcript, checkpoint: checkpoint)
+            }
+        }
+    }
+}
+
+struct TurnSnapshotView: View {
+    var transcript: TranscriptModel
+    var checkpoint: TurnCheckpoint
+    @Environment(AppModel.self) private var app
+    @Environment(\.dismiss) private var dismiss
+    @State private var patch: String?
+    @State private var failure: String?
+    @State private var paths: [String] = []
+    @State private var selectedPath = ""
+    @State private var showsLargeDiff = false
+    @State private var confirmsRewind = false
+
+    init(transcript: TranscriptModel, checkpoint: TurnCheckpoint, initialPath: String = "") {
+        self.transcript = transcript
+        self.checkpoint = checkpoint
+        _selectedPath = State(initialValue: initialPath)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing) {
+            HStack {
+                Text("Changes During This Turn").font(Typo.label)
+                Spacer()
+                if !paths.isEmpty {
+                    Picker("File", selection: $selectedPath) {
+                        Text("All files").tag("")
+                        ForEach(paths, id: \.self) { Text($0).tag($0) }
+                    }
+                    .frame(maxWidth: 380)
+                }
+                if let patch { CopyButton(text: patch, title: "Copy patch") }
+                Button("Done") { dismiss() }.keyboardShortcut(.cancelAction)
+            }
+            Text("Includes changes made by other conversations or terminal commands during the same period.")
+                .font(Typo.caption).foregroundStyle(Palette.textSecondary)
+            if let failure {
+                Text(failure).textSelection(.enabled)
+            } else if let patch {
+                if patch.isEmpty {
+                    Text("No file changes during this turn.")
+                } else if patch.utf8.count > 200_000 && !showsLargeDiff {
+                    Text("This diff is large. Choose a file above or show the full patch.")
+                    Button("Show Full Patch") { showsLargeDiff = true }
+                } else {
+                    ScrollView([.horizontal, .vertical]) {
+                        Text(patch).font(Typo.codeSmall).textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            } else {
+                ProgressView("Loading the saved diff")
+            }
+            Spacer(minLength: 0)
+            if checkpoint.providerTurnID != nil, transcript.session.agentKind == .codex {
+                Button("Edit From Here") { confirmsRewind = true }
+                    .disabled(transcript.isRunning || transcript.history.isRewinding)
+                    .help("Rewind to before this turn and return its prompt to the composer")
+            }
+        }
+        .padding(Metrics.gutter)
+        .frame(minWidth: 720, idealWidth: 900, minHeight: 480, idealHeight: 640)
+        .task(id: selectedPath) { await loadPatch() }
+        .alert("Edit from before this turn?", isPresented: $confirmsRewind) {
+            Button("Cancel", role: .cancel) {}
+            Button("Rewind and Keep Files") { rewind(restoringFiles: false) }
+            Button("Rewind and Restore Files", role: .destructive) { rewind(restoringFiles: true) }
+        } message: {
+            Text("The agent's later conversation will be removed. The original prompt and attachments return to your draft. Restoring files also replaces later file changes and staging. Stop terminal commands before restoring files.")
+        }
+    }
+
+    private func loadPatch() async {
+        guard let store = app.store else { return }
+        let path = selectedPath
+        patch = nil
+        failure = nil
+        showsLargeDiff = false
+        do {
+            let loaded = try await transcript.history.diff(
+                checkpoint, store: store, cwd: transcript.cwd, path: path.isEmpty ? nil : path
+            )
+            guard !Task.isCancelled else { return }
+            if paths.isEmpty {
+                let files = try await transcript.history.files(checkpoint, cwd: transcript.cwd)
+                guard !Task.isCancelled else { return }
+                paths = files.map(\.path).sorted()
+            }
+            patch = loaded
+        } catch { if !Task.isCancelled { failure = "Could not load the saved diff: \(error)" } }
+    }
+
+    private func rewind(restoringFiles: Bool) {
+        Task { @MainActor in
+            await transcript.history.rewind(checkpoint, restoringFiles: restoringFiles, transcript: transcript, app: app)
+            if transcript.history.failure == nil { dismiss() }
+        }
+    }
+}

--- a/Sources/Bloom/Views/Transcript/TurnScan.swift
+++ b/Sources/Bloom/Views/Transcript/TurnScan.swift
@@ -140,6 +140,20 @@ enum TurnScanCache {
         return cache
     }()
 
+    private static let snapshots: NSCache<NSString, TurnFilesBox> = {
+        let cache = NSCache<NSString, TurnFilesBox>()
+        cache.countLimit = limit
+        return cache
+    }()
+
+    static func files(snapshotID: GitSnapshotID) -> [TurnFile]? {
+        snapshots.object(forKey: snapshotID.rawValue as NSString)?.value
+    }
+
+    static func remember(_ files: [TurnFile], snapshotID: GitSnapshotID) {
+        snapshots.setObject(TurnFilesBox(files), forKey: snapshotID.rawValue as NSString)
+    }
+
     static func files(rowID: Int64) -> [TurnFile]? {
         values.object(forKey: NSNumber(value: rowID))?.value
     }

--- a/Sources/BloomCore/Agent/AgentEvent.swift
+++ b/Sources/BloomCore/Agent/AgentEvent.swift
@@ -167,7 +167,7 @@ public enum JSONValue: Sendable, Hashable, Codable {
 
 /// Everything the first line of a session binds: the id to resume with, the model that answered,
 /// and what it was allowed to do.
-public struct AgentInit: Sendable, Hashable {
+public struct AgentInit: Sendable, Hashable, Codable {
     public let sessionID: String
     public let cwd: String
     public let model: String
@@ -369,7 +369,7 @@ public struct AgentHook: Sendable, Hashable {
 }
 
 /// The last line of a turn, and the only place a real cost and context window show up.
-public struct AgentResult: Sendable, Hashable {
+public struct AgentResult: Sendable, Hashable, Codable {
     public let usage: AgentUsage
     public let summary: String
     public let isError: Bool
@@ -426,7 +426,7 @@ public struct AgentResult: Sendable, Hashable {
 
 /// Not a CLI event type. The runner synthesises one when the process dies without ever saying
 /// how it went, so the transcript never just stops mid sentence.
-public struct AgentError: Sendable, Hashable {
+public struct AgentError: Sendable, Hashable, Codable {
     public let message: String
     public let raw: Data
 
@@ -479,7 +479,7 @@ extension AgentError {
 
 /// Token accounting, filled from either the thin `assistant` usage object or the richer one on
 /// `result`. Cost and the context window only ever arrive on `result`.
-public struct AgentUsage: Sendable, Hashable {
+public struct AgentUsage: Sendable, Hashable, Codable {
     public var inputTokens: Int
     public var outputTokens: Int
     public var cacheReadTokens: Int

--- a/Sources/BloomCore/Agent/AgentLifecycleSpool.swift
+++ b/Sources/BloomCore/Agent/AgentLifecycleSpool.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Synchronization
+
+public struct AgentLifecycleEntry: Sendable {
+    public let revision: UInt64
+    public let event: AgentEvent
+    public let messageSeq: Int?
+}
+
+/// A temporary transport journal, not conversation storage. Store remains authoritative. Only
+/// lifecycle boundaries spill here; acknowledged history is truncated and the file is removed
+/// when its feed closes. Read pages and total capacity have explicit bounds.
+final class AgentLifecycleSpool: Sendable {
+    private enum Boundary: Codable {
+        case initialized(AgentInit)
+        case result(AgentResult)
+        case error(AgentError)
+
+        init?(_ event: AgentEvent) {
+            switch event {
+            case .initialized(let value): self = .initialized(value)
+            case .result(let value): self = .result(value)
+            case .error(let value): self = .error(value)
+            default: return nil
+            }
+        }
+
+        var event: AgentEvent {
+            switch self {
+            case .initialized(let value): .initialized(value)
+            case .result(let value): .result(value)
+            case .error(let value): .error(value)
+            }
+        }
+    }
+    private struct Record: Codable {
+        let revision: UInt64
+        let boundary: Boundary
+        let messageSeq: Int?
+    }
+    private struct State {
+        var file: FileHandle?
+        var bytes: UInt64 = 0
+        var lastRevision: UInt64 = 0
+        var closed = false
+        var recordCount = 0
+        var offsets: [(revision: UInt64, offset: UInt64)] = []
+    }
+    private let state = Mutex(State())
+    private let url: URL
+    private let capacity: Int
+    private static let maximumRecordBytes = 8 * 1_024 * 1_024
+
+    init(capacity: Int = 64 * 1_024 * 1_024) {
+        self.capacity = max(1, capacity)
+        url = FileManager.default.temporaryDirectory.appendingPathComponent("bloom-lifecycle-\(UUID().uuidString)")
+    }
+
+    static func isBoundary(_ event: AgentEvent) -> Bool { Boundary(event) != nil }
+
+    func append(_ event: AgentEvent, revision: UInt64, messageSeq: Int?) throws {
+        guard let boundary = Boundary(event) else { return }
+        let data = try JSONEncoder().encode(Record(revision: revision, boundary: boundary, messageSeq: messageSeq))
+        guard data.count <= Self.maximumRecordBytes else { throw Failure.capacity }
+        try state.withLock { value in
+            guard !value.closed, value.bytes + UInt64(data.count + 8) <= UInt64(capacity) else { throw Failure.capacity }
+            if value.file == nil {
+                guard FileManager.default.createFile(atPath: url.path, contents: nil,
+                    attributes: [.posixPermissions: 0o600]) else { throw Failure.unavailable }
+                value.file = try FileHandle(forUpdating: url)
+            }
+            guard let file = value.file else { throw Failure.unavailable }
+            try file.seekToEnd()
+            var length = UInt64(data.count).bigEndian
+            try file.write(contentsOf: withUnsafeBytes(of: &length) { Data($0) })
+            try file.write(contentsOf: data)
+            if value.recordCount.isMultiple(of: 32) {
+                value.offsets.append((revision, value.bytes))
+            }
+            value.recordCount += 1
+            value.bytes += UInt64(data.count + 8)
+            value.lastRevision = revision
+        }
+    }
+
+    func read(after cursor: UInt64, through revision: UInt64, limit: Int = 32) throws -> [AgentLifecycleEntry] {
+        try state.withLock { value in
+            guard let file = value.file, value.bytes > 0 else { return [] }
+            // One sparse offset per 32 boundaries bounds rescanning to a single block, even
+            // when a window catches up through thousands of pages.
+            var lower = 0
+            var upper = value.offsets.count
+            while lower < upper {
+                let middle = lower + (upper - lower) / 2
+                if value.offsets[middle].revision <= cursor { lower = middle + 1 } else { upper = middle }
+            }
+            let offset = lower > 0 ? value.offsets[lower - 1].offset : 0
+            try file.seek(toOffset: offset)
+            var output: [AgentLifecycleEntry] = []
+            var pageBytes = 0
+            while try file.offset() < value.bytes {
+                let header = try Self.read(8, from: file)
+                let length = header.reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+                guard length <= UInt64(Self.maximumRecordBytes) else { throw Failure.unavailable }
+                let data = try Self.read(Int(length), from: file)
+                let record = try JSONDecoder().decode(Record.self, from: data)
+                if record.revision > revision { break }
+                if record.revision > cursor {
+                    if !output.isEmpty, pageBytes + data.count > Self.maximumRecordBytes { break }
+                    output.append(AgentLifecycleEntry(revision: record.revision, event: record.boundary.event, messageSeq: record.messageSeq))
+                    pageBytes += data.count
+                    if output.count >= max(1, min(limit, 128)) || pageBytes >= Self.maximumRecordBytes { break }
+                }
+            }
+            return output
+        }
+    }
+
+    func acknowledge(through revision: UInt64) throws {
+        try state.withLock { value in
+            guard revision >= value.lastRevision, let file = value.file, value.bytes > 0 else { return }
+            try file.truncate(atOffset: 0)
+            try file.seek(toOffset: 0)
+            value.bytes = 0
+            value.recordCount = 0
+            value.offsets = []
+        }
+    }
+
+    var retainedBytes: UInt64 { state.withLock { $0.bytes } }
+
+    func close() {
+        state.withLock { value in
+            value.closed = true
+            try? value.file?.close()
+            value.file = nil
+            value.bytes = 0
+            value.recordCount = 0
+            value.offsets = []
+        }
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    deinit { close() }
+
+    private static func read(_ count: Int, from file: FileHandle) throws -> Data {
+        var data = Data()
+        while data.count < count {
+            guard let chunk = try file.read(upToCount: count - data.count), !chunk.isEmpty else { throw Failure.unavailable }
+            data.append(chunk)
+        }
+        return data
+    }
+
+    private enum Failure: Error, LocalizedError {
+        case capacity, unavailable
+        var errorDescription: String? {
+            switch self {
+            case .capacity: "The live conversation buffer is full. Bloom stopped the agent to keep its turn history consistent."
+            case .unavailable: "Bloom could not preserve the live conversation updates. The agent was stopped."
+            }
+        }
+    }
+}
+
+public enum AgentPresentationReconciliation {
+    public static func permitsAutomaticDrain(isCatchingUp: Bool, isTurnRunning: Bool) -> Bool {
+        !isCatchingUp && !isTurnRunning
+    }
+}

--- a/Sources/BloomCore/Agent/AgentPresentationFeed.swift
+++ b/Sources/BloomCore/Agent/AgentPresentationFeed.swift
@@ -1,0 +1,272 @@
+import Foundation
+import Synchronization
+
+public struct AgentPresentationBatch: Sendable {
+    public let revision: UInt64
+    public let events: [AgentEvent]
+    public let eventRevisions: [UInt64]
+    public let messageSequences: [Int?]
+    public let failure: String?
+    public let recovery: AgentPresentationRecovery?
+}
+
+/// The durable transcript remains in Store. This is only the current live projection needed
+/// when a slow window has fallen behind the bounded event window.
+public struct AgentPresentationRecovery: Sendable {
+    public let text: String
+    public let thinking: String
+    public let toolName: String?
+    public let status: String?
+    public let thinkingTokens: Int
+    public let subagents: SubagentRoster
+    public let stateEvent: AgentEvent?
+    public let stateRevision: UInt64
+    public let retry: AgentRetry?
+    public let quota: Data?
+}
+
+/// A subscriber queues one wake-up, never an unbounded copy of provider output. The shared
+/// replay window has both an item and byte budget. Overflow recovers the live projection and
+/// reloads durable rows, rather than dropping text deltas or blocking protocol ingestion.
+public final class AgentPresentationFeed: Sendable {
+    private struct Entry: Sendable {
+        let revision: UInt64
+        let event: AgentEvent
+        let bytes: Int
+        let messageSeq: Int?
+    }
+    private struct State: Sendable {
+        var lastActivity = ContinuousClock.now
+        var revision: UInt64 = 0
+        var entries: [Entry] = []
+        var bytes = 0
+        var text = ""
+        var thinking = ""
+        var toolName: String?
+        var status: String?
+        var thinkingTokens = 0
+        var subagents = SubagentRoster()
+        var stateEvent: AgentEvent?
+        var stateRevision: UInt64 = 0
+        var latestStartRevision: UInt64 = 0
+        var isTurnRunning = false
+        var retry: AgentRetry?
+        var quota: Data?
+        var subscribers: [UUID: AsyncStream<UInt64>.Continuation] = [:]
+        var acknowledged: [UUID: UInt64] = [:]
+        var failure: String?
+        var finished = false
+    }
+    private let state = Mutex(State())
+    private let raw = EventFanout<AgentEvent>()
+    private let lifecycle: AgentLifecycleSpool
+    private let maxItems: Int
+    private let maxBytes: Int
+
+    public init(maxItems: Int = 512, maxBytes: Int = 8 * 1_024 * 1_024, lifecycleCapacity: Int = 64 * 1_024 * 1_024) {
+        lifecycle = AgentLifecycleSpool(capacity: lifecycleCapacity)
+        self.maxItems = max(1, maxItems)
+        self.maxBytes = max(1, maxBytes)
+    }
+
+    /// Compatibility for non-UI consumers. The window uses notifications and read(after:).
+    public func stream() -> AsyncStream<AgentEvent> { raw.stream() }
+
+    public func notifications(id: UUID = UUID(), after cursor: UInt64? = nil) -> AsyncStream<UInt64> {
+        return AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            continuation.onTermination = { [weak self] reason in
+                if case .cancelled = reason { self?.unregister(id) }
+            }
+            let initial = state.withLock { value -> (Bool, UInt64) in
+                guard !value.finished else { return (false, value.revision) }
+                value.subscribers[id] = continuation
+                value.acknowledged[id] = cursor ?? value.revision
+                return (true, value.revision)
+            }
+            if initial.0 { continuation.yield(initial.1) } else { continuation.finish() }
+        }
+    }
+
+    public func yield(_ event: AgentEvent, messageSeq: Int? = nil) {
+        let targets = state.withLock { value -> ([AsyncStream<UInt64>.Continuation], UInt64) in
+            guard !value.finished else { return ([], value.revision) }
+            value.lastActivity = ContinuousClock.now
+            value.revision += 1
+            if value.failure == nil {
+                do { try lifecycle.append(event, revision: value.revision, messageSeq: messageSeq) } catch {
+                    value.failure = error.localizedDescription
+                }
+            }
+            let bytes = Self.size(of: event)
+            value.entries.append(Entry(revision: value.revision, event: event, bytes: bytes, messageSeq: messageSeq))
+            value.bytes += bytes
+            while value.entries.count > maxItems || value.bytes > maxBytes {
+                value.bytes -= value.entries.removeFirst().bytes
+            }
+            switch event {
+            case .streamDelta(.text(let text)): value.text += text
+            case .streamDelta(.thinking(let text)): value.thinking += text
+            case .streamDelta(.toolName(let name)): value.toolName = name
+            case .status(let status): value.status = status
+            case .thinkingTokens(let tokens): value.thinkingTokens = tokens
+            case .subagent(let signal): value.subagents.apply(signal)
+            case .retrying(let retry): value.retry = retry
+            case .rateLimit(let quota): value.quota = quota
+            case .initialized, .result, .error:
+                value.stateEvent = event
+                value.stateRevision = value.revision
+                value.text = ""
+                value.thinking = ""
+                value.toolName = nil
+                value.retry = nil
+                value.status = nil
+                if case .initialized = event {
+                    value.latestStartRevision = value.revision
+                    value.isTurnRunning = true
+                    value.subagents.turnStarted()
+                } else { value.isTurnRunning = false }
+                if case .error = event { value.subagents.agentExited() }
+            case .assistantText, .thinking, .toolUse, .toolResult, .permissionAsk:
+                value.text = ""
+                value.thinking = ""
+                value.toolName = nil
+                value.retry = nil
+            default: break
+            }
+            return (Array(value.subscribers.values), value.revision)
+        }
+        raw.yield(event)
+        for target in targets.0 { target.yield(targets.1) }
+    }
+
+    public func snapshot() -> AgentPresentationBatch {
+        state.withLock { value in
+            AgentPresentationBatch(revision: value.revision, events: [], eventRevisions: [], messageSequences: [], failure: value.failure, recovery: AgentPresentationRecovery(
+                text: value.text, thinking: value.thinking, toolName: value.toolName,
+                status: value.status, thinkingTokens: value.thinkingTokens,
+                subagents: value.subagents, stateEvent: value.stateEvent,
+                stateRevision: value.stateRevision, retry: value.retry, quota: value.quota
+            ))
+        }
+    }
+
+    public func read(after cursor: UInt64) -> AgentPresentationBatch {
+        state.withLock { value in
+            let first = value.entries.first?.revision ?? (value.revision + 1)
+            let missed = cursor < value.revision && cursor + 1 < first
+            let recovery = missed ? AgentPresentationRecovery(
+                text: value.text, thinking: value.thinking, toolName: value.toolName,
+                status: value.status, thinkingTokens: value.thinkingTokens,
+                subagents: value.subagents, stateEvent: value.stateEvent,
+                stateRevision: value.stateRevision, retry: value.retry, quota: value.quota
+            ) : nil
+            return AgentPresentationBatch(revision: value.revision,
+                events: missed ? [] : value.entries.filter { $0.revision > cursor }.map(\.event),
+                eventRevisions: missed ? [] : value.entries.filter { $0.revision > cursor }.map(\.revision),
+                messageSequences: missed ? [] : value.entries.filter { $0.revision > cursor }.map(\.messageSeq),
+                failure: value.failure, recovery: recovery)
+        }
+    }
+
+    public func lifecycleEvents(after cursor: UInt64, through revision: UInt64, limit: Int = 32) throws -> [AgentLifecycleEntry] {
+        try lifecycle.read(after: cursor, through: revision, limit: limit)
+    }
+
+    public func lifecyclePage(after cursor: UInt64, through revision: UInt64) async throws -> [AgentLifecycleEntry] {
+        try await Task.detached { [self] in
+            try lifecycleEvents(after: cursor, through: revision)
+        }.value
+    }
+
+    public func acknowledgePage(subscriber id: UUID, through revision: UInt64) async {
+        await Task.detached { [self] in acknowledge(subscriber: id, through: revision) }.value
+    }
+
+    public func acknowledge(subscriber id: UUID, through revision: UInt64) {
+        let cursor = state.withLock { value -> UInt64? in
+            guard let current = value.acknowledged[id] else { return nil }
+            value.acknowledged[id] = max(current, revision)
+            return value.acknowledged.values.min()
+        }
+        if let cursor { reclaim(through: cursor) }
+    }
+
+    public func unsubscribe(_ id: UUID) { unregister(id) }
+
+    private func unregister(_ id: UUID) {
+        let cursor = state.withLock { value in
+            value.subscribers[id] = nil
+            value.acknowledged[id] = nil
+            return value.acknowledged.values.min() ?? value.revision
+        }
+        reclaim(through: cursor)
+        if state.withLock({ $0.finished && $0.acknowledged.isEmpty }) { lifecycle.close() }
+    }
+
+    private func reclaim(through revision: UInt64) {
+        do {
+            try lifecycle.acknowledge(through: revision)
+            if state.withLock({ $0.finished && revision >= $0.revision }) { lifecycle.close() }
+        } catch {
+            state.withLock { $0.failure = error.localizedDescription }
+        }
+    }
+
+    public var isTurnRunning: Bool { state.withLock { $0.isTurnRunning } }
+    public func hasLaterTurn(than revision: UInt64) -> Bool {
+        state.withLock { $0.latestStartRevision > revision }
+    }
+
+    public var retainedLifecycleBytes: UInt64 { lifecycle.retainedBytes }
+
+    public var retainedUsage: (items: Int, bytes: Int) {
+        state.withLock { ($0.entries.count, $0.bytes) }
+    }
+
+    public func noteProcessEnded() {
+        let notification = state.withLock { value in
+            value.subagents.agentExited()
+            value.isTurnRunning = false
+            value.revision += 1
+            value.entries = []
+            value.bytes = 0
+            value.text = ""
+            value.thinking = ""
+            value.toolName = nil
+            value.status = nil
+            return (Array(value.subscribers.values), value.revision)
+        }
+        for target in notification.0 { target.yield(notification.1) }
+    }
+
+    public var lastActivity: ContinuousClock.Instant { state.withLock { $0.lastActivity } }
+    public func noteActivity() { state.withLock { $0.lastActivity = .now } }
+
+    public var hasBackgroundWork: Bool { state.withLock { $0.subagents.isWorking } }
+
+    public func finish() {
+        let targets = state.withLock { value in
+            value.finished = true
+            let targets = Array(value.subscribers.values)
+            value.subscribers = [:]
+            value.entries = []
+            value.bytes = 0
+            return targets
+        }
+        if state.withLock({ $0.acknowledged.isEmpty }) { lifecycle.close() }
+        raw.finish()
+        for target in targets { target.finish() }
+    }
+
+    private static func size(of event: AgentEvent) -> Int {
+        switch event {
+        case .streamDelta(.text(let value)), .streamDelta(.thinking(let value)),
+             .streamDelta(.toolName(let value)), .streamDelta(.toolInput(let value)), .status(let value):
+            return value.utf8.count + 64
+        case .subagent(let signal): return String(describing: signal).utf8.count + 256
+        case .result(let result): return event.raw.count + result.summary.utf8.count + 256
+        case .error(let error): return event.raw.count + error.message.utf8.count + 256
+        default: return event.raw.count * 2 + 256
+        }
+    }
+}

--- a/Sources/BloomCore/Agent/AgentRunner.swift
+++ b/Sources/BloomCore/Agent/AgentRunner.swift
@@ -54,7 +54,9 @@ public actor AgentRunner {
     /// See the initialiser. Long enough for SIGTERM, the grace period and the SIGKILL behind it.
     private let shutdownBudget: Duration
     private let makeProcess: @Sendable (AgentLaunch) -> any AgentProcessing
-    private let sink = EventFanout<AgentEvent>()
+    private let sink = AgentPresentationFeed()
+    private var sendsInFlight = 0
+    private var wasEvicted = false
     /// Held outside the actor so `cancelNow()` can signal a process from synchronous main-actor
     /// code without waiting for a turn on the actor, which is exactly when it is least available.
     private let handle = ProcessHandle()
@@ -344,6 +346,7 @@ public actor AgentRunner {
     /// that stream for good, so pressing Stop once left the UI staring at a runner that was still
     /// working and still writing rows nobody would ever see.
     public nonisolated var events: AsyncStream<AgentEvent> { sink.stream() }
+    public nonisolated var presentationFeed: AgentPresentationFeed? { sink }
 
     public func setPersistsStreamDeltas(_ value: Bool) {
         persistsStreamDeltas = value
@@ -357,6 +360,34 @@ public actor AgentRunner {
     /// asked for: see `SessionRunner.send(_:recording:)` for why what goes out and what is drawn
     /// are not the same string.
     public func send(_ text: String, recording: Data? = nil) async throws {
+        try await send(text, recording: recording, deliveryID: nil, interactionMode: nil)
+    }
+
+    public func evictIfIdle(for duration: Duration) async -> Bool {
+        guard !wasEvicted, sendsInFlight == 0, !session.state.isMidTurn,
+              session.agentSessionID != nil, pending.isEmpty, !sink.hasBackgroundWork else { return false }
+        let lastActivity = sink.lastActivity
+        guard lastActivity.duration(to: .now) >= duration,
+              let waiting = try? await store.pendingDeliveries(sessionID: session.id), waiting.isEmpty else { return false }
+        // Recheck after the store hop. A send or a native background event invalidates the lease.
+        guard sendsInFlight == 0, !session.state.isMidTurn, pending.isEmpty,
+              !sink.hasBackgroundWork, sink.lastActivity == lastActivity else { return false }
+        wasEvicted = true
+        terminateNow()
+        return true
+    }
+
+    public func sendDelivery(_ delivery: Delivery) async throws {
+        try await send(delivery.sent, recording: delivery.crewPayload,
+                       deliveryID: delivery.id, interactionMode: delivery.interactionMode)
+    }
+
+    private func send(_ text: String, recording: Data?, deliveryID: DeliveryID?,
+                      interactionMode: InteractionMode?) async throws {
+        guard !wasEvicted else { throw ProviderIdleError.retired }
+        sendsInFlight += 1
+        sink.noteActivity()
+        defer { sendsInFlight -= 1 }
         // The settings reads come first, and that ordering is the whole of the fix.
         //
         // They were between the wait and the start, and each is a store round trip, so there were
@@ -375,15 +406,19 @@ public actor AgentRunner {
         start()
 
         let line = try Self.encodeTurn(text)
-        handle.current?.writeLine(try Self.encodeTurn(prompt))
+        let outgoing = try Self.encodeTurn(prompt)
+        let generation = handle.generation
+        guard let process = handle.current else { throw DeliveryDispatchError.processUnavailable }
+        if let deliveryID { try await store.beginDeliveryDispatch(id: deliveryID) }
+        guard !handle.isCancelled(generation), handle.generation == generation else { throw CancellationError() }
+        process.writeLine(outgoing)
+        if let deliveryID { try await store.acceptDelivery(id: deliveryID) }
 
         // One row, whichever it is. The crew payload carries what a person reads and what the
         // model was handed, so writing the user row beside it would put the envelope back on
         // screen, which is the whole of what this argument exists to stop.
-        if let recording {
-            await persist(kind: .crew, payload: recording)
-        } else {
-            await persist(kind: .user, payload: Data(line.utf8))
+        if deliveryID == nil {
+            if let recording { await persist(kind: .crew, payload: recording) } else { await persist(kind: .user, payload: Data(line.utf8)) }
         }
 
         session.apply(.turnStarted)
@@ -507,6 +542,13 @@ public actor AgentRunner {
     func ingest(_ event: AgentEvent) async {
         var event = event
         if case .permissionAsk(let ask) = event, ask.isPlanApproval {
+            if let markdown = ask.input["plan"]?.stringValue {
+                do {
+                    _ = try await store.recordPlan(sessionID: session.id, sourceID: ask.requestID, markdown: markdown)
+                } catch {
+                    await report("could not save the proposed plan", error)
+                }
+            }
             let mode = (try? await store.planImplementationMode(
                 sessionID: session.id, hasWorktree: session.workspaceID != nil
             )) ?? .acceptEdits
@@ -534,10 +576,11 @@ public actor AgentRunner {
             await persist(kind: .system, payload: report.raw)
         }
 
+        var storedMessage: Message?
         if event.isTranscriptRow || persistsStreamDeltas {
             var durationMS: Int?
             if case .result(let result) = event { durationMS = result.durationMS }
-            await persist(kind: event.kind, payload: event.raw, durationMS: durationMS, refID: event.refID)
+            storedMessage = await persist(kind: event.kind, payload: event.raw, durationMS: durationMS, refID: event.refID)
         }
 
         switch event {
@@ -602,7 +645,7 @@ public actor AgentRunner {
             break
         }
 
-        sink.yield(event)
+        sink.yield(event, messageSeq: storedMessage?.seq)
 
         // After the yield, deliberately. A question a stored rule answers is decided in the same
         // breath it arrives, and `.permissionDecided` reaching a view before the `.permissionAsk`
@@ -619,9 +662,10 @@ public actor AgentRunner {
     /// The sequence number is allocated by the store, in the same call and the same transaction as
     /// the insert, so two writers can never both reserve it. That is also why a failed write
     /// advances nothing: the number was never handed out.
-    private func persist(kind: MessageKind, payload: Data, durationMS: Int? = nil, refID: String? = nil) async {
+    @discardableResult
+    private func persist(kind: MessageKind, payload: Data, durationMS: Int? = nil, refID: String? = nil) async -> Message? {
         do {
-            try await store.appendNext(
+            return try await store.appendNext(
                 sessionID: session.id,
                 kind: kind,
                 payload: payload,
@@ -630,6 +674,7 @@ public actor AgentRunner {
             )
         } catch {
             await report("could not store a \(kind.rawValue) row", error)
+            return nil
         }
     }
 
@@ -881,6 +926,7 @@ public actor AgentRunner {
     private func finish(status: Int32, sawResult: Bool, generation: Int) async {
         // A run that is no longer the current one has nothing left to say about the session.
         guard generation == handle.generation else { return }
+        sink.noteProcessEnded()
 
         alive = false
         handle.endRun(generation)

--- a/Sources/BloomCore/Agent/Codex/CodexChildTurns.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexChildTurns.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Synchronization
+
+/// Stop captures the family at the instant it is pressed, before an actor hop or a replacement
+/// turn can change which children belong to that intent.
+final class CodexChildTurns: Sendable {
+    private let state = Mutex<[String: String]>([:])
+    func replace(_ turns: [String: String]) { state.withLock { $0 = turns } }
+    var snapshot: [String: String] { state.withLock { $0 } }
+}
+
+public enum CodexFamilyStop {
+    /// A wedged child cannot prevent the parent being interrupted. Every child request receives
+    /// its own remaining deadline, and the number of simultaneous requests is bounded.
+    public static func interrupt(
+        _ turns: [String: String],
+        budget: Duration = .seconds(10),
+        concurrency: Int = 8,
+        send: @escaping @Sendable (String, String, Duration) async -> Void
+    ) async {
+        let deadline = ContinuousClock.now.advanced(by: budget)
+        await withTaskGroup(of: Void.self) { group in
+            var pending = turns.makeIterator()
+            func add(_ child: (key: String, value: String)) {
+                group.addTask {
+                    let remaining = ContinuousClock.now.duration(to: deadline)
+                    guard remaining > .zero, !Task.isCancelled else { return }
+                    await send(child.key, child.value, min(.seconds(3), remaining))
+                }
+            }
+            for _ in 0..<max(1, concurrency) {
+                if let child = pending.next() { add(child) }
+            }
+            while await group.next() != nil {
+                guard ContinuousClock.now < deadline, !Task.isCancelled else {
+                    group.cancelAll()
+                    return
+                }
+                if let child = pending.next() { add(child) }
+            }
+        }
+    }
+}

--- a/Sources/BloomCore/Agent/Codex/CodexClient.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexClient.swift
@@ -116,6 +116,9 @@ public actor CodexClient {
     private var nextRequestID = 1
     private var pending: [CodexRequestID: CheckedContinuation<JSONValue, Error>] = [:]
     private var handshakeCompleted = false
+    private var collaborationModeSupported: Bool?
+    public var planningIsSupported: Bool? { collaborationModeSupported }
+    public func resetPlanningSupport() { collaborationModeSupported = nil }
     private var closedReason: String?
 
     /// stderr, kept short. It only ever surfaces when the process dies without answering, which is
@@ -193,9 +196,9 @@ public actor CodexClient {
                     "name": .string(configuration.clientName),
                     "version": .string(configuration.clientVersion),
                 ]),
-                // Experimental methods are not opted into: everything Bloom needs is in the stable
-                // surface, and opting in would mean fields that can change without notice.
-                "capabilities": .object(["experimentalApi": .bool(false)]),
+                // codex-cli 0.153.4 exposes collaborationMode only in its experimental schema.
+                // Opting in is required for the independent Plan/Build control to reach the wire.
+                "capabilities": .object(["experimentalApi": .bool(true)]),
             ])
         )
         notify("initialized", params: nil)
@@ -383,9 +386,14 @@ public actor CodexClient {
         effort: String? = nil,
         approvalPolicy: CodexApprovalPolicy? = nil,
         sandboxPolicy: JSONValue? = nil,
-        approvalsReviewer: CodexApprovalsReviewer? = nil
+        approvalsReviewer: CodexApprovalsReviewer? = nil,
+        interactionMode: InteractionMode? = nil
     ) async throws -> CodexTurn {
-        let result = try await send("turn/start", params: .object(omittingNil: [
+        if interactionMode == .plan, collaborationModeSupported == false {
+            throw InteractionModeFailure.unsupported
+        }
+        if interactionMode != nil, model?.isEmpty != false { throw InteractionModeFailure.missingModel }
+        var params = JSONValue.object(omittingNil: [
             "threadId": .string(threadID),
             "input": .array(input.map(\.json)),
             "model": model.map(JSONValue.string),
@@ -393,7 +401,23 @@ public actor CodexClient {
             "approvalPolicy": approvalPolicy.map { .string($0.rawValue) },
             "sandboxPolicy": sandboxPolicy,
             "approvalsReviewer": approvalsReviewer.map { .string($0.rawValue) },
-        ]))
+            "collaborationMode": collaborationModeSupported == false ? nil : interactionMode.flatMap { mode in
+                model.map { mode.codexSettings(model: $0, effort: effort) }
+            },
+        ])
+        let result: JSONValue
+        do {
+            result = try await send("turn/start", params: params)
+        } catch let rejection as CodexRPCError where CodexPlanningCapability.isUnsupportedField(rejection) {
+            // Invalid parameters are an explicit rejection before acceptance. No timeout,
+            // disconnect, internal error or accepted turn can enter this retry path.
+            collaborationModeSupported = false
+            guard interactionMode == .build else { throw InteractionModeFailure.unsupported }
+            var fields = params.objectValue ?? [:]
+            fields.removeValue(forKey: "collaborationMode")
+            params = .object(fields)
+            result = try await send("turn/start", params: params)
+        }
         return CodexTurn.decode(result["turn"] ?? .null, threadID: threadID, raw: Data())
     }
 
@@ -420,11 +444,92 @@ public actor CodexClient {
 
     /// Stops a running turn. Both ids are required: `turn/interrupt` with only a thread id is
     /// refused with "missing field `turnId`".
-    public func interruptTurn(threadID: String, turnID: String) async throws {
+    public func interruptTurn(
+        threadID: String, turnID: String, timeout: Duration = CodexClient.requestTimeout
+    ) async throws {
         _ = try await send("turn/interrupt", params: .object([
             "threadId": .string(threadID),
             "turnId": .string(turnID),
+        ]), timeout: timeout)
+    }
+
+    /// Both history contracts occur in installed codex-cli 0.153.4. A provider turn ID is an
+    /// exact boundary; counting Bloom rows would also count steering messages and retries.
+    public func rewindThread(threadID: String, beforeTurnID: String) async throws {
+        let metadata = try await send("thread/read", params: .object([
+            "threadId": .string(threadID), "includeTurns": .bool(false),
         ]))
+        guard metadata["thread"]?["id"]?.stringValue == threadID else {
+            throw ConversationRewindError.invalidHistory
+        }
+        let historyMode = metadata["thread"]?["historyMode"]?.stringValue
+        guard historyMode == nil || historyMode == "legacy" || historyMode == "paginated" else {
+            throw ConversationRewindError.invalidHistory
+        }
+        if historyMode == "paginated" {
+            _ = try await send("thread/revert", params: .object([
+                "threadId": .string(threadID), "beforeTurnId": .string(beforeTurnID),
+            ]))
+            return
+        }
+        let history = try await send("thread/read", params: .object([
+            "threadId": .string(threadID), "includeTurns": .bool(true),
+        ]))
+        guard history["thread"]?["id"]?.stringValue == threadID,
+              let turns = history["thread"]?["turns"]?.arrayValue,
+              turns.allSatisfy({ $0["id"]?.stringValue != nil }) else {
+            throw ConversationRewindError.invalidHistory
+        }
+        guard let index = turns.firstIndex(where: { $0["id"]?.stringValue == beforeTurnID }) else {
+            throw ConversationRewindError.missingTurn
+        }
+        _ = try await send("thread/rollback", params: .object([
+            "threadId": .string(threadID), "numTurns": .integer(turns.count - index),
+        ]))
+    }
+
+    public func threadContainsTurn(threadID: String, turnID: String) async throws -> Bool {
+        let metadata = try await send("thread/read", params: .object([
+            "threadId": .string(threadID), "includeTurns": .bool(false),
+        ]))
+        guard metadata["thread"]?["id"]?.stringValue == threadID else {
+            throw ConversationRewindError.invalidHistory
+        }
+        let historyMode = metadata["thread"]?["historyMode"]?.stringValue
+        guard historyMode == nil || historyMode == "legacy" || historyMode == "paginated" else {
+            throw ConversationRewindError.invalidHistory
+        }
+        if historyMode != "paginated" {
+            let history = try await send("thread/read", params: .object([
+                "threadId": .string(threadID), "includeTurns": .bool(true),
+            ]))
+            guard history["thread"]?["id"]?.stringValue == threadID,
+                  let turns = history["thread"]?["turns"]?.arrayValue,
+                  turns.allSatisfy({ $0["id"]?.stringValue != nil }) else {
+                throw ConversationRewindError.invalidHistory
+            }
+            return turns.contains { $0["id"]?.stringValue == turnID }
+        }
+        var cursor: String?
+        var seen = Set<String>()
+        for _ in 0..<1_000 {
+            let page = try await send("thread/turns/list", params: .object([
+                "threadId": .string(threadID), "limit": .integer(100),
+                "sortDirection": .string("asc"), "itemsView": .string("summary"),
+                "cursor": cursor.map(JSONValue.string) ?? .null,
+            ]))
+            guard let turns = page["data"]?.arrayValue,
+                  turns.allSatisfy({ $0["id"]?.stringValue != nil }), let next = page.objectValue?["nextCursor"] else {
+                throw ConversationRewindError.invalidHistory
+            }
+            if turns.contains(where: { $0["id"]?.stringValue == turnID }) { return true }
+            if next == .null { return false }
+            guard let value = next.stringValue, seen.insert(value).inserted else {
+                throw ConversationRewindError.invalidHistory
+            }
+            cursor = value
+        }
+        throw ConversationRewindError.invalidHistory
     }
 
     /// The models this account may use, with each one's own reasoning efforts.

--- a/Sources/BloomCore/Agent/Codex/CodexPlanningCapability.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexPlanningCapability.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public enum CodexPlanningCapability {
+    public static let unavailableKey = "codex.planning.unavailable"
+    public static let rescanKey = "codex.planning.rescan"
+    public static let explanation = "This Codex version does not support Plan. Update Codex, then check again."
+
+    public static func isUnsupportedField(_ error: CodexRPCError) -> Bool {
+        let message = error.message.lowercased()
+        return error.code == -32602 && message.contains("collaborationmode")
+            && ["unknown field", "unrecognized field", "unrecognised field", "unsupported field",
+                "not supported", "unavailable", "experimental"].contains(where: message.contains)
+    }
+}

--- a/Sources/BloomCore/Agent/Codex/CodexRunner.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexRunner.swift
@@ -26,6 +26,8 @@ public actor CodexRunner: SessionRunner {
     private var pumpTask: Task<Void, Never>?
     private var translation: CodexTranslation
     private var threadID: String?
+    private var isRewinding = false
+    private var planningRescanToken: String?
 
     /// What this project has already approved. One type for both backends: see `SessionGrants`.
     private let grants: SessionGrants
@@ -60,7 +62,9 @@ public actor CodexRunner: SessionRunner {
 
     private let pending = PendingAsks()
     private let handle = CodexTurnHandle()
-    private let sink = EventFanout<AgentEvent>()
+    private let sink = AgentPresentationFeed()
+    private var sendsInFlight = 0
+    private var wasEvicted = false
 
     /// Whether this run has already been stopped because its transcript was deleted underneath
     /// it. See `stopBecauseTheTranscriptWentAway`.
@@ -102,6 +106,7 @@ public actor CodexRunner: SessionRunner {
     // MARK: - SessionRunner
 
     public nonisolated var events: AsyncStream<AgentEvent> { sink.stream() }
+    public nonisolated var presentationFeed: AgentPresentationFeed? { sink }
 
     /// Whether the server process is still there, which on this backend is **not** whether a turn
     /// is running.
@@ -134,11 +139,49 @@ public actor CodexRunner: SessionRunner {
     /// sentence. See `AgentKind.acceptsMidTurnMessage` for why a message reaches here mid turn at
     /// all, and `steer(_:threadID:turnID:on:)` for the fall back when the turn has just ended.
     public func send(_ text: String, recording: Data? = nil) async throws {
+        try await send(text, recording: recording, deliveryID: nil, interactionMode: nil)
+    }
+
+    public func evictIfIdle(for duration: Duration) async -> Bool {
+        guard !wasEvicted, !isRewinding, sendsInFlight == 0, !session.state.isMidTurn,
+              session.agentSessionID != nil, pending.isEmpty, !sink.hasBackgroundWork else { return false }
+        let lastActivity = sink.lastActivity
+        guard lastActivity.duration(to: .now) >= duration,
+              let waiting = try? await store.pendingDeliveries(sessionID: session.id), waiting.isEmpty else { return false }
+        // Recheck after the store hop. A send or a native background event invalidates the lease.
+        guard sendsInFlight == 0, !session.state.isMidTurn, pending.isEmpty,
+              !sink.hasBackgroundWork, sink.lastActivity == lastActivity else { return false }
+        wasEvicted = true
+        terminateNow()
+        return true
+    }
+
+    public func sendDelivery(_ delivery: Delivery) async throws {
+        var mode = delivery.interactionMode
+        if mode == nil { mode = try await store.session(id: sessionID)?.interactionMode }
+        try await send(delivery.sent, recording: delivery.crewPayload,
+                       deliveryID: delivery.id, interactionMode: mode)
+    }
+
+    private func send(_ text: String, recording: Data?, deliveryID: DeliveryID?,
+                      interactionMode: InteractionMode?) async throws {
+        guard !wasEvicted else { throw ProviderIdleError.retired }
+        guard !isRewinding else { throw ConversationRewindError.busy }
+        sendsInFlight += 1
+        sink.noteActivity()
+        defer { sendsInFlight -= 1 }
         let generation = handle.generation
         let replacement = handle.prepareReplacement()
         defer { handle.finishReplacement(replacement) }
         let prompt = try await store.sideConversationTurn(text, sessionID: sessionID)
         await applyContextWindowChange()
+        let token = try await store.setting(CodexPlanningCapability.rescanKey)
+        if token != planningRescanToken, handle.turnID == nil {
+            // After updating the CLI, discovery must use the new executable rather than the
+            // old app-server process that intentionally survives between turns.
+            await dropConnection()
+            planningRescanToken = token
+        }
         try handle.check(generation)
         let client = try await connected()
         try handle.check(generation)
@@ -146,10 +189,8 @@ public actor CodexRunner: SessionRunner {
         try handle.check(generation)
         // One row, whichever it is, for the reason `AgentRunner.send` gives: the crew payload
         // already holds both renderings, and a user row beside it is the envelope back on screen.
-        if let recording {
-            await persist(kind: .crew, payload: recording)
-        } else {
-            await persist(kind: .user, payload: Self.userPayload(text))
+        if deliveryID == nil {
+            if let recording { await persist(kind: .crew, payload: recording) } else { await persist(kind: .user, payload: Self.userPayload(text)) }
         }
         try handle.check(generation)
 
@@ -160,21 +201,39 @@ public actor CodexRunner: SessionRunner {
         // Asked rather than left to the steer failing, because a state has to be guarded by asking:
         // a turn the server has been told to abandon is not a turn a message belongs in, whatever
         // the server answers about it.
+        if let deliveryID { try await store.beginDeliveryDispatch(id: deliveryID) }
         if let turnID = handle.steerableTurnID,
-           await steer(prompt, threadID: threadID, turnID: turnID, on: client) {
+           try await steer(prompt, threadID: threadID, turnID: turnID, on: client) {
+            if let deliveryID { try await store.acceptDelivery(id: deliveryID, providerTurnID: turnID) }
             return
         }
         try handle.check(generation)
 
-        let turn = try await client.startTurn(
-            threadID: threadID,
-            input: [.text(prompt)],
-            model: wireModel,
-            effort: session.effort,
-            approvalPolicy: Self.approvalPolicy(for: session.permissionMode),
-            sandboxPolicy: Self.sandboxPolicy(for: session.permissionMode, writableRoot: workspacePath),
-            approvalsReviewer: Self.approvalsReviewer(for: session.permissionMode)
-        )
+        let turn: CodexTurn
+        do {
+            turn = try await client.startTurn(
+                threadID: threadID,
+                input: [.text(prompt)],
+                model: wireModel,
+                effort: session.effort,
+                approvalPolicy: Self.approvalPolicy(for: session.permissionMode),
+                sandboxPolicy: Self.sandboxPolicy(for: session.permissionMode, writableRoot: workspacePath),
+                approvalsReviewer: Self.approvalsReviewer(for: session.permissionMode),
+                interactionMode: interactionMode ?? session.interactionMode
+            )
+        } catch {
+            if await client.planningIsSupported == false {
+                try? await store.setSetting(CodexPlanningCapability.unavailableKey, "1")
+            }
+            if let deliveryID, InteractionModeFailure.isDefinitiveTurnRejection(error) {
+                try await store.restoreDelivery(id: deliveryID)
+            }
+            throw error
+        }
+        if await client.planningIsSupported == false {
+            try? await store.setSetting(CodexPlanningCapability.unavailableKey, "1")
+        }
+        if let deliveryID { try await store.acceptDelivery(id: deliveryID, providerTurnID: turn.id) }
         guard handle.begin(turnID: turn.id, generation: generation) else {
             // Stop can arrive while turn/start is in flight, before there is an id to interrupt.
             // Do not resurrect that turn when the reply finally supplies its id.
@@ -205,7 +264,8 @@ public actor CodexRunner: SessionRunner {
     /// is expected to survive.
     public nonisolated func cancelNow() {
         let stopped = handle.markCancelled()
-        Task { await self.stopTurn(stopped) }
+        let children = childTurns.snapshot
+        Task { await self.stopTurn(stopped, children: children) }
     }
 
     /// Stop, as the button means it: file the questions and then interrupt the turn.
@@ -220,11 +280,16 @@ public actor CodexRunner: SessionRunner {
     /// Answered before the interrupt rather than after, for the reason `AgentRunner.cancelNow`
     /// gives: an answer written after the thing that closes the turn is an answer the model never
     /// receives.
-    private func stopTurn(_ stopped: CodexTurnHandle.Stopped) async {
+    private func stopTurn(_ stopped: CodexTurnHandle.Stopped, children: [String: String]) async {
+        let connection = client
+        async let family: Void = CodexFamilyStop.interrupt(children) { thread, turn, timeout in
+            try? await connection?.interruptTurn(threadID: thread, turnID: turn, timeout: timeout)
+        }
         if handle.generation == stopped.generation, handle.wasCancelled {
             await filePendingAsks()
         }
         await interrupt(stopped)
+        await family
     }
 
     /// Answers every question this turn can no longer answer, and files it as stopped.
@@ -273,7 +338,7 @@ public actor CodexRunner: SessionRunner {
         if handle.generation == stopped.generation, handle.wasCancelled,
            session.apply(.cancelled).moves { await save(session) }
         guard let client, let threadID, let target else { return }
-        try? await client.interruptTurn(threadID: threadID, turnID: target)
+        do { try await client.interruptTurn(threadID: threadID, turnID: target, timeout: .seconds(3)) } catch { client.terminateNow() }
     }
 
     /// Answer one question, as a person. The turn resumes on the other side of this line.
@@ -336,6 +401,9 @@ public actor CodexRunner: SessionRunner {
         // stored id on the session row makes that message a `thread/resume`, which is the whole
         // reason the id is on the row.
         threadID = nil
+        subagents = CodexSubagents()
+        childTurns.replace([:])
+        sink.noteProcessEnded()
         items.removeAll()
         pumpTask?.cancel()
         pumpTask = nil
@@ -507,6 +575,27 @@ public actor CodexRunner: SessionRunner {
     // MARK: - Events
 
     private var subagents = CodexSubagents()
+    private nonisolated let childTurns = CodexChildTurns()
+
+    public nonisolated var supportsConversationRewind: Bool { true }
+
+    public func rewind(beforeTurnID: String) async throws {
+        guard !isRewinding, sendsInFlight == 0, handle.turnID == nil,
+              pending.isEmpty, !sink.hasBackgroundWork else { throw ConversationRewindError.busy }
+        isRewinding = true
+        defer { isRewinding = false }
+        let connection = try await connected()
+        let thread = try await openThread(on: connection)
+        try await connection.rewindThread(threadID: thread, beforeTurnID: beforeTurnID)
+        items.removeAll()
+    }
+
+    public func containsTurn(_ turnID: String) async throws -> Bool {
+        guard sendsInFlight == 0, handle.turnID == nil, pending.isEmpty else { throw ConversationRewindError.busy }
+        let connection = try await connected()
+        let thread = try await openThread(on: connection)
+        return try await connection.threadContainsTurn(threadID: thread, turnID: turnID)
+    }
 
     public func subagentTranscript(for id: SubagentID) async -> SubagentTranscript? {
         guard let child = subagents.threadID(for: id), let client,
@@ -518,9 +607,25 @@ public actor CodexRunner: SessionRunner {
     }
 
     private func handle(_ event: CodexEvent) async {
+        if case .itemCompleted(let item) = event, case .plan(let plan) = item.item,
+           item.threadID == threadID {
+            _ = try? await store.recordPlan(sessionID: session.id, sourceID: plan.id, markdown: plan.text)
+        }
         if let threadID {
+            let previousChildTurns = subagents.liveTurns
             for signal in subagents.receive(event, parentThreadID: threadID) {
                 sink.yield(.subagent(signal))
+            }
+            childTurns.replace(subagents.liveTurns)
+            if handle.wasCancelled, let client {
+                let arrived = subagents.liveTurns.filter { previousChildTurns[$0.key] != $0.value }
+                if !arrived.isEmpty {
+                    Task {
+                        await CodexFamilyStop.interrupt(arrived) { child, turn, timeout in
+                            try? await client.interruptTurn(threadID: child, turnID: turn, timeout: timeout)
+                        }
+                    }
+                }
             }
             if let source = event.threadID, source != threadID {
                 // Child approvals still need an answer, but their prose, usage and completion
@@ -592,8 +697,9 @@ public actor CodexRunner: SessionRunner {
 
     private func emit(_ event: AgentEvent, endingTurn: String? = nil) async {
         let intent = handle.intent
+        var storedMessage: Message?
         if event.isTranscriptRow {
-            await persist(
+            storedMessage = await persist(
                 kind: event.kind,
                 payload: event.raw.isEmpty ? Data("{}".utf8) : event.raw,
                 refID: event.refID
@@ -627,7 +733,7 @@ public actor CodexRunner: SessionRunner {
         }
 
         if let endingTurn, !handle.acceptsTerminal(turnID: endingTurn, intent: intent) { return }
-        sink.yield(event)
+        sink.yield(event, messageSeq: storedMessage?.seq)
     }
 
     // MARK: - Asking
@@ -679,11 +785,12 @@ public actor CodexRunner: SessionRunner {
     /// this is reached.
     private func steer(
         _ text: String, threadID: String, turnID: String, on client: CodexClient
-    ) async -> Bool {
+    ) async throws -> Bool {
         do {
             _ = try await client.steerTurn(threadID: threadID, turnID: turnID, input: [.text(text)])
             return true
         } catch {
+            guard CodexSendRecovery.permitsNewTurn(after: error) else { throw error }
             Self.log.info("a message missed the turn it was steered into, so it starts one")
             return false
         }
@@ -764,9 +871,10 @@ public actor CodexRunner: SessionRunner {
         return Data(json.compactJSON.utf8)
     }
 
-    private func persist(kind: MessageKind, payload: Data, refID: String? = nil) async {
+    @discardableResult
+    private func persist(kind: MessageKind, payload: Data, refID: String? = nil) async -> Message? {
         do {
-            try await store.appendNext(
+            return try await store.appendNext(
                 sessionID: session.id,
                 kind: kind,
                 payload: payload,
@@ -774,6 +882,7 @@ public actor CodexRunner: SessionRunner {
             )
         } catch {
             await report("could not store a \(kind.rawValue) row", error)
+            return nil
         }
     }
 

--- a/Sources/BloomCore/Agent/Codex/CodexSendRecovery.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexSendRecovery.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public enum CodexSendRecovery {
+    /// A reply explicitly rejecting the expected turn permits a fresh turn. Transport failures
+    /// and generic provider errors give no evidence that the steer was not already delivered.
+    public static func permitsNewTurn(after error: any Error) -> Bool {
+        guard let refusal = error as? CodexRPCError,
+              refusal.code == -32602 || refusal.code == -32000 else { return false }
+        let message = refusal.message.lowercased()
+        return message.contains("no active turn") || message.contains("turn is not active")
+            || message.contains("expectedturnid") || message.contains("expected turn id")
+            || message.contains("turn id mismatch")
+    }
+}

--- a/Sources/BloomCore/Agent/Codex/CodexSubagents.swift
+++ b/Sources/BloomCore/Agent/Codex/CodexSubagents.swift
@@ -5,6 +5,11 @@ import Foundation
 public struct CodexSubagents: Sendable {
     private var children: [String: CodexSubAgentActivity] = [:]
     private var seenActivities: Set<String> = []
+    private var observedTurns: [String: String] = [:]
+
+    public var liveTurns: [String: String] {
+        observedTurns.filter { children[$0.key] != nil }
+    }
 
     public init() {}
 
@@ -17,6 +22,17 @@ public struct CodexSubagents: Sendable {
     public static func id(for threadID: String) -> SubagentID { SubagentID("codex:\(threadID)") }
 
     public mutating func receive(_ event: CodexEvent, parentThreadID: String) -> [SubagentSignal] {
+        // A child can announce its turn before the parent announces the child. Retain a bounded
+        // set of those candidates, but never interrupt a thread until ownership is established.
+        if case .turnStarted(let turn) = event, turn.threadID != parentThreadID {
+            if children[turn.threadID] != nil || observedTurns.count < 256 {
+                observedTurns[turn.threadID] = turn.id
+            }
+        }
+        if case .turnCompleted(let turn) = event {
+            if let active = observedTurns[turn.threadID], active != turn.id { return [] }
+            observedTurns[turn.threadID] = nil
+        }
         guard let source = event.threadID,
               source == parentThreadID || contains(threadID: source) else { return [] }
         switch event {
@@ -30,6 +46,7 @@ public struct CodexSubagents: Sendable {
                 signals.append(.started(start(activity)))
             }
             if activity.kind == "completed" || activity.kind == "interrupted" {
+                observedTurns[activity.agentThreadID] = nil
                 signals.append(.reported(SubagentReport(
                     id: Self.id(for: activity.agentThreadID), status: activity.kind, summary: ""
                 )))

--- a/Sources/BloomCore/Agent/ComposerControls.swift
+++ b/Sources/BloomCore/Agent/ComposerControls.swift
@@ -32,7 +32,10 @@ public struct ComposerControls: Equatable, Sendable {
     /// workspace start, and the app-wide "start in plan mode" default, which is chosen in Settings
     /// long before any backend is. See `PermissionMode.nearest(on:)` for where each one lands.
     public var agentKind: AgentKind {
-        didSet { permissionMode = permissionMode.nearest(on: agentKind) }
+        didSet {
+            permissionMode = permissionMode.nearest(on: agentKind)
+            interactionMode = interactionMode.nearest(on: agentKind)
+        }
     }
     /// The mode, which can never be one this backend does not have. Assigning one this backend
     /// has no row for lands it on the nearest mode that backend does have, by the same rule the
@@ -41,6 +44,8 @@ public struct ComposerControls: Equatable, Sendable {
     public var permissionMode: PermissionMode {
         didSet { permissionMode = permissionMode.nearest(on: agentKind) }
     }
+    public var interactionMode: InteractionMode
+    public var offersInteractionMode: Bool { InteractionMode.supports(agentKind) }
     public var isFastMode: Bool
     /// How the agent is asked to write, by name. `OutputStyle.defaultName` for "leave it alone",
     /// which is what a session is until somebody picks something else.
@@ -62,7 +67,8 @@ public struct ComposerControls: Equatable, Sendable {
         isFastMode: Bool = false,
         outputStyle: String = OutputStyle.defaultName,
         codexContextWindow: Int = CodexContextWindow.modelDefault,
-        hasWorktree: Bool = true
+        hasWorktree: Bool = true,
+        interactionMode: InteractionMode = .build
     ) {
         self.model = model
         self.effort = effort
@@ -75,6 +81,7 @@ public struct ComposerControls: Equatable, Sendable {
         self.outputStyle = outputStyle
         self.codexContextWindow = codexContextWindow
         self.hasWorktree = hasWorktree
+        self.interactionMode = interactionMode.nearest(on: agentKind)
     }
 
     public init(
@@ -93,15 +100,15 @@ public struct ComposerControls: Equatable, Sendable {
             codexContextWindow: codexContextWindow,
             // Read off the row rather than passed in, so the one caller that has a chat with no
             // worktree cannot forget to say so.
-            hasWorktree: session.workspaceID != nil
+            hasWorktree: session.workspaceID != nil,
+            interactionMode: session.interactionMode
         )
     }
 
     /// The modes this backend actually has.
     ///
-    /// Codex has no Plan. Its permission story is an approval policy crossed with a sandbox, and
-    /// there is nothing in that grid that means "work it out and do not touch anything". Offering
-    /// the mode anyway would be a control that silently does nothing.
+    /// Codex planning is a separate interaction mode, not a permission setting. Its permission
+    /// picker therefore excludes the legacy Plan case used by the other providers.
     ///
     /// Claude Code has no Approve for me, and loses nothing by it: its own Auto mode is that mode
     /// under another name, so a second row would be two names for one `--permission-mode auto`.
@@ -184,7 +191,8 @@ public struct ComposerControls: Equatable, Sendable {
             permissionMode: defaults.permissionMode,
             isFastMode: isFastMode,
             outputStyle: outputStyle,
-            codexContextWindow: codexContextWindow
+            codexContextWindow: codexContextWindow,
+            interactionMode: defaults.interactionMode
         )
     }
 

--- a/Sources/BloomCore/Agent/ComposerDefaults.swift
+++ b/Sources/BloomCore/Agent/ComposerDefaults.swift
@@ -27,6 +27,7 @@ public struct ComposerDefaults: Equatable {
     /// beside it, because a model id already names its backend: see `DefaultBackend` for the three
     /// questions and for why the one Settings recorded is asked first.
     public var backend: AgentKind = .claudeCode
+    public var interactionMode: InteractionMode = .build
 
     /// Pure, so the rules above can be checked without a store, a repository or a view.
     ///
@@ -98,9 +99,10 @@ public struct ComposerDefaults: Equatable {
             // is the whole point of settling the two together: Plan plus a Codex default used to
             // depend on the caller passing the right backend in, and the create window passed none.
             permissionMode: (hasWorktree
-                ? (app.planMode ? .plan : app.permissionMode)
+                ? (app.planMode && resolved.kind != .codex ? .plan : app.permissionMode)
                 : AskConversation.permissionMode).nearest(on: resolved.kind),
-            backend: resolved.kind
+            backend: resolved.kind,
+            interactionMode: hasWorktree && app.planMode && resolved.kind == .codex ? .plan : .build
         )
     }
 

--- a/Sources/BloomCore/Agent/ConversationRewind.swift
+++ b/Sources/BloomCore/Agent/ConversationRewind.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public enum ConversationRewindError: Error, LocalizedError, Sendable {
+    case unsupported
+    case busy
+    case missingTurn
+    case invalidHistory
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupported: "This agent does not support conversation rewind."
+        case .busy: "Stop all work in this conversation before rewinding."
+        case .missingTurn: "The selected turn is no longer in the agent's history."
+        case .invalidHistory: "The agent returned incomplete conversation history. Nothing was rewound."
+        }
+    }
+}

--- a/Sources/BloomCore/Agent/Delivery.swift
+++ b/Sources/BloomCore/Agent/Delivery.swift
@@ -40,6 +40,13 @@ public struct Delivery: Identifiable, Sendable, Hashable {
         case report
     }
 
+    public enum State: String, Sendable, Hashable, Codable {
+        case pending, claimed, accepted, uncertain
+    }
+
+    public var state: State
+    public var interactionMode: InteractionMode?
+    public var providerTurnID: String?
     public var id: DeliveryID
     /// The conversation this is addressed to, resolved when it was asked for rather than when it
     /// goes. A workspace can hold several chats, so a message addressed to a workspace is
@@ -86,8 +93,14 @@ public struct Delivery: Identifiable, Sendable, Hashable {
         crewPayload: Data? = nil,
         createdAt: Date = Date(),
         deliveredAt: Date? = nil,
-        deliveredSeq: Int? = nil
+        deliveredSeq: Int? = nil,
+        state: State? = nil,
+        interactionMode: InteractionMode? = nil,
+        providerTurnID: String? = nil
     ) {
+        self.state = state ?? (deliveredAt == nil ? .pending : .accepted)
+        self.interactionMode = interactionMode
+        self.providerTurnID = providerTurnID
         self.id = id
         self.targetSessionID = targetSessionID
         self.sourceWorkspaceID = sourceWorkspaceID
@@ -139,7 +152,7 @@ public struct Delivery: Identifiable, Sendable, Hashable {
     /// place decides which of the two renderings goes to the model.
     public var sent: String { crewMessage?.sent ?? body }
 
-    public var isPending: Bool { deliveredAt == nil }
+    public var isPending: Bool { state == .pending || state == .uncertain }
 
     /// Everything that may be handed over right now, in the order it was asked for.
     ///
@@ -168,8 +181,9 @@ public struct Delivery: Identifiable, Sendable, Hashable {
         from pending: [Delivery], hold: DeliveryHold, on agent: AgentKind
     ) -> [Delivery] {
         guard hold.allowsDelivery(on: agent) else { return [] }
-        guard agent.acceptsMidTurnMessage else { return Array(pending.prefix(1)) }
-        return pending
+        let ready = Array(pending.prefix { $0.state == .pending })
+        guard agent.acceptsMidTurnMessage else { return Array(ready.prefix(1)) }
+        return ready
     }
 
     /// Which of the waiting messages goes next, if any may go at all.
@@ -206,6 +220,6 @@ public struct Delivery: Identifiable, Sendable, Hashable {
         // Anything already waiting is in front of it, and the front of the queue always wins.
         // This is the guard that keeps immediate delivery from being a reordering: a backend that
         // takes a message mid turn still takes the oldest one first.
-        return next(from: pending, hold: hold, on: agent) == nil
+        return pending.isEmpty
     }
 }

--- a/Sources/BloomCore/Agent/DeliveryDispatchError.swift
+++ b/Sources/BloomCore/Agent/DeliveryDispatchError.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public enum DeliveryDispatchError: Error, LocalizedError, Sendable {
+    case notClaimed
+    case processUnavailable
+
+    public var errorDescription: String? {
+        switch self {
+        case .notClaimed: "This message is no longer waiting to be sent."
+        case .processUnavailable: "The agent process could not start. Try again."
+        }
+    }
+}

--- a/Sources/BloomCore/Agent/Grok/GrokRunner.swift
+++ b/Sources/BloomCore/Agent/Grok/GrokRunner.swift
@@ -35,7 +35,9 @@ public actor GrokRunner: SessionRunner {
     private let connection = LiveConnection()
     private let pending = PendingAsks()
     private let handle = CodexTurnHandle()
-    private let sink = EventFanout<AgentEvent>()
+    private let sink = AgentPresentationFeed()
+    private var sendsInFlight = 0
+    private var wasEvicted = false
     private var trouble = PersistenceTrouble()
     private let bridge: BridgeAttachment?
 
@@ -65,6 +67,7 @@ public actor GrokRunner: SessionRunner {
     }
 
     public nonisolated var events: AsyncStream<AgentEvent> { sink.stream() }
+    public nonisolated var presentationFeed: AgentPresentationFeed? { sink }
 
     public var isProcessAlive: Bool { connection.current?.isProcessAlive ?? false }
 
@@ -79,6 +82,34 @@ public actor GrokRunner: SessionRunner {
     // MARK: - SessionRunner
 
     public func send(_ text: String, recording: Data? = nil) async throws {
+        try await send(text, recording: recording, deliveryID: nil, interactionMode: nil)
+    }
+
+    public func evictIfIdle(for duration: Duration) async -> Bool {
+        guard !wasEvicted, sendsInFlight == 0, !session.state.isMidTurn,
+              session.agentSessionID != nil, pending.isEmpty, !sink.hasBackgroundWork else { return false }
+        let lastActivity = sink.lastActivity
+        guard lastActivity.duration(to: .now) >= duration,
+              let waiting = try? await store.pendingDeliveries(sessionID: session.id), waiting.isEmpty else { return false }
+        // Recheck after the store hop. A send or a native background event invalidates the lease.
+        guard sendsInFlight == 0, !session.state.isMidTurn, pending.isEmpty,
+              !sink.hasBackgroundWork, sink.lastActivity == lastActivity else { return false }
+        wasEvicted = true
+        terminateNow()
+        return true
+    }
+
+    public func sendDelivery(_ delivery: Delivery) async throws {
+        try await send(delivery.sent, recording: delivery.crewPayload,
+                       deliveryID: delivery.id, interactionMode: delivery.interactionMode)
+    }
+
+    private func send(_ text: String, recording: Data?, deliveryID: DeliveryID?,
+                      interactionMode: InteractionMode?) async throws {
+        guard !wasEvicted else { throw ProviderIdleError.retired }
+        sendsInFlight += 1
+        sink.noteActivity()
+        defer { sendsInFlight -= 1 }
         let generation = handle.generation
         let replacement = handle.prepareReplacement()
         defer { handle.finishReplacement(replacement) }
@@ -94,14 +125,14 @@ public actor GrokRunner: SessionRunner {
         try await applyComposerSettings(on: client, sessionID: grokSessionID)
         try handle.check(generation)
 
-        if let recording {
-            await persist(kind: .crew, payload: recording)
-        } else {
-            await persist(kind: .user, payload: Self.userPayload(text))
+        if deliveryID == nil {
+            if let recording { await persist(kind: .crew, payload: recording) } else { await persist(kind: .user, payload: Self.userPayload(text)) }
         }
         try handle.check(generation)
 
+        if let deliveryID { try await store.beginDeliveryDispatch(id: deliveryID) }
         let promptID = try await client.beginPrompt(sessionID: grokSessionID, text: text)
+        if let deliveryID { try await store.acceptDelivery(id: deliveryID, providerTurnID: promptID.turnID) }
         guard handle.begin(turnID: promptID.turnID, generation: generation) else {
             await client.cancel(sessionID: grokSessionID)
             throw CancellationError()
@@ -129,6 +160,7 @@ public actor GrokRunner: SessionRunner {
     }
 
     public nonisolated func terminateNow() {
+        sink.noteProcessEnded()
         handle.markCancelled()
         connection.current?.terminateNow()
         Task { await self.shutdown() }
@@ -306,8 +338,9 @@ public actor GrokRunner: SessionRunner {
 
     private func emit(_ event: AgentEvent, endingTurn: String? = nil) async {
         let intent = handle.intent
+        var storedMessage: Message?
         if event.isTranscriptRow {
-            await persist(
+            storedMessage = await persist(
                 kind: event.kind,
                 payload: event.raw.isEmpty ? Data("{}".utf8) : event.raw,
                 refID: event.refID
@@ -337,7 +370,7 @@ public actor GrokRunner: SessionRunner {
         }
 
         if let endingTurn, !handle.acceptsTerminal(turnID: endingTurn, intent: intent) { return }
-        sink.yield(event)
+        sink.yield(event, messageSeq: storedMessage?.seq)
     }
 
     // MARK: - Asking
@@ -430,9 +463,10 @@ public actor GrokRunner: SessionRunner {
         return Data(json.compactJSON.utf8)
     }
 
-    private func persist(kind: MessageKind, payload: Data, refID: String? = nil) async {
+    @discardableResult
+    private func persist(kind: MessageKind, payload: Data, refID: String? = nil) async -> Message? {
         do {
-            try await store.appendNext(
+            return try await store.appendNext(
                 sessionID: session.id,
                 kind: kind,
                 payload: payload,
@@ -440,6 +474,7 @@ public actor GrokRunner: SessionRunner {
             )
         } catch {
             await report("could not store a \(kind.rawValue) row", error)
+            return nil
         }
     }
 

--- a/Sources/BloomCore/Agent/InteractionMode.swift
+++ b/Sources/BloomCore/Agent/InteractionMode.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Planning describes the requested work, independently of permission to change files.
+public enum InteractionMode: String, Codable, CaseIterable, Sendable, Hashable {
+    case build
+    case plan
+
+    public var label: String { self == .plan ? "Plan" : "Build" }
+
+    public static func supports(_ agent: AgentKind) -> Bool { agent == .codex }
+
+    public func nearest(on agent: AgentKind) -> InteractionMode {
+        Self.supports(agent) ? self : .build
+    }
+
+    /// Verified against the schema emitted by codex-cli 0.153.4. Null instructions preserve
+    /// Codex's own planning instructions instead of copying a second application's prompt.
+    public func codexSettings(model: String, effort: String?) -> JSONValue {
+        .object([
+            "mode": .string(self == .plan ? "plan" : "default"),
+            "settings": .object([
+                "model": .string(model),
+                "reasoning_effort": effort.flatMap { $0.isEmpty ? nil : .string($0) } ?? .null,
+                "developer_instructions": .null,
+            ]),
+        ])
+    }
+}

--- a/Sources/BloomCore/Agent/InteractionModeFailure.swift
+++ b/Sources/BloomCore/Agent/InteractionModeFailure.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public enum InteractionModeFailure: Error, LocalizedError, Sendable {
+    case unsupported
+    case missingModel
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupported: "This Codex version does not support Plan mode. Update Codex or switch to Build."
+        case .missingModel: "Choose a Codex model before changing the work mode."
+        }
+    }
+
+    /// Only local validation and JSON-RPC's explicit request rejection prove a turn was not
+    /// accepted. A timeout, connection loss or provider internal error remains uncertain.
+    public static func isDefinitiveTurnRejection(_ error: any Error) -> Bool {
+        if error is InteractionModeFailure { return true }
+        guard let rpc = error as? CodexRPCError else { return false }
+        return rpc.code == -32602 || rpc.code == -32601
+    }
+}

--- a/Sources/BloomCore/Agent/PlanArtefact.swift
+++ b/Sources/BloomCore/Agent/PlanArtefact.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Each revision keeps its exact text. A handoff refers to that revision even if planning
+/// continues in the original conversation while implementation is running elsewhere.
+public struct PlanArtefact: Identifiable, Codable, Sendable, Hashable {
+    public var id: PlanArtefactID
+    public var sessionID: SessionID
+    public var sourceID: String
+    public var version: Int
+    public var markdown: String
+    public var createdAt: Date
+    public var implementationSessionID: SessionID?
+
+    public init(
+        id: PlanArtefactID = .new(), sessionID: SessionID, sourceID: String,
+        version: Int, markdown: String, createdAt: Date = Date(),
+        implementationSessionID: SessionID? = nil
+    ) {
+        self.id = id
+        self.sessionID = sessionID
+        self.sourceID = sourceID
+        self.version = version
+        self.markdown = markdown
+        self.createdAt = createdAt
+        self.implementationSessionID = implementationSessionID
+    }
+
+    public var title: String {
+        let heading = markdown.components(separatedBy: .newlines).first {
+            $0.trimmingCharacters(in: .whitespaces).hasPrefix("#")
+        }
+        let text = heading?.trimmingCharacters(in: CharacterSet(charactersIn: "# ")) ?? "Plan"
+        return text.isEmpty ? "Plan" : String(text.prefix(120))
+    }
+
+    public var implementationPrompt: String {
+        "Implement this plan (revision \(version)):\n\n\(markdown)"
+    }
+
+    public static func storageKey(sessionID: SessionID) -> String { "session.\(sessionID).plans" }
+    public static func sourceKey(sessionID: SessionID) -> String { "session.\(sessionID).sourcePlan" }
+}

--- a/Sources/BloomCore/Agent/ProviderIdlePolicy.swift
+++ b/Sources/BloomCore/Agent/ProviderIdlePolicy.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public enum ProviderIdlePolicy {
+    public static let settingKey = "agents.idleProcessMinutes"
+    public static let choices = [0, 15, 30, 60, 120]
+    /// Opt in: restarting a provider trades memory for startup time and process-local grants.
+    public static func duration(stored: String?) -> Duration? {
+        guard let value = stored.flatMap(Int.init), choices.contains(value), value > 0 else { return nil }
+        return .seconds(value * 60)
+    }
+}
+
+public enum ProviderIdleError: Error, Sendable {
+    case retired
+}

--- a/Sources/BloomCore/Agent/SessionRunner.swift
+++ b/Sources/BloomCore/Agent/SessionRunner.swift
@@ -26,6 +26,7 @@ public protocol SessionRunner: Actor {
     /// stream each time because one shared stream lets the first consumer to walk away finish it
     /// for everybody.
     nonisolated var events: AsyncStream<AgentEvent> { get }
+    nonisolated var presentationFeed: AgentPresentationFeed? { get }
 
     /// Whether the backend process is still there.
     ///
@@ -36,6 +37,7 @@ public protocol SessionRunner: Actor {
     /// is open", so quit interrupted the turn, watched it close and concluded the process was gone
     /// while it was still running. One name, two facts, and the wrong one was being polled.
     var isProcessAlive: Bool { get }
+    func evictIfIdle(for duration: Duration) async -> Bool
 
     /// Write one turn. Starts whatever has to be started, on first use.
     ///
@@ -49,6 +51,10 @@ public protocol SessionRunner: Actor {
     /// record, once, and the runner writes one row either way. Never two: a turn is one message
     /// in the transcript whoever asked for it.
     func send(_ text: String, recording: Data?) async throws
+    func sendDelivery(_ delivery: Delivery) async throws
+    nonisolated var supportsConversationRewind: Bool { get }
+    func rewind(beforeTurnID: String) async throws
+    func containsTurn(_ turnID: String) async throws -> Bool
 
     /// Stop the turn now, from synchronous code that cannot wait for a turn on the actor. Which is
     /// exactly when the actor is least available, because it is busy running the thing being
@@ -74,6 +80,15 @@ public protocol SessionRunner: Actor {
 }
 
 extension SessionRunner {
+    public nonisolated var supportsConversationRewind: Bool { false }
+    public func rewind(beforeTurnID: String) async throws { throw ConversationRewindError.unsupported }
+    public func containsTurn(_ turnID: String) async throws -> Bool { throw ConversationRewindError.unsupported }
+    public func evictIfIdle(for duration: Duration) async -> Bool { false }
+    public nonisolated var presentationFeed: AgentPresentationFeed? { nil }
+    public func sendDelivery(_ delivery: Delivery) async throws {
+        try await send(delivery.sent, recording: delivery.crewPayload)
+    }
+
     /// The owner's own turn: what goes out is what is written down.
     ///
     /// An extension rather than a default argument on the requirement, because Swift does not

--- a/Sources/BloomCore/Bridge/AgentStartSource.swift
+++ b/Sources/BloomCore/Bridge/AgentStartSource.swift
@@ -149,6 +149,7 @@ public enum AgentStartBranch: Sendable, Equatable {
         async let local = Git.branches(of: repo.path)
         async let remote = Git.remoteBranches(of: repo.path)
         async let worktrees = Git.worktrees(of: repo.path)
+        async let remoteNames = Git.remoteNames(of: repo.path)
 
         let holders = BranchHolder.byBranch(
             worktrees: (try? await worktrees) ?? [],
@@ -158,7 +159,8 @@ public enum AgentStartBranch: Sendable, Equatable {
             )
         )
         return WorkspaceCheckoutPlan.everyBranch(
-            local: (try? await local) ?? [], remote: (try? await remote) ?? [], inUse: holders
+            local: (try? await local) ?? [], remote: (try? await remote) ?? [], inUse: holders,
+            remoteNames: (try? await remoteNames) ?? []
         )
     }
 

--- a/Sources/BloomCore/Bridge/WorkspaceArchiveSafety.swift
+++ b/Sources/BloomCore/Bridge/WorkspaceArchiveSafety.swift
@@ -25,6 +25,7 @@ public enum WorkspaceArchiveSafety {
             return "Workspace setup is still running. Wait for it to finish before archiving."
         }
         do {
+            try await store.requireWorkspaceCanBeRemoved(id: workspace.id)
             for session in try await store.sessions(workspaceID: workspace.id) {
                 if session.id != asking, session.state == .running || session.state == .waiting {
                     return """
@@ -36,6 +37,8 @@ public enum WorkspaceArchiveSafety {
                     return "This workspace has queued messages. Handle them before archiving."
                 }
             }
+        } catch WorkspaceError.recoveryPending {
+            return WorkspaceError.recoveryPending.description
         } catch {
             return "Bloom could not check this workspace's activity. Nothing was archived; try again shortly."
         }

--- a/Sources/BloomCore/Git/DiffRefreshInvalidations.swift
+++ b/Sources/BloomCore/Git/DiffRefreshInvalidations.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// A completed Git read can acknowledge only the file events that preceded it. Events that
+/// arrived while that read was suspended remain pending for the next pass.
+public struct DiffRefreshInvalidations: Sendable {
+    public private(set) var pending: Set<WorkspaceID> = []
+    private var generations: [WorkspaceID: UInt64] = [:]
+
+    public init() {}
+
+    public mutating func record(_ ids: Set<WorkspaceID>) {
+        for id in ids {
+            generations[id, default: 0] &+= 1
+            pending.insert(id)
+        }
+    }
+
+    public func generation(for id: WorkspaceID) -> UInt64 { generations[id, default: 0] }
+
+    public mutating func finish(_ id: WorkspaceID, generation: UInt64, succeeded: Bool) {
+        if succeeded, generation == self.generation(for: id) {
+            pending.remove(id)
+        } else {
+            pending.insert(id)
+        }
+    }
+
+    public mutating func retain(_ ids: Set<WorkspaceID>) {
+        pending.formIntersection(ids)
+        generations = generations.filter { ids.contains($0.key) }
+    }
+}

--- a/Sources/BloomCore/Git/Git+Branches.swift
+++ b/Sources/BloomCore/Git/Git+Branches.swift
@@ -29,10 +29,8 @@ extension Git {
 
     // MARK: - Cutting a branch from an updated base
 
-    /// The remote Bloom talks to. Spelled once here rather than threaded through every call: the
-    /// rest of the app already hardcodes it (`GitHub.push`, `GitHub.deleteRemoteBranch`), and a
-    /// second, configurable idea of which remote is the real one would only be able to disagree
-    /// with those.
+    /// The conventional fallback for caller-facing defaults. Live operations resolve the
+    /// repository's configured base and publication destinations through repositoryContext.
     public static let remote = "origin"
 
     /// Updates one branch's remote-tracking ref, and says whether it worked.
@@ -45,9 +43,15 @@ extension Git {
     /// Never throws. Being offline is an ordinary thing rather than an error, and every caller
     /// here has somewhere to fall back to.
     public static func fetch(
-        _ branch: String, in directory: String, timeout: Duration = .seconds(20)
+        _ branch: String, in directory: String, remote: String? = nil,
+        timeout: Duration = .seconds(20)
     ) async -> Bool {
         guard isValidBranchName(branch) else { return false }
+        let destination: String?
+        if let remote { destination = remote } else {
+            destination = try? await repositoryContext(in: directory, baseBranch: branch).baseRemote
+        }
+        guard let remote = destination, (try? validate(ref: remote, label: "remote")) != nil else { return false }
         let refspec = "+refs/heads/\(branch):refs/remotes/\(remote)/\(branch)"
         let result = try? await run(
             ["fetch", "--no-tags", "--", remote, refspec], in: directory, timeout: timeout
@@ -80,9 +84,13 @@ extension Git {
         branch: String, in directory: String
     ) async throws -> (revision: String, base: ContinuationBase) {
         try validate(branch: branch)
-        let fetched = await fetch(branch, in: directory)
+        let context = try await repositoryContext(in: directory, baseBranch: branch)
+        let fetched = if let remote = context.baseRemote {
+            await fetch(context.baseBranch, in: directory, remote: remote)
+        } else { false }
 
-        if let revision = await revision(of: "refs/remotes/\(remote)/\(branch)", in: directory) {
+        if let tracking = context.baseTrackingRef,
+           let revision = await revision(of: tracking, in: directory) {
             return (revision, fetched ? .fetched : .cachedRemote)
         }
         if let revision = await revision(of: "refs/heads/\(branch)", in: directory) {
@@ -91,7 +99,7 @@ extension Git {
         throw ShellError(
             command: "git rev-parse \(branch)",
             status: 1,
-            stderr: "Bloom could not find \(branch) here, on \(remote) or on this disk."
+            stderr: "Bloom could not find \(branch) in this repository or on its configured base remote."
         )
     }
 

--- a/Sources/BloomCore/Git/Git+Diffs.swift
+++ b/Sources/BloomCore/Git/Git+Diffs.swift
@@ -243,16 +243,28 @@ extension Git {
     ) async throws -> String {
         if file.change == .untracked {
             let result = try await run(
-                ["diff", "--no-index", "--no-color", "--", "/dev/null", file.path], in: worktree
+                ["diff", "--no-index"] + patchOptions + ["--", "/dev/null", file.path], in: worktree
             )
             // --no-index exits 1 whenever there is a difference, which is the normal case here.
+            // Some Git versions also use exit 1 for a missing input. A real difference has
+            // patch output; an empty stdout accompanied by diagnostics is not an empty file.
+            guard result.status == 0 || result.status == 1,
+                  !(result.status == 1 && result.stdout.isEmpty && !result.stderr.isEmpty) else {
+                throw error(["diff", "--no-index"], result.status, result.stderr, result.stdout)
+            }
             return result.stdout
         }
         let mergeBase = try await revision(for: scope, base: base, in: worktree)
         return try await check(
-            ["diff", "--no-color", "-M", mergeBase, "--", file.path], in: worktree
+            literalPaths(["diff"] + patchOptions + ["-M", mergeBase, "--", file.path]), in: worktree
         ).stdout
     }
+
+    /// A patch is a data format here. Personal diff tools and text converters can replace it
+    /// with arbitrary output, while mnemonic prefixes change the paths the parser reads.
+    private static let patchOptions = [
+        "--no-color", "--no-ext-diff", "--no-textconv", "--src-prefix=a/", "--dst-prefix=b/",
+    ]
 
     /// What a scope diffs against, resolved against this worktree.
     ///

--- a/Sources/BloomCore/Git/Git+SnapshotSummary.swift
+++ b/Sources/BloomCore/Git/Git+SnapshotSummary.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+extension Git {
+    /// A turn's footer describes its net file changes, including shell writes and files edited
+    /// several times. Only the two saved trees participate, so later work cannot change it.
+    public static func snapshotFiles(
+        from before: GitSnapshot, to after: GitSnapshot, in worktree: String
+    ) async throws -> [ChangedFile] {
+        guard UUID(uuidString: before.id.rawValue) != nil, UUID(uuidString: after.id.rawValue) != nil else {
+            throw SnapshotFailure("Invalid snapshot identifier.")
+        }
+        let range = [before.worktreeRef + "^{tree}", after.worktreeRef + "^{tree}", "--"]
+        let options = ["diff", "--no-ext-diff", "--no-textconv", "--no-color", "--find-renames"]
+        async let namesRead = checkRaw(literalPaths(options + ["--name-status", "-z"] + range), in: worktree)
+        async let countsRead = checkRaw(literalPaths(options + ["--numstat", "-z"] + range), in: worktree)
+        let names = try await namesRead
+        let counts = try await countsRead
+        // A replacement character could name another real file when the footer opens its diff.
+        guard String(data: names.stdout, encoding: .utf8) != nil,
+              String(data: counts.stdout, encoding: .utf8) != nil else {
+            throw SnapshotFailure("A snapshot filename cannot be represented safely.")
+        }
+        let changes = parseNameStatus(names.stdout)
+        var files = parseNumstat(counts.stdout, changes: changes)
+        for (path, change) in changes where files[path] == nil {
+            files[path] = ChangedFile(path: path, oldPath: change.1, change: change.0)
+        }
+        return files.values.sorted { $0.path < $1.path }
+    }
+}

--- a/Sources/BloomCore/Git/Git+Snapshots.swift
+++ b/Sources/BloomCore/Git/Git+Snapshots.swift
@@ -1,0 +1,221 @@
+import Foundation
+
+extension Git {
+    /// The real index is only read. Each capture has independent indexes in the Git directory,
+    /// so simultaneous sessions cannot overwrite each other's staging or checkpoint files.
+    public static func captureSnapshot(in worktree: String, sessionID: SessionID) async throws -> GitSnapshot {
+        try await validateSnapshotWorktree(worktree)
+        let gitDirectory = try await check(["rev-parse", "--absolute-git-dir"], in: worktree).trimmed
+        let indexPath = (gitDirectory as NSString).appendingPathComponent("index")
+        let snapshot = GitSnapshot(sessionID: sessionID, indexWasPresent: FileManager.default.fileExists(atPath: indexPath))
+        let temporary = (gitDirectory as NSString).appendingPathComponent("bloom-snapshot-\(snapshot.id)")
+        let workIndex = temporary + "-work"
+        let savedIndex = temporary + "-index"
+        defer {
+            for path in [workIndex, savedIndex, workIndex + ".lock", savedIndex + ".lock"] {
+                try? FileManager.default.removeItem(atPath: path)
+            }
+        }
+        if FileManager.default.fileExists(atPath: indexPath + ".lock") {
+            throw SnapshotFailure("Git is updating the index. Try again when it has finished.")
+        }
+        if FileManager.default.fileExists(atPath: indexPath) {
+            try FileManager.default.copyItem(atPath: indexPath, toPath: savedIndex)
+        } else {
+            _ = try await snapshotCommand(["read-tree", "--empty"], in: worktree, index: savedIndex)
+        }
+        do {
+            // A split index references an expiring sharedindex file. Store a standalone index
+            // blob so intent-to-add and per-path flags survive both GC and a tree round trip.
+            _ = try await snapshotCommand(["update-index", "--no-split-index"], in: worktree, index: savedIndex)
+            let rawIndex = try await snapshotCommand(["hash-object", "-w", "--", savedIndex], in: worktree).trimmed
+            _ = try await snapshotCommand(["update-ref", snapshot.rawIndexRef, rawIndex], in: worktree)
+            try FileManager.default.copyItem(atPath: savedIndex, toPath: workIndex)
+            // Worktree capture must read real file contents even when the owner's index tells
+            // ordinary Git commands to skip them. Names travel as NUL-delimited bytes.
+            let paths = try await snapshotBytes(["ls-files", "-z"], in: worktree, index: workIndex)
+            for flag in ["--no-assume-unchanged", "--no-skip-worktree"] {
+                _ = try await snapshotBytes(["update-index", flag, "-z", "--stdin"],
+                                            in: worktree, index: workIndex, stdin: paths)
+            }
+            _ = try await snapshotCommand(["add", "-A", "--", "."], in: worktree, index: workIndex)
+            for (index, ref) in [(savedIndex, snapshot.indexRef), (workIndex, snapshot.worktreeRef)] {
+                let tree = try await snapshotCommand(["write-tree"], in: worktree, index: index).trimmed
+                let commit = try await snapshotCommand(
+                    ["commit-tree", tree, "-m", "Bloom workspace snapshot"], in: worktree, index: index
+                ).trimmed
+                _ = try await snapshotCommand(["update-ref", ref, commit], in: worktree, index: index)
+            }
+            return snapshot
+        } catch {
+            await Task.detached { try? await deleteSnapshot(snapshot, in: worktree) }.value
+            throw error
+        }
+    }
+
+    public static func snapshotDiff(
+        from before: GitSnapshot, to after: GitSnapshot, in worktree: String, path: String? = nil
+    ) async throws -> String {
+        try validateSnapshot(before)
+        try validateSnapshot(after)
+        var arguments = [
+            "--literal-pathspecs", "diff", "--no-color", "--no-ext-diff", "--no-textconv",
+            "--src-prefix=a/", "--dst-prefix=b/", "-M", before.worktreeRef, after.worktreeRef, "--",
+        ]
+        if let path { arguments.append(path) }
+        return try await snapshotCommand(arguments, in: worktree).stdout
+    }
+
+    /// Preflight never changes workspace files or the real index. A rejected restore must not
+    /// create a recovery journal that would itself require the same unsupported restore.
+    public static func validateSnapshotRestore(_ target: GitSnapshot, in worktree: String) async throws {
+        _ = try await snapshotRestorePreparation(target, in: worktree)
+    }
+
+    /// Callers persist a recovery snapshot first and exclude running sessions. Validation is
+    /// repeated under Git's index lock because conditions may change after the earlier preflight.
+    public static func restoreSnapshot(_ target: GitSnapshot, in worktree: String) async throws {
+        try await validateSnapshotWorktree(worktree)
+        let gitDirectory = try await check(["rev-parse", "--absolute-git-dir"], in: worktree).trimmed
+        let indexLease = try GitSnapshotIndex(directory: gitDirectory)
+        defer { indexLease.release() }
+        let prepared = try await snapshotRestorePreparation(target, in: worktree)
+        let restoreIndex = (gitDirectory as NSString).appendingPathComponent("bloom-restore-\(UUID().uuidString)")
+        defer {
+            for path in [restoreIndex, restoreIndex + ".lock"] {
+                try? FileManager.default.removeItem(atPath: path)
+            }
+        }
+        if FileManager.default.fileExists(atPath: indexLease.indexPath) {
+            try FileManager.default.copyItem(atPath: indexLease.indexPath, toPath: restoreIndex)
+        } else {
+            _ = try await snapshotCommand(["read-tree", "--empty"], in: worktree, index: restoreIndex)
+        }
+        let restorePaths = try await snapshotBytes(["ls-files", "-z"], in: worktree, index: restoreIndex)
+        for flag in ["--no-assume-unchanged", "--no-skip-worktree"] {
+            _ = try await snapshotBytes(["update-index", flag, "-z", "--stdin"],
+                                        in: worktree, index: restoreIndex, stdin: restorePaths)
+        }
+        // git restore refuses an empty pathspec match in a wholly empty repository.
+        if !prepared.wanted.isEmpty || !prepared.current.isEmpty {
+            _ = try await snapshotCommand(
+                ["restore", "--ignore-skip-worktree-bits", "--source", target.worktreeRef, "--worktree", "--staged", "--", "."], in: worktree, index: restoreIndex
+            )
+        }
+        for path in prepared.extras {
+            _ = try await snapshotCommand(["--literal-pathspecs", "clean", "-f", "-x", "--", path], in: worktree)
+        }
+        try Task.checkCancellation()
+        try indexLease.install(prepared.indexWasPresent ? prepared.rawIndex : nil)
+    }
+
+    private struct SnapshotRestorePreparation {
+        let indexWasPresent: Bool
+        let rawIndex: Data
+        let wanted: [String]
+        let current: [String]
+        let extras: [String]
+    }
+
+    private static func snapshotRestorePreparation(
+        _ target: GitSnapshot, in worktree: String
+    ) async throws -> SnapshotRestorePreparation {
+        try validateSnapshot(target)
+        try await validateSnapshotWorktree(worktree)
+        _ = try await snapshotCommand(["rev-parse", "--verify", target.worktreeRef + "^{tree}"], in: worktree)
+        _ = try await snapshotCommand(["rev-parse", "--verify", target.indexRef + "^{tree}"], in: worktree)
+        guard let indexWasPresent = target.indexWasPresent else {
+            throw SnapshotFailure("This older snapshot does not preserve complete staging metadata. Files were not restored.")
+        }
+        let rawIndex = try await snapshotBytes(["cat-file", "blob", target.rawIndexRef], in: worktree)
+        let gitDirectory = try await check(["rev-parse", "--absolute-git-dir"], in: worktree).trimmed
+        let validationIndex = (gitDirectory as NSString).appendingPathComponent("bloom-restore-validation-\(UUID().uuidString)")
+        defer {
+            for path in [validationIndex, validationIndex + ".lock"] {
+                try? FileManager.default.removeItem(atPath: path)
+            }
+        }
+        try rawIndex.write(to: URL(fileURLWithPath: validationIndex))
+        let validatedTree = try await snapshotCommand(["write-tree"], in: worktree, index: validationIndex).trimmed
+        let expectedTree = try await snapshotCommand(["rev-parse", target.indexRef + "^{tree}"], in: worktree).trimmed
+        guard validatedTree == expectedTree else { throw SnapshotFailure("The saved Git index is inconsistent. Files were not restored.") }
+        let sparse = try await run(["config", "--bool", "core.sparseCheckout"], in: worktree)
+        if sparse.ok && sparse.trimmed == "true" {
+            throw SnapshotFailure("Restoring files is unavailable in a sparse checkout.")
+        }
+        let tree = try await snapshotCommand(["ls-tree", "-r", "-z", target.worktreeRef], in: worktree)
+        if tree.stdout.split(separator: "\0").contains(where: { $0.hasPrefix("160000 ") }) {
+            throw SnapshotFailure("Restoring files is unavailable for snapshots containing submodules.")
+        }
+        let wanted = try await snapshotPaths(["ls-tree", "--name-only", "-r", "-z", target.worktreeRef], in: worktree)
+        let ignored = try await snapshotPaths(["ls-files", "--others", "--ignored", "--exclude-standard", "-z"], in: worktree)
+        if ignored.contains(where: { path in wanted.contains { $0 == path || path.hasPrefix($0 + "/") || $0.hasPrefix(path + "/") } }) {
+            throw SnapshotFailure("An ignored file would be replaced by this snapshot. Move it before restoring files.")
+        }
+        let extras = try await snapshotPaths(["ls-files", "--others", "--exclude-standard", "-z"], in: worktree)
+            .filter { !wanted.contains($0) }
+        if extras.contains(where: { $0.hasSuffix("/") }) {
+            throw SnapshotFailure("A nested repository is outside the snapshot. Move it before restoring files.")
+        }
+        let current = try await snapshotPaths(["ls-files", "--cached", "-z"], in: worktree)
+        return SnapshotRestorePreparation(indexWasPresent: indexWasPresent, rawIndex: rawIndex,
+                                          wanted: wanted, current: current, extras: extras)
+    }
+
+    public static func deleteSnapshot(_ snapshot: GitSnapshot, in worktree: String) async throws {
+        try validateSnapshot(snapshot)
+        for ref in [snapshot.worktreeRef, snapshot.indexRef, snapshot.rawIndexRef] {
+            _ = try await snapshotCommand(["update-ref", "-d", ref], in: worktree)
+        }
+    }
+
+    private static func validateSnapshot(_ snapshot: GitSnapshot) throws {
+        guard UUID(uuidString: snapshot.id.rawValue) != nil else { throw SnapshotFailure("Invalid snapshot identifier.") }
+    }
+
+    private static func validateSnapshotWorktree(_ worktree: String) async throws {
+        guard FileManager.default.fileExists(atPath: worktree) else { throw SnapshotFailure("The workspace no longer exists.") }
+        let root = try await check(["rev-parse", "--show-toplevel"], in: worktree).trimmed
+        guard URL(fileURLWithPath: root).resolvingSymlinksInPath().path == URL(fileURLWithPath: worktree).resolvingSymlinksInPath().path else {
+            throw SnapshotFailure("The workspace is not the root of its Git checkout.")
+        }
+    }
+
+    private static func snapshotPaths(_ arguments: [String], in worktree: String) async throws -> [String] {
+        let result = try await Shell.runBytes(
+            "git", arguments, cwd: worktree, env: ["GIT_OPTIONAL_LOCKS": "0", "GIT_TERMINAL_PROMPT": "0"], timeout: .seconds(30)
+        )
+        guard result.status == 0 else { throw SnapshotFailure(String(decoding: result.stderr, as: UTF8.self)) }
+        return try nulRecords(result.stdout).map {
+            guard let path = String(data: $0, encoding: .utf8) else {
+                throw SnapshotFailure("A filename cannot be represented safely. Files were not restored.")
+            }
+            return path
+        }
+    }
+
+    private static func snapshotBytes(
+        _ arguments: [String], in worktree: String, index: String? = nil, stdin: Data? = nil
+    ) async throws -> Data {
+        var environment = ["GIT_OPTIONAL_LOCKS": "0", "GIT_TERMINAL_PROMPT": "0"]
+        if let index { environment["GIT_INDEX_FILE"] = index }
+        let result = try await Shell.runBytes("git", arguments, cwd: worktree, env: environment,
+                                              stdin: stdin, timeout: .seconds(30))
+        guard result.status == 0 else { throw SnapshotFailure(String(decoding: result.stderr, as: UTF8.self)) }
+        return result.stdout
+    }
+
+    private static func snapshotCommand(
+        _ arguments: [String], in worktree: String, index: String? = nil
+    ) async throws -> ShellResult {
+        var environment = [
+            "GIT_OPTIONAL_LOCKS": "0", "GIT_TERMINAL_PROMPT": "0",
+            "GIT_AUTHOR_NAME": "Bloom", "GIT_AUTHOR_EMAIL": "snapshot@localhost",
+            "GIT_COMMITTER_NAME": "Bloom", "GIT_COMMITTER_EMAIL": "snapshot@localhost",
+        ]
+        if let index { environment["GIT_INDEX_FILE"] = index }
+        let result = try await Shell.run("git", arguments, cwd: worktree, env: environment, timeout: .seconds(30))
+        guard result.ok else { throw SnapshotFailure(result.stderr.isEmpty ? result.stdout : result.stderr) }
+        return result
+    }
+}

--- a/Sources/BloomCore/Git/Git+Worktrees.swift
+++ b/Sources/BloomCore/Git/Git+Worktrees.swift
@@ -14,7 +14,7 @@ import Foundation
 
 extension Git {
     public static func worktrees(of repo: String) async throws -> [WorktreeEntry] {
-        WorktreeListing.parse(try await check(["worktree", "list", "--porcelain"], in: repo).stdout)
+        WorktreeListing.parse(try await checkRaw(["worktree", "list", "--porcelain", "-z"], in: repo).stdout)
     }
 
     /// Cuts a worktree, creating the branch when it is not already there.
@@ -40,6 +40,7 @@ extension Git {
         branchIsNew: Bool? = nil,
         replacingPrunableWorktreeAt previousPath: String? = nil
     ) async throws {
+        guard FileManager.default.fileExists(atPath: repo) else { throw WorkspaceError.projectFolderMissing }
         try validate(branch: branch)
         try validate(ref: base, label: "base branch")
         try validate(ref: path, label: "worktree path")

--- a/Sources/BloomCore/Git/Git.swift
+++ b/Sources/BloomCore/Git/Git.swift
@@ -62,71 +62,14 @@ public enum Git {
 
     /// Same contract as `run`, but stdout is not decoded. Used for the `-z` parsers.
     static func runRaw(_ arguments: [String], in directory: String) async throws -> GitOutput {
-        // The same gate `Shell.run` opens with, for the same caller: the refresh loop's deadline
-        // cancels a queue of these at once, and spawning git for a caller that has already given
-        // up would fork it and terminate it in the same breath.
-        try Task.checkCancellation()
-
-        guard let executable = Shell.which("git") else {
-            throw ShellError(command: "git", status: 127, stderr: "git not found on PATH")
-        }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: executable)
-        process.arguments = arguments
-        process.environment = Shell.environment(extra: [
+        let result = try await Shell.runBytes("git", arguments, cwd: directory, env: [
             "GIT_TERMINAL_PROMPT": "0",
             "GIT_OPTIONAL_LOCKS": "0",
         ])
-        process.currentDirectoryURL = URL(fileURLWithPath: directory)
-
-        let outPipe = Pipe()
-        let errPipe = Pipe()
-        process.standardOutput = outPipe
-        process.standardError = errPipe
-
-        let collector = PipeCollector()
-        // Both pipes have to be drained while the process runs, or a large diff fills the buffer
-        // and git blocks forever on write. A reader thread per pipe rather than a
-        // `readabilityHandler`, because clearing the handler once the process exits can discard
-        // what the dispatch source had already buffered. That showed up as `git diff` returning
-        // nothing at all, which `changedFiles` would have reported as a clean worktree.
-        let outReader = Thread {
-            collector.appendOut(outPipe.fileHandleForReading.readDataToEndOfFile())
-            collector.finishOut()
-        }
-        let errReader = Thread {
-            collector.appendErr(errPipe.fileHandleForReading.readDataToEndOfFile())
-            collector.finishErr()
-        }
-        outReader.stackSize = 512 * 1_024
-        errReader.stackSize = 512 * 1_024
-
-        // Installed before `run()`, never after. See `ProcessExitGate`: a git call that finishes
-        // before the handler exists never calls it, and this wait would never end. Most git calls
-        // here pass no timeout, so nothing would break the hang afterwards either.
-        let exit = ProcessExitGate()
-        process.terminationHandler = { _ in exit.signal() }
-
-        try process.run()
-        Shell.countSpawn()
-
-        outReader.start()
-        errReader.start()
-
-        await withTaskCancellationHandler {
-            await exit.wait()
-        } onCancel: {
-            if process.isRunning { process.terminate() }
-        }
-
-        // Exit does not mean the output is complete. Both pipes have to reach EOF first.
-        await collector.waitForEOF()
-
         return GitOutput(
-            status: process.terminationStatus,
-            stdout: collector.out,
-            stderr: String(decoding: collector.err, as: UTF8.self)
+            status: result.status,
+            stdout: result.stdout,
+            stderr: String(decoding: result.stderr, as: UTF8.self)
         )
     }
 
@@ -210,15 +153,9 @@ public enum Git {
     /// The branch a new workspace should be cut from. Prefers what origin points HEAD at, then
     /// the conventional names, then whatever is checked out.
     public static func defaultBranch(of repo: String) async throws -> String {
-        let remote = try await run(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], in: repo)
-        if remote.ok, case let value = remote.trimmed, value.hasPrefix("origin/") {
-            return String(value.dropFirst("origin/".count))
-        }
-        for candidate in ["main", "master", "develop"] {
-            let exists = try await run(["show-ref", "--verify", "--quiet", "refs/heads/\(candidate)"], in: repo)
-            if exists.ok { return candidate }
-        }
-        return try await currentBranch(of: repo) ?? "main"
+        let config = try await repositoryConfiguration(in: repo)
+        let branch = try await currentBranch(of: repo) ?? "HEAD"
+        return try await defaultBase(config: config, current: branch, in: repo)
     }
 
     public static func currentBranch(of path: String) async throws -> String? {
@@ -303,32 +240,35 @@ public enum Git {
     public static func baseline(_ base: String, in worktree: String) async throws -> String {
         try validate(ref: base, label: "base branch")
 
+        let context = try await repositoryContext(in: worktree, baseBranch: base)
         // No fingerprint means git could not be asked, so there is nothing to remember it under
         // and nothing to join: every such call resolves on its own.
-        guard let refs = await refPositions(base, in: worktree) else {
-            return try await resolveBaseline(base, in: worktree)
+        guard let refs = await refPositions(context, in: worktree) else {
+            return try await resolveBaseline(context, in: worktree)
         }
 
         return try await BaselineCache.shared.baseline(
             worktree: worktree, base: base, fingerprint: refs
         ) {
-            try await resolveBaseline(base, in: worktree)
+            try await resolveBaseline(context, in: worktree)
         }
     }
 
     /// Where the three refs are now, as one string. Nil when git could not be asked at all, which
     /// makes every call a miss rather than letting a broken repository share an entry with another.
-    private static func refPositions(_ base: String, in worktree: String) async -> String? {
-        let arguments = BaselineFingerprint.arguments(base: base, remote: remote)
+    private static func refPositions(_ context: GitRepositoryContext, in worktree: String) async -> String? {
+        let arguments = ["rev-parse", "--revs-only", "HEAD", context.baseBranch]
+            + [context.baseTrackingRef].compactMap { $0 }
         guard let result = try? await run(arguments, in: worktree), result.ok else { return nil }
         return BaselineFingerprint.make(result.stdout)
     }
 
-    private static func resolveBaseline(_ base: String, in worktree: String) async throws -> String {
+    private static func resolveBaseline(_ context: GitRepositoryContext, in worktree: String) async throws -> String {
+        let base = context.baseBranch
         let local = try? await mergeBase(base, in: worktree)
 
-        let tracking = "refs/remotes/\(remote)/\(base)"
-        guard await revision(of: tracking, in: worktree) != nil,
+        guard let tracking = context.baseTrackingRef,
+              await revision(of: tracking, in: worktree) != nil,
               let remoteSide = try? await mergeBase(tracking, in: worktree)
         else {
             // No remote-tracking copy, so the local answer is the only answer. Asking for it

--- a/Sources/BloomCore/Git/GitExistingCheckout.swift
+++ b/Sources/BloomCore/Git/GitExistingCheckout.swift
@@ -28,10 +28,17 @@ public extension Git {
     /// made without one behaves like local work that has never been shared, which is the opposite
     /// of what has just been checked out.
     static func addTrackingWorktree(
-        repo: String, path: String, branch: String, remote: String = Git.remote
+        repo: String, path: String, branch: String, remote: String? = nil
     ) async throws {
         try validate(branch: branch)
         try validate(ref: path, label: "worktree path")
+        let destination: String?
+        if let remote { destination = remote } else {
+            destination = try await repositoryContext(in: repo, branch: branch).publishRemote
+        }
+        guard let remote = destination else {
+            throw error(["worktree", "add"], 1, "No remote is configured for \(branch).", "")
+        }
         try validate(ref: remote, label: "remote")
 
         let parent = (path as NSString).deletingLastPathComponent

--- a/Sources/BloomCore/Git/GitFileRevert.swift
+++ b/Sources/BloomCore/Git/GitFileRevert.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+extension Git {
+    /// `--` ends options, but leaves globbing and pathspec magic enabled. A route named
+    /// `[id].tsx` must never restore its neighbours `i.tsx` and `d.tsx` as well.
+    static func literalPaths(_ arguments: [String]) -> [String] {
+        ["--literal-pathspecs"] + arguments
+    }
+
+    /// Reverts a tracked file to the same baseline the review shows. Untracked files belong
+    /// to the app's Trash operation, because Git has no recoverable version of them.
+    public static func revertTrackedFile(_ file: ChangedFile, worktree: String, base: String) async throws {
+        guard file.change != .untracked else {
+            throw error(["restore"], 1, "Untracked files must be moved to the Trash.", "")
+        }
+        let revision = try await baseline(base, in: worktree)
+        if file.change == .renamed, let oldPath = file.oldPath {
+            try await check(literalPaths(["checkout", revision, "--", oldPath]), in: worktree)
+            try await check(literalPaths(["rm", "-f", "--", file.path]), in: worktree)
+            return
+        }
+        let exists = try await run(["cat-file", "-e", "\(revision):\(file.path)"], in: worktree)
+        if exists.ok {
+            try await check(literalPaths(["checkout", revision, "--", file.path]), in: worktree)
+        } else {
+            try await check(literalPaths(["rm", "-f", "--", file.path]), in: worktree)
+        }
+    }
+}

--- a/Sources/BloomCore/Git/GitRepositoryContext.swift
+++ b/Sources/BloomCore/Git/GitRepositoryContext.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Fetching the base and publishing the feature branch are different destinations in a fork.
+/// Resolve them together so a change to pushRemote cannot leave PR lookup using another repo.
+public struct GitRepositoryContext: Sendable, Equatable {
+    public let baseBranch: String
+    public let baseRemote: String?
+    public let publishBranch: String
+    public let publishRemote: String?
+    public let baseRemoteURL: String?
+    public let publishRemoteURL: String?
+
+    public var baseTrackingRef: String? {
+        baseRemote.map { "refs/remotes/\($0)/\(baseBranch)" }
+    }
+
+    public var publishTrackingRef: String? {
+        publishRemote.map { "refs/remotes/\($0)/\(publishBranch)" }
+    }
+
+    /// One config snapshot is shared by every decision. Git has already applied includes,
+    /// worktree configuration and precedence before producing these records.
+    static func resolve(config: [String: String], base: String, branch: String) -> Self {
+        let remotes = config.keys.compactMap { key -> String? in
+            guard key.hasPrefix("remote."), key.hasSuffix(".url") else { return nil }
+            return String(key.dropFirst(7).dropLast(4))
+        }.sorted { $0.count == $1.count ? $0 < $1 : $0.count > $1.count }
+        let primary = remotes.contains("origin") ? "origin" : remotes.min()
+        let given = base.hasPrefix("refs/remotes/") ? String(base.dropFirst(13)) : base
+        let explicitRemote = remotes.first { given.hasPrefix($0 + "/") }
+        let baseBranch = explicitRemote.map { String(given.dropFirst($0.count + 1)) } ?? given
+        let configuredBase = config["branch.\(baseBranch).remote"]
+        let currentRemote = config["branch.\(branch).remote"]
+        let merge = config["branch.\(branch).merge"]
+        let baseRemote = explicitRemote ?? config["branch.\(branch).bloom-base-remote"]
+            ?? configuredBase ?? currentRemote ?? primary
+        let explicitPublication = config["branch.\(branch).pushremote"] ?? config["remote.pushdefault"]
+        // A review ref names the base repository's synthetic PR ref, not a writable fork
+        // branch. Only explicit publication configuration can supply the missing destination.
+        let publishRemote = explicitPublication
+            ?? ((merge?.hasPrefix("refs/pull/") ?? false) ? nil
+                : ((merge == "refs/heads/\(branch)" ? currentRemote : nil) ?? primary))
+        return Self(
+            baseBranch: baseBranch,
+            baseRemote: baseRemote == "." ? nil : baseRemote,
+            publishBranch: branch,
+            publishRemote: publishRemote == "." ? nil : publishRemote,
+            baseRemoteURL: baseRemote.flatMap { config["remote.\($0).url"] },
+            publishRemoteURL: publishRemote.flatMap { config["remote.\($0).pushurl"] ?? config["remote.\($0).url"] }
+        )
+    }
+}
+
+extension Git {
+    public static func remoteNames(of directory: String) async throws -> [String] {
+        try await check(["remote"], in: directory).lines
+    }
+
+    static func recordBase(_ context: GitRepositoryContext, for branch: String, in directory: String) async throws {
+        try validate(branch: branch)
+        try await check(["config", "branch.\(branch).gh-merge-base", context.baseBranch], in: directory)
+        if let remote = context.baseRemote {
+            try await check(["config", "branch.\(branch).bloom-base-remote", remote], in: directory)
+        }
+    }
+
+    public static func repositoryContext(
+        in directory: String, baseBranch: String? = nil, branch: String? = nil
+    ) async throws -> GitRepositoryContext {
+        let current: String
+        if let branch { current = branch } else if let head = headBranch(in: directory) {
+            current = head
+        } else { current = try await currentBranch(of: directory) ?? "HEAD" }
+        let config = try await repositoryConfiguration(in: directory)
+        let base: String
+        if let baseBranch { base = baseBranch } else if let recorded = config["branch.\(current).gh-merge-base"] {
+            base = recorded
+        } else if let merge = config["branch.\(current).merge"], merge.hasPrefix("refs/heads/"),
+                  merge != "refs/heads/\(current)" {
+            base = String(merge.dropFirst(11))
+        } else {
+            base = try await defaultBase(config: config, current: current, in: directory)
+        }
+        try validate(ref: base, label: "base branch")
+        if current != "HEAD" { try validate(branch: current) }
+        return GitRepositoryContext.resolve(config: config, base: base, branch: current)
+    }
+
+    static func repositoryConfiguration(in directory: String) async throws -> [String: String] {
+        let output = try await checkRaw(["config", "--null", "--list", "--includes"], in: directory)
+        var config: [String: String] = [:]
+        for record in nulRecords(output.stdout) {
+            guard let separator = record.firstIndex(of: 10) else { continue }
+            let key = String(decoding: record[..<separator], as: UTF8.self)
+            config[key] = String(decoding: record[record.index(after: separator)...], as: UTF8.self)
+        }
+        return config
+    }
+
+    static func defaultBase(config: [String: String], current: String, in directory: String) async throws -> String {
+        let provisional = GitRepositoryContext.resolve(config: config, base: "main", branch: current)
+        if let remote = provisional.baseRemote {
+            let prefix = "refs/remotes/\(remote)/"
+            let head = try await run(["symbolic-ref", prefix + "HEAD"], in: directory)
+            if head.ok, head.trimmed.hasPrefix(prefix) { return String(head.trimmed.dropFirst(prefix.count)) }
+        }
+        let candidates = ["main", "master", "develop"]
+        let names = try await check(
+            ["for-each-ref", "--format=%(refname:short)"] + candidates.map { "refs/heads/\($0)" }, in: directory
+        ).lines
+        return candidates.first(where: { names.contains($0) }) ?? (current == "HEAD" ? "main" : current)
+    }
+    private static func headBranch(in directory: String) -> String? {
+        guard let paths = repositoryPaths(in: directory),
+              let head = try? String(contentsOfFile: (paths.gitDirectory as NSString).appendingPathComponent("HEAD"), encoding: .utf8)
+        else { return nil }
+        let prefix = "ref: refs/heads/"
+        guard head.hasPrefix(prefix) else { return "HEAD" }
+        return String(head.dropFirst(prefix.count)).trimmingCharacters(in: .newlines)
+    }
+
+}

--- a/Sources/BloomCore/Git/GitRepositoryPaths.swift
+++ b/Sources/BloomCore/Git/GitRepositoryPaths.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Linked worktrees store their index and HEAD beside the original repository, not under
+/// the worktree's `.git` pointer file. Shared refs have a separate directory again.
+public struct GitRepositoryPaths: Sendable, Equatable {
+    public let gitDirectory: String
+    public let commonDirectory: String
+}
+
+extension Git {
+    public static func repositoryPaths(in worktree: String) -> GitRepositoryPaths? {
+        let dotGit = (worktree as NSString).appendingPathComponent(".git")
+        var directory = ObjCBool(false)
+        guard FileManager.default.fileExists(atPath: dotGit, isDirectory: &directory) else { return nil }
+        let gitDirectory: String
+        if directory.boolValue {
+            gitDirectory = dotGit
+        } else {
+            guard let pointer = try? String(contentsOfFile: dotGit, encoding: .utf8),
+                  pointer.hasPrefix("gitdir: ") else { return nil }
+            gitDirectory = resolveGitPath(String(pointer.dropFirst(8)), relativeTo: worktree)
+        }
+        let commonFile = (gitDirectory as NSString).appendingPathComponent("commondir")
+        let common = (try? String(contentsOfFile: commonFile, encoding: .utf8))
+            .map { resolveGitPath($0, relativeTo: gitDirectory) } ?? gitDirectory
+        return GitRepositoryPaths(
+            gitDirectory: URL(fileURLWithPath: gitDirectory).resolvingSymlinksInPath().standardized.path,
+            commonDirectory: URL(fileURLWithPath: common).resolvingSymlinksInPath().standardized.path
+        )
+    }
+
+    private static func resolveGitPath(_ text: String, relativeTo directory: String) -> String {
+        var path = text
+        if path.hasSuffix("\n") { path.removeLast() }
+        if path.hasSuffix("\r") { path.removeLast() }
+        if (path as NSString).isAbsolutePath { return path }
+        return (directory as NSString).appendingPathComponent(path)
+    }
+}

--- a/Sources/BloomCore/Git/GitSnapshot.swift
+++ b/Sources/BloomCore/Git/GitSnapshot.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Worktree and staging are distinct snapshots. Restoring only a worktree tree into both would
+/// turn every untracked file into a staged addition and lose the owner's partial staging.
+public struct GitSnapshot: Codable, Sendable, Equatable {
+    public let id: GitSnapshotID
+    public let sessionID: SessionID
+    public let createdAt: Date
+    public let indexWasPresent: Bool?
+    public var worktreeRef: String { "refs/bloom/checkpoints/\(id)/worktree" }
+    public var indexRef: String { "refs/bloom/checkpoints/\(id)/index" }
+    public var rawIndexRef: String { "refs/bloom/checkpoints/\(id)/raw-index" }
+
+    public init(id: GitSnapshotID = .new(), sessionID: SessionID, createdAt: Date = Date(), indexWasPresent: Bool? = nil) {
+        self.id = id
+        self.sessionID = sessionID
+        self.createdAt = createdAt
+        self.indexWasPresent = indexWasPresent
+    }
+}
+
+public struct SnapshotFailure: Error, Sendable, CustomStringConvertible {
+    public let description: String
+    public init(_ message: String) { description = message }
+}

--- a/Sources/BloomCore/Git/GitSnapshotIndex.swift
+++ b/Sources/BloomCore/Git/GitSnapshotIndex.swift
@@ -1,0 +1,54 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+/// Hold Git's real index lock while restore uses a private index. Only the final atomic rename
+/// publishes the captured staging state; other Git writers cannot interleave with the restore.
+final class GitSnapshotIndex {
+    let indexPath: String
+    let lockPath: String
+    private var descriptor: Int32
+    private var ownsLock = false
+
+    init(directory: String) throws {
+        indexPath = (directory as NSString).appendingPathComponent("index")
+        lockPath = indexPath + ".lock"
+        descriptor = open(lockPath, O_WRONLY | O_CREAT | O_EXCL, mode_t(0o666))
+        guard descriptor >= 0 else {
+            throw SnapshotFailure("Git is updating the index. Try again when it has finished.")
+        }
+        ownsLock = true
+    }
+
+    func install(_ bytes: Data?) throws {
+        if let bytes {
+            let file = FileHandle(fileDescriptor: descriptor, closeOnDealloc: false)
+            try file.write(contentsOf: bytes)
+            try file.synchronize()
+            close(descriptor)
+            descriptor = -1
+            guard rename(lockPath, indexPath) == 0 else {
+                throw SnapshotFailure("The restored Git index could not be installed.")
+            }
+            ownsLock = false
+        } else {
+            if unlink(indexPath) != 0 && errno != ENOENT {
+                throw SnapshotFailure("The previous missing-index state could not be restored.")
+            }
+            release()
+        }
+    }
+
+    func release() {
+        if descriptor >= 0 { close(descriptor); descriptor = -1 }
+        if ownsLock {
+            ownsLock = false
+            try? FileManager.default.removeItem(atPath: lockPath)
+        }
+    }
+
+    deinit { release() }
+}

--- a/Sources/BloomCore/Git/GitSubmodules.swift
+++ b/Sources/BloomCore/Git/GitSubmodules.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension Git {
+    public static func hasSubmodules(in worktree: String) -> Bool {
+        FileManager.default.fileExists(atPath: (worktree as NSString).appendingPathComponent(".gitmodules"))
+    }
+
+    /// Submodule files must exist before a project script or the opening agent turn reads
+    /// them. The workspace survives failure, and its ordinary setup retry repeats this step.
+    public static func initialiseSubmodules(in worktree: String, timeout: Duration = .seconds(120)) async throws -> String {
+        guard hasSubmodules(in: worktree) else { return "" }
+        try Task.checkCancellation()
+        let arguments = ["submodule", "update", "--init", "--recursive"]
+        let result = try await run(arguments, in: worktree, timeout: timeout)
+        guard result.ok else { throw error(arguments, result.status, result.stderr, result.stdout) }
+        return result.stdout + result.stderr
+    }
+}

--- a/Sources/BloomCore/Git/WorktreeListing.swift
+++ b/Sources/BloomCore/Git/WorktreeListing.swift
@@ -63,6 +63,14 @@ public struct WorktreeEntry: Sendable, Hashable {
 }
 
 public enum WorktreeListing {
+    /// Git's NUL records preserve newlines in worktree paths and lock reasons. Keep the
+    /// textual entry point for older stored fixtures, but live listings always use bytes.
+    public static func parse(_ porcelain: Data) -> [WorktreeEntry] {
+        parseFields(porcelain.split(separator: 0, omittingEmptySubsequences: false).map {
+            String(decoding: $0, as: UTF8.self)
+        })
+    }
+
     /// Every worktree git listed, in the order it listed them, the main checkout first.
     ///
     /// Records are separated by a blank line, and a record is flushed on the next `worktree` line
@@ -75,6 +83,12 @@ public enum WorktreeListing {
     /// worktree under a folder with spaces in its name survives. Git does not quote paths in this
     /// format, which is why `-z` exists; nothing here can do better than git can.
     public static func parse(_ porcelain: String) -> [WorktreeEntry] {
+        parseFields(porcelain.components(separatedBy: "\n").map {
+            $0.hasSuffix("\r") ? String($0.dropLast()) : $0
+        })
+    }
+
+    private static func parseFields(_ fields: [String]) -> [WorktreeEntry] {
         var entries: [WorktreeEntry] = []
         var current: WorktreeEntry?
 
@@ -83,8 +97,7 @@ public enum WorktreeListing {
             current = nil
         }
 
-        for line in porcelain.components(separatedBy: "\n") {
-            let line = line.hasSuffix("\r") ? String(line.dropLast()) : line
+        for line in fields {
             if line.isEmpty {
                 flush()
             } else if let path = value(of: "worktree", in: line) {

--- a/Sources/BloomCore/GitHub/GitHub.swift
+++ b/Sources/BloomCore/GitHub/GitHub.swift
@@ -131,6 +131,7 @@ private actor GitHubCache {
     struct Key: Hashable, Sendable {
         let worktree: String
         let lookup: Lookup
+        let repository: String?
     }
 
     struct Entry: Sendable {
@@ -187,6 +188,8 @@ public enum GitHub {
     /// itself. None of that output is stored, logged or shown anywhere.
     public static func access() async -> GitHubAccess {
         guard Shell.which("gh") != nil else { return .notInstalled }
+        // Availability owns its own coalescing. A PR refresh cooldown is not evidence that
+        // credentials disappeared, and must not turn a forced auth check into signedOut.
         guard let result = try? await Shell.run(
             "gh", ["auth", "status"], timeout: .seconds(20)
         ) else {
@@ -291,13 +294,13 @@ public enum GitHub {
         var selector = [target.runID]
         if let jobID = target.jobID { selector = ["--job", jobID] }
 
-        let failed = try await Shell.run(
+        let failed = try await run(
             "gh", ["run", "view"] + selector + ["--log-failed"], cwd: worktree, timeout: timeout
         )
         let trimmed = failed.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         if failed.ok, !trimmed.isEmpty { return failed.stdout }
 
-        let whole = try await Shell.run(
+        let whole = try await run(
             "gh", ["run", "view"] + selector + ["--log"], cwd: worktree, timeout: timeout
         )
         guard whole.ok, !whole.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -320,7 +323,7 @@ public enum GitHub {
     // agent, and everything that was known about them here is written down there. There is one
     // way to merge a pull request in this app and it goes through the transcript.
 
-    /// Pushes the current HEAD to `branch` on origin.
+    /// Pushes the current HEAD to `branch` on its configured publication remote.
     ///
     /// The branch never travels as a bare argument. Git will happily create a branch called
     /// `--mirror`, and `git push origin --mirror` is not a push: it makes the remote match the
@@ -341,11 +344,16 @@ public enum GitHub {
             throw GitHubError("refusing to push to '\(branch)': not a valid branch name")
         }
 
+        let context = try await Git.repositoryContext(in: worktree, branch: branch)
+        guard let remote = context.publishRemote else {
+            throw GitHubError("No publication remote is configured. For a pull request checkout, set branch.\(branch).pushRemote or remote.pushDefault before pushing directly.")
+        }
+        if setUpstream { try await Git.recordBase(context, for: branch, in: worktree) }
         var arguments = ["push"]
         if setUpstream { arguments.append("--set-upstream") }
-        arguments += ["--", "origin", "HEAD:refs/heads/\(branch)"]
+        arguments += ["--", remote, "HEAD:refs/heads/\(context.publishBranch)"]
 
-        let result = try await Shell.run("git", arguments, cwd: worktree, timeout: timeout)
+        let result = try await run("git", arguments, cwd: worktree, timeout: timeout)
         guard result.ok else {
             throw ShellError(
                 command: "git " + arguments.joined(separator: " "),
@@ -357,8 +365,10 @@ public enum GitHub {
 
     public static func hasRemoteBranch(_ branch: String, worktree: String) async -> Bool {
         guard Git.isValidBranchName(branch) else { return false }
-        guard let result = try? await Shell.run(
-            "git", ["ls-remote", "--exit-code", "--heads", "--", "origin", "refs/heads/\(branch)"],
+        guard let context = try? await Git.repositoryContext(in: worktree, branch: branch),
+              let remote = context.publishRemote else { return false }
+        guard let result = try? await run(
+            "git", ["ls-remote", "--exit-code", "--heads", "--", remote, "refs/heads/\(context.publishBranch)"],
             cwd: worktree,
             timeout: .seconds(20)
         ) else { return false }
@@ -368,6 +378,7 @@ public enum GitHub {
     /// gh has no structured error code for a branch without a pull request.
     public static func indicatesNoPullRequest(stderr: String) -> Bool {
         stderr.localizedCaseInsensitiveContains("no pull requests found")
+            || stderr.localizedCaseInsensitiveContains("could not resolve to a pullrequest")
     }
 
     static func snapshot(
@@ -381,13 +392,18 @@ public enum GitHub {
             throw GitHubError("refusing to look up '\(branch)': not a valid branch name")
         }
 
-        let key = GitHubCache.Key(worktree: worktree, lookup: .branch(branch))
+        try Task.checkCancellation()
+        let context = try? await Git.repositoryContext(in: worktree, branch: branch)
+        let key = GitHubCache.Key(
+            worktree: worktree, lookup: .branch(branch),
+            repository: [context?.baseRemoteURL, context?.publishRemoteURL].compactMap { $0 }.joined(separator: "\n")
+        )
         if let cached = await cache.value(for: key, maxAge: maxAge) { return cached }
 
-        let result = try await Shell.run(
+        let result = try await run(
             "gh", ["pr", "view", branch, "--json", fields],
             cwd: worktree,
-            timeout: .seconds(20)
+            timeout: .seconds(20), repositoryContext: context
         )
         guard result.ok else {
             if indicatesNoPullRequest(stderr: result.stderr) {
@@ -422,29 +438,28 @@ public enum GitHub {
     /// than a hypothetical, because `decodeSnapshot` reads a missing `number` as 0 and that 0 can
     /// be written down.
     ///
-    /// Nothing here throws. The branch route has already run and did not throw by the time this is
-    /// reached, so gh is working and a refusal means this repository has no such pull request,
-    /// which is an answer rather than a failure. Cached as nil so a wrong number is asked about
-    /// once rather than on every poll.
+    /// A failed request stays a failure. A preceding branch lookup may have succeeded just
+    /// before a rate limit, timeout or malformed response on this independent request.
     static func snapshot(
         forNumber number: Int,
         worktree: String,
         maxAge: Duration
-    ) async -> PullRequestSnapshot? {
+    ) async throws -> PullRequestSnapshot? {
         guard number > 0 else { return nil }
-
-        let key = GitHubCache.Key(worktree: worktree, lookup: .number(number))
+        try Task.checkCancellation()
+        let context = try? await Git.repositoryContext(in: worktree)
+        let key = GitHubCache.Key(worktree: worktree, lookup: .number(number), repository: context?.baseRemoteURL)
         if let cached = await cache.value(for: key, maxAge: maxAge) { return cached }
-
-        guard let result = try? await Shell.run(
-            "gh", ["pr", "view", String(number), "--json", fields],
-            cwd: worktree,
-            timeout: .seconds(20)
-        ), result.ok, let snapshot = try? decodeSnapshot(from: Data(result.stdout.utf8)) else {
-            await cache.store(nil, for: key)
-            return nil
+        let arguments = ["pr", "view", String(number), "--json", fields]
+        let result = try await run("gh", arguments, cwd: worktree, repositoryContext: context)
+        guard result.ok else {
+            if indicatesNoPullRequest(stderr: result.stderr) {
+                await cache.store(nil, for: key)
+                return nil
+            }
+            throw shellError(arguments: arguments, result: result)
         }
-
+        let snapshot = try decodeSnapshot(from: Data(result.stdout.utf8))
         await cache.store(snapshot, for: key)
         return snapshot
     }
@@ -473,9 +488,9 @@ public enum GitHub {
     /// an empty list where `--head patch-2` finds the fork's pull request.
     static func pullRequestsWithHead(
         _ branch: String, worktree: String
-    ) async -> [PullRequestHeadMatch] {
+    ) async throws -> [PullRequestHeadMatch] {
         guard Git.isValidBranchName(branch) else { return [] }
-        guard let result = try? await Shell.run(
+        let result = try await run(
             "gh",
             [
                 "pr", "list", "--head", branch, "--state", "all", "--limit", "20",
@@ -483,11 +498,9 @@ public enum GitHub {
             ],
             cwd: worktree,
             timeout: .seconds(20)
-        ), result.ok else { return [] }
-
-        guard let payloads = try? JSONDecoder().decode(
-            [HeadPayload].self, from: Data(result.stdout.utf8)
-        ) else { return [] }
+        )
+        guard result.ok else { throw shellError(arguments: ["pr", "list", "--head", branch], result: result) }
+        let payloads = try JSONDecoder().decode([HeadPayload].self, from: Data(result.stdout.utf8))
 
         return payloads
             .compactMap { payload in
@@ -513,9 +526,11 @@ public enum GitHub {
     private static func snapshotOfCheckedOutBranch(
         _ branch: String, worktree: String
     ) async throws -> PullRequestSnapshot? {
-        guard let result = try? await Shell.run(
-            "gh", ["pr", "view", "--json", fields], cwd: worktree, timeout: .seconds(20)
-        ), result.ok else { return nil }
+        let result = try await run("gh", ["pr", "view", "--json", fields], cwd: worktree)
+        guard result.ok else {
+            if indicatesNoPullRequest(stderr: result.stderr) { return nil }
+            throw shellError(arguments: ["pr", "view"], result: result)
+        }
 
         let snapshot = try decodeSnapshot(from: Data(result.stdout.utf8))
         guard snapshot.pullRequest.branch == branch else { return nil }
@@ -597,7 +612,7 @@ public enum GitHub {
 
     @discardableResult
     private static func checkGH(_ arguments: [String], worktree: String) async throws -> ShellResult {
-        let result = try await Shell.run(
+        let result = try await run(
             "gh", arguments, cwd: worktree, timeout: .seconds(20)
         )
         guard result.ok else { throw shellError(arguments: arguments, result: result) }
@@ -688,7 +703,7 @@ public extension GitHub {
         guard GitHubRepositoryName.isValid(name), isPlausibleLogin(owner) else {
             return .unknown("Bloom did not check that name.")
         }
-        guard let result = try? await Shell.run(
+        guard let result = try? await run(
             "gh", ["api", "--silent", "repos/\(owner)/\(name)"], timeout: .seconds(15)
         ) else {
             return .unknown("Bloom could not reach GitHub to check that name.")
@@ -723,7 +738,7 @@ public extension GitHub {
         let arguments = [
             "repo", "create", "\(owner)/\(name)", isPrivate ? "--private" : "--public",
         ]
-        let result = try await Shell.run("gh", arguments, timeout: .seconds(60))
+        let result = try await run("gh", arguments, timeout: .seconds(60))
         guard result.ok else {
             throw ShellError(
                 command: "gh " + arguments.joined(separator: " "),
@@ -737,7 +752,7 @@ public extension GitHub {
     /// The address to give `origin`, in whichever protocol the user has told gh they prefer.
     /// Somebody who clones over SSH everywhere should not get one HTTPS remote from Bloom.
     static func remoteURL(owner: String, name: String) async -> String {
-        let configured = try? await Shell.run(
+        let configured = try? await run(
             "gh", ["config", "get", "git_protocol"], timeout: .seconds(10)
         )
         let usesSSH = (configured?.ok ?? false) && configured?.trimmed == "ssh"
@@ -762,7 +777,7 @@ public extension GitHub {
 
     private static func api(_ path: [String], timeout: Duration) async throws -> String {
         let arguments = ["api"] + path
-        let result = try await Shell.run("gh", arguments, timeout: timeout)
+        let result = try await run("gh", arguments, timeout: timeout)
         guard result.ok else {
             throw ShellError(
                 command: "gh " + arguments.joined(separator: " "),

--- a/Sources/BloomCore/GitHub/GitHubPullRequestList.swift
+++ b/Sources/BloomCore/GitHub/GitHubPullRequestList.swift
@@ -25,7 +25,7 @@ public extension GitHub {
     /// sentence.
     static func openPullRequests(repoPath: String, limit: Int = 30) async throws -> [PullRequestListing] {
         guard await isAvailable() else { return [] }
-        let result = try await Shell.run(
+        let result = try await run(
             "gh",
             ["pr", "list", "--state", "open", "--limit", String(limit), "--json", summaryFields],
             cwd: repoPath,
@@ -44,7 +44,7 @@ public extension GitHub {
     /// number reaches pull requests the list deliberately does not offer.
     static func pullRequestSummary(number: Int, repoPath: String) async throws -> PullRequestListing {
         guard number > 0 else { throw GitHubError("\(number) is not a pull request number") }
-        let result = try await Shell.run(
+        let result = try await run(
             "gh", ["pr", "view", String(number), "--json", summaryFields],
             cwd: repoPath,
             timeout: .seconds(20)
@@ -61,7 +61,11 @@ public extension GitHub {
 
     /// `owner/name` for the repository at `path`, or nil when it is not on GitHub.
     static func repositorySlug(repoPath: String) async -> String? {
-        guard let result = try? await Shell.run(
+        if let context = try? await Git.repositoryContext(in: repoPath),
+           let repository = repositorySpecifier(context.baseRemoteURL) {
+            return repository.split(separator: "/").dropFirst().joined(separator: "/")
+        }
+        guard let result = try? await run(
             "gh", ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
             cwd: repoPath,
             timeout: .seconds(20)
@@ -89,7 +93,7 @@ public extension GitHub {
         guard Git.isValidBranchName(localBranch) else {
             throw GitHubError("'\(localBranch)' is not a valid branch name")
         }
-        let result = try await Shell.run(
+        let result = try await run(
             "gh", ["pr", "checkout", String(number), "--branch", localBranch],
             cwd: worktree,
             // Longer than the twenty seconds every other gh call gets, because this one fetches

--- a/Sources/BloomCore/GitHub/GitHubRateLimits.swift
+++ b/Sources/BloomCore/GitHub/GitHubRateLimits.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// A host-wide pause prevents each workspace from independently spending another failed request.
+/// The lease protects a new pause from a success belonging to an older concurrent request.
+actor GitHubRateLimits {
+    private struct Entry {
+        var generation = 0
+        var attempts = 0
+        var retryAt = Date.distantPast
+    }
+
+    private var entries: [String: Entry] = [:]
+
+    func check(host: String, interactive: Bool = false, now: Date = Date()) throws -> Int {
+        let entry = entries[host.lowercased()] ?? Entry()
+        if !interactive && entry.retryAt > now {
+            throw GitHubReadFailure(
+                reason: .rateLimited, message: "GitHub refresh is paused until its rate limit resets.",
+                retryAt: entry.retryAt
+            )
+        }
+        return entry.generation
+    }
+
+    @discardableResult
+    func limited(host: String, lease: Int, retryAt: Date?, now: Date = Date()) -> Date {
+        let key = host.lowercased()
+        var entry = entries[key] ?? Entry()
+        if entry.generation <= lease {
+            entry.generation += 1
+            entry.attempts = min(entry.attempts + 1, 6)
+            let fallback = now.addingTimeInterval(min(900, 30 * pow(2, Double(entry.attempts - 1))))
+            entry.retryAt = max(entry.retryAt, retryAt.flatMap { $0 > now ? $0 : nil } ?? fallback)
+        } else if let retryAt {
+            entry.retryAt = max(entry.retryAt, retryAt)
+        }
+        entries[key] = entry
+        return entry.retryAt
+    }
+
+    func succeeded(host: String, lease: Int, now: Date = Date()) {
+        let key = host.lowercased()
+        guard var entry = entries[key], entry.generation == lease, entry.retryAt <= now else { return }
+        entry.attempts = 0
+        entry.retryAt = .distantPast
+        entries[key] = entry
+    }
+}

--- a/Sources/BloomCore/GitHub/GitHubReadFailure.swift
+++ b/Sources/BloomCore/GitHub/GitHubReadFailure.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// A missing pull request is an answer. A rate limit or a broken response must never be cached
+/// as that answer, especially when a merged branch has left only its PR number behind.
+public struct GitHubReadFailure: Error, Sendable, Equatable, CustomStringConvertible {
+    public enum Reason: Sendable, Equatable {
+        case rateLimited, authentication, unavailable
+    }
+
+    public let reason: Reason
+    public let message: String
+    public let retryAt: Date?
+
+    public init(reason: Reason, message: String, retryAt: Date? = nil) {
+        self.reason = reason
+        self.message = message
+        self.retryAt = retryAt
+    }
+
+    public var description: String { message }
+
+    public static func classify(_ error: Error) -> GitHubReadFailure {
+        if let failure = error as? GitHubReadFailure { return failure }
+        let message = String(describing: error)
+        let lower = message.lowercased()
+        let authentication = lower.contains("http 401") || lower.contains("authentication failed")
+            || lower.contains("bad credentials") || lower.contains("gh auth login")
+        return GitHubReadFailure(
+            reason: authentication ? .authentication : .unavailable,
+            message: authentication ? "Connect GitHub again to refresh pull requests." : String(message.prefix(1_000))
+        )
+    }
+
+    static func isRateLimit(_ output: String) -> Bool {
+        let text = output.lowercased()
+        return text.contains("rate limit") || text.contains("rate_limit")
+            || text.contains("http 429") || text.contains("too many requests")
+    }
+
+    static func retryDate(from output: String, now: Date) -> Date? {
+        for line in output.components(separatedBy: .newlines) {
+            let fields = line.split(separator: ":", maxSplits: 1).map(String.init)
+            guard fields.count == 2 else { continue }
+            let header = fields[0].trimmingCharacters(in: .whitespaces).lowercased()
+            let value = fields[1].trimmingCharacters(in: .whitespaces)
+            if header == "retry-after" {
+                if let seconds = TimeInterval(value), seconds >= 0, seconds.isFinite {
+                    return now.addingTimeInterval(seconds)
+                }
+                let formatter = DateFormatter()
+                formatter.locale = Locale(identifier: "en_US_POSIX")
+                formatter.timeZone = TimeZone(secondsFromGMT: 0)
+                formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss z"
+                if let date = formatter.date(from: value), date > now { return date }
+            }
+            if header == "x-ratelimit-reset", let seconds = TimeInterval(value), seconds.isFinite {
+                let date = Date(timeIntervalSince1970: seconds)
+                if date > now { return date }
+            }
+        }
+        return nil
+    }
+}
+
+public enum PullRequestRead: Sendable {
+    case current(PullRequest?)
+    case unavailable(GitHubReadFailure)
+}

--- a/Sources/BloomCore/GitHub/GitHubRequestWaiter.swift
+++ b/Sources/BloomCore/GitHub/GitHubRequestWaiter.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Synchronization
+
+/// Cancellation belongs to the subscriber, not to a shared request. A continuation lets a
+/// disappeared inspector leave immediately while a sidebar keeps waiting for the same result.
+private final class GitHubWaitGate: Sendable {
+    private struct State {
+        var continuation: CheckedContinuation<ShellResult, Error>?
+        var result: Result<ShellResult, Error>?
+    }
+    private let state = Mutex(State())
+
+    func install(_ continuation: CheckedContinuation<ShellResult, Error>) {
+        let result = state.withLock { state -> Result<ShellResult, Error>? in
+            if let result = state.result { return result }
+            state.continuation = continuation
+            return nil as Result<ShellResult, Error>?
+        }
+        if let result { continuation.resume(with: result) }
+    }
+
+    func finish(_ result: Result<ShellResult, Error>) {
+        let continuation = state.withLock { state in
+            guard state.result == nil else { return nil as CheckedContinuation<ShellResult, Error>? }
+            state.result = result
+            let continuation = state.continuation
+            state.continuation = nil
+            return continuation
+        }
+        continuation?.resume(with: result)
+    }
+}
+
+enum GitHubRequestWaiter {
+    static func value(of task: Task<ShellResult, Error>) async throws -> ShellResult {
+        let gate = GitHubWaitGate()
+        return try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            return try await withCheckedThrowingContinuation { continuation in
+                gate.install(continuation)
+                Task {
+                    do { gate.finish(.success(try await task.value)) } catch { gate.finish(.failure(error)) }
+                }
+            }
+        } onCancel: {
+            gate.finish(.failure(CancellationError()))
+        }
+    }
+}

--- a/Sources/BloomCore/GitHub/GitHubRequests.swift
+++ b/Sources/BloomCore/GitHub/GitHubRequests.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+/// Only identical reads share a task. A cancelled inspector cannot cancel a request also being
+/// consumed by the sidebar, and an explicit mutation is never coalesced or automatically retried.
+actor GitHubRequests {
+    struct Key: Hashable, Sendable {
+        let host: String
+        let directory: String?
+        let arguments: [String]
+    }
+    private struct Flight {
+        let id: UUID
+        let task: Task<ShellResult, Error>
+    }
+    private var flights: [Key: Flight] = [:]
+    private let limits = GitHubRateLimits()
+    private(set) var activeSubscribers = 0
+
+    func run(
+        key: Key, interactive: Bool,
+        execute: @escaping @Sendable () async throws -> ShellResult
+    ) async throws -> ShellResult {
+        try Task.checkCancellation()
+        if !interactive, let flight = flights[key] {
+            return try await wait(for: flight.task)
+        }
+        let lease = try await limits.check(host: key.host, interactive: interactive)
+        try Task.checkCancellation()
+        // Checking another actor suspends this one. A sibling may have installed the same
+        // request while the rate-limit check was in flight.
+        if !interactive, let flight = flights[key] {
+            return try await wait(for: flight.task)
+        }
+        let id = UUID()
+        let task = Task { [limits] in
+            let result = try await execute()
+            if !result.ok && GitHubReadFailure.isRateLimit(result.stderr + result.stdout) {
+                let retryAt = await limits.limited(
+                    host: key.host, lease: lease,
+                    retryAt: GitHubReadFailure.retryDate(from: result.stderr, now: Date())
+                )
+                throw GitHubReadFailure(
+                    reason: .rateLimited, message: "GitHub's rate limit was reached. Refresh will resume automatically.",
+                    retryAt: retryAt
+                )
+            }
+            if result.ok { await limits.succeeded(host: key.host, lease: lease) }
+            return result
+        }
+        if !interactive {
+            flights[key] = Flight(id: id, task: task)
+            Task { [weak self] in
+                _ = try? await task.value
+                await self?.completed(key: key, id: id)
+            }
+        }
+        return try await wait(for: task)
+    }
+
+    private func wait(for task: Task<ShellResult, Error>) async throws -> ShellResult {
+        activeSubscribers += 1
+        defer { activeSubscribers -= 1 }
+        return try await GitHubRequestWaiter.value(of: task)
+    }
+
+    private func completed(key: Key, id: UUID) {
+        if flights[key]?.id == id { flights[key] = nil }
+    }
+}
+
+extension GitHub {
+    private static let requests = GitHubRequests()
+    @TaskLocal static var commandOverride: (@Sendable ([String], String?) async throws -> ShellResult)?
+
+    static func run(
+        _ executable: String, _ arguments: [String] = [], cwd: String? = nil,
+        timeout: Duration = .seconds(20), repositoryContext: GitRepositoryContext? = nil
+    ) async throws -> ShellResult {
+        guard executable == "gh" else {
+            return try await Shell.run(executable, arguments, cwd: cwd, timeout: timeout)
+        }
+        let context: GitRepositoryContext?
+        if let repositoryContext { context = repositoryContext } else {
+            context = await readContext(arguments: arguments, cwd: cwd)
+        }
+        let action = arguments.dropFirst().first ?? ""
+        let interactive = ["create", "edit", "merge", "checkout", "delete"].contains(action)
+        let resolved = repositoryArguments(arguments, context: context)
+        let host = requestHost(arguments: resolved, context: context)
+        let command = commandOverride
+        return try await requests.run(
+            key: .init(host: host, directory: cwd, arguments: resolved), interactive: interactive
+        ) {
+            if let command { return try await command(resolved, cwd) }
+            return try await Shell.run(executable, resolved, cwd: cwd, timeout: timeout)
+        }
+    }
+
+    static func readContext(arguments: [String], cwd: String?) async -> GitRepositoryContext? {
+        guard let cwd else { return nil }
+        let base = arguments.firstIndex(of: "--base").flatMap { index in
+            arguments.indices.contains(index + 1) ? arguments[index + 1] : nil
+        }
+        let branch: String? = if arguments.count > 2, arguments[0] == "pr", arguments[1] == "view",
+                                Git.isValidBranchName(arguments[2]), Int(arguments[2]) == nil {
+            arguments[2]
+        } else { nil }
+        return try? await Git.repositoryContext(in: cwd, baseBranch: base, branch: branch)
+    }
+
+    static func requestHost(arguments: [String], context: GitRepositoryContext?) -> String {
+        if let repository = repositoryOption(in: arguments) {
+            let pieces = repository.split(separator: "/")
+            if pieces.count == 3 { return String(pieces[0]).lowercased() }
+        }
+        if let url = arguments.compactMap({ URL(string: $0) }).first(where: { $0.scheme == "https" || $0.scheme == "http" }),
+           let host = url.host { return host.lowercased() }
+        return repositoryHost(context?.baseRemoteURL) ?? ProcessInfo.processInfo.environment["GH_HOST"] ?? "github.com"
+    }
+
+    private static func repositoryOption(in arguments: [String]) -> String? {
+        for (index, argument) in arguments.enumerated() {
+            if argument == "--repo" || argument == "-R", arguments.indices.contains(index + 1) {
+                return arguments[index + 1]
+            }
+            if argument.hasPrefix("--repo=") { return String(argument.dropFirst(7)) }
+            if argument.hasPrefix("-R"), argument.count > 2 { return String(argument.dropFirst(2)) }
+        }
+        return nil
+    }
+
+    static func repositoryArguments(_ arguments: [String], context: GitRepositoryContext?) -> [String] {
+        let family = arguments.first ?? ""
+        let action = arguments.dropFirst().first ?? ""
+        let acceptsRepo = family == "pr" || (family == "run" && action == "view")
+        guard acceptsRepo,
+              repositoryOption(in: arguments) == nil,
+              !arguments.contains("--repo"), !arguments.contains("-R"),
+              let context, let base = repositorySpecifier(context.baseRemoteURL) else { return arguments }
+        var result = arguments
+        if family == "pr", result.count > 2, result[1] == "view", !result[2].hasPrefix("-"),
+           Int(result[2]) == nil, !result[2].contains(":"),
+           let publication = repositorySpecifier(context.publishRemoteURL), publication != base {
+            let pieces = publication.split(separator: "/")
+            if pieces.count == 3 { result[2] = "\(pieces[1]):\(result[2])" }
+        }
+        if family == "pr", action == "create", !result.contains("--head"),
+           context.publishBranch != "HEAD",
+           let publication = repositorySpecifier(context.publishRemoteURL), publication != base {
+            let pieces = publication.split(separator: "/")
+            if pieces.count == 3 { result += ["--head", "\(pieces[1]):\(context.publishBranch)"] }
+        }
+        result += ["--repo", base]
+        return result
+    }
+
+    static func repositorySpecifier(_ remote: String?) -> String? {
+        guard let remote, let host = repositoryHost(remote) else { return nil }
+        let path: String
+        if let url = URL(string: remote), url.host != nil {
+            path = url.path
+        } else if let colon = remote.firstIndex(of: ":") {
+            path = String(remote[remote.index(after: colon)...])
+        } else { return nil }
+        var pieces = path.split(separator: "/").map(String.init)
+        guard pieces.count == 2 else { return nil }
+        if pieces[1].hasSuffix(".git") { pieces[1].removeLast(4) }
+        guard pieces.allSatisfy({ !$0.isEmpty && !$0.hasPrefix("-") }) else { return nil }
+        return "\(host)/\(pieces[0])/\(pieces[1])"
+    }
+
+    static func repositoryHost(_ remote: String?) -> String? {
+        guard let remote else { return nil }
+        if let host = URL(string: remote)?.host { return host.lowercased() }
+        if let at = remote.firstIndex(of: "@"), let colon = remote[at...].firstIndex(of: ":") {
+            return String(remote[remote.index(after: at)..<colon]).lowercased()
+        }
+        return nil
+    }
+
+    public static func readPullRequest(for workspace: Workspace, maxAge: Duration = .zero) async -> PullRequestRead {
+        do { return .current(try await pullRequest(for: workspace, maxAge: maxAge)) } catch { return .unavailable(.classify(error)) }
+    }
+}

--- a/Sources/BloomCore/GitHub/PullRequestOwnership.swift
+++ b/Sources/BloomCore/GitHub/PullRequestOwnership.swift
@@ -158,9 +158,8 @@ public extension GitHub {
     /// this ladder was built for: a review of pull request #222 was squashed, the branch went on
     /// both sides, the worktree moved to `main`, and every route Bloom had ran out at once. `gh pr
     /// view sentry-worker-src-blob` answered "no pull requests found for branch", the unnamed
-    /// fallback answered the same about `main`, and because a nil is deliberately never written
-    /// over a known pull request (see `WorkspaceModel.refreshPullRequest`, and that rule is
-    /// right), the strip went on showing the snapshot taken before the merge: open, eighteen
+    /// fallback answered the same about `main`, and the old ambiguous nil preserved the known
+    /// pull request. The strip went on showing the snapshot taken before the merge: open, eighteen
     /// checks passed, and a live Squash and merge button over work GitHub had already landed.
     ///
     /// So, three routes, in order, each one only asked when the one above it came away empty:
@@ -193,20 +192,20 @@ public extension GitHub {
         }
 
         if let number = workspace.pullRequestNumber,
-           let found = await snapshot(forNumber: number, worktree: workspace.path, maxAge: maxAge) {
+           let found = try await snapshot(forNumber: number, worktree: workspace.path, maxAge: maxAge) {
             return found
         }
 
         let branchIsGone = await !Git.branchExists(head, in: workspace.path)
         guard branchIsGone else { return nil }
 
-        let matches = await pullRequestsWithHead(head, worktree: workspace.path)
+        let matches = try await pullRequestsWithHead(head, worktree: workspace.path)
         guard let chosen = PullRequestOwnership.choose(
             from: matches,
             startedAt: workspace.createdAt,
             checkedOutAs: await Git.checkedOutPullRequest(branch: head, worktree: workspace.path)
         ) else { return nil }
-        return await snapshot(forNumber: chosen, worktree: workspace.path, maxAge: maxAge)
+        return try await snapshot(forNumber: chosen, worktree: workspace.path, maxAge: maxAge)
     }
 
     /// This workspace's checks, which are the checks of this workspace's pull request.

--- a/Sources/BloomCore/GitHub/PullRequestRefreshState.swift
+++ b/Sources/BloomCore/GitHub/PullRequestRefreshState.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Absence clears the previous result; an unavailable service preserves it with an explanation.
+/// The sidebar and inspector share this decision so a failed poll never means a clean slate.
+public struct PullRequestRefreshState: Sendable, Equatable {
+    public private(set) var pullRequest: PullRequest?
+    public private(set) var failure: GitHubReadFailure?
+
+    public init(pullRequest: PullRequest? = nil) {
+        self.pullRequest = pullRequest
+    }
+
+    public mutating func record(_ read: PullRequestRead) {
+        switch read {
+        case .current(let pullRequest):
+            self.pullRequest = pullRequest
+            failure = nil
+        case .unavailable(let failure):
+            self.failure = failure
+        }
+    }
+}

--- a/Sources/BloomCore/Model/GitSnapshotID.swift
+++ b/Sources/BloomCore/Model/GitSnapshotID.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public struct GitSnapshotID: Identifier {
+    public let rawValue: String
+    public init(_ rawValue: String) { self.rawValue = rawValue }
+}

--- a/Sources/BloomCore/Model/Models.swift
+++ b/Sources/BloomCore/Model/Models.swift
@@ -414,7 +414,10 @@ public struct Session: Identifiable, Sendable, Hashable, Codable {
     /// Every row that existed before this column defaults to Claude Code, because that is what
     /// every one of them was.
     public var agentKind: AgentKind {
-        didSet { permissionMode = permissionMode.nearest(on: agentKind) }
+        didSet {
+            permissionMode = permissionMode.nearest(on: agentKind)
+            interactionMode = interactionMode.nearest(on: agentKind)
+        }
     }
     /// How much this chat may do without asking.
     ///
@@ -429,6 +432,9 @@ public struct Session: Identifiable, Sendable, Hashable, Codable {
     /// The two observers hold the pair legal whichever of them is written, and in whichever order,
     /// so `sessionEditor.apply` setting a backend and a mode in one block cannot land a
     /// combination that does not exist. Writing inside a `didSet` does not run the observer again.
+    public var interactionMode: InteractionMode {
+        didSet { interactionMode = interactionMode.nearest(on: agentKind) }
+    }
     public var permissionMode: PermissionMode {
         didSet { permissionMode = permissionMode.nearest(on: agentKind) }
     }
@@ -461,6 +467,7 @@ public struct Session: Identifiable, Sendable, Hashable, Codable {
         effort: String = AppDefaults.fallbackEffort,
         agentKind: AgentKind = .claudeCode,
         permissionMode: PermissionMode = AppDefaults.fallbackPermissionMode,
+        interactionMode: InteractionMode = .build,
         state: SessionState = .idle,
         sortOrder: Int = 0,
         createdAt: Date = Date(),
@@ -484,6 +491,7 @@ public struct Session: Identifiable, Sendable, Hashable, Codable {
         // Through the rule rather than straight in. See the property's own note: this is the one
         // door every `Session` comes through, the ones `Store` builds from a row included.
         self.permissionMode = permissionMode.nearest(on: agentKind)
+        self.interactionMode = interactionMode.nearest(on: agentKind)
         self.state = state
         self.sortOrder = sortOrder
         self.createdAt = createdAt
@@ -509,6 +517,7 @@ public struct Session: Identifiable, Sendable, Hashable, Codable {
         effort: String = AppDefaults.fallbackEffort,
         agentKind: AgentKind = .claudeCode,
         permissionMode: PermissionMode = AppDefaults.fallbackPermissionMode,
+        interactionMode: InteractionMode = .build,
         sortOrder: Int = 0,
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
@@ -529,6 +538,7 @@ public struct Session: Identifiable, Sendable, Hashable, Codable {
             effort: effort,
             agentKind: agentKind,
             permissionMode: permissionMode,
+            interactionMode: interactionMode,
             state: .idle,
             sortOrder: sortOrder,
             createdAt: createdAt,
@@ -572,7 +582,7 @@ public enum MessageKind: String, Sendable, Codable, CaseIterable {
     case crew
 }
 
-public struct Message: Identifiable, Sendable, Hashable {
+public struct Message: Identifiable, Sendable, Hashable, Codable {
     public var id: Int64
     public var sessionID: SessionID
     public var seq: Int

--- a/Sources/BloomCore/Model/PlanArtefactID.swift
+++ b/Sources/BloomCore/Model/PlanArtefactID.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct PlanArtefactID: Identifier {
+    public let rawValue: String
+    public init(_ rawValue: String) { self.rawValue = rawValue }
+    public init(rawValue: String) { self.rawValue = rawValue }
+}

--- a/Sources/BloomCore/Persistence/Store+Plans.swift
+++ b/Sources/BloomCore/Persistence/Store+Plans.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public extension Store {
+    func queuePlanSource(_ plan: PlanArtefact, delivery: Delivery) throws {
+        var source = plan
+        source.implementationSessionID = nil
+        let encoded = String(decoding: try JSONEncoder().encode(source), as: UTF8.self)
+        try setSetting("delivery.\(delivery.id).sourcePlan", encoded)
+        try setSetting(PlanArtefact.sourceKey(sessionID: delivery.targetSessionID), encoded)
+    }
+
+    func acceptPlanSource(delivery: Delivery) throws {
+        guard let value = try setting("delivery.\(delivery.id).sourcePlan") else { return }
+        let plan = try JSONDecoder().decode(PlanArtefact.self, from: Data(value.utf8))
+        try markPlanImplementation(planID: plan.id, sessionID: plan.sessionID,
+                                   implementationSessionID: delivery.targetSessionID)
+    }
+
+    func planArtefacts(sessionID: SessionID) throws -> [PlanArtefact] {
+        guard let value = try setting(PlanArtefact.storageKey(sessionID: sessionID)) else { return [] }
+        return try JSONDecoder().decode([PlanArtefact].self, from: Data(value.utf8))
+    }
+
+    /// No suspension between the read and write: two completed plans cannot overwrite one
+    /// another, and replaying a completed provider item never creates another revision.
+    @discardableResult
+    func recordPlan(sessionID: SessionID, sourceID: String, markdown: String) throws -> PlanArtefact? {
+        let text = markdown.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return nil }
+        var plans = try planArtefacts(sessionID: sessionID)
+        if let existing = plans.last(where: { $0.sourceID == sourceID && $0.markdown == text }) { return existing }
+        let plan = PlanArtefact(sessionID: sessionID, sourceID: sourceID,
+                                version: (plans.last?.version ?? 0) + 1, markdown: text)
+        plans.append(plan)
+        try setSetting(PlanArtefact.storageKey(sessionID: sessionID),
+                       String(decoding: JSONEncoder().encode(plans), as: UTF8.self))
+        return plan
+    }
+
+    func markPlanImplementation(
+        planID: PlanArtefactID, sessionID: SessionID, implementationSessionID: SessionID
+    ) throws {
+        var plans = try planArtefacts(sessionID: sessionID)
+        guard let index = plans.firstIndex(where: { $0.id == planID }) else { return }
+        plans[index].implementationSessionID = implementationSessionID
+        try setSetting(PlanArtefact.storageKey(sessionID: sessionID),
+                       String(decoding: JSONEncoder().encode(plans), as: UTF8.self))
+        // A full immutable revision on the destination keeps the source readable even if the
+        // original conversation is subsequently archived or removed.
+        try setSetting(PlanArtefact.sourceKey(sessionID: implementationSessionID),
+                       String(decoding: JSONEncoder().encode(plans[index]), as: UTF8.self))
+    }
+
+    func sourcePlan(sessionID: SessionID) throws -> PlanArtefact? {
+        guard let value = try setting(PlanArtefact.sourceKey(sessionID: sessionID)) else { return nil }
+        return try JSONDecoder().decode(PlanArtefact.self, from: Data(value.utf8))
+    }
+}

--- a/Sources/BloomCore/Persistence/Store+RetiredCheckpoints.swift
+++ b/Sources/BloomCore/Persistence/Store+RetiredCheckpoints.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension Store {
+    public func retiredRewindCheckpoints(sessionID: SessionID) throws -> [TurnCheckpoint] {
+        guard let value = try setting("turn.rewind.retired.\(sessionID)") else { return [] }
+        return try JSONDecoder().decode([TurnCheckpoint].self, from: Data(value.utf8))
+    }
+
+    public func queueRetiredCheckpoints(_ records: [TurnCheckpoint], sessionID: SessionID) throws {
+        var current = try retiredRewindCheckpoints(sessionID: sessionID)
+        let known = Set(current.map(\.id))
+        current += records.filter { !known.contains($0.id) }
+        try setSetting("turn.rewind.retired.\(sessionID)", String(decoding: JSONEncoder().encode(current), as: UTF8.self))
+    }
+
+    public func acknowledgeRetiredCheckpoints(_ ids: Set<GitSnapshotID>, sessionID: SessionID) throws {
+        let retained = try retiredRewindCheckpoints(sessionID: sessionID).filter { !ids.contains($0.id) }
+        try setSetting("turn.rewind.retired.\(sessionID)",
+                       retained.isEmpty ? nil : String(decoding: JSONEncoder().encode(retained), as: UTF8.self))
+    }
+}

--- a/Sources/BloomCore/Persistence/Store+TurnCheckpoints.swift
+++ b/Sources/BloomCore/Persistence/Store+TurnCheckpoints.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+extension Store {
+    public func turnCheckpoints(sessionID: SessionID) throws -> [TurnCheckpoint] {
+        guard let value = try setting("turn.checkpoints.\(sessionID)") else { return [] }
+        return try JSONDecoder().decode([TurnCheckpoint].self, from: Data(value.utf8))
+    }
+
+    /// This read/modify/write has no suspension and belongs to the Store actor. Two completed
+    /// turns cannot overwrite each other's checkpoint metadata with an old whole-session value.
+    public func saveTurnCheckpoint(_ checkpoint: TurnCheckpoint) throws {
+        var records = try turnCheckpoints(sessionID: checkpoint.sessionID)
+        if let index = records.firstIndex(where: { $0.id == checkpoint.id }) {
+            let current = records[index]
+            guard current.startSeq == checkpoint.startSeq, current.before == checkpoint.before else {
+                throw SnapshotFailure("A checkpoint update cannot change its starting boundary.")
+            }
+            var merged = checkpoint
+            if current.endSeq != nil {
+                merged.after = current.after
+                merged.endSeq = current.endSeq
+            }
+            merged.providerTurnID = current.providerTurnID ?? checkpoint.providerTurnID
+            records[index] = merged
+        } else { records.append(checkpoint) }
+        records.sort { $0.startSeq < $1.startSeq }
+        try setSetting("turn.checkpoints.\(checkpoint.sessionID)", String(decoding: JSONEncoder().encode(records), as: UTF8.self))
+    }
+
+    /// The provider may answer while completion is between capture and refreshing the UI list.
+    /// Link inside the Store actor regardless of which transient UI collection holds the turn.
+    @discardableResult
+    public func linkTurnCheckpoint(sessionID: SessionID, startSeq: Int, providerTurnID: String) throws -> Bool {
+        var records = try turnCheckpoints(sessionID: sessionID)
+        guard let index = records.indices.filter({ records[$0].startSeq == startSeq }).max(by: {
+            records[$0].before.createdAt < records[$1].before.createdAt
+        }) else { return false }
+        if let current = records[index].providerTurnID, current != providerTurnID {
+            throw SnapshotFailure("This snapshot is already linked to a different agent turn.")
+        }
+        records[index].providerTurnID = providerTurnID
+        try setSetting("turn.checkpoints.\(sessionID)", String(decoding: JSONEncoder().encode(records), as: UTF8.self))
+        return true
+    }
+
+    @discardableResult
+    public func removeTurnCheckpoints(sessionID: SessionID, fromSeq: Int) throws -> [TurnCheckpoint] {
+        let records = try turnCheckpoints(sessionID: sessionID)
+        let removed = records.filter { $0.startSeq >= fromSeq }
+        let retained = records.filter { $0.startSeq < fromSeq }
+        try setSetting("turn.checkpoints.\(sessionID)", String(decoding: JSONEncoder().encode(retained), as: UTF8.self))
+        return removed
+    }
+
+    public func checkpointRewind(sessionID: SessionID) throws -> CheckpointRewind? {
+        guard let value = try setting("turn.rewind.\(sessionID)") else { return nil }
+        return try JSONDecoder().decode(CheckpointRewind.self, from: Data(value.utf8))
+    }
+
+    public func saveCheckpointRewind(_ rewind: CheckpointRewind) throws {
+        if rewind.stage == .prepared,
+           let session = try session(id: rewind.checkpoint.sessionID),
+           let workspaceID = session.workspaceID,
+           let workspace = try workspace(id: workspaceID),
+           workspace.setupState == .running || WorkspaceOperationLease.isHeld(in: workspace.path, operation: .setup) {
+            throw SnapshotFailure("Setup is using this worktree. Wait for it to finish before rewinding.")
+        }
+        if let current = try checkpointRewind(sessionID: rewind.checkpoint.sessionID) {
+            if current.token != rewind.token {
+                guard current.stage == .complete, rewind.stage == .prepared else {
+                    throw SnapshotFailure("A different rewind already owns this recovery record.")
+                }
+            } else {
+                let rank: [CheckpointRewind.Stage: Int] = [
+                    .prepared: 0, .filesRestored: 1, .failed: 1, .providerReverted: 2, .complete: 3,
+                ]
+                guard (rank[rewind.stage] ?? 0) >= (rank[current.stage] ?? 0) else {
+                    throw SnapshotFailure("A stale rewind update cannot replace a completed recovery step.")
+                }
+            }
+        }
+        try setSetting("turn.rewind.\(rewind.checkpoint.sessionID)", String(decoding: JSONEncoder().encode(rewind), as: UTF8.self))
+    }
+
+    public func pruneTurnCheckpoints(sessionID: SessionID, keepingLast limit: Int) throws -> [TurnCheckpoint] {
+        let records = try turnCheckpoints(sessionID: sessionID)
+        let complete = records.filter { $0.endSeq != nil }
+        let kept = Set(complete.suffix(max(1, limit)).map(\.id))
+        let journal = try checkpointRewind(sessionID: sessionID)
+        let removed = complete.filter { !kept.contains($0.id) && $0.id != journal?.checkpoint.id }
+        let removedIDs = Set(removed.map(\.id))
+        let retained = records.filter { !removedIDs.contains($0.id) }
+        try setSetting("turn.checkpoints.\(sessionID)", String(decoding: JSONEncoder().encode(retained), as: UTF8.self))
+        return removed
+    }
+}

--- a/Sources/BloomCore/Persistence/Store.swift
+++ b/Sources/BloomCore/Persistence/Store.swift
@@ -1064,6 +1064,22 @@ public actor Store {
                 END;
                 """)
             },
+            { db in
+                for (table, column, definition) in [
+                    ("sessions", "interaction_mode", "TEXT NOT NULL DEFAULT 'build'"),
+                    ("deliveries", "interaction_mode", "TEXT"),
+                    ("deliveries", "delivery_state", "TEXT NOT NULL DEFAULT 'pending'"),
+                    ("deliveries", "provider_turn_id", "TEXT"),
+                ] {
+                    let columns = Set(try db.query("PRAGMA table_info(\(table));").compactMap { $0.string("name") })
+                    if !columns.contains(column) {
+                        try db.execute("ALTER TABLE \(table) ADD COLUMN \(column) \(definition);")
+                        if column == "delivery_state" {
+                            try db.execute("UPDATE deliveries SET delivery_state = 'accepted' WHERE delivered_at IS NOT NULL;")
+                        }
+                    }
+                }
+            },
         ]
 
         let current = Int(try db.readUserVersion())
@@ -1211,7 +1227,18 @@ public actor Store {
     }
 
     public func deleteRepo(id: RepoID) throws {
+        try requireRepoCanBeRemoved(id: id)
         try db.run("DELETE FROM repos WHERE id = ?", [.text(id)])
+    }
+
+    public func requireRepoCanBeRemoved(id: RepoID) throws {
+        for workspace in try workspaces(repoID: id, includeArchived: true) {
+            try requireWorkspaceCanBeRemoved(id: workspace.id)
+        }
+    }
+
+    public func requireWorkspaceCanBeRemoved(id: WorkspaceID) throws {
+        guard try pendingCheckpointRewind(workspaceID: id) == nil else { throw WorkspaceError.recoveryPending }
     }
 
     // MARK: - Workspaces
@@ -1364,6 +1391,7 @@ public actor Store {
     }
 
     public func deleteWorkspace(id: WorkspaceID) throws {
+        try requireWorkspaceCanBeRemoved(id: id)
         try db.run("DELETE FROM workspaces WHERE id = ?", [.text(id)])
     }
 
@@ -1470,6 +1498,7 @@ public actor Store {
                     "SELECT 1 AS ok FROM workspaces WHERE id = ? AND state = 'archived'", [.text(id)]
                 ).first != nil
                 guard isArchived else { continue }
+                try requireWorkspaceCanBeRemoved(id: id)
 
                 try db.run(
                     "DELETE FROM drafts WHERE session_id IN (SELECT id FROM sessions WHERE workspace_id = ?)",
@@ -1932,14 +1961,15 @@ public actor Store {
     /// before the agent answered takes resume with it.
     @discardableResult
     public func upsert(_ session: Session) throws -> Session {
+        if session.archivedAt != nil { try requireSessionCanClose(id: session.id) }
         try rememberImplementationMode(for: session)
         try db.run(
             """
             INSERT INTO sessions (
                 id, workspace_id, parent_session_id, side_conversation_parent_id, title, agent_session_id, model, effort,
-                agent_kind, permission_mode, state, sort_order, created_at, updated_at,
+                agent_kind, permission_mode, interaction_mode, state, sort_order, created_at, updated_at,
                 archived_at, last_read_seq, input_tokens, output_tokens, cost_usd, context_tokens
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 side_conversation_parent_id = excluded.side_conversation_parent_id,
                 title = excluded.title,
@@ -1948,6 +1978,7 @@ public actor Store {
                 effort = excluded.effort,
                 agent_kind = excluded.agent_kind,
                 permission_mode = excluded.permission_mode,
+                interaction_mode = excluded.interaction_mode,
                 state = excluded.state,
                 sort_order = excluded.sort_order,
                 updated_at = excluded.updated_at,
@@ -1965,7 +1996,7 @@ public actor Store {
                 .text(session.title),
                 session.agentSessionID.map { .text($0) } ?? .null,
                 .text(session.model), .text(session.effort), .text(session.agentKind.rawValue),
-                .text(session.permissionMode.rawValue),
+                .text(session.permissionMode.rawValue), .text(session.interactionMode.rawValue),
                 .text(session.state.rawValue), .int(Int64(session.sortOrder)),
                 .double(session.createdAt.timeIntervalSince1970),
                 .double(session.updatedAt.timeIntervalSince1970),
@@ -2021,6 +2052,7 @@ public actor Store {
         model: String? = nil,
         effort: String? = nil,
         permissionMode: PermissionMode? = nil,
+        interactionMode: InteractionMode? = nil,
         implementationMode: PermissionMode? = nil,
         /// Only ever set on a chat that has not spoken yet. Changing the backend of a chat that
         /// already has a message strands its transcript half in one vocabulary and half in the
@@ -2044,6 +2076,7 @@ public actor Store {
                 model = COALESCE(?, model),
                 effort = COALESCE(?, effort),
                 permission_mode = COALESCE(?, permission_mode),
+                interaction_mode = COALESCE(?, interaction_mode),
                 agent_kind = COALESCE(?, agent_kind),
                 updated_at = ?
             WHERE id = ?
@@ -2053,6 +2086,7 @@ public actor Store {
                 model.map { .text($0) } ?? .null,
                 effort.map { .text($0) } ?? .null,
                 permissionMode.map { .text($0.rawValue) } ?? .null,
+                interactionMode.map { .text($0.rawValue) } ?? .null,
                 agentKind.map { .text($0.rawValue) } ?? .null,
                 .double(Date().timeIntervalSince1970),
                 .text(id),
@@ -2086,7 +2120,14 @@ public actor Store {
     }
 
     public func deleteSession(id: SessionID) throws {
+        try requireSessionCanClose(id: id)
         try db.run("DELETE FROM sessions WHERE id = ?", [.text(id)])
+    }
+
+    public func requireSessionCanClose(id: SessionID) throws {
+        if let journal = try checkpointRewind(sessionID: id), journal.stage != .complete {
+            throw SnapshotFailure("Resolve this conversation's interrupted rewind before closing it.")
+        }
     }
 
     /// Any session left `running` or `waiting` when the app died is doing neither now.
@@ -2175,6 +2216,84 @@ public actor Store {
     }
 
     // MARK: - Messages
+
+    public func pendingCheckpointRewind(workspaceID: WorkspaceID) throws -> CheckpointRewind? {
+        for row in try db.query("SELECT id FROM sessions WHERE workspace_id = ?", [.text(workspaceID)]) {
+            guard let id = row.string("id"), let journal = try checkpointRewind(sessionID: SessionID(id)),
+                  journal.stage != .complete else { continue }
+            return journal
+        }
+        return nil
+    }
+
+    /// Persist the original transcript before either files or provider history can change.
+    /// No partial backup is accepted: a very large rewind fails before its destructive steps.
+    public func prepareTranscriptRewind(_ checkpoint: TurnCheckpoint) throws -> TranscriptRewindBackup {
+        let removed = try db.query(
+            "SELECT * FROM messages WHERE session_id = ? AND seq >= ? ORDER BY seq",
+            [.text(checkpoint.sessionID), .int(Int64(checkpoint.startSeq))]
+        ).map(Self.message(from:))
+        guard let first = removed.first, first.seq == checkpoint.startSeq, first.kind == .user else {
+            throw SnapshotFailure("The original user message is unavailable for this rewind.")
+        }
+        let backup = TranscriptRewindBackup(
+            checkpointID: checkpoint.id, messages: removed, prompt: UserTurnPrompt.text(in: first.payload),
+            originalDraft: try draft(sessionID: checkpoint.sessionID)
+        )
+        let encoded = try JSONEncoder().encode(backup)
+        guard encoded.count <= 50 * 1_024 * 1_024 else {
+            throw SnapshotFailure("This rewind exceeds the transcript backup limit. Choose a more recent message.")
+        }
+        try setSetting(TranscriptRewindBackup.key(sessionID: checkpoint.sessionID), String(decoding: encoded, as: UTF8.self))
+        return backup
+    }
+
+    public func transcriptRewindBackup(sessionID: SessionID) throws -> TranscriptRewindBackup? {
+        guard let value = try setting(TranscriptRewindBackup.key(sessionID: sessionID)) else { return nil }
+        return try JSONDecoder().decode(TranscriptRewindBackup.self, from: Data(value.utf8))
+    }
+
+    /// Provider confirmation is required. Transcript deletion, restored draft and the completed
+    /// journal commit together, so recovery never repeats the prompt or erases unconfirmed history.
+    @discardableResult
+    public func completeTranscriptRewind(sessionID: SessionID) throws -> String {
+        try db.transaction {
+            guard var journal = try checkpointRewind(sessionID: sessionID) else {
+                throw SnapshotFailure("The rewind recovery record is unavailable.")
+            }
+            if journal.stage == .complete { return try draft(sessionID: sessionID) }
+            guard journal.stage == .providerReverted,
+                  let backup = try transcriptRewindBackup(sessionID: sessionID),
+                  backup.checkpointID == journal.checkpoint.id else {
+                throw SnapshotFailure("The agent has not confirmed this rewind.")
+            }
+            let seq = journal.checkpoint.startSeq
+            for message in backup.messages where message.kind == .permissionAsk {
+                if let ask = PermissionAsk.decode(payload: message.payload) {
+                    try db.run("DELETE FROM permission_asks WHERE id = ? AND session_id = ?", [.text(ask.requestID), .text(sessionID)])
+                }
+            }
+            try db.run("DELETE FROM messages WHERE session_id = ? AND seq >= ?", [.text(sessionID), .int(Int64(seq))])
+            // These deliveries were sent. Detach deleted row references, never make them pending.
+            try db.run("UPDATE deliveries SET delivered_seq = NULL WHERE target_session_id = ? AND delivered_seq >= ?", [
+                .text(sessionID), .int(Int64(seq)),
+            ])
+            let current = try draft(sessionID: sessionID)
+            let restored = current.isEmpty ? backup.prompt : current + "\n\n" + backup.prompt
+            try saveDraft(sessionID: sessionID, body: restored)
+            try db.run("UPDATE sessions SET last_read_seq = MIN(last_read_seq, ?), context_tokens = 0 WHERE id = ?", [
+                .int(Int64(seq - 1)), .text(sessionID),
+            ])
+            // Retire row associations in this same transaction: after a crash, reused message
+            // sequence numbers must never inherit a diff belonging to the removed conversation.
+            let retired = try removeTurnCheckpoints(sessionID: sessionID, fromSeq: seq)
+            try queueRetiredCheckpoints(retired, sessionID: sessionID)
+            journal.stage = .complete
+            journal.failure = nil
+            try saveCheckpointRewind(journal)
+            return restored
+        }
+    }
 
     public func messages(sessionID: SessionID, afterSeq: Int = -1, limit: Int = 100_000) throws -> [Message] {
         try db.query(
@@ -2651,9 +2770,12 @@ public actor Store {
     /// Queue acceptance and draft removal either both commit or neither does. A newer saved
     /// draft belongs to the next message and must survive an earlier submission completing.
     @discardableResult
-    public func enqueueDelivery(_ delivery: Delivery, clearingDraftMatching draft: String?) throws -> Delivery {
+    public func enqueueDelivery(
+        _ delivery: Delivery, clearingDraftMatching draft: String?, sourcePlan: PlanArtefact? = nil
+    ) throws -> Delivery {
         try db.transaction {
             let queued = try enqueueDelivery(delivery)
+            if let sourcePlan { try queuePlanSource(sourcePlan, delivery: queued) }
             if let draft, try self.draft(sessionID: delivery.targetSessionID) == draft {
                 try saveDraft(sessionID: delivery.targetSessionID, body: "")
             }
@@ -2670,7 +2792,7 @@ public actor Store {
         try db.query(
             """
             SELECT * FROM deliveries
-            WHERE target_session_id = ? AND delivered_at IS NULL
+            WHERE target_session_id = ? AND delivery_state IN ('pending', 'uncertain')
             ORDER BY created_at, rowid
             """,
             [.text(sessionID)]
@@ -2683,12 +2805,16 @@ public actor Store {
     /// the ones on disk. Callers hold that id to cancel the row again.
     @discardableResult
     public func enqueueDelivery(_ delivery: Delivery) throws -> Delivery {
+        var delivery = delivery
+        if delivery.kind == .owner, delivery.interactionMode == nil {
+            delivery.interactionMode = try session(id: delivery.targetSessionID)?.interactionMode
+        }
         try db.run(
             """
             INSERT INTO deliveries
                 (id, target_session_id, source_workspace_id, kind, verdict, body, crew_payload,
-                 created_at, delivered_at, delivered_seq)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 created_at, delivered_at, delivered_seq, delivery_state, interaction_mode, provider_turn_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
                 .text(delivery.id),
@@ -2701,9 +2827,70 @@ public actor Store {
                 .double(delivery.createdAt.timeIntervalSince1970),
                 delivery.deliveredAt.map { .double($0.timeIntervalSince1970) } ?? .null,
                 delivery.deliveredSeq.map { .int(Int64($0)) } ?? .null,
+                .text(delivery.state.rawValue),
+                delivery.interactionMode.map { .text($0.rawValue) } ?? .null,
+                delivery.providerTurnID.map { .text($0) } ?? .null,
             ]
         )
         return delivery
+    }
+
+    /// Claim and transcript insertion share a transaction. Retrying the same delivery reuses
+    /// its message, so a crash or a lost acknowledgement cannot duplicate the user's words.
+    public func claimDelivery(id: DeliveryID) throws -> Bool {
+        try db.transaction {
+            guard let row = try db.query("SELECT * FROM deliveries WHERE id = ?", [.text(id)]).first,
+                  row.string("delivery_state") == "pending" else { return false }
+            let delivery = Self.delivery(from: row)
+            var seq = delivery.deliveredSeq
+            if seq == nil {
+                let payload = delivery.crewPayload ?? Data(JSONValue.object([
+                    "type": .string("user"),
+                    "message": .object(["role": .string("user"), "content": .array([
+                        .object(["type": .string("text"), "text": .string(delivery.body)]),
+                    ])]),
+                ]).compactJSON.utf8)
+                let next = try nextSeqLocked(sessionID: delivery.targetSessionID)
+                _ = try insert(Message(sessionID: delivery.targetSessionID, seq: next,
+                    kind: delivery.crewPayload == nil ? .user : .crew, payload: payload,
+                    createdAt: delivery.createdAt))
+                seq = next
+            }
+            try db.run("UPDATE deliveries SET delivery_state = 'claimed', delivered_seq = ? WHERE id = ?", [
+                seq.map { .int(Int64($0)) } ?? .null, .text(id),
+            ])
+            return true
+        }
+    }
+
+    /// Written before touching the provider. A crash from here on has an unknown outcome;
+    /// neither a timeout nor a restart is evidence that it is safe to send again.
+    public func beginDeliveryDispatch(id: DeliveryID) throws {
+        try db.run("UPDATE deliveries SET delivery_state = 'uncertain' WHERE id = ? AND delivery_state = 'claimed'", [.text(id)])
+        guard db.changedRowCount == 1 else { throw DeliveryDispatchError.notClaimed }
+    }
+
+    public func acceptDelivery(id: DeliveryID, providerTurnID: String? = nil) throws {
+        try db.transaction {
+            try db.run("UPDATE deliveries SET delivery_state = 'accepted', delivered_at = ?, provider_turn_id = ? WHERE id = ? AND delivery_state = 'uncertain'", [
+                .double(Date().timeIntervalSince1970), providerTurnID.map { .text($0) } ?? .null, .text(id),
+            ])
+            if db.changedRowCount == 1, let accepted = try delivery(id: id) { try acceptPlanSource(delivery: accepted) }
+        }
+    }
+
+    public func delivery(id: DeliveryID) throws -> Delivery? {
+        try db.query("SELECT * FROM deliveries WHERE id = ?", [.text(id)]).first.map(Self.delivery(from:))
+    }
+
+    /// Only claims known not to have reached dispatch are automatically made pending again.
+    /// Uncertain attempts remain visible and require an explicit resend.
+    public func recoverDeliveryClaims() throws {
+        try db.run("UPDATE deliveries SET delivery_state = 'pending' WHERE delivery_state = 'claimed'")
+    }
+
+    public func releaseDeliveryClaim(id: DeliveryID) throws {
+        try db.run("UPDATE deliveries SET delivery_state = 'pending' WHERE id = ? AND delivery_state = 'claimed'", [.text(id)])
     }
 
     /// Marks one as gone.
@@ -2718,7 +2905,7 @@ public actor Store {
     @discardableResult
     public func markDelivered(id: DeliveryID, seq: Int? = nil, at date: Date = Date()) throws -> Bool {
         try db.run(
-            "UPDATE deliveries SET delivered_at = ?, delivered_seq = ? WHERE id = ? AND delivered_at IS NULL",
+            "UPDATE deliveries SET delivered_at = ?, delivered_seq = ?, delivery_state = 'accepted' WHERE id = ? AND delivery_state = 'pending'",
             [.double(date.timeIntervalSince1970), seq.map { .int(Int64($0)) } ?? .null, .text(id)]
         )
         return db.changedRowCount == 1
@@ -2740,7 +2927,7 @@ public actor Store {
     /// in the gap, because there is no gap.
     @discardableResult
     public func cancelDelivery(id: DeliveryID) throws -> Bool {
-        try db.run("DELETE FROM deliveries WHERE id = ? AND delivered_at IS NULL", [.text(id)])
+        try db.run("DELETE FROM deliveries WHERE id = ? AND delivery_state IN ('pending', 'uncertain')", [.text(id)])
         return db.changedRowCount == 1
     }
 
@@ -2752,7 +2939,7 @@ public actor Store {
     /// than reading as sent.
     public func restoreDelivery(id: DeliveryID) throws {
         try db.run(
-            "UPDATE deliveries SET delivered_at = NULL, delivered_seq = NULL WHERE id = ?",
+            "UPDATE deliveries SET delivered_at = NULL, delivery_state = 'pending', provider_turn_id = NULL WHERE id = ?",
             [.text(id)]
         )
     }
@@ -3204,6 +3391,7 @@ public actor Store {
             next.effort = controls.effort
             next.agentKind = controls.agentKind
             next.permissionMode = controls.permissionMode
+            next.interactionMode = controls.interactionMode
             try upsert(next)
             for (key, value) in controls.settings(sessionID: next.id) {
                 try setSetting(key, value)
@@ -3227,6 +3415,7 @@ public actor Store {
             next.effort = controls.effort
             next.agentKind = controls.agentKind
             next.permissionMode = controls.permissionMode
+            next.interactionMode = controls.interactionMode
             try upsert(next)
             for (key, value) in controls.settings(sessionID: next.id) {
                 try setSetting(key, value)
@@ -3253,6 +3442,7 @@ public actor Store {
                 next.effort = controls.effort
                 next.agentKind = controls.agentKind
                 next.permissionMode = controls.permissionMode
+            next.interactionMode = controls.interactionMode
             }
             try upsert(next)
             if let controls {
@@ -3419,7 +3609,10 @@ public actor Store {
             crewPayload: row.data("crew_payload"),
             createdAt: row.date("created_at") ?? Date(),
             deliveredAt: row.date("delivered_at"),
-            deliveredSeq: row.int("delivered_seq").map(Int.init)
+            deliveredSeq: row.int("delivered_seq").map(Int.init),
+            state: Delivery.State(rawValue: row.string("delivery_state") ?? ""),
+            interactionMode: row.string("interaction_mode").flatMap(InteractionMode.init(rawValue:)),
+            providerTurnID: row.string("provider_turn_id")
         )
     }
 
@@ -3472,6 +3665,7 @@ public actor Store {
             // A row written before the column existed reads as Claude Code, which is what it was.
             agentKind: AgentKind(rawValue: row.string("agent_kind") ?? "") ?? .claudeCode,
             permissionMode: PermissionMode(rawValue: row.string("permission_mode") ?? "") ?? .acceptEdits,
+            interactionMode: InteractionMode(rawValue: row.string("interaction_mode") ?? "") ?? .build,
             state: SessionState(rawValue: row.string("state") ?? "idle") ?? .idle,
             sortOrder: Int(row.int("sort_order") ?? 0),
             createdAt: row.date("created_at") ?? Date(),

--- a/Sources/BloomCore/System/CapturedProcess.swift
+++ b/Sources/BloomCore/System/CapturedProcess.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Synchronization
+
+/// One worker owns the pipe descriptors, from opening to closing. Nonblocking I/O lets the same
+/// deadline cover a blocked stdin writer, a stubborn child, and inherited output after exit.
+/// Previously Shell stopped its timer at child exit and could return success minutes later.
+final class CapturedProcess: Sendable {
+    private let cancelled = Mutex(false)
+    private let executable: String
+    private let arguments: [String]
+    private let cwd: String?
+    private let environment: [String: String]
+    private let input: Data?
+    private let timeout: Duration?
+    private let outputLimit: Int
+
+    init(
+        executable: String, arguments: [String], cwd: String?, environment: [String: String],
+        input: Data?, timeout: Duration?, outputLimit: Int
+    ) {
+        self.executable = executable
+        self.arguments = arguments
+        self.cwd = cwd
+        self.environment = environment
+        self.input = input
+        self.timeout = timeout
+        self.outputLimit = max(1, outputLimit)
+    }
+
+    func run() async throws -> ShellBytes {
+        try Task.checkCancellation()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let worker = Thread { [self] in
+                    do { continuation.resume(returning: try capture()) } catch { continuation.resume(throwing: error) }
+                }
+                worker.stackSize = 512 * 1_024
+                worker.start()
+            }
+        } onCancel: {
+            self.cancelled.withLock { $0 = true }
+        }
+    }
+
+    private func capture() throws -> ShellBytes {
+        if cancelled.withLock({ $0 }) { throw CancellationError() }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.environment = environment
+        if let cwd { process.currentDirectoryURL = URL(fileURLWithPath: cwd) }
+        let output = Pipe()
+        let errors = Pipe()
+        let stdin = Pipe()
+        process.standardOutput = output
+        process.standardError = errors
+        process.standardInput = stdin
+
+        // The worker is the only reader/writer. Closing in its defer cannot race a readability
+        // callback or close a descriptor that another reader has already released and reused.
+        let handles = [output.fileHandleForReading, errors.fileHandleForReading, stdin.fileHandleForWriting]
+        defer {
+            for handle in handles { try? handle.close() }
+            try? output.fileHandleForWriting.close()
+            try? errors.fileHandleForWriting.close()
+            try? stdin.fileHandleForReading.close()
+        }
+        for handle in handles {
+            let descriptor = handle.fileDescriptor
+            let flags = fcntl(descriptor, F_GETFL)
+            guard flags >= 0, fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) == 0 else {
+                throw pipeFailure("configure pipes", errno)
+            }
+        }
+        _ = fcntl(stdin.fileHandleForWriting.fileDescriptor, F_SETNOSIGPIPE, 1)
+
+        let started = ContinuousClock.now
+        let deadline = timeout.map { started.advanced(by: $0) }
+        try process.run()
+        Shell.countSpawn()
+        let pid = process.processIdentifier
+        let ownsGroup = getpgid(pid) == pid && pid != getpgrp()
+        try? output.fileHandleForWriting.close()
+        try? errors.fileHandleForWriting.close()
+        try? stdin.fileHandleForReading.close()
+
+        do {
+            return try collect(
+                process: process, handles: handles, deadline: deadline
+            )
+        } catch {
+            // Only this invocation's process/group is signalled. Never kill Bloom's own group
+            // when a platform or launcher has kept the child in it.
+            stop(process, pid: pid, ownsGroup: ownsGroup)
+            throw error
+        }
+    }
+
+    private func collect(
+        process: Process, handles: [FileHandle], deadline: ContinuousClock.Instant?
+    ) throws -> ShellBytes {
+        var streams = [Data(), Data()]
+        var readers = [true, true]
+        var inputOffset = 0
+        var inputOpen = true
+        var exitedAt: ContinuousClock.Instant?
+        let bytes = input ?? Data()
+        while true {
+            if cancelled.withLock({ $0 }) { throw CancellationError() }
+            let now = ContinuousClock.now
+            if let deadline, now >= deadline { throw ShellFailure.timedOut(command: executable) }
+            if !process.isRunning {
+                if exitedAt == nil { exitedAt = now }
+                if !readers.contains(true) {
+                    return ShellBytes(status: process.terminationStatus, stdout: streams[0], stderr: streams[1])
+                }
+                // Even calls with no execution deadline cannot wait forever on a grandchild.
+                if let exitedAt, exitedAt.duration(to: now) >= .seconds(2) {
+                    throw ShellFailure.incompleteOutput(command: executable)
+                }
+            }
+            if inputOpen && inputOffset == bytes.count {
+                try? handles[2].close()
+                inputOpen = false
+            }
+            var descriptors = handles.enumerated().map { index, handle in
+                let active = index < 2 ? readers[index] : inputOpen
+                return pollfd(
+                    fd: active ? handle.fileDescriptor : -1,
+                    events: Int16(index < 2 ? POLLIN : POLLOUT), revents: 0
+                )
+            }
+            let ready = poll(&descriptors, nfds_t(descriptors.count), 20)
+            if ready < 0 {
+                if errno == EINTR { continue }
+                throw pipeFailure("wait for output", errno)
+            }
+            for index in 0..<2 where readers[index] && descriptors[index].revents != 0 {
+                let chunk = try readChunk(descriptors[index].fd)
+                if let chunk {
+                    if chunk.isEmpty { readers[index] = false } else {
+                        guard chunk.count <= outputLimit - streams[index].count else {
+                            throw ShellFailure.outputLimit(
+                                command: executable, stream: index == 0 ? "stdout" : "stderr", limit: outputLimit
+                            )
+                        }
+                        streams[index].append(chunk)
+                    }
+                }
+            }
+            if inputOpen && descriptors[2].revents != 0 {
+                let count = bytes.withUnsafeBytes { buffer in
+                    write(descriptors[2].fd, buffer.baseAddress!.advanced(by: inputOffset), min(65_536, bytes.count - inputOffset))
+                }
+                if count > 0 { inputOffset += count } else if count < 0 && errno != EAGAIN && errno != EINTR {
+                    // A child may legitimately reject input with its own useful exit status.
+                    // EPIPE closes stdin while stdout/stderr continue to drain that explanation.
+                    if errno != EPIPE { throw pipeFailure("write input", errno) }
+                    try? handles[2].close()
+                    inputOpen = false
+                }
+            }
+        }
+    }
+
+    private func readChunk(_ descriptor: Int32) throws -> Data? {
+        var buffer = [UInt8](repeating: 0, count: 65_536)
+        let count = read(descriptor, &buffer, buffer.count)
+        if count >= 0 { return Data(buffer.prefix(count)) }
+        if errno == EAGAIN || errno == EINTR { return nil }
+        throw pipeFailure("read output", errno)
+    }
+
+    private func pipeFailure(_ operation: String, _ code: Int32) -> ShellFailure {
+        .pipe(command: executable, operation: operation, code: code)
+    }
+
+    private func stop(_ process: Process, pid: Int32, ownsGroup: Bool) {
+        if ownsGroup { _ = killpg(pid, SIGTERM) } else if process.isRunning { _ = kill(pid, SIGTERM) }
+        let grace = ContinuousClock.now.advanced(by: .milliseconds(200))
+        while process.isRunning && ContinuousClock.now < grace { Thread.sleep(forTimeInterval: 0.01) }
+        if ownsGroup { _ = killpg(pid, SIGKILL) } else if process.isRunning { _ = kill(pid, SIGKILL) }
+        // Reap only the child we created. SIGKILL cannot be ignored by a userspace process.
+        process.waitUntilExit()
+    }
+}

--- a/Sources/BloomCore/System/Shell.swift
+++ b/Sources/BloomCore/System/Shell.swift
@@ -51,9 +51,8 @@ public enum Shell {
     /// is synchronised against it.
     private static let spawns = Atomic<Int>(0)
 
-    /// Called by every site that starts a process. `Git.runRaw` has its own `Process` for the
-    /// byte-preserving parsers, so it calls this too, and a new spawn site that forgets to is a
-    /// probe that quietly under-reports.
+    /// Called by the captured-process worker and other process launchers. Git's raw and text
+    /// reads share that worker, so both contribute exactly once.
     static func countSpawn() {
         spawns.add(1, ordering: .relaxed)
     }
@@ -135,102 +134,38 @@ public enum Shell {
         cwd: String? = nil,
         env: [String: String] = [:],
         stdin: String? = nil,
-        timeout: Duration? = nil
+        timeout: Duration? = nil,
+        outputLimit: Int = 64 * 1_024 * 1_024
     ) async throws -> ShellResult {
-        // Spawning a process the caller has already given up on is pure cost: the cancellation
-        // handler below would fork it and SIGTERM it in the same breath. The refresh loop's five
-        // second deadline cancels a whole queue of these at once.
-        try Task.checkCancellation()
+        let result = try await runBytes(
+            executable, arguments, cwd: cwd, env: env,
+            stdin: stdin.map { Data($0.utf8) }, timeout: timeout, outputLimit: outputLimit
+        )
+        return ShellResult(
+            status: result.status,
+            stdout: String(decoding: result.stdout, as: UTF8.self),
+            stderr: String(decoding: result.stderr, as: UTF8.self)
+        )
+    }
 
+    /// Limits fail explicitly, so a partial status or patch can never masquerade as complete.
+    public static func runBytes(
+        _ executable: String,
+        _ arguments: [String] = [],
+        cwd: String? = nil,
+        env: [String: String] = [:],
+        stdin: Data? = nil,
+        timeout: Duration? = nil,
+        outputLimit: Int = 64 * 1_024 * 1_024
+    ) async throws -> ShellBytes {
+        try Task.checkCancellation()
         guard let path = which(executable) else {
             throw ShellError(command: executable, status: 127, stderr: "\(executable) not found on PATH")
         }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: path)
-        process.arguments = arguments
-        process.environment = environment(extra: env)
-        if let cwd { process.currentDirectoryURL = URL(fileURLWithPath: cwd) }
-
-        let outPipe = Pipe()
-        let errPipe = Pipe()
-        process.standardOutput = outPipe
-        process.standardError = errPipe
-
-        let inPipe: Pipe? = stdin == nil ? nil : Pipe()
-        if let inPipe { process.standardInput = inPipe }
-
-        let collector = PipeCollector()
-
-        // Read each pipe to EOF on its own thread rather than through `readabilityHandler`.
-        //
-        // The handler approach has a race that loses output: clearing the handler after the
-        // process exits can discard whatever the dispatch source had already buffered, and
-        // draining with `readToEnd` afterwards then returns nothing. It is rare and load
-        // dependent, which is the worst kind: under a parallel test run it turned up as an empty
-        // `git diff`, and in the app it would have been an empty diff shown as though the file
-        // had not changed. Reading to EOF cannot lose anything, and EOF is also the signal that
-        // the child is done writing.
-        let outReader = Thread {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-            collector.appendOut(data)
-            collector.finishOut()
-        }
-        let errReader = Thread {
-            let data = errPipe.fileHandleForReading.readDataToEndOfFile()
-            collector.appendErr(data)
-            collector.finishErr()
-        }
-        outReader.stackSize = 512 * 1_024
-        errReader.stackSize = 512 * 1_024
-
-        // Installed before `run()`, never after. See `ProcessExitGate`: a child that exits before
-        // the handler exists never calls it, and the wait below would never end.
-        let exit = ProcessExitGate()
-        process.terminationHandler = { _ in exit.signal() }
-
-        try process.run()
-        Shell.countSpawn()
-
-        outReader.start()
-        errReader.start()
-
-        if let inPipe, let stdin {
-            // The same SIGPIPE that `StreamingProcess.init` and `UnixSocketConnection` guard
-            // against, on the only other descriptor in the tree Bloom writes a child on. A child
-            // that exited between `run()` above and this line leaves nobody reading, and the
-            // default disposition of the signal that raises is to kill Bloom. `Git.run` passes a
-            // commit message and a patch through here, so the child dying early is a bad
-            // invocation rather than a hypothetical.
-            _ = fcntl(inPipe.fileHandleForWriting.fileDescriptor, F_SETNOSIGPIPE, 1)
-            try? inPipe.fileHandleForWriting.write(contentsOf: Data(stdin.utf8))
-            try? inPipe.fileHandleForWriting.close()
-        }
-
-        let timeoutTask: Task<Void, Never>? = timeout.map { duration in
-            Task {
-                try? await Task.sleep(for: duration)
-                if process.isRunning { process.terminate() }
-            }
-        }
-
-        await withTaskCancellationHandler {
-            await exit.wait()
-        } onCancel: {
-            if process.isRunning { process.terminate() }
-        }
-
-        timeoutTask?.cancel()
-
-        // The child has exited, but its output is only complete once both pipes have reached EOF.
-        // Returning before that is exactly how output goes missing.
-        await collector.waitForEOF()
-
-        return ShellResult(
-            status: process.terminationStatus,
-            stdout: String(decoding: collector.out, as: UTF8.self),
-            stderr: String(decoding: collector.err, as: UTF8.self)
-        )
+        return try await CapturedProcess(
+            executable: path, arguments: arguments, cwd: cwd, environment: environment(extra: env),
+            input: stdin, timeout: timeout, outputLimit: outputLimit
+        ).run()
     }
 
     /// Run and throw unless the exit status is zero.
@@ -264,50 +199,4 @@ public enum Shell {
     ) async throws -> ShellResult {
         try await run("/bin/zsh", ["-c", source], cwd: cwd, env: env, timeout: timeout)
     }
-}
-
-/// Thread-safe accumulator for a subprocess's two output streams, and the gate that says both are
-/// complete. `Shell.run` and `Git.runRaw` share it, because it was two identical classes whose
-/// only difference was whether the caller decoded stdout afterwards.
-///
-/// The two buffers share one `Mutex` because they are two halves of one result, read together
-/// once both streams have finished. `Mutex<State>` rather than `NSLock` plus
-/// `@unchecked Sendable`, for the reason given on `EventFanout` in `SessionRunner`.
-final class PipeCollector: Sendable {
-    private struct State {
-        var out = Data()
-        var err = Data()
-    }
-
-    private let state = Mutex(State())
-    /// One count per stream. Waiting on both is what guarantees nothing is still in flight.
-    private let eof = DispatchGroup()
-
-    init() {
-        eof.enter()
-        eof.enter()
-    }
-
-    func appendOut(_ data: Data) {
-        state.withLock { $0.out.append(data) }
-    }
-
-    func appendErr(_ data: Data) {
-        state.withLock { $0.err.append(data) }
-    }
-
-    func finishOut() { eof.leave() }
-    func finishErr() { eof.leave() }
-
-    func waitForEOF() async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            eof.notify(queue: .global()) { continuation.resume() }
-        }
-    }
-
-    /// Bytes, undecoded, because git's `-z` output is byte strings that a `String` round trip
-    /// would silently rewrite. `Shell.run` decodes at the call site instead.
-    var out: Data { state.withLock(\.out) }
-
-    var err: Data { state.withLock(\.err) }
 }

--- a/Sources/BloomCore/System/ShellBytes.swift
+++ b/Sources/BloomCore/System/ShellBytes.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Structured command output stays as bytes until its caller chooses an encoding. In particular,
+/// Git's NUL-delimited filenames must never make a lossy trip through a String.
+public struct ShellBytes: Sendable {
+    public let status: Int32
+    public let stdout: Data
+    public let stderr: Data
+}
+
+public enum ShellFailure: Error, Sendable, Equatable, CustomStringConvertible {
+    case timedOut(command: String)
+    case outputLimit(command: String, stream: String, limit: Int)
+    case incompleteOutput(command: String)
+    case pipe(command: String, operation: String, code: Int32)
+
+    public var description: String {
+        switch self {
+        case .timedOut(let command): "\(command) timed out."
+        case .outputLimit(let command, let stream, let limit):
+            "\(command) produced more than \(limit) bytes on \(stream)."
+        case .incompleteOutput(let command):
+            "\(command) exited, but a child process kept its output open."
+        case .pipe(let command, let operation, let code):
+            "Could not \(operation) for \(command): \(String(cString: strerror(code)))."
+        }
+    }
+}

--- a/Sources/BloomCore/System/WorktreeWatcher.swift
+++ b/Sources/BloomCore/System/WorktreeWatcher.swift
@@ -59,6 +59,7 @@ public final class WorktreeWatcher: Sendable {
         var matching: [String] = []
         /// Real path back to the spelling the caller uses.
         var origins: [String: String] = [:]
+        var metadata: [String: Set<String>] = [:]
     }
 
     private let watched = Mutex(Watched())
@@ -95,7 +96,8 @@ public final class WorktreeWatcher: Sendable {
             for root in wanted { origins[Self.resolve(root)] = root }
             state.origins = origins
             state.matching = Self.ordered(Array(origins.keys))
-            state.stream = wanted.isEmpty ? nil : makeStream(for: wanted)
+            state.metadata = Self.metadataRoots(for: wanted)
+            state.stream = wanted.isEmpty ? nil : makeStream(for: Array(Set(wanted + Array(state.metadata.keys))))
         }
     }
 
@@ -108,6 +110,7 @@ public final class WorktreeWatcher: Sendable {
             state.given = []
             state.matching = []
             state.origins = [:]
+            state.metadata = [:]
         }
     }
 
@@ -170,10 +173,16 @@ public final class WorktreeWatcher: Sendable {
     /// directory it watched when a root itself is moved or deleted, and a caller told about a
     /// worktree it does not have would ask git about a path that is not there.
     private func report(_ paths: [String]) {
-        let (matching, origins) = watched.withLock { ($0.matching, $0.origins) }
-        let changed = Self.roots(of: paths, in: matching).compactMap { origins[$0] }
+        let (matching, origins, metadata) = watched.withLock { ($0.matching, $0.origins, $0.metadata) }
+        // The main checkout's metadata is also inside a watched file root. Route those events
+        // only through the metadata filter, or ignored object writes would still wake it.
+        let files = paths.filter { path in
+            !metadata.keys.contains { path == $0 || path.hasPrefix($0 + "/") }
+        }
+        var changed = Set(Self.roots(of: files, in: matching).compactMap { origins[$0] })
+        changed.formUnion(Self.metadataWorktrees(changed: paths, metadata: metadata))
         guard !changed.isEmpty else { return }
-        onChange(Set(changed))
+        onChange(changed)
     }
 
     private func reportFiles(_ paths: [String], flags: [FSEventStreamEventFlags]) {
@@ -191,6 +200,54 @@ public final class WorktreeWatcher: Sendable {
     }
 
     // MARK: - The arithmetic, which is the part worth testing
+
+    static func metadataRoots(for roots: [String]) -> [String: Set<String>] {
+        var result: [String: Set<String>] = [:]
+        for root in roots {
+            guard let paths = Git.repositoryPaths(in: root) else { continue }
+            result[resolve(paths.gitDirectory), default: []].insert(root)
+            // A shared subscription covers packed refs and config as well as loose refs.
+            // The routing filter excludes object writes and hidden snapshot refs.
+            result[resolve(paths.commonDirectory), default: []].insert(root)
+        }
+        return result
+    }
+
+    static func metadataWorktrees(changed paths: [String], metadata: [String: Set<String>]) -> Set<String> {
+        var worktrees: Set<String> = []
+        let ordered = Self.ordered(Array(metadata.keys))
+        for path in paths {
+            // A per-worktree index is beneath the common directory. The most specific match
+            // belongs only to that worktree; common refs deliberately reach every sibling.
+            if let root = ordered.first(where: { path == $0 || path.hasPrefix($0 + "/") }) {
+                let relative = path == root ? "" : String(path.dropFirst(root.count + 1))
+                guard metadataAffectsWorktree(relative) else { continue }
+                worktrees.formUnion(metadata[root] ?? [])
+            }
+        }
+        return worktrees
+    }
+
+    private static func metadataAffectsWorktree(_ relative: String) -> Bool {
+        // Directory-level FSEvents can coalesce to an ancestor. An exact metadata root or
+        // refs parent cannot tell us which child changed, so invalidate conservatively.
+        let parts = relative.split(separator: "/").map(String.init)
+        guard let first = parts.first else { return true }
+        if first == "refs" {
+            guard parts.count > 1 else { return true }
+            return ["heads", "remotes", "tags"].contains(parts[1])
+        }
+        if first == "logs" {
+            guard parts.count > 1 else { return true }
+            return metadataAffectsWorktree(parts.dropFirst().joined(separator: "/"))
+        }
+        if first == "worktrees" { return parts.count == 1 }
+        return [
+            "HEAD", "index", "index.lock", "packed-refs", "packed-refs.lock", "config",
+            "config.worktree", "commondir", "gitdir", "shallow", "MERGE_HEAD", "REBASE_HEAD",
+            "CHERRY_PICK_HEAD", "REVERT_HEAD", "BISECT_LOG", "rebase-apply", "rebase-merge", "sequencer",
+        ].contains(first)
+    }
 
     /// The roots a batch of changed paths belong to.
     ///

--- a/Sources/BloomCore/Transcript/PendingMessageDiscard.swift
+++ b/Sources/BloomCore/Transcript/PendingMessageDiscard.swift
@@ -90,6 +90,17 @@ public enum PendingMessageDiscard {
     /// which of the two it is decides the answer: handing the sentence back to the composer is a
     /// tidy-up, and losing minutes of thought is not, and a dialog that read the same either way
     /// would be teaching the owner to click through it.
+    public static func question(for delivery: Delivery, composerDraft: String) -> Question {
+        guard delivery.deliveredSeq != nil else {
+            return question(for: recovery(of: delivery, composerDraft: composerDraft))
+        }
+        return Question(
+            title: "Remove this retry reminder?",
+            message: "The message stays in the conversation. Removing this reminder does not stop any work the agent may already have started.",
+            confirmLabel: "Remove Reminder", cancelLabel: "Keep"
+        )
+    }
+
     public static func question(for recovery: Recovery) -> Question {
         let message =
             switch recovery {

--- a/Sources/BloomCore/Transcript/PendingMessageReturn.swift
+++ b/Sources/BloomCore/Transcript/PendingMessageReturn.swift
@@ -39,7 +39,7 @@ public enum PendingMessageReturn {
     /// coming back as the machine's rendering of itself. It keeps its place and its order, and the
     /// owner still has Delete on it.
     public static func canReturn(_ delivery: Delivery) -> Bool {
-        delivery.kind == .owner
+        delivery.state == .pending && delivery.kind == .owner
             && delivery.crewPayload == nil
             && PendingMessageEdit.canEdit(delivery)
     }

--- a/Sources/BloomCore/Transcript/TerminalExcerpt.swift
+++ b/Sources/BloomCore/Transcript/TerminalExcerpt.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// A selection is copied now, not looked up in a terminal whose scrollback can change or vanish.
+public struct TerminalExcerpt: Codable, Sendable, Hashable {
+    public var terminalID: TerminalTabID
+    public var workspaceID: WorkspaceID
+    public var label: String
+    public var firstLine: Int
+    public var lastLine: Int
+    public var text: String
+    public var capturedAt: Date
+
+    public init?(
+        terminalID: TerminalTabID, workspaceID: WorkspaceID, label: String,
+        firstLine: Int, lastLine: Int, text: String, capturedAt: Date = Date()
+    ) {
+        guard text.contains(where: { !$0.isWhitespace }) else { return nil }
+        self.terminalID = terminalID
+        self.workspaceID = workspaceID
+        self.label = label
+        self.firstLine = max(1, min(firstLine, lastLine))
+        self.lastLine = max(self.firstLine, max(firstLine, lastLine))
+        self.text = text
+        self.capturedAt = capturedAt
+    }
+
+    /// JSON avoids ambiguous fences when a log itself contains Markdown or control sequences.
+    /// The attachment remains both machine-readable and independently recoverable from disk.
+    public func attachmentText() throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return String(decoding: try encoder.encode(self), as: UTF8.self)
+    }
+
+    public var filename: String { "terminal-excerpt.json" }
+}

--- a/Sources/BloomCore/Transcript/TranscriptRewindBackup.swift
+++ b/Sources/BloomCore/Transcript/TranscriptRewindBackup.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct TranscriptRewindBackup: Codable, Sendable {
+    public let checkpointID: GitSnapshotID
+    public let messages: [Message]
+    public let prompt: String
+    public let originalDraft: String
+
+    public init(checkpointID: GitSnapshotID, messages: [Message], prompt: String, originalDraft: String) {
+        self.checkpointID = checkpointID
+        self.messages = messages
+        self.prompt = prompt
+        self.originalDraft = originalDraft
+    }
+
+    public static func key(sessionID: SessionID) -> String { "turn.rewind.transcript.\(sessionID)" }
+}

--- a/Sources/BloomCore/Transcript/TurnCheckpoint.swift
+++ b/Sources/BloomCore/Transcript/TurnCheckpoint.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+public struct TurnCheckpoint: Codable, Sendable, Equatable, Identifiable {
+    public let id: GitSnapshotID
+    public let sessionID: SessionID
+    public let startSeq: Int
+    public var endSeq: Int?
+    public let before: GitSnapshot
+    public var after: GitSnapshot?
+    public var providerTurnID: String?
+
+    public init(sessionID: SessionID, startSeq: Int, before: GitSnapshot) {
+        self.id = before.id
+        self.sessionID = sessionID
+        self.startSeq = startSeq
+        self.before = before
+    }
+}
+
+/// Files and provider history cannot commit atomically. Keeping the recovery snapshot and the
+/// last completed step makes a failure visible after relaunch instead of silently losing context.
+public struct CheckpointRewind: Codable, Sendable, Equatable {
+    public enum Stage: String, Codable, Sendable {
+        case prepared, filesRestored, providerReverted, complete, failed
+    }
+    public let token: UUID
+    public let checkpoint: TurnCheckpoint
+    public let recovery: GitSnapshot?
+    public let restoringFiles: Bool
+    public var stage: Stage
+    public var failure: String?
+
+    public init(checkpoint: TurnCheckpoint, recovery: GitSnapshot?, restoringFiles: Bool, token: UUID = UUID()) {
+        self.token = token
+        self.checkpoint = checkpoint
+        self.recovery = recovery
+        self.restoringFiles = restoringFiles
+        self.stage = .prepared
+    }
+}

--- a/Sources/BloomCore/Transcript/TurnCheckpointStore.swift
+++ b/Sources/BloomCore/Transcript/TurnCheckpointStore.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// Git owns file contents; Store owns their association with transcript rows. A checkpoint is
+/// taken before the send and after the result, so shell edits and repeated edits are net changes.
+public actor TurnCheckpointStore {
+    private let store: Store
+    private var preparing: Set<SessionID> = []
+    private var completing: [GitSnapshotID: Task<TurnCheckpoint, Error>] = [:]
+
+    public init(store: Store) { self.store = store }
+
+    public func begin(sessionID: SessionID, cwd: String, startSeq: Int) async throws -> TurnCheckpoint {
+        let snapshot = try await Git.captureSnapshot(in: cwd, sessionID: sessionID)
+        let checkpoint = TurnCheckpoint(sessionID: sessionID, startSeq: startSeq, before: snapshot)
+        do { try await store.saveTurnCheckpoint(checkpoint) } catch {
+            try? await Git.deleteSnapshot(snapshot, in: cwd)
+            throw error
+        }
+        return checkpoint
+    }
+
+    @discardableResult
+    public func finish(
+        id: GitSnapshotID, sessionID: SessionID, cwd: String, endSeq: Int, providerTurnID: String? = nil
+    ) async throws -> TurnCheckpoint {
+        if let task = completing[id] { return try await task.value }
+        let task = Task {
+            try await complete(id: id, sessionID: sessionID, cwd: cwd, endSeq: endSeq, providerTurnID: providerTurnID)
+        }
+        completing[id] = task
+        defer { completing[id] = nil }
+        return try await task.value
+    }
+
+    private func complete(
+        id: GitSnapshotID, sessionID: SessionID, cwd: String, endSeq: Int, providerTurnID: String?
+    ) async throws -> TurnCheckpoint {
+        guard var checkpoint = try await list(sessionID: sessionID).first(where: { $0.id == id }) else {
+            throw SnapshotFailure("The turn's starting snapshot is unavailable.")
+        }
+        if checkpoint.endSeq != nil { return checkpoint }
+        let after = try await Git.captureSnapshot(in: cwd, sessionID: sessionID)
+        checkpoint.after = after
+        checkpoint.endSeq = endSeq
+        checkpoint.providerTurnID = providerTurnID
+        do { try await store.saveTurnCheckpoint(checkpoint) } catch {
+            try? await Git.deleteSnapshot(after, in: cwd)
+            throw error
+        }
+        // Bound hidden refs as well as metadata. Old conversations retain their transcript, but
+        // only the most recent 200 completed turns keep restorable filesystem snapshots.
+        let retired = try await store.pruneTurnCheckpoints(sessionID: sessionID, keepingLast: 200)
+        for record in retired {
+            for snapshot in [record.before, record.after].compactMap({ $0 }) {
+                try? await Git.deleteSnapshot(snapshot, in: cwd)
+            }
+        }
+        return checkpoint
+    }
+
+    public func list(sessionID: SessionID) async throws -> [TurnCheckpoint] {
+        try await store.turnCheckpoints(sessionID: sessionID)
+    }
+
+    public func diff(_ checkpoint: TurnCheckpoint, cwd: String, path: String? = nil) async throws -> String {
+        guard let after = checkpoint.after else { throw SnapshotFailure("This turn has no completed snapshot.") }
+        return try await Git.snapshotDiff(from: checkpoint.before, to: after, in: cwd, path: path)
+    }
+
+    public func prepareRewind(
+        checkpoint: TurnCheckpoint, cwd: String, restoringFiles: Bool,
+        operationLease: WorkspaceOperationLease? = nil
+    ) async throws -> CheckpointRewind {
+        guard let lease = operationLease ?? WorkspaceOperationLease.acquire(in: cwd, operation: .rewind),
+              lease.isValid(in: cwd, operation: .rewind) else {
+            throw SnapshotFailure("Setup or another rewind is already using this worktree.")
+        }
+        defer { if operationLease == nil { lease.release() } }
+        guard preparing.insert(checkpoint.sessionID).inserted else {
+            throw SnapshotFailure("A rewind is already being prepared for this conversation.")
+        }
+        defer { preparing.remove(checkpoint.sessionID) }
+        let previous = try await store.checkpointRewind(sessionID: checkpoint.sessionID)
+        if let previous, previous.stage != .complete {
+            throw SnapshotFailure("Resolve the previous interrupted rewind before starting another.")
+        }
+        if restoringFiles { try await Git.validateSnapshotRestore(checkpoint.before, in: cwd) }
+        let recovery = restoringFiles ? try await Git.captureSnapshot(in: cwd, sessionID: checkpoint.sessionID) : nil
+        let journal = CheckpointRewind(checkpoint: checkpoint, recovery: recovery, restoringFiles: restoringFiles)
+        do { try await store.saveCheckpointRewind(journal) } catch {
+            if let recovery { try? await Git.deleteSnapshot(recovery, in: cwd) }
+            throw error
+        }
+        // The new journal is durable before old recovery refs are retired. A checkpoint still
+        // listed in turn history remains protected even when its previous rewind is superseded.
+        if let previous {
+            let records = try await store.turnCheckpoints(sessionID: checkpoint.sessionID)
+            let retained = Set(records.flatMap { [$0.before.id, $0.after?.id].compactMap { $0 } }
+                + [checkpoint.before.id, checkpoint.after?.id, recovery?.id].compactMap { $0 })
+            for snapshot in [previous.checkpoint.before, previous.checkpoint.after, previous.recovery].compactMap({ $0 })
+                where !retained.contains(snapshot.id) {
+                try? await Git.deleteSnapshot(snapshot, in: cwd)
+            }
+        }
+        return journal
+    }
+
+    public func markRewind(_ journal: CheckpointRewind) async throws {
+        try await store.saveCheckpointRewind(journal)
+    }
+
+    public func pendingRewind(sessionID: SessionID) async throws -> CheckpointRewind? {
+        let journal = try await store.checkpointRewind(sessionID: sessionID)
+        return journal?.stage == .complete ? nil : journal
+    }
+
+    public func removeAfter(sessionID: SessionID, seq: Int, cwd: String) async throws {
+        let removed = try await store.removeTurnCheckpoints(sessionID: sessionID, fromSeq: seq)
+        try await store.queueRetiredCheckpoints(removed, sessionID: sessionID)
+        try await cleanupRetired(sessionID: sessionID, cwd: cwd)
+    }
+
+    public func cleanupRetired(sessionID: SessionID, cwd: String) async throws {
+        let removed = try await store.retiredRewindCheckpoints(sessionID: sessionID)
+        // Keep refs referenced by the recovery journal. They are the recovery path even after the
+        // conversation has been rewound successfully, until another rewind supersedes it.
+        let journal = try await store.checkpointRewind(sessionID: sessionID)
+        let protected = [journal?.checkpoint.before.id, journal?.checkpoint.after?.id, journal?.recovery?.id].compactMap { $0 }
+        var completed = Set<GitSnapshotID>()
+        for record in removed {
+            let snapshots = [record.before, record.after].compactMap { $0 }
+            guard !snapshots.contains(where: { protected.contains($0.id) }) else { continue }
+            do {
+                for snapshot in snapshots { try await Git.deleteSnapshot(snapshot, in: cwd) }
+                completed.insert(record.id)
+            } catch {
+                // Leave failed cleanup in the durable queue for the next load or rewind.
+            }
+        }
+        try await store.acknowledgeRetiredCheckpoints(completed, sessionID: sessionID)
+    }
+}

--- a/Sources/BloomCore/Transcript/UserTurnPrompt.swift
+++ b/Sources/BloomCore/Transcript/UserTurnPrompt.swift
@@ -10,7 +10,9 @@ public enum UserTurnPrompt {
     public static let summaryLimit = 180
 
     public static func text(in payload: Data) -> String {
-        guard let blocks = JSONValue.parse(payload)?["message"]?["content"]?.arrayValue else {
+        let content = JSONValue.parse(payload)?["message"]?["content"]
+        if let text = content?.stringValue { return text }
+        guard let blocks = content?.arrayValue else {
             return ""
         }
         return blocks.compactMap { $0["text"]?.stringValue }.joined(separator: "\n")

--- a/Sources/BloomCore/Workspace/SetupRunConfirmation.swift
+++ b/Sources/BloomCore/Workspace/SetupRunConfirmation.swift
@@ -44,16 +44,16 @@ public enum SetupRunConfirmation {
     /// The title follows the item that was pressed, which says "again" only when there was a first
     /// time. See `WorkspaceModel.hasRunSetup`.
     public static func question(hasRunSetup: Bool, isAgentRunning: Bool) -> Question {
-        var message = "This project\u{2019}s setup script runs in the worktree. It can take "
-            + "minutes, and Bloom cannot undo what it writes."
+        var message = "Setup runs in the worktree, preparing its submodules and running any configured "
+            + "setup script. It can take minutes, and Bloom cannot undo what it writes."
 
         if isAgentRunning {
-            message += "\n\nAn agent is mid turn here. The script does not stop it, so both "
+            message += "\n\nAn agent is mid turn here. Setup does not stop it, so both "
                 + "write to this worktree at once."
         }
 
         return Question(
-            title: hasRunSetup ? "Run the setup script again?" : "Run the setup script?",
+            title: hasRunSetup ? "Run setup again?" : "Run setup?",
             message: message,
             confirmLabel: hasRunSetup ? "Run Setup Again" : "Run Setup",
             cancelLabel: "Don\u{2019}t Run"

--- a/Sources/BloomCore/Workspace/WorkspaceCheckout.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceCheckout.swift
@@ -72,6 +72,7 @@ public struct ExistingBranch: Sendable, Hashable, Identifiable, Codable {
     /// Whether there is a local `refs/heads` copy. False means the branch is only on the remote,
     /// which needs a tracking branch made for it rather than a plain checkout.
     public let isLocal: Bool
+    public let remoteName: String?
     /// What is already sitting on this branch, or nil when it is free.
     ///
     /// Carried on the branch rather than worked out by the picker, because the picker used to be
@@ -88,9 +89,10 @@ public struct ExistingBranch: Sendable, Hashable, Identifiable, Codable {
 
     public var id: String { name }
 
-    public init(name: String, isLocal: Bool, inUseBy: BranchHolder? = nil) {
+    public init(name: String, isLocal: Bool, inUseBy: BranchHolder? = nil, remoteName: String? = nil) {
         self.name = name
         self.isLocal = isLocal
+        self.remoteName = remoteName
         self.inUseBy = inUseBy
     }
 }
@@ -233,19 +235,23 @@ public enum WorkspaceCheckoutPlan {
         remote: [String],
         defaultBranch: String,
         inUse: [String: BranchHolder] = [:],
-        pullRequestHeads: Set<String> = []
+        pullRequestHeads: Set<String> = [],
+        remoteNames: [String] = ["origin"]
     ) -> [ExistingBranch] {
         var byName: [String: Bool] = [:]
+        var remoteByName: [String: String] = [:]
         for name in local where !name.isEmpty { byName[name] = true }
         for reference in remote {
-            let name = remoteBranchName(reference)
+            let remote = remoteNames.sorted { $0.count > $1.count }.first { reference.hasPrefix($0 + "/") }
+            let name = remote.flatMap { remoteBranchName(reference, remote: $0) }
             guard let name, byName[name] == nil else { continue }
             byName[name] = false
+            remoteByName[name] = remote
         }
         byName[defaultBranch] = nil
         for name in pullRequestHeads { byName[name] = nil }
         return byName
-            .map { ExistingBranch(name: $0.key, isLocal: $0.value, inUseBy: inUse[$0.key]) }
+            .map { ExistingBranch(name: $0.key, isLocal: $0.value, inUseBy: inUse[$0.key], remoteName: remoteByName[$0.key]) }
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
     }
 
@@ -264,11 +270,11 @@ public enum WorkspaceCheckoutPlan {
     /// Pull request heads are not dropped either, for the same reason: there is no pull request
     /// row here to offer instead.
     public static func everyBranch(
-        local: [String], remote: [String], inUse: [String: BranchHolder] = [:]
+        local: [String], remote: [String], inUse: [String: BranchHolder] = [:], remoteNames: [String] = ["origin"]
     ) -> [ExistingBranch] {
         // The empty string excludes nothing: `offeredBranches` drops the branch it is given as the
         // default, and no branch is called "". One merge rule, asked for twice.
-        offeredBranches(local: local, remote: remote, defaultBranch: "", inUse: inUse)
+        offeredBranches(local: local, remote: remote, defaultBranch: "", inUse: inUse, remoteNames: remoteNames)
     }
 
     /// The branches the offered pull requests are already speaking for.

--- a/Sources/BloomCore/Workspace/WorkspaceContinuation.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceContinuation.swift
@@ -425,7 +425,9 @@ public extension WorkspaceManager {
             branch: workspace.baseBranch, in: workspace.path
         )
 
+        let context = try await Git.repositoryContext(in: workspace.path, baseBranch: workspace.baseBranch)
         try await Git.checkoutNewBranch(branch, at: resolved.revision, in: workspace.path)
+        try await Git.recordBase(context, for: branch, in: workspace.path)
 
         // The branch and the pull request it belonged to, and nothing else: `git checkout -b` ran
         // between the read and here.

--- a/Sources/BloomCore/Workspace/WorkspaceManager.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceManager.swift
@@ -2,12 +2,15 @@ import Foundation
 import os
 
 public enum WorkspaceError: Error, CustomStringConvertible {
+    case projectFolderMissing
+    case recoveryPending
     case notARepository(String)
     case pathInUse(String)
     /// Archiving would destroy work that exists nowhere else. Carries the full report so the UI
     /// can list what is at stake instead of asking "are you sure?" about nothing in particular.
     case unsafeToArchive(WorkspaceSafetyReport)
     case archiveScriptFailed(status: Int32, output: String)
+    case archiveScriptIncomplete(ShellFailure)
     /// The row was read, the work was done, and by the time it came to write the result there was
     /// no such workspace in the database any more. Only reachable when the project it belonged to
     /// was removed while this was running, which cascades its workspaces away.
@@ -15,6 +18,8 @@ public enum WorkspaceError: Error, CustomStringConvertible {
 
     public var description: String {
         switch self {
+        case .projectFolderMissing: "The project folder is no longer on disk."
+        case .recoveryPending: "Resolve the interrupted rewind before removing or archiving this workspace."
         case .notARepository(let path): "\(path) is not a git repository"
         case .pathInUse(let path): "\(path) already exists"
         case .unsafeToArchive(let report):
@@ -22,6 +27,8 @@ public enum WorkspaceError: Error, CustomStringConvertible {
         case .archiveScriptFailed(let status, let output):
             "the archive script exited \(status), so nothing was removed: "
                 + output.trimmingCharacters(in: .whitespacesAndNewlines).suffix(500)
+        case .archiveScriptIncomplete(let failure):
+            "The archive script did not finish, so nothing was removed: \(failure.description)"
         case .workspaceGone(let name): "\(name) is no longer in the database"
         }
     }
@@ -173,7 +180,9 @@ public struct WorkspaceManager: Sendable {
         // running at once in one project decide on the same branch and the same directory and the
         // second one loses. See `WorktreeCutQueue` for why this is serialised rather than
         // coalesced.
-        try await WorktreeCutQueue.shared.cut(in: repo.path) {
+        let repositoryKey = Git.repositoryPaths(in: repo.path)?.commonDirectory
+            ?? URL(fileURLWithPath: repo.path).resolvingSymlinksInPath().standardized.path
+        return try await WorktreeCutQueue.shared.cut(in: repositoryKey) {
             if let checkout {
                 return try await open(
                     checkout, id: id, repo: repo, name: name, origin: origin, setupPolicy: setupPolicy
@@ -200,6 +209,9 @@ public struct WorkspaceManager: Sendable {
     ) async throws -> Workspace {
         let settings = SettingsLoader.load(repo: repo.path)
         let base = baseBranch ?? repo.defaultBranch
+        let repository = try await Git.repositoryContext(in: repo.path, baseBranch: base)
+        let start = await Git.revision(of: base, in: repo.path) == nil
+            ? (repository.baseTrackingRef ?? base) : base
 
         let existingBranches = Set(try await Git.branches(of: repo.path))
         let stem = Git.branchStem(prompt: prompt, prefix: settings.branchPrefix, branch: branch)
@@ -219,8 +231,9 @@ public struct WorkspaceManager: Sendable {
         // name that is not in `existingBranches` by construction. This is the one path where that
         // is known, and it is the path a person is waiting on. See `Git.addWorktree`.
         try await Git.addWorktree(
-            repo: repo.path, path: worktreePath, branch: finalBranch, base: base, branchIsNew: true
+            repo: repo.path, path: worktreePath, branch: finalBranch, base: start, branchIsNew: true
         )
+        try await Git.recordBase(repository, for: finalBranch, in: worktreePath)
 
         try copyFiles(settings.filesToCopy, from: repo.path, to: worktreePath)
 
@@ -235,7 +248,7 @@ public struct WorkspaceManager: Sendable {
             branch: finalBranch,
             path: worktreePath,
             baseBranch: base,
-            setupState: setupPolicy.initialState(script: settings.setupScript),
+            setupState: setupPolicy.initialState(script: settings.setupScript, hasSubmodules: Git.hasSubmodules(in: worktreePath)),
             sortOrder: try await store.nextWorkspaceSortOrder(repoID: repo.id),
             origin: origin
         )
@@ -313,7 +326,7 @@ public struct WorkspaceManager: Sendable {
                 try? await Git.removeWorktree(repo: repo.path, path: worktreePath, force: true)
                 throw error
             }
-        case .branch:
+        case .branch(let existing):
             // Asked of git here rather than read off `ExistingBranch.isLocal`, which is what the
             // picker measured when the sheet was opened. A branch fetched by hand in between, or
             // one the picker listed from the remote while a local copy already existed, took the
@@ -325,7 +338,7 @@ public struct WorkspaceManager: Sendable {
                 )
             } else {
                 try await Git.addTrackingWorktree(
-                    repo: repo.path, path: worktreePath, branch: branch
+                    repo: repo.path, path: worktreePath, branch: branch, remote: existing.remoteName
                 )
             }
         }
@@ -339,7 +352,7 @@ public struct WorkspaceManager: Sendable {
             branch: branch,
             path: worktreePath,
             baseBranch: checkout.baseBranch(default: repo.defaultBranch),
-            setupState: setupPolicy.initialState(script: settings.setupScript),
+            setupState: setupPolicy.initialState(script: settings.setupScript, hasSubmodules: Git.hasSubmodules(in: worktreePath)),
             sortOrder: try await store.nextWorkspaceSortOrder(repoID: repo.id),
             origin: origin,
             // Written now rather than waited for. A review workspace knows its pull request before
@@ -471,16 +484,63 @@ public struct WorkspaceManager: Sendable {
         workspace: Workspace,
         repo: Repo,
         port: Int,
+        operationLease: WorkspaceOperationLease? = nil,
         onExit: (@Sendable (Int) -> Void)? = nil,
         onOutput: @escaping @Sendable (String) -> Void
     ) async -> Bool {
+        guard let lease = operationLease ?? WorkspaceOperationLease.acquire(in: workspace.path, operation: .setup),
+              lease.isValid(in: workspace.path, operation: .setup) else {
+            onOutput("Setup cannot run while another setup or rewind is using this worktree.")
+            return false
+        }
+        defer { if operationLease == nil { lease.release() } }
+        do {
+            try Task.checkCancellation()
+            guard try await store.pendingCheckpointRewind(workspaceID: workspace.id) == nil else {
+                onOutput("Resolve the interrupted rewind before running setup. Nothing was started.")
+                return false
+            }
+        } catch {
+            onOutput("Bloom could not check this workspace's rewind state. Nothing was started.")
+            return false
+        }
         let settings = SettingsLoader.load(repo: repo.path)
         let launch = ScriptLaunch.resolve(
             text: settings.setupScript, file: settings.scriptFiles[.setup], repo: repo.path
         )
 
+        let hasSubmodules = Git.hasSubmodules(in: workspace.path)
+        var preparationLog = ""
+        if hasSubmodules {
+            _ = try? await store.update(workspaceID: workspace.id) { $0.apply(.runStarted) }
+            preparationLog = "Preparing this worktree's submodules.\n"
+            onOutput(preparationLog.trimmingCharacters(in: .newlines))
+            do {
+                guard try await store.pendingCheckpointRewind(workspaceID: workspace.id) == nil else {
+                    throw WorkspaceError.recoveryPending
+                }
+                let output = try await Git.initialiseSubmodules(in: workspace.path)
+                preparationLog += output
+                if !output.isEmpty { onOutput(output) }
+            } catch {
+                let note = "Submodule setup failed. Some files may be missing. Run setup again to retry.\n"
+                    + error.readableMessage
+                onOutput(note)
+                let log = preparationLog + note
+                _ = try? await store.update(workspaceID: workspace.id) {
+                    $0.apply(.runFinished(succeeded: false, log: log))
+                }
+                onExit?(1)
+                return false
+            }
+        }
+
         guard let launch else {
-            _ = try? await store.update(workspaceID: workspace.id) { $0.apply(.runSkipped(note: nil)) }
+            let log = preparationLog
+            _ = try? await store.update(workspaceID: workspace.id) {
+                $0.apply(hasSubmodules ? .runFinished(succeeded: true, log: log) : .runSkipped(note: nil))
+            }
+            if hasSubmodules { onExit?(0) }
             return true
         }
 
@@ -492,7 +552,10 @@ public struct WorkspaceManager: Sendable {
             let note = "The settings file names \(path) as the setup script and there is nothing "
                 + "there, so nothing ran."
             onOutput(note)
-            _ = try? await store.update(workspaceID: workspace.id) { $0.apply(.runSkipped(note: note)) }
+            let log = preparationLog + note
+            _ = try? await store.update(workspaceID: workspace.id) {
+                $0.apply(hasSubmodules ? .runFinished(succeeded: true, log: log) : .runSkipped(note: note))
+            }
             return true
         case .executable, .source:
             break
@@ -508,15 +571,33 @@ public struct WorkspaceManager: Sendable {
             environment: Shell.environment(extra: env)
         )
 
-        var log = ""
-        do {
-            for try await line in runner.lines {
-                log += line + "\n"
-                onOutput(line)
+        var log = preparationLog
+        var didStart = false
+        await withTaskCancellationHandler {
+            do {
+                try Task.checkCancellation()
+                guard try await store.pendingCheckpointRewind(workspaceID: workspace.id) == nil else {
+                    throw WorkspaceError.recoveryPending
+                }
+                let lines = runner.lines
+                didStart = true
+                try Task.checkCancellation()
+                for try await line in lines {
+                    try Task.checkCancellation()
+                    log += line + "\n"
+                    onOutput(line)
+                }
+            } catch {
+                if Task.isCancelled { runner.terminate() }
+                log += "\n\(error)\n"
+                onOutput("\(error)")
             }
-        } catch {
-            log += "\n\(error)\n"
-            onOutput("\(error)")
+        } onCancel: {
+            runner.terminate()
+            Task.detached {
+                try? await Task.sleep(for: Self.setupStopGrace)
+                runner.kill()
+            }
         }
 
         // Stopped rather than finished: the reader pressed Stop, or the workspace is being archived
@@ -525,17 +606,13 @@ public struct WorkspaceManager: Sendable {
         // `exitStatus` for ever and leave the row `running`, so it gets SIGKILL after a grace
         // period. The line in the log is what tells a reader later that nobody's script failed.
         if Task.isCancelled {
-            Task.detached {
-                try? await Task.sleep(for: Self.setupStopGrace)
-                runner.kill()
-            }
             log += Self.setupStoppedNote + "\n"
             onOutput(Self.setupStoppedNote)
         }
 
-        let status = await runner.exitStatus
-        onExit?(Int(status))
-        let succeeded = status == 0
+        let status: Int32? = didStart ? await runner.exitStatus : nil
+        if let status { onExit?(Int(status)) }
+        let succeeded = status == 0 && !Task.isCancelled
         let printed = log
         // The whole `workspace` value here is as old as the run, and a run can take minutes, so
         // upserting it would clobber every other write to the row made in the meantime. `update`
@@ -665,6 +742,7 @@ public struct WorkspaceManager: Sendable {
         // in `WorkspaceLifecycle`, but this is the one edge that table would have had, so it is
         // written where the destructive work starts rather than where the row is finally saved.
         guard workspace.state == .active else { return }
+        try await store.requireWorkspaceCanBeRemoved(id: workspace.id)
 
         // Read before anything is removed, because the removal below is what makes it false.
         // See the branch delete near the end of this method for what it guards.
@@ -721,10 +799,15 @@ public struct WorkspaceManager: Sendable {
             // holding since before the block was allocated.
             let stored = try? await store.workspace(id: workspace.id)
             let env = environment(for: workspace, repo: repo, port: stored?.port ?? workspace.port)
-            let result = try await Shell.run(
-                archiveLaunch.executable, archiveLaunch.arguments,
-                cwd: workspace.path, env: env, timeout: archiveScriptTimeout
-            )
+            let result: ShellResult
+            do {
+                result = try await Shell.run(
+                    archiveLaunch.executable, archiveLaunch.arguments,
+                    cwd: workspace.path, env: env, timeout: archiveScriptTimeout
+                )
+            } catch let failure as ShellFailure {
+                throw WorkspaceError.archiveScriptIncomplete(failure)
+            }
             guard result.ok else {
                 throw WorkspaceError.archiveScriptFailed(
                     status: result.status,
@@ -733,6 +816,7 @@ public struct WorkspaceManager: Sendable {
             }
         }
 
+        try await store.requireWorkspaceCanBeRemoved(id: workspace.id)
         try await Git.removeWorktree(repo: repo.path, path: workspace.path, force: force)
 
         // **Only when the worktree was really there.** Deleting a branch is the one step here
@@ -775,19 +859,24 @@ public struct WorkspaceManager: Sendable {
 
     /// Deliberately leaves the stored counts alone when git fails, rather than writing zeroes.
     /// A stale count is a small lie; "0 files changed" on a workspace full of work is a big one.
-    public func refreshDiffStat(workspace: Workspace) async {
+    @discardableResult
+    public func refreshDiffStat(workspace: Workspace) async -> Bool {
         // Branch discovery must survive a missing base ref: an agent may rename that ref too,
         // which makes the diff fail but leaves HEAD perfectly readable.
         await refreshBranch(workspace: workspace)
         guard let stat = try? await Git.diffStat(worktree: workspace.path, base: workspace.baseBranch) else {
-            return
+            return false
         }
-        try? await store.updateDiffStat(
-            workspaceID: workspace.id,
-            additions: stat.additions,
-            deletions: stat.deletions,
-            files: stat.files
-        )
+        do {
+            try Task.checkCancellation()
+            try await store.updateDiffStat(
+                workspaceID: workspace.id,
+                additions: stat.additions,
+                deletions: stat.deletions,
+                files: stat.files
+            )
+            return true
+        } catch { return false }
     }
 }
 

--- a/Sources/BloomCore/Workspace/WorkspaceOperationLease.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceOperationLease.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Synchronization
+
+/// Setup and history restoration both write the same worktree. Their reservation must be
+/// synchronous: checking another actor and launching later leaves a window for the other writer.
+public final class WorkspaceOperationLease: Sendable {
+    public enum Operation: Sendable, Equatable { case setup, rewind }
+
+    private struct Claim: Sendable {
+        let token: UUID
+        let operation: Operation
+    }
+    private static let claims = Mutex<[String: Claim]>([:])
+    private let path: String
+    private let token: UUID
+    private let operation: Operation
+
+    private init(path: String, token: UUID, operation: Operation) {
+        self.path = path
+        self.token = token
+        self.operation = operation
+    }
+
+    public static func acquire(in worktree: String, operation: Operation) -> WorkspaceOperationLease? {
+        let path = canonical(worktree)
+        let token = UUID()
+        let claimed = claims.withLock { claims in
+            guard claims[path] == nil else { return false }
+            claims[path] = Claim(token: token, operation: operation)
+            return true
+        }
+        return claimed ? WorkspaceOperationLease(path: path, token: token, operation: operation) : nil
+    }
+
+    public func isValid(in worktree: String, operation: Operation) -> Bool {
+        guard path == Self.canonical(worktree), self.operation == operation else { return false }
+        return Self.claims.withLock { $0[path]?.token == token }
+    }
+
+    public static func isHeld(in worktree: String, operation: Operation) -> Bool {
+        let path = canonical(worktree)
+        return claims.withLock { $0[path]?.operation == operation }
+    }
+
+    public func release() {
+        Self.claims.withLock { claims in
+            if claims[path]?.token == token { claims[path] = nil }
+        }
+    }
+
+    deinit { release() }
+
+    private static func canonical(_ worktree: String) -> String {
+        URL(fileURLWithPath: worktree).resolvingSymlinksInPath().standardized.path
+    }
+}

--- a/Sources/BloomCore/Workspace/WorkspaceRestore.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceRestore.swift
@@ -9,7 +9,7 @@ public enum WorkspaceRestoreRefusal: Error, CustomStringConvertible, Sendable {
     public var description: String {
         switch self {
         case .branchGone(let branch):
-            "the branch \(branch) no longer exists here or on \(Git.remote)"
+            "the branch \(branch) no longer exists here or on its configured remote"
         }
     }
 }
@@ -185,8 +185,10 @@ public extension WorkspaceManager {
     func restoreSource(workspace: Workspace, repo: Repo) async -> RestoreSource {
         if await Git.branchExists(workspace.branch, in: repo.path) { return .localBranch }
 
-        _ = await Git.fetch(workspace.branch, in: repo.path)
-        let ref = "refs/remotes/\(Git.remote)/\(workspace.branch)"
+        guard let context = try? await Git.repositoryContext(
+            in: repo.path, baseBranch: workspace.baseBranch, branch: workspace.branch
+        ), let remote = context.publishRemote, let ref = context.publishTrackingRef else { return .gone }
+        _ = await Git.fetch(workspace.branch, in: repo.path, remote: remote)
         let remoteRef = await Git.revision(of: ref, in: repo.path) == nil ? nil : ref
         return RestoreSource.of(hasLocalBranch: false, remoteRef: remoteRef)
     }
@@ -215,6 +217,16 @@ public extension WorkspaceManager {
     func restore(
         workspace: Workspace, repo: Repo, from source: RestoreSource
     ) async throws -> RestoreOutcome {
+        let repositoryKey = Git.repositoryPaths(in: repo.path)?.commonDirectory
+            ?? URL(fileURLWithPath: repo.path).resolvingSymlinksInPath().standardized.path
+        return try await WorktreeCutQueue.shared.cut(in: repositoryKey) {
+            try await rebuild(workspace: workspace, repo: repo, from: source)
+        }
+    }
+
+    private func rebuild(
+        workspace: Workspace, repo: Repo, from source: RestoreSource
+    ) async throws -> RestoreOutcome {
         guard source.canRebuild else {
             throw WorkspaceRestoreRefusal.branchGone(branch: workspace.branch)
         }
@@ -241,6 +253,7 @@ public extension WorkspaceManager {
 
         let settings = SettingsLoader.load(repo: repo.path)
         try copyFiles(settings.filesToCopy, from: repo.path, to: path)
+        let needsSetup = settings.setupScript != nil || Git.hasSubmodules(in: path)
 
         // Nothing is installed in this worktree, and the row has to say so.
         //
@@ -260,7 +273,7 @@ public extension WorkspaceManager {
         // for a turn to finish or a diff stat pass to land, and a restore that put the whole value
         // back would undo whatever they wrote.
         let updated = try await store.update(workspaceID: workspace.id) {
-            $0.restore(to: path, hasSetupScript: settings.setupScript != nil)
+            $0.restore(to: path, hasSetupScript: needsSetup)
         }
         guard let restored = updated else { throw WorkspaceError.workspaceGone(workspace.name) }
 

--- a/Sources/BloomCore/Workspace/WorkspaceSetupPolicy.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceSetupPolicy.swift
@@ -7,12 +7,9 @@ public enum WorkspaceSetupPolicy: Sendable {
     case run
     case skip
 
-    public func initialState(script: String?) -> SetupState {
-        guard self != .skip,
-              let script,
-              !script.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return .skipped
-        }
-        return .pending
+    public func initialState(script: String?, hasSubmodules: Bool = false) -> SetupState {
+        guard self != .skip else { return .skipped }
+        let hasScript = script.map { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty } ?? false
+        return hasScript || hasSubmodules ? .pending : .skipped
     }
 }

--- a/Sources/BloomCore/Workspace/WorkspaceStart.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceStart.swift
@@ -223,7 +223,8 @@ extension WorkspaceManager {
                 // opened in this worktree afterwards picks its own, and two chats in one worktree
                 // can be on different ones.
                 agentKind: backend,
-                permissionMode: mode
+                permissionMode: mode,
+                interactionMode: controls?.interactionMode ?? .build
             ))
             // Fast mode and the output style have no column. Writing them here also marks the
             // session settled, which is what stops the composer's first-open defaults from

--- a/Sources/BloomCore/Workspace/WorkspaceStartContext.swift
+++ b/Sources/BloomCore/Workspace/WorkspaceStartContext.swift
@@ -110,8 +110,10 @@ public struct WorkspaceCheckoutOptions: Sendable {
         async let localListing = Git.branches(of: repoPath)
         async let remoteListing = Git.remoteBranches(of: repoPath)
         async let worktreeListing = Git.worktrees(of: repoPath)
+        async let remoteNamesRead = Git.remoteNames(of: repoPath)
         let local = (try? await localListing) ?? []
         let remote = (try? await remoteListing) ?? []
+        let remoteNames = (try? await remoteNamesRead) ?? []
         let branchesInUse = BranchHolder.byBranch(
             worktrees: (try? await worktreeListing) ?? [],
             projectPath: repoPath,
@@ -130,7 +132,8 @@ public struct WorkspaceCheckoutOptions: Sendable {
                     remote: remote,
                     defaultBranch: defaultBranch,
                     inUse: branchesInUse,
-                    pullRequestHeads: WorkspaceCheckoutPlan.heads(of: pullRequests)
+                    pullRequestHeads: WorkspaceCheckoutPlan.heads(of: pullRequests),
+                    remoteNames: remoteNames
                 ),
                 access: access,
                 failure: failure,

--- a/Sources/BloomCore/Workspace/WorktreeCutQueue.swift
+++ b/Sources/BloomCore/Workspace/WorktreeCutQueue.swift
@@ -21,9 +21,8 @@ import Foundation
 /// serialises instead: everybody gets their own run, one after another. `SingleFlight` is also
 /// `@MainActor`, and none of this is.
 ///
-/// Keyed on the repository path, because that is what the contention is over: two creates in two
-/// different projects share no branch list, no worktree directory and no git index, and making
-/// them queue behind each other would be a made up cost.
+/// Keyed on the canonical common Git directory. Two aliases or linked checkouts of one
+/// repository share refs and registrations, while unrelated projects can still cut in parallel.
 public actor WorktreeCutQueue {
     public static let shared = WorktreeCutQueue()
 

--- a/Tests/BloomCoreTests/AgentPresentationFeedTests.swift
+++ b/Tests/BloomCoreTests/AgentPresentationFeedTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite struct AgentPresentationFeedTests {
+    @Test func aStalledWindowRecoversEveryTextChunkWithoutKeepingEveryEvent() throws {
+        let feed = AgentPresentationFeed(maxItems: 4, maxBytes: 1_024)
+        for _ in 0..<2_000 { feed.yield(.streamDelta(.text("é🌱"))) }
+        let batch = feed.read(after: 0)
+        let recovery = try #require(batch.recovery)
+        #expect(recovery.text == String(repeating: "é🌱", count: 2_000))
+        #expect(feed.retainedUsage.items <= 4)
+        #expect(feed.retainedUsage.bytes <= 1_024)
+        #expect(batch.events.isEmpty)
+    }
+
+    @Test func overflowingACompletedBlockKeepsTheTerminalStateAndClearsLiveText() throws {
+        let feed = AgentPresentationFeed(maxItems: 2)
+        feed.yield(.streamDelta(.text("partial")))
+        feed.yield(.result(AgentResult(summary: "Finished")))
+        for _ in 0..<10 { feed.yield(.status("idle")) }
+        let recovery = try #require(feed.read(after: 0).recovery)
+        #expect(recovery.text.isEmpty)
+        guard case .result(let result) = recovery.stateEvent else {
+            Issue.record("The completion must survive overflow")
+            return
+        }
+        #expect(result.summary == "Finished")
+    }
+
+    @Test func independentSubscribersDoNotConsumeEachOthersWakeups() async throws {
+        let feed = AgentPresentationFeed(maxItems: 2)
+        var first = feed.notifications().makeAsyncIterator()
+        var second = feed.notifications().makeAsyncIterator()
+        _ = await first.next()
+        _ = await second.next()
+        for index in 0..<1_000 { feed.yield(.status(String(index))) }
+        let firstRevision = await first.next()
+        let secondRevision = await second.next()
+        #expect(firstRevision == 1_000)
+        #expect(secondRevision == 1_000)
+        feed.finish()
+        let firstEnd = await first.next()
+        let secondEnd = await second.next()
+        #expect(firstEnd == nil)
+        #expect(secondEnd == nil)
+    }
+
+    @Test func aFastConsumerReceivesLifecycleBoundariesInOrder() {
+        let feed = AgentPresentationFeed()
+        feed.yield(.streamDelta(.text("answer")))
+        feed.yield(.permissionDecided(PermissionResolution(requestID: "q", decision: "allow")))
+        feed.yield(.result(AgentResult()))
+        let batch = feed.read(after: 0)
+        #expect(batch.recovery == nil)
+        #expect(batch.events.count == 3)
+        guard case .permissionDecided = batch.events[1], case .result = batch.events[2] else {
+            Issue.record("Critical events must stay ordered")
+            return
+        }
+        #expect(feed.read(after: batch.revision).events.isEmpty)
+    }
+}
+
+extension AgentPresentationFeedTests {
+    @Test func lifecycleOverflowKeepsCompletionBeforeAnAutonomousFollowup() throws {
+        let feed = AgentPresentationFeed(maxItems: 2)
+        feed.yield(.result(AgentResult(summary: "First finished")), messageSeq: 10)
+        feed.yield(.initialized(AgentInit(sessionID: "session")), messageSeq: 11)
+        for word in ["new", " autonomous", " answer"] { feed.yield(.streamDelta(.text(word))) }
+        let batch = feed.read(after: 0)
+        #expect(batch.recovery != nil)
+        let firstPage = try feed.lifecycleEvents(after: 0, through: batch.revision, limit: 1)
+        #expect(firstPage.count == 1)
+        guard case .result(let result) = firstPage[0].event else {
+            Issue.record("Completion must precede the autonomous start")
+            return
+        }
+        #expect(result.summary == "First finished")
+        #expect(firstPage[0].messageSeq == 10)
+        #expect(feed.hasLaterTurn(than: firstPage[0].revision))
+        let secondPage = try feed.lifecycleEvents(after: firstPage[0].revision, through: batch.revision, limit: 1)
+        #expect(secondPage.count == 1)
+        guard case .initialized = secondPage[0].event else {
+            Issue.record("The autonomous start must also survive")
+            return
+        }
+        #expect(secondPage[0].messageSeq == 11)
+        #expect(!AgentPresentationReconciliation.permitsAutomaticDrain(isCatchingUp: true, isTurnRunning: false))
+        #expect(!AgentPresentationReconciliation.permitsAutomaticDrain(isCatchingUp: false, isTurnRunning: feed.isTurnRunning))
+        #expect(batch.recovery?.text == "new autonomous answer")
+    }
+
+    @Test func acknowledgedLifecycleHistoryIsReclaimedOnlyAfterEverySubscriber() throws {
+        let feed = AgentPresentationFeed(maxItems: 2)
+        let first = UUID()
+        let second = UUID()
+        let firstStream = feed.notifications(id: first, after: 0)
+        let secondStream = feed.notifications(id: second, after: 0)
+        defer { withExtendedLifetime((firstStream, secondStream)) {} }
+        feed.yield(.result(AgentResult(summary: "finished")))
+        let revision = feed.snapshot().revision
+        #expect(feed.retainedLifecycleBytes > 0)
+        feed.acknowledge(subscriber: first, through: revision)
+        #expect(feed.retainedLifecycleBytes > 0)
+        #expect(try feed.lifecycleEvents(after: 0, through: revision).count == 1)
+        feed.acknowledge(subscriber: second, through: revision)
+        #expect(feed.retainedLifecycleBytes == 0)
+        feed.unsubscribe(first)
+        feed.unsubscribe(second)
+        feed.finish()
+    }
+
+    @Test func lifecycleCapacityFailureIsExplicitRatherThanDroppingTheBoundary() {
+        let feed = AgentPresentationFeed(lifecycleCapacity: 1)
+        feed.yield(.result(AgentResult(summary: "will not fit")))
+        #expect(feed.read(after: 0).failure != nil)
+        #expect(feed.retainedLifecycleBytes == 0)
+    }
+
+    @Test func finishPreservesTheFinalUnacknowledgedBoundaryUntilConsumption() throws {
+        let feed = AgentPresentationFeed(maxItems: 1)
+        let reader = UUID()
+        let stream = feed.notifications(id: reader, after: 0)
+        defer { withExtendedLifetime(stream) {} }
+        feed.yield(.result(AgentResult(summary: "last")), messageSeq: 7)
+        let revision = feed.snapshot().revision
+        feed.finish()
+        #expect(try feed.lifecycleEvents(after: 0, through: revision).first?.messageSeq == 7)
+        feed.acknowledge(subscriber: reader, through: revision)
+        #expect(feed.retainedLifecycleBytes == 0)
+        feed.unsubscribe(reader)
+    }
+}
+
+extension AgentPresentationFeedTests {
+    @Test func pagedLifecycleReplayCrossesSparseOffsetsWithoutDuplicates() throws {
+        let feed = AgentPresentationFeed(maxItems: 1)
+        let reader = UUID()
+        let stream = feed.notifications(id: reader, after: 0)
+        defer { withExtendedLifetime(stream) {}; feed.unsubscribe(reader) }
+        for index in 0..<150 {
+            feed.yield(.result(AgentResult(summary: String(index))), messageSeq: index)
+        }
+        let end = feed.snapshot().revision
+        var cursor: UInt64 = 0
+        var sequences: [Int] = []
+        while true {
+            let page = try feed.lifecycleEvents(after: cursor, through: end, limit: 7)
+            guard let last = page.last else { break }
+            #expect(page.count <= 7)
+            sequences.append(contentsOf: page.compactMap(\.messageSeq))
+            cursor = last.revision
+            feed.acknowledge(subscriber: reader, through: cursor)
+        }
+        #expect(sequences == Array(0..<150))
+        #expect(feed.retainedLifecycleBytes == 0)
+    }
+}

--- a/Tests/BloomCoreTests/CodexFamilyStopTests.swift
+++ b/Tests/BloomCoreTests/CodexFamilyStopTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Synchronization
+import Testing
+@testable import BloomCore
+
+@Suite struct CodexFamilyStopTests {
+    @Test func earlyTurnAnnouncementsBecomeOwnedOnlyAfterRegistration() {
+        var children = CodexSubagents()
+        _ = children.receive(.turnStarted(CodexTurn(id: "turn", threadID: "child", status: .inProgress)), parentThreadID: "parent")
+        #expect(children.liveTurns.isEmpty)
+        _ = children.receive(.itemCompleted(CodexItemEvent(item: .subAgentActivity(CodexSubAgentActivity(
+            id: "spawn", agentPath: "/root/worker", agentThreadID: "child", kind: "started"
+        )), threadID: "parent", turnID: "parent-turn")), parentThreadID: "parent")
+        #expect(children.liveTurns == ["child": "turn"])
+        let stale = children.receive(.turnCompleted(CodexTurn(id: "old-turn", threadID: "child", status: .completed)), parentThreadID: "parent")
+        #expect(stale.isEmpty)
+        #expect(children.liveTurns == ["child": "turn"])
+        _ = children.receive(.turnCompleted(CodexTurn(id: "turn", threadID: "child", status: .completed)), parentThreadID: "parent")
+        #expect(children.liveTurns.isEmpty)
+    }
+
+    @Test func eachChildGetsABoundedDeadlineAndConcurrencyIsLimited() async {
+        let state = Mutex((active: 0, peak: 0, completed: 0))
+        let children = Dictionary(uniqueKeysWithValues: (0..<20).map { ("child-\($0)", "turn-\($0)") })
+        await CodexFamilyStop.interrupt(children, budget: .seconds(60), concurrency: 3) { _, _, timeout in
+            #expect(timeout > .zero && timeout <= .seconds(3))
+            state.withLock { $0.active += 1; $0.peak = max($0.peak, $0.active) }
+            await Task.yield()
+            state.withLock { $0.active -= 1; $0.completed += 1 }
+        }
+        let result = state.withLock { $0 }
+        #expect(result.peak <= 3)
+        #expect(result.completed == 20)
+    }
+    @Test func anExpiredBudgetNeverStartsChildRequests() async {
+        let calls = Mutex(0)
+        await CodexFamilyStop.interrupt(["child": "turn"], budget: .zero) { _, _, _ in
+            calls.withLock { $0 += 1 }
+        }
+        #expect(calls.withLock { $0 } == 0)
+    }
+
+}

--- a/Tests/BloomCoreTests/CodexRunnerTests.swift
+++ b/Tests/BloomCoreTests/CodexRunnerTests.swift
@@ -895,3 +895,89 @@ struct SideConversationCodexRunnerTests {
         await retryRunner.shutdown()
     }
 }
+
+extension CodexRunnerTests {
+    @Test func deliveryAcceptanceLinksTheExistingPromptToTheProviderTurn() async throws {
+        let store = try makeTestStore("codex-delivery-acceptance")
+        let (session, _) = try await makeCodexSession(store)
+        let delivery = try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "Only once"))
+        let claimed = try await store.claimDelivery(id: delivery.id)
+        #expect(claimed)
+        let box = scriptedBox()
+        let runner = makeRunner(store: store, session: session, box: box)
+        try await runner.sendDelivery(delivery)
+        #expect(try await store.delivery(id: delivery.id)?.state == .accepted)
+        #expect(try await store.delivery(id: delivery.id)?.providerTurnID == "01a02144-3bab-7fe3-a92c-6eec594d84fd")
+        #expect(try await store.messages(sessionID: session.id).filter { $0.kind == .user }.count == 1)
+        await runner.shutdown()
+    }
+
+    @Test func stopInterruptsOwnedChildrenAsWellAsTheParent() async throws {
+        let store = try makeTestStore("codex-family-stop")
+        let (session, _) = try await makeCodexSession(store)
+        let box = scriptedBox()
+        let runner = makeRunner(store: store, session: session, box: box)
+        try await runner.send("Start a child")
+        box.process.emit(#"{"method":"turn/started","params":{"threadId":"child","turn":{"id":"child-turn","status":"inProgress","items":[]}}}"#)
+        box.process.emit(#"{"method":"item/completed","params":{"threadId":"01a02144-3b7e-7233-97f2-73ebd5105085","turnId":"01a02144-3bab-7fe3-a92c-6eec594d84fd","item":{"id":"spawn-child","type":"subAgentActivity","agentPath":"/root/child","agentThreadId":"child","kind":"started"}}}"#)
+        await eventually("registered child") { runner.presentationFeed?.hasBackgroundWork == true }
+        runner.cancelNow()
+        await eventually("family interrupts") {
+            let frames = box.process.stdin.compactMap(JSONValue.parse).filter { $0["method"]?.stringValue == "turn/interrupt" }
+            return frames.contains { $0["params"]?["threadId"]?.stringValue == "child" }
+                && frames.contains { $0["params"]?["threadId"]?.stringValue == "01a02144-3b7e-7233-97f2-73ebd5105085" }
+        }
+        await runner.shutdown()
+    }
+
+    @Test func idleEvictionPreservesRunningTurnsAndPendingDeliveries() async throws {
+        let store = try makeTestStore("codex-idle-guard")
+        let (session, _) = try await makeCodexSession(store, agentSessionID: "resumable")
+        let box = scriptedBox()
+        let runner = makeRunner(store: store, session: session, box: box)
+        let delivery = try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "waiting"))
+        let queuedEviction = await runner.evictIfIdle(for: .zero)
+        #expect(!queuedEviction)
+        _ = try await store.cancelDelivery(id: delivery.id)
+        try await runner.send("working")
+        let activeEviction = await runner.evictIfIdle(for: .zero)
+        #expect(!activeEviction)
+        box.process.emit(#"{"method":"turn/completed","params":{"threadId":"01a02144-3b7e-7233-97f2-73ebd5105085","turn":{"id":"01a02144-3bab-7fe3-a92c-6eec594d84fd","status":"completed","items":[]}}}"#)
+        await eventually("idle turn") { await runner.currentSession.state == .idle }
+        let idleEviction = await runner.evictIfIdle(for: .zero)
+        #expect(idleEviction)
+        await #expect(throws: ProviderIdleError.self) { try await runner.send("must use a new runner") }
+        await runner.shutdown()
+    }
+}
+
+extension CodexRunnerTests {
+    @Test func anAmbiguousSteerFailureDoesNotStartTheSameMessageAgain() async throws {
+        let store = try makeTestStore("codex-ambiguous-steer")
+        let (session, _) = try await makeCodexSession(store)
+        let box = scriptedBox()
+        let runner = makeRunner(store: store, session: session, box: box)
+        try await runner.send("first")
+        box.fail("turn/steer", code: -32603, message: "internal failure after dispatch")
+        let delivery = try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "follow up"))
+        _ = try await store.claimDelivery(id: delivery.id)
+        await #expect(throws: CodexRPCError.self) { try await runner.sendDelivery(delivery) }
+        #expect(box.process.sentMethods.filter { $0 == "turn/start" }.count == 1)
+        #expect(try await store.delivery(id: delivery.id)?.state == .uncertain)
+        await runner.shutdown()
+    }
+
+    @Test func anExplicitTurnRejectionReturnsThePromptToPending() async throws {
+        let store = try makeTestStore("codex-definitive-rejection")
+        let (session, _) = try await makeCodexSession(store)
+        let box = scriptedBox()
+        box.fail("turn/start", code: -32602, message: "invalid model parameter")
+        let runner = makeRunner(store: store, session: session, box: box)
+        let delivery = try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "safe to retry"))
+        _ = try await store.claimDelivery(id: delivery.id)
+        await #expect(throws: CodexRPCError.self) { try await runner.sendDelivery(delivery) }
+        #expect(try await store.delivery(id: delivery.id)?.state == .pending)
+        #expect(try await store.messages(sessionID: session.id).filter { $0.kind == .user }.count == 1)
+        await runner.shutdown()
+    }
+}

--- a/Tests/BloomCoreTests/CodexSendRecoveryTests.swift
+++ b/Tests/BloomCoreTests/CodexSendRecoveryTests.swift
@@ -1,0 +1,11 @@
+import Testing
+@testable import BloomCore
+
+@Suite struct CodexSendRecoveryTests {
+    @Test func onlyADefinitiveInactiveTurnRejectionAllowsFallback() {
+        #expect(CodexSendRecovery.permitsNewTurn(after: CodexRPCError(code: -32602, message: "No active turn")))
+        #expect(!CodexSendRecovery.permitsNewTurn(after: CodexRPCError(code: -32603, message: "internal failure")))
+        #expect(!CodexSendRecovery.permitsNewTurn(after: CodexClientError.timedOut(method: "turn/steer", seconds: 120)))
+        #expect(!CodexSendRecovery.permitsNewTurn(after: CodexClientError.connectionClosed("EOF")))
+    }
+}

--- a/Tests/BloomCoreTests/ConversationRewindTests.swift
+++ b/Tests/BloomCoreTests/ConversationRewindTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Conversation rewind")
+struct ConversationRewindTests {
+    private func client(_ box: ProcessBox) -> CodexClient {
+        CodexClient(configuration: .init(cwd: "/tmp/rewind-peer"), makeProcess: box.factory)
+    }
+
+    @Test("Legacy rollback counts actual provider turns from the selected ID")
+    func legacy() async throws {
+        let box = ProcessBox()
+        box.reply(to: "thread/read", with: .object(["thread": .object([
+            "id": .string("thread"), "historyMode": .string("legacy"),
+            "turns": .array(["first", "selected", "last"].map { .object(["id": .string($0)]) }),
+        ])]))
+        let client = client(box)
+        try await client.start()
+        try await client.rewindThread(threadID: "thread", beforeTurnID: "selected")
+        let sent = try #require(box.process.sentFrame { $0["method"]?.stringValue == "thread/rollback" })
+        #expect(sent["params"]?["numTurns"]?.intValue == 2)
+        #expect(!box.process.sentMethods.contains("thread/revert"))
+        await client.stop()
+    }
+
+    @Test("Paginated rollback uses an exact boundary and does not call the deprecated endpoint")
+    func paginated() async throws {
+        let box = ProcessBox()
+        box.reply(to: "thread/read", with: .object(["thread": .object([
+            "id": .string("thread"), "historyMode": .string("paginated"),
+        ])]))
+        let client = client(box)
+        try await client.start()
+        try await client.rewindThread(threadID: "thread", beforeTurnID: "selected")
+        let sent = try #require(box.process.sentFrame { $0["method"]?.stringValue == "thread/revert" })
+        #expect(sent["params"]?["beforeTurnId"]?.stringValue == "selected")
+        #expect(!box.process.sentMethods.contains("thread/rollback"))
+        await client.stop()
+    }
+
+    @Test("A missing legacy boundary never sends a mutating request")
+    func missingBoundary() async throws {
+        let box = ProcessBox()
+        box.reply(to: "thread/read", with: .object(["thread": .object([
+            "id": .string("thread"), "turns": .array([.object(["id": .string("other")])]),
+        ])]))
+        let client = client(box)
+        try await client.start()
+        await #expect(throws: ConversationRewindError.self) {
+            try await client.rewindThread(threadID: "thread", beforeTurnID: "selected")
+        }
+        #expect(!box.process.sentMethods.contains("thread/rollback"))
+        await client.stop()
+    }
+
+    @Test("Recovery distinguishes absent turns from malformed pages and repeated cursors")
+    func recoveryPage() async throws {
+        let box = ProcessBox()
+        box.reply(to: "thread/read", with: .object(["thread": .object([
+            "id": .string("thread"), "historyMode": .string("paginated"),
+        ])]))
+        box.reply(to: "thread/turns/list", with: .object([
+            "data": .array([]), "nextCursor": .null,
+        ]))
+        let client = client(box)
+        try await client.start()
+        #expect(try await client.threadContainsTurn(threadID: "thread", turnID: "selected") == false)
+        box.process.reply(to: "thread/turns/list", with: .object(["data": .array([])]))
+        await #expect(throws: ConversationRewindError.self) {
+            _ = try await client.threadContainsTurn(threadID: "thread", turnID: "selected")
+        }
+        box.process.reply(to: "thread/turns/list", with: .object([
+            "data": .array([]), "nextCursor": .string("repeated"),
+        ]))
+        await #expect(throws: ConversationRewindError.self) {
+            _ = try await client.threadContainsTurn(threadID: "thread", turnID: "selected")
+        }
+        await client.stop()
+    }
+}

--- a/Tests/BloomCoreTests/DefaultBackendTests.swift
+++ b/Tests/BloomCoreTests/DefaultBackendTests.swift
@@ -273,13 +273,15 @@ struct DefaultBackendTests {
     // MARK: - The permission mode follows the backend
 
     /// "Start new sessions in plan mode" is one app-wide switch above two model rows, so it is set
-    /// long before this chat's backend is known. Codex has no Plan, and the mode a chat is written
-    /// with has to be one its backend has a row for.
-    @Test("plan mode cannot reach a chat opened on Codex")
-    func planModeNeverReachesCodex() {
+    /// long before this chat's backend is known. Codex receives planning independently of its
+    /// permission setting, while Claude retains its native permission mode.
+    @Test("the plan default uses the backend's planning mechanism")
+    func planModeUsesBackendMechanism() {
         var codex = AppDefaults(model: "gpt-5.6-sol", backend: .codex)
         codex.planMode = true
-        #expect(ComposerDefaults.resolve(repo: RepoSettings(), app: codex).permissionMode == .auto)
+        let resolved = ComposerDefaults.resolve(repo: RepoSettings(), app: codex)
+        #expect(resolved.permissionMode == codex.permissionMode)
+        #expect(resolved.interactionMode == .plan)
 
         var claude = AppDefaults()
         claude.planMode = true
@@ -299,7 +301,8 @@ struct DefaultBackendTests {
             outputStyle: OutputStyle.defaultName
         )
         #expect(controls.agentKind == .codex)
-        #expect(controls.permissionMode == .auto)
+        #expect(controls.permissionMode == defaults.permissionMode)
+        #expect(controls.interactionMode == .plan)
         #expect(!controls.offersOutputStyle)
     }
 }

--- a/Tests/BloomCoreTests/DeliveryRecoveryTests.swift
+++ b/Tests/BloomCoreTests/DeliveryRecoveryTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite(.scratchDirectory) struct DeliveryRecoveryTests {
+    @Test func aClaimSurvivesRestartWithOneLinkedMessageAndNoAutomaticDispatch() async throws {
+        let store = try makeTestStore("delivery-claim-restart")
+        let session = try await store.upsert(AskConversation.newSession())
+        let delivery = try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "Do the work"))
+        let claimed = try await store.claimDelivery(id: delivery.id)
+        #expect(claimed)
+        let reopened = try Store(path: store.path)
+        try await reopened.recoverDeliveryClaims()
+        let restored = try #require(await reopened.pendingDeliveries(sessionID: session.id).first)
+        #expect(restored.state == .pending)
+        #expect(restored.deliveredSeq != nil)
+        let reclaimed = try await reopened.claimDelivery(id: delivery.id)
+        #expect(reclaimed)
+        #expect(try await reopened.messages(sessionID: session.id).count == 1)
+    }
+
+    @Test func anUnknownOutcomeBlocksLaterMessagesUntilAnExplicitRetry() async throws {
+        let store = try makeTestStore("delivery-uncertain")
+        let session = try await store.upsert(AskConversation.newSession())
+        let first = try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "First"))
+        _ = try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "Second"))
+        _ = try await store.claimDelivery(id: first.id)
+        try await store.beginDeliveryDispatch(id: first.id)
+        let reopened = try Store(path: store.path)
+        try await reopened.recoverDeliveryClaims()
+        let waiting = try await reopened.pendingDeliveries(sessionID: session.id)
+        #expect(waiting.first?.state == .uncertain)
+        #expect(Delivery.deliverable(from: waiting, hold: .none, on: .codex).isEmpty)
+        #expect(!Delivery.goesImmediately(behind: waiting, hold: .none, on: .codex))
+        try await reopened.restoreDelivery(id: first.id)
+        _ = try await reopened.claimDelivery(id: first.id)
+        try await reopened.beginDeliveryDispatch(id: first.id)
+        try await reopened.acceptDelivery(id: first.id, providerTurnID: "turn-42")
+        #expect(try await reopened.delivery(id: first.id)?.providerTurnID == "turn-42")
+        #expect(try await reopened.messages(sessionID: session.id).count == 1)
+        #expect(try await reopened.pendingDeliveries(sessionID: session.id).count == 1)
+    }
+
+    @Test func failedMessageInsertionRollsBackTheClaim() async throws {
+        let store = try makeTestStore("delivery-atomic-claim")
+        let session = try await store.upsert(AskConversation.newSession())
+        let delivery = try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "Keep me"))
+        let raw = try SQLiteDatabase(path: store.path)
+        try raw.execute("CREATE TRIGGER fail_message BEFORE INSERT ON messages BEGIN SELECT RAISE(ABORT, 'disk full'); END")
+        await #expect(throws: SQLiteError.self) { try await store.claimDelivery(id: delivery.id) }
+        #expect(try await store.delivery(id: delivery.id)?.state == .pending)
+        #expect(try await store.messages(sessionID: session.id).isEmpty)
+    }
+
+    @Test func ownerMessagesCaptureInteractionModeAtEnqueue() async throws {
+        let store = try makeTestStore("delivery-mode")
+        let session = try await store.upsert(Session(workspaceID: nil, agentKind: .codex, interactionMode: .plan))
+        let delivery = try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "Plan first"))
+        try await store.updateSessionPreferences(id: session.id, interactionMode: .build)
+        #expect(delivery.interactionMode == .plan)
+        #expect(try await store.delivery(id: delivery.id)?.interactionMode == .plan)
+    }
+}

--- a/Tests/BloomCoreTests/GitHubRateLimitTests.swift
+++ b/Tests/BloomCoreTests/GitHubRateLimitTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("GitHub rate limits")
+struct GitHubRateLimitTests {
+    @Test("an older success cannot clear a newer pause")
+    func staleSuccess() async throws {
+        let limits = GitHubRateLimits()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let first = try await limits.check(host: "github.com", now: now)
+        let concurrent = try await limits.check(host: "github.com", now: now)
+        let retry = await limits.limited(host: "github.com", lease: first, retryAt: nil, now: now)
+        await limits.succeeded(host: "github.com", lease: concurrent, now: now)
+        #expect(retry == now.addingTimeInterval(30))
+        await #expect(throws: GitHubReadFailure.self) { try await limits.check(host: "github.com", now: now) }
+        let other = try await limits.check(host: "github.example.com", now: now)
+        #expect(other == 0)
+    }
+
+    @Test("explicit operations do not clear the background cooldown")
+    func interactiveLease() async throws {
+        let limits = GitHubRateLimits()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let lease = try await limits.check(host: "GITHUB.COM", now: now)
+        await limits.limited(host: "github.com", lease: lease, retryAt: now.addingTimeInterval(120), now: now)
+        let interactive = try await limits.check(host: "github.com", interactive: true, now: now)
+        await limits.succeeded(host: "github.com", lease: interactive, now: now)
+        await #expect(throws: GitHubReadFailure.self) { try await limits.check(host: "github.com", now: now) }
+        let after = try await limits.check(host: "github.com", now: now.addingTimeInterval(121))
+        await limits.succeeded(host: "github.com", lease: after, now: now.addingTimeInterval(121))
+        let next = await limits.limited(host: "github.com", lease: after, retryAt: nil, now: now.addingTimeInterval(121))
+        #expect(next == now.addingTimeInterval(151))
+    }
+
+    @Test("reset headers are parsed without confusing missing PRs with throttling")
+    func headers() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        #expect(GitHubReadFailure.retryDate(from: "Retry-After: 120", now: now) == now.addingTimeInterval(120))
+        #expect(GitHubReadFailure.retryDate(from: "X-RateLimit-Reset: 1200", now: now) == Date(timeIntervalSince1970: 1_200))
+        #expect(GitHubReadFailure.retryDate(from: "Retry-After: later", now: now) == nil)
+        #expect(GitHubReadFailure.isRateLimit("API rate limit exceeded"))
+        #expect(!GitHubReadFailure.isRateLimit("no pull requests found"))
+    }
+
+    @Test("fork lookups identify the base repo and the publication owner")
+    func forkArguments() {
+        let context = GitRepositoryContext.resolve(config: [
+            "remote.origin.url": "git@github.com:fork/project.git",
+            "remote.upstream.url": "https://github.com/upstream/project.git",
+            "branch.main.remote": "upstream", "remote.pushdefault": "origin",
+        ], base: "main", branch: "feature")
+        #expect(GitHub.repositoryArguments(["pr", "view", "feature", "--json", "number"], context: context)
+            == ["pr", "view", "fork:feature", "--json", "number", "--repo", "github.com/upstream/project"])
+        #expect(GitHub.repositoryArguments(["pr", "view", "123"], context: context)
+            == ["pr", "view", "123", "--repo", "github.com/upstream/project"])
+    }
+}

--- a/Tests/BloomCoreTests/GitHubReadReliabilityTests.swift
+++ b/Tests/BloomCoreTests/GitHubReadReliabilityTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("GitHub read reliability", .scratchDirectory)
+struct GitHubReadReliabilityTests {
+    @Test("a missing numbered PR is an answer, while transport and malformed output remain failures")
+    func absenceVersusFailure() async throws {
+        let missingPath = TestScratch.unique("missing-pr")
+        let missing = try await GitHub.$commandOverride.withValue({ _, _ in
+            ShellResult(status: 1, stdout: "", stderr: "GraphQL: Could not resolve to a PullRequest with the number of 123.")
+        }) {
+            try await GitHub.snapshot(forNumber: 123, worktree: missingPath, maxAge: .zero)
+        }
+        #expect(missing == nil)
+        let cached = try await GitHub.$commandOverride.withValue({ _, _ in
+            Issue.record("A confirmed absence should be cached")
+            throw GitHubError("unexpected command")
+        }) {
+            try await GitHub.snapshot(forNumber: 123, worktree: missingPath, maxAge: .seconds(30))
+        }
+        #expect(cached == nil)
+
+        let failedPath = TestScratch.unique("failed-pr")
+        await #expect(throws: ShellError.self) {
+            try await GitHub.$commandOverride.withValue({ _, _ in
+                ShellResult(status: 1, stdout: "", stderr: "error connecting to github.com")
+            }) {
+                try await GitHub.snapshot(forNumber: 123, worktree: failedPath, maxAge: .zero)
+            }
+        }
+        await #expect(throws: (any Error).self) {
+            try await GitHub.$commandOverride.withValue({ _, _ in
+                ShellResult(status: 0, stdout: "{broken", stderr: "")
+            }) {
+                // If the transport failure had been cached as nil, this would return nil.
+                try await GitHub.snapshot(forNumber: 123, worktree: failedPath, maxAge: .seconds(30))
+            }
+        }
+    }
+
+    @Test("refresh failures retain content and a successful absence clears it")
+    func displayedState() {
+        let pullRequest = PullRequest(number: 123, title: "Work", url: "https://github.com/org/repo/pull/123", state: "OPEN", branch: "feature")
+        var state = PullRequestRefreshState(pullRequest: pullRequest)
+        let failure = GitHubReadFailure(reason: .unavailable, message: "Could not connect")
+        state.record(.unavailable(failure))
+        #expect(state.pullRequest == pullRequest)
+        #expect(state.failure == failure)
+        state.record(.current(nil))
+        #expect(state.pullRequest == nil)
+        #expect(state.failure == nil)
+    }
+
+    @Test("identical concurrent reads execute once", .timeLimit(.minutes(1)))
+    func sharedRead() async throws {
+        let requests = GitHubRequests()
+        let probe = ReadProbe()
+        let key = GitHubRequests.Key(host: "github.com", directory: "shared", arguments: ["pr", "view", "1"])
+        let readers = Task {
+            try await withThrowingTaskGroup(of: ShellResult.self) { group in
+                for _ in 0..<20 {
+                    group.addTask {
+                        try await requests.run(key: key, interactive: false) { await probe.execute() }
+                    }
+                }
+                var results: [ShellResult] = []
+                for try await result in group { results.append(result) }
+                return results
+            }
+        }
+        await probe.waitUntilStarted()
+        // Release only after every caller is actually subscribed, not after a guessed delay.
+        while await requests.activeSubscribers < 20 { await Task.yield() }
+        await probe.release()
+        let results = try await readers.value
+        #expect(results.count == 20)
+        #expect(await probe.count == 1)
+    }
+
+    @Test("a cancelled subscriber leaves promptly without cancelling a shared request")
+    func cancelledSubscriber() async throws {
+        let probe = ReadProbe()
+        let underlying = Task<ShellResult, Error> { await probe.execute() }
+        await probe.waitUntilStarted()
+        let subscriber = Task { try await GitHubRequestWaiter.value(of: underlying) }
+        subscriber.cancel()
+        await #expect(throws: CancellationError.self) { try await subscriber.value }
+        #expect(!underlying.isCancelled)
+        await probe.release()
+        let result = try await underlying.value
+        #expect(result.stdout == "answer")
+    }
+
+    @Test("checkout and run logs use the same base repository as PR reads")
+    func repositoryRouting() {
+        let context = GitRepositoryContext.resolve(config: [
+            "remote.origin.url": "git@github.com:person/project.git",
+            "remote.upstream.url": "https://github.com/organisation/project.git",
+            "branch.main.remote": "upstream",
+        ], base: "main", branch: "feature")
+        #expect(GitHub.repositoryArguments(["pr", "checkout", "123"], context: context)
+            == ["pr", "checkout", "123", "--repo", "github.com/organisation/project"])
+        #expect(GitHub.repositoryArguments(["run", "view", "456", "--log"], context: context)
+            == ["run", "view", "456", "--log", "--repo", "github.com/organisation/project"])
+        #expect(GitHub.repositoryArguments(["pr", "view", "123", "--repo", "other/repo"], context: context)
+            == ["pr", "view", "123", "--repo", "other/repo"])
+    }
+}
+
+private actor ReadProbe {
+    private(set) var count = 0
+    private var released = false
+    private var readers: [CheckedContinuation<Void, Never>] = []
+    private var started: [CheckedContinuation<Void, Never>] = []
+
+    func execute() async -> ShellResult {
+        count += 1
+        let waiting = started
+        started.removeAll()
+        for continuation in waiting { continuation.resume() }
+        if !released { await withCheckedContinuation { readers.append($0) } }
+        return ShellResult(status: 0, stdout: "answer", stderr: "")
+    }
+
+    func waitUntilStarted() async {
+        if count > 0 { return }
+        await withCheckedContinuation { started.append($0) }
+    }
+
+    func release() {
+        released = true
+        let waiting = readers
+        readers.removeAll()
+        for continuation in waiting { continuation.resume() }
+    }
+}

--- a/Tests/BloomCoreTests/GitReliabilityTests.swift
+++ b/Tests/BloomCoreTests/GitReliabilityTests.swift
@@ -1,0 +1,329 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Git operation reliability", .tags(.git), .scratchDirectory)
+struct GitReliabilityTests {
+    @Test("reverting a dynamic route preserves neighbouring worktree and index edits")
+    func literalRevert() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        for name in ["[id].tsx", "i.tsx", "d.tsx"] { try repo.write(name, "before\n") }
+        try await repo.commit("Routes")
+        for name in ["[id].tsx", "i.tsx", "d.tsx"] { try repo.write(name, "after\n") }
+        try await Shell.check("git", ["add", "--", "i.tsx"], cwd: repo.path)
+        let file = ChangedFile(path: "[id].tsx", change: .modified)
+        let patch = try await Git.patch(worktree: repo.path, base: "main", file: file)
+        #expect(DiffParser.parse(patch).count == 1)
+        try await Git.revertTrackedFile(file, worktree: repo.path, base: "main")
+        #expect(repo.read("[id].tsx") == "before\n")
+        #expect(repo.read("i.tsx") == "after\n")
+        #expect(repo.read("d.tsx") == "after\n")
+        let staged = try await Shell.check("git", ["show", ":i.tsx"], cwd: repo.path)
+        #expect(staged.stdout == "after\n")
+    }
+
+    @Test("removing an added glob path does not remove matching files")
+    func literalRemoval() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        try repo.write("keep.txt", "keep\n")
+        try await repo.commit("Keep")
+        let base = try await Git.headSHA(of: repo.path)
+        try repo.write("*.txt", "new\n")
+        try await repo.commit("Added")
+        try await Git.revertTrackedFile(ChangedFile(path: "*.txt", change: .added), worktree: repo.path, base: base)
+        #expect(!repo.exists("*.txt"))
+        #expect(repo.read("keep.txt") == "keep\n")
+    }
+
+    @Test("rendered patches bypass external diff tools and normalise prefixes")
+    func controlledPatch() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        try repo.write("space name.txt", "before\n")
+        try await repo.commit("Before")
+        try repo.write("space name.txt", "after\n")
+        let executable = try #require(Shell.which("true"))
+        try await Shell.check("git", ["config", "diff.external", executable], cwd: repo.path)
+        try await Shell.check("git", ["config", "diff.mnemonicPrefix", "true"], cwd: repo.path)
+        try await Shell.check("git", ["config", "diff.noprefix", "true"], cwd: repo.path)
+        let patch = try await Git.patch(
+            worktree: repo.path, base: "main", file: ChangedFile(path: "space name.txt", change: .modified)
+        )
+        #expect(patch.contains("+after"))
+        #expect(patch.contains("+++ b/space name.txt"))
+        #expect(DiffParser.parse(patch).first?.newPath == "space name.txt")
+    }
+
+    @Test("untracked previews accept diff exit one but report an unreadable path")
+    func untrackedErrors() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        let file = ChangedFile(path: "new.txt", change: .untracked)
+        try repo.write(file.path, "new\n")
+        let patch = try await Git.patch(worktree: repo.path, base: "main", file: file)
+        #expect(patch.contains("+new"))
+        try FileManager.default.removeItem(atPath: repo.path + "/" + file.path)
+        await #expect(throws: ShellError.self) {
+            try await Git.patch(worktree: repo.path, base: "main", file: file)
+        }
+    }
+
+    @Test("worktree listings preserve newline paths and lock reasons")
+    func nulWorktreeListing() async throws {
+        let repo = try await TempRepo()
+        let path = TestScratch.unique("worktree-with\nnewline")
+        defer {
+            try? FileManager.default.removeItem(atPath: path)
+            repo.cleanUp()
+        }
+        try await Git.addWorktree(repo: repo.path, path: path, branch: "newline", base: "main")
+        try await Shell.check("git", ["worktree", "lock", "--reason", "reason\ncontinued", "--", path], cwd: repo.path)
+        let listed = try await Git.worktrees(of: repo.path)
+        let entry = try #require(listed.first { $0.branch == "newline" })
+        #expect(WorktreeWatcher.resolve(entry.path) == WorktreeWatcher.resolve(path))
+        #expect(entry.lockReason == "reason\ncontinued")
+    }
+
+    @Test("linked metadata invalidates its owner and common refs invalidate siblings")
+    func metadataWatchRoots() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        let one = TestScratch.unique("first-worktree")
+        let two = TestScratch.unique("second-worktree")
+        try await Git.addWorktree(repo: repo.path, path: one, branch: "one", base: "main")
+        try await Git.addWorktree(repo: repo.path, path: two, branch: "two", base: "main")
+        let first = try #require(Git.repositoryPaths(in: one))
+        let second = try #require(Git.repositoryPaths(in: two))
+        #expect(first.commonDirectory == second.commonDirectory)
+        #expect(first.gitDirectory != second.gitDirectory)
+        let metadata = WorktreeWatcher.metadataRoots(for: [one, two])
+        let local = WorktreeWatcher.metadataWorktrees(
+            changed: [WorktreeWatcher.resolve(first.gitDirectory) + "/index"], metadata: metadata
+        )
+        #expect(local == [one])
+        let shared = WorktreeWatcher.metadataWorktrees(
+            changed: [WorktreeWatcher.resolve(first.commonDirectory) + "/refs/heads/main"], metadata: metadata
+        )
+        #expect(shared == [one, two])
+        let ignored = WorktreeWatcher.metadataWorktrees(changed: [
+            WorktreeWatcher.resolve(first.commonDirectory) + "/objects/ab/object",
+            WorktreeWatcher.resolve(first.commonDirectory) + "/refs/bloom/checkpoints/turn/worktree",
+            WorktreeWatcher.resolve(first.commonDirectory) + "/logs/refs/bloom/checkpoints/turn/worktree",
+            WorktreeWatcher.resolve(first.gitDirectory) + "/bloom-snapshot-turn-index",
+            WorktreeWatcher.resolve(first.gitDirectory) + "/bloom-restore-temporary",
+        ], metadata: metadata)
+        #expect(ignored.isEmpty)
+        let coalesced = WorktreeWatcher.metadataWorktrees(
+            changed: [WorktreeWatcher.resolve(first.commonDirectory) + "/refs"], metadata: metadata
+        )
+        #expect(coalesced == [one, two])
+    }
+
+    @Test("a write during a read survives that read's completion and failures stay due")
+    func invalidationDuringRefresh() {
+        let id = WorkspaceID("worktree")
+        var invalidations = DiffRefreshInvalidations()
+        invalidations.record([id])
+        let oldRead = invalidations.generation(for: id)
+        invalidations.record([id])
+        invalidations.finish(id, generation: oldRead, succeeded: true)
+        #expect(invalidations.pending == [id])
+        let currentRead = invalidations.generation(for: id)
+        invalidations.finish(id, generation: currentRead, succeeded: false)
+        #expect(invalidations.pending == [id])
+        invalidations.finish(id, generation: currentRead, succeeded: true)
+        #expect(invalidations.pending.isEmpty)
+    }
+
+    @Test("fork publication settings remain separate from the base and survive upstream changes")
+    func remoteContext() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        for (key, value) in [
+            ("remote.upstream.url", "https://example.invalid/organisation/project.git"),
+            ("remote.fork.url", "https://example.invalid/person/project.git"),
+            ("branch.main.remote", "upstream"),
+            ("branch.main.merge", "refs/heads/main"),
+            ("remote.pushDefault", "upstream"),
+            ("branch.feature.pushRemote", "fork"),
+            ("branch.feature.remote", "upstream"),
+            ("branch.feature.merge", "refs/heads/main"),
+        ] { try await Shell.check("git", ["config", key, value], cwd: repo.path) }
+        let context = try await Git.repositoryContext(in: repo.path, baseBranch: "main", branch: "feature")
+        #expect(context.baseRemote == "upstream")
+        #expect(context.publishRemote == "fork")
+        #expect(context.publishBranch == "feature")
+        try await Git.recordBase(context, for: "feature", in: repo.path)
+        try await Shell.check("git", ["config", "branch.feature.remote", "fork"], cwd: repo.path)
+        try await Shell.check("git", ["config", "branch.feature.merge", "refs/heads/feature"], cwd: repo.path)
+        let afterPush = try await Git.repositoryContext(in: repo.path, branch: "feature")
+        #expect(afterPush.baseTrackingRef == "refs/remotes/upstream/main")
+        #expect(afterPush.publishTrackingRef == "refs/remotes/fork/feature")
+    }
+
+    @Test("fetch and baseline use a configured non-origin base")
+    func nonOriginBaseline() async throws {
+        let remote = try await TempRepo()
+        let repo = try await TempRepo()
+        defer { remote.cleanUp(); repo.cleanUp() }
+        try remote.write("remote.txt", "new base\n")
+        try await remote.commit("New base")
+        try await Shell.check("git", ["remote", "add", "upstream", remote.path], cwd: repo.path)
+        try await Shell.check("git", ["config", "branch.main.remote", "upstream"], cwd: repo.path)
+        let fetched = await Git.fetch("main", in: repo.path)
+        #expect(fetched)
+        let worktree = TestScratch.unique("upstream-feature")
+        try await Git.addWorktree(repo: repo.path, path: worktree, branch: "feature", base: "upstream/main")
+        let baseline = try await Git.baseline("main", in: worktree)
+        #expect(baseline == (try await Git.headSHA(of: remote.path)))
+        let branches = WorkspaceCheckoutPlan.offeredBranches(
+            local: [], remote: ["upstream/topic"], defaultBranch: "main", remoteNames: ["upstream"]
+        )
+        #expect(branches.first?.remoteName == "upstream")
+    }
+
+    @Test("repository context preserves a custom default instead of inventing main")
+    func customDefaultBranch() async throws {
+        let repo = try await TempRepo(defaultBranch: "release")
+        defer { repo.cleanUp() }
+        let context = try await Git.repositoryContext(in: repo.path)
+        #expect(context.baseBranch == "release")
+        #expect(try await Git.defaultBranch(of: repo.path) == "release")
+    }
+
+    @Test("a synthetic PR ref needs an explicit publication remote")
+    func reviewRefPublication() {
+        var config = [
+            "remote.origin.url": "https://github.com/organisation/project.git",
+            "remote.fork.url": "https://github.com/person/project.git",
+            "branch.feature.remote": "origin",
+            "branch.feature.merge": "refs/pull/123/head",
+        ]
+        let review = GitRepositoryContext.resolve(config: config, base: "main", branch: "feature")
+        #expect(review.baseRemote == "origin")
+        #expect(review.publishRemote == nil)
+        config["branch.feature.pushremote"] = "fork"
+        let publishable = GitRepositoryContext.resolve(config: config, base: "main", branch: "feature")
+        #expect(publishable.publishRemote == "fork")
+        #expect(publishable.publishTrackingRef == "refs/remotes/fork/feature")
+    }
+
+    @Test("submodule-only setup records failure, retains the workspace, and supports retry")
+    func submoduleReadinessAndRetry() async throws {
+        let submodule = try await TempRepo()
+        let repo = try await TempRepo()
+        defer { submodule.cleanUp(); repo.cleanUp() }
+        try await Shell.check("git", ["-c", "protocol.file.allow=always", "submodule", "add", submodule.path, "shared"], cwd: repo.path)
+        try await repo.commit("Submodule")
+        let store = try makeTestStore("submodule-readiness")
+        let manager = WorkspaceManager(store: store)
+        let registered = try await manager.addRepository(at: repo.path)
+        let started = try await manager.start(WorkspaceStartRequest(
+            repo: registered, prompt: "Prepare submodules", origin: .user, opensSession: false
+        ))
+        #expect(started.workspace.setupState == .pending)
+        let first = await manager.runSetup(workspace: started.workspace, repo: registered, port: 0) { _ in }
+        #expect(!first)
+        let failed = try #require(try await store.workspace(id: started.workspace.id))
+        #expect(failed.setupState == .failed)
+        #expect(failed.setupLog.contains("Submodule setup failed"))
+        #expect(FileManager.default.fileExists(atPath: failed.path))
+        // A local fixture needs explicit file transport permission for its initial clone.
+        // This command changes no global policy; production setup must respect Git's refusal.
+        try await Shell.check("git", ["-c", "protocol.file.allow=always", "submodule", "update", "--init", "--recursive"], cwd: failed.path)
+        let retried = await manager.runSetup(workspace: failed, repo: registered, port: 0) { _ in }
+        #expect(retried)
+        let ready = try #require(try await store.workspace(id: failed.id))
+        #expect(ready.setupState == .succeeded)
+        let status = try await Shell.check("git", ["submodule", "status"], cwd: ready.path)
+        #expect(status.stdout.hasPrefix(" "))
+        let restored = WorkspaceSetupPolicy.deferred.initialState(script: nil, hasSubmodules: true)
+        #expect(restored == .pending)
+    }
+
+    @Test("an unresolved rewind blocks forced archive and parent deletion before side effects")
+    func rewindBlocksRemoval() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        try repo.write(".conductor/settings.toml", """
+        [scripts]
+        archive = 'touch archive-ran'
+        setup = 'touch setup-ran'
+        """)
+        let store = try makeTestStore("rewind-archive")
+        let manager = WorkspaceManager(store: store)
+        let registered = try await manager.addRepository(at: repo.path)
+        let workspace = try await manager.createWorkspace(repo: registered, prompt: "Recovery")
+        var session = Session(workspaceID: workspace.id)
+        session.archivedAt = Date()
+        session = try await store.upsert(session)
+        let snapshot = try await Git.captureSnapshot(in: workspace.path, sessionID: session.id)
+        let checkpoint = TurnCheckpoint(sessionID: session.id, startSeq: 0, before: snapshot)
+        let journal = CheckpointRewind(checkpoint: checkpoint, recovery: snapshot, restoringFiles: true)
+        try await store.saveCheckpointRewind(journal)
+
+        let output = LineCollector()
+        for _ in 0..<2 {
+            let ran = await manager.runSetup(
+                workspace: workspace, repo: registered, port: 0,
+                onExit: { output.append("exit: \($0)") }, onOutput: { output.append($0) }
+            )
+            #expect(!ran)
+        }
+        let refused = try #require(try await store.workspace(id: workspace.id))
+        #expect(refused.setupState == workspace.setupState)
+        #expect(refused.setupLog == workspace.setupLog)
+        #expect(output.joined.contains("interrupted rewind"))
+        #expect(!output.joined.contains("exit:"))
+        #expect(!FileManager.default.fileExists(atPath: workspace.path + "/setup-ran"))
+
+        await #expect(throws: WorkspaceError.self) {
+            try await manager.archive(workspace: workspace, repo: registered, force: true)
+        }
+        await #expect(throws: WorkspaceError.self) { try await store.deleteWorkspace(id: workspace.id) }
+        await #expect(throws: WorkspaceError.self) { try await store.deleteRepo(id: registered.id) }
+        let objection = await WorkspaceArchiveSafety.objection(to: workspace, excusing: nil, store: store)
+        #expect(objection?.contains("rewind") == true)
+        #expect(FileManager.default.fileExists(atPath: workspace.path))
+        #expect(!FileManager.default.fileExists(atPath: workspace.path + "/archive-ran"))
+        #expect(await Git.revision(of: snapshot.worktreeRef, in: workspace.path) != nil)
+        #expect(try await store.workspace(id: workspace.id)?.state == .active)
+    }
+
+    @Test("setup and rewind reservations exclude each other before any awaited state check")
+    func setupAndRewindReservation() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        try repo.write(".conductor/settings.toml", """
+        [scripts]
+        setup = 'touch setup-ran'
+        """)
+        let store = try makeTestStore("setup-reservation")
+        let manager = WorkspaceManager(store: store)
+        let registered = try await manager.addRepository(at: repo.path)
+        let workspace = try await manager.createWorkspace(repo: registered, prompt: "Reserve setup")
+        let session = try await store.upsert(Session(workspaceID: workspace.id))
+        let checkpoint = TurnCheckpoint(sessionID: session.id, startSeq: 0, before: GitSnapshot(sessionID: session.id))
+        let setup = try #require(WorkspaceOperationLease.acquire(in: workspace.path, operation: .setup))
+        defer { setup.release() }
+        #expect(WorkspaceOperationLease.acquire(in: workspace.path + "/.", operation: .rewind) == nil)
+        await #expect(throws: SnapshotFailure.self) {
+            try await TurnCheckpointStore(store: store).prepareRewind(
+                checkpoint: checkpoint, cwd: workspace.path, restoringFiles: false
+            )
+        }
+        await #expect(throws: SnapshotFailure.self) {
+            try await store.saveCheckpointRewind(CheckpointRewind(checkpoint: checkpoint, recovery: nil, restoringFiles: false))
+        }
+        setup.release()
+
+        let rewind = try #require(WorkspaceOperationLease.acquire(in: workspace.path, operation: .rewind))
+        defer { rewind.release() }
+        let ran = await manager.runSetup(workspace: workspace, repo: registered, port: 0) { _ in }
+        #expect(!ran)
+        #expect(!FileManager.default.fileExists(atPath: workspace.path + "/setup-ran"))
+        #expect(try await store.workspace(id: workspace.id)?.setupState == workspace.setupState)
+    }
+}

--- a/Tests/BloomCoreTests/InteractionModeTests.swift
+++ b/Tests/BloomCoreTests/InteractionModeTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Synchronization
+import Testing
+@testable import BloomCore
+
+@Suite("Interaction modes", .scratchDirectory)
+struct InteractionModeTests {
+    @Test("Codex planning leaves permission selection independent")
+    func permissionIndependence() {
+        var controls = ComposerControls(agentKind: .codex, permissionMode: .bypassPermissions, interactionMode: .plan)
+        #expect(controls.permissionMode == .bypassPermissions)
+        #expect(controls.interactionMode == .plan)
+        controls.agentKind = .claudeCode
+        #expect(controls.interactionMode == .build)
+        #expect(controls.permissionMode == .bypassPermissions)
+    }
+
+    @Test("Plan and Build reach the provider with explicit default reset", arguments: InteractionMode.allCases)
+    func wire(mode: InteractionMode) async throws {
+        let box = ProcessBox()
+        let client = CodexClient(configuration: .init(cwd: "/tmp/plan-wire"), makeProcess: box.factory)
+        box.reply(to: "turn/start", with: .object(["turn": .object([
+            "id": .string("turn-plan"), "status": .string("inProgress"),
+        ])]))
+        try await client.start()
+        let initialise = try #require(box.process.sentFrame { $0["method"]?.stringValue == "initialize" })
+        #expect(initialise["params"]?["capabilities"]?["experimentalApi"]?.boolValue == true)
+        _ = try await client.startTurn(
+            threadID: "thread", input: [.text("Plan the change")], model: "gpt-5.6-sol", effort: "high",
+            approvalPolicy: .never, sandboxPolicy: .object(["type": .string("dangerFullAccess")]),
+            interactionMode: mode
+        )
+        let frame = try #require(box.process.sentFrame { $0["method"]?.stringValue == "turn/start" })
+        let params = try #require(frame["params"])
+        #expect(params["approvalPolicy"]?.stringValue == "never")
+        #expect(params["sandboxPolicy"]?["type"]?.stringValue == "dangerFullAccess")
+        #expect(params["collaborationMode"]?["mode"]?.stringValue == (mode == .plan ? "plan" : "default"))
+        #expect(params["collaborationMode"]?["settings"]?["model"]?.stringValue == "gpt-5.6-sol")
+        #expect(params["collaborationMode"]?["settings"]?["reasoning_effort"]?.stringValue == "high")
+        #expect(params["collaborationMode"]?["settings"]?.objectValue?["developer_instructions"] == .null)
+        await client.stop()
+    }
+
+    @Test("A queued plan keeps its mode after preferences change and the store reopens")
+    func queueSnapshot() async throws {
+        let path = TestScratch.unique("interaction-mode") + ".sqlite"
+        let store = try Store(path: path)
+        let session = try await store.upsert(Session(workspaceID: nil, agentKind: .codex, interactionMode: .plan))
+        _ = try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "Plan", interactionMode: .plan))
+        try await store.updateSessionPreferences(id: session.id, interactionMode: .build)
+        let reopened = try Store(path: path)
+        #expect(try await reopened.session(id: session.id)?.interactionMode == .build)
+        #expect(try await reopened.pendingDeliveries(sessionID: session.id).first?.interactionMode == .plan)
+    }
+
+    @Test("A known old-CLI field rejection retries Build once without changing permissions")
+    func oldBuildFallback() async throws {
+        let peer = Mutex<ScriptedCodexProcess?>(nil)
+        let acceptsPlanning = Mutex(false)
+        let box = ProcessBox(onWrite: { line in
+            guard let frame = JSONValue.parse(line), frame["method"]?.stringValue == "turn/start",
+                  let id = frame["id"], let process = peer.withLock({ $0 }) else { return }
+            let response: JSONValue
+            if frame["params"]?["collaborationMode"] != nil && !acceptsPlanning.withLock({ $0 }) {
+                response = .object(["id": id, "error": .object([
+                    "code": .integer(-32602), "message": .string("unknown field collaborationMode"),
+                ])])
+            } else {
+                response = .object(["id": id, "result": .object(["turn": .object([
+                    "id": .string("accepted"), "status": .string("inProgress"),
+                ])])])
+            }
+            process.emit(response.compactJSON)
+        })
+        box.ignore("turn/start")
+        let client = CodexClient(configuration: .init(cwd: "/tmp/older-codex"), makeProcess: box.factory)
+        try await client.start()
+        peer.withLock { $0 = box.process }
+        let turn = try await client.startTurn(
+            threadID: "thread", input: [.text("Build")], model: "model", approvalPolicy: .never, interactionMode: .build
+        )
+        #expect(turn.id == "accepted")
+        let frames = box.process.stdin.compactMap(JSONValue.parse).filter { $0["method"]?.stringValue == "turn/start" }
+        #expect(frames.count == 2)
+        #expect(frames[0]["params"]?["collaborationMode"] != nil)
+        #expect(frames[1]["params"]?["collaborationMode"] == nil)
+        #expect(frames.allSatisfy { $0["params"]?["approvalPolicy"]?.stringValue == "never" })
+        await #expect(throws: InteractionModeFailure.self) {
+            _ = try await client.startTurn(threadID: "thread", input: [.text("Plan")], model: "model", interactionMode: .plan)
+        }
+        #expect(box.process.sentMethods.filter { $0 == "turn/start" }.count == 2)
+        acceptsPlanning.withLock { $0 = true }
+        await client.resetPlanningSupport()
+        _ = try await client.startTurn(threadID: "thread", input: [.text("Plan")], model: "model", interactionMode: .plan)
+        #expect(box.process.sentMethods.filter { $0 == "turn/start" }.count == 3)
+        await client.stop()
+    }
+
+    @Test("Plan rejection and ambiguous provider errors never retry as Build")
+    func noUnsafeFallback() async throws {
+        for code in [-32602, -32603] {
+            let box = ProcessBox()
+            box.fail("turn/start", code: code, message: "collaborationMode unavailable")
+            let client = CodexClient(configuration: .init(cwd: "/tmp/old-plan"), makeProcess: box.factory)
+            try await client.start()
+            do {
+                _ = try await client.startTurn(threadID: "thread", input: [.text("Plan")], model: "model", interactionMode: .plan)
+                Issue.record("The unsupported request unexpectedly succeeded")
+            } catch {
+                #expect(InteractionModeFailure.isDefinitiveTurnRejection(error) == (code == -32602))
+            }
+            #expect(box.process.sentMethods.filter { $0 == "turn/start" }.count == 1)
+            await client.stop()
+        }
+    }
+
+    @Test("A malformed planning setting does not disable a supported capability or retry")
+    func invalidSettingIsNotMissingCapability() async throws {
+        let box = ProcessBox()
+        box.fail("turn/start", code: -32602, message: "collaborationMode.settings.reasoning_effort is invalid")
+        let client = CodexClient(configuration: .init(cwd: "/tmp/invalid-setting"), makeProcess: box.factory)
+        try await client.start()
+        await #expect(throws: CodexRPCError.self) {
+            _ = try await client.startTurn(threadID: "thread", input: [.text("Build")], model: "model", interactionMode: .build)
+        }
+        #expect(box.process.sentMethods.filter { $0 == "turn/start" }.count == 1)
+        #expect(await client.planningIsSupported != false)
+        await client.stop()
+    }
+}

--- a/Tests/BloomCoreTests/MergedPullRequestTests.swift
+++ b/Tests/BloomCoreTests/MergedPullRequestTests.swift
@@ -141,13 +141,13 @@ struct MergedPullRequestTests {
     // MARK: - A number gh could never be asked about
 
     @Test("a number that is not a number is never handed to gh")
-    func refusesToAskAboutANonPositiveNumber() async {
+    func refusesToAskAboutANonPositiveNumber() async throws {
         // gh reads its positional argument with the same parser it uses for flags, which is why
         // the branch route validates the name first. A positive Int renders as digits with no
         // leading `-`, so the guard is what makes that true of this route too. No worktree exists
         // at the path below, so anything that did reach a subprocess would fail rather than pass.
-        #expect(await GitHub.snapshot(forNumber: 0, worktree: "/nowhere", maxAge: .zero) == nil)
-        #expect(await GitHub.snapshot(forNumber: -1, worktree: "/nowhere", maxAge: .zero) == nil)
+        #expect(try await GitHub.snapshot(forNumber: 0, worktree: "/nowhere", maxAge: .zero) == nil)
+        #expect(try await GitHub.snapshot(forNumber: -1, worktree: "/nowhere", maxAge: .zero) == nil)
     }
 
     // MARK: - The column

--- a/Tests/BloomCoreTests/PermissionVocabularyTests.swift
+++ b/Tests/BloomCoreTests/PermissionVocabularyTests.swift
@@ -161,7 +161,7 @@ struct PermissionVocabularyTests {
     /// Which backend that session is on used to be handed in by the caller. It is read off the
     /// default model now, which is the same question asked where it can actually be answered: see
     /// `DefaultBackend`, and `DefaultBackendTests` for the rest of that rule.
-    @Test("the app-wide plan default does not reach a Codex chat")
+    @Test("the app-wide plan default does not replace Codex permissions")
     func theDefaultLandsOnAModeTheBackendHas() {
         var claude = AppDefaults()
         claude.planMode = true
@@ -169,7 +169,9 @@ struct PermissionVocabularyTests {
 
         var codex = AppDefaults(model: "gpt-5.6-sol", backend: .codex)
         codex.planMode = true
-        #expect(ComposerDefaults.resolve(repo: RepoSettings(), app: codex).permissionMode == .auto)
+        let resolved = ComposerDefaults.resolve(repo: RepoSettings(), app: codex)
+        #expect(resolved.permissionMode == codex.permissionMode)
+        #expect(resolved.interactionMode == .plan)
     }
 
     /// The wire slugs are older than the labels over them and are grouped by on a chart, so the

--- a/Tests/BloomCoreTests/PlanArtefactTests.swift
+++ b/Tests/BloomCoreTests/PlanArtefactTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Plan artefacts", .scratchDirectory)
+struct PlanArtefactTests {
+    @Test("Provider replay is idempotent while refinements retain previous versions")
+    func revisions() async throws {
+        let store = try makeTestStore("plan-versions")
+        let sessionID = SessionID.new()
+        let first = try await store.recordPlan(sessionID: sessionID, sourceID: "item-1", markdown: "# First\nKeep this")
+        let replay = try await store.recordPlan(sessionID: sessionID, sourceID: "item-1", markdown: "# First\nKeep this")
+        let second = try await store.recordPlan(sessionID: sessionID, sourceID: "item-2", markdown: "# Revised\nNew approach")
+        #expect(first?.id == replay?.id)
+        #expect(second?.version == 2)
+        let plans = try await store.planArtefacts(sessionID: sessionID)
+        #expect(plans.map(\.markdown) == ["# First\nKeep this", "# Revised\nNew approach"])
+    }
+
+    @Test("Handoff retains the selected revision across later refinements and reopening")
+    func immutableSource() async throws {
+        let path = TestScratch.unique("plan-handoff") + ".sqlite"
+        let store = try Store(path: path)
+        let origin = SessionID.new()
+        let destination = SessionID.new()
+        let recorded = try await store.recordPlan(sessionID: origin, sourceID: "plan-1", markdown: "# Original\nDo this")
+        let plan = try #require(recorded)
+        try await store.markPlanImplementation(planID: plan.id, sessionID: origin, implementationSessionID: destination)
+        _ = try await store.recordPlan(sessionID: origin, sourceID: "plan-2", markdown: "# Different\nDo that")
+        let reopened = try Store(path: path)
+        let source = try #require(await reopened.sourcePlan(sessionID: destination))
+        #expect(source.id == plan.id)
+        #expect(source.sessionID == origin)
+        #expect(source.markdown == "# Original\nDo this")
+        #expect(source.implementationPrompt.contains("revision 1"))
+    }
+
+    @Test("Empty plan events do not create a version")
+    func empty() async throws {
+        let store = try makeTestStore("plan-empty")
+        let sessionID = SessionID.new()
+        let recorded = try await store.recordPlan(sessionID: sessionID, sourceID: "empty", markdown: " \n")
+        #expect(recorded == nil)
+        #expect(try await store.planArtefacts(sessionID: sessionID).isEmpty)
+    }
+
+    @Test("Queued, failed-start and uncertain plan deliveries do not claim implementation")
+    func implementationRequiresProviderAcceptance() async throws {
+        let store = try makeTestStore("plan-acceptance")
+        let origin = try await store.upsert(Session(workspaceID: nil, agentKind: .codex))
+        let destination = try await store.upsert(Session(workspaceID: nil, agentKind: .codex))
+        let saved = try await store.recordPlan(sessionID: origin.id, sourceID: "proposal", markdown: "# Plan\nBuild this")
+        let plan = try #require(saved)
+        let delivery = Delivery(targetSessionID: destination.id, body: plan.implementationPrompt)
+        _ = try await store.enqueueDelivery(delivery, clearingDraftMatching: nil, sourcePlan: plan)
+        #expect(try await store.sourcePlan(sessionID: destination.id)?.id == plan.id)
+        #expect(try await store.planArtefacts(sessionID: origin.id).first?.implementationSessionID == nil)
+
+        let firstClaim = try await store.claimDelivery(id: delivery.id)
+        #expect(firstClaim)
+        try await store.releaseDeliveryClaim(id: delivery.id)
+        #expect(try await store.planArtefacts(sessionID: origin.id).first?.implementationSessionID == nil)
+
+        let retryClaim = try await store.claimDelivery(id: delivery.id)
+        #expect(retryClaim)
+        try await store.beginDeliveryDispatch(id: delivery.id)
+        #expect(try await store.planArtefacts(sessionID: origin.id).first?.implementationSessionID == nil)
+        try await store.acceptDelivery(id: delivery.id, providerTurnID: "accepted-turn")
+        #expect(try await store.planArtefacts(sessionID: origin.id).first?.implementationSessionID == destination.id)
+        #expect(try await store.sourcePlan(sessionID: destination.id)?.implementationSessionID == destination.id)
+    }
+}

--- a/Tests/BloomCoreTests/ProviderIdlePolicyTests.swift
+++ b/Tests/BloomCoreTests/ProviderIdlePolicyTests.swift
@@ -1,0 +1,11 @@
+import Testing
+@testable import BloomCore
+
+@Suite struct ProviderIdlePolicyTests {
+    @Test func evictionIsExplicitlyEnabledAndInvalidValuesAreDisabled() {
+        for value in [nil, "0", "-1", "nonsense", "9999999"] {
+            #expect(ProviderIdlePolicy.duration(stored: value) == nil)
+        }
+        #expect(ProviderIdlePolicy.duration(stored: "30") == .seconds(1_800))
+    }
+}

--- a/Tests/BloomCoreTests/SetupRunConfirmationTests.swift
+++ b/Tests/BloomCoreTests/SetupRunConfirmationTests.swift
@@ -25,11 +25,11 @@ struct SetupRunConfirmationTests {
     func theTitleFollowsTheItem() {
         #expect(
             SetupRunConfirmation.question(hasRunSetup: true, isAgentRunning: false).title
-                == "Run the setup script again?"
+                == "Run setup again?"
         )
         #expect(
             SetupRunConfirmation.question(hasRunSetup: false, isAgentRunning: false).title
-                == "Run the setup script?"
+                == "Run setup?"
         )
     }
 

--- a/Tests/BloomCoreTests/ShellCaptureTests.swift
+++ b/Tests/BloomCoreTests/ShellCaptureTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Shell capture", .tags(.subprocess))
+struct ShellCaptureTests {
+    @Test("deadline includes inherited pipes after parent exit")
+    func inheritedPipe() async throws {
+        await #expect(throws: ShellFailure.timedOut(command: "/bin/sh")) {
+            try await Shell.run("/bin/sh", ["-c", "(sleep 2) & exit 0"], timeout: .milliseconds(100))
+        }
+    }
+
+    @Test("a child ignoring TERM cannot defeat the deadline")
+    func ignoresTermination() async throws {
+        await #expect(throws: ShellFailure.timedOut(command: "/bin/sh")) {
+            try await Shell.run("/bin/sh", ["-c", "trap '' TERM; sleep 2"], timeout: .milliseconds(100))
+        }
+    }
+
+    @Test("deadline also covers writing input that the child does not read")
+    func blockedInput() async throws {
+        await #expect(throws: ShellFailure.timedOut(command: "/bin/sh")) {
+            try await Shell.run(
+                "/bin/sh", ["-c", "sleep 2"], stdin: String(repeating: "x", count: 1_000_000),
+                timeout: .milliseconds(100)
+            )
+        }
+    }
+
+    @Test("oversized structured output fails instead of returning a partial success")
+    func outputBudget() async throws {
+        await #expect(throws: ShellFailure.outputLimit(command: "/usr/bin/yes", stream: "stdout", limit: 128)) {
+            try await Shell.run("/usr/bin/yes", timeout: .seconds(2), outputLimit: 128)
+        }
+    }
+
+    @Test("raw bytes and the final flush survive collection")
+    func bytesAndFlush() async throws {
+        let result = try await Shell.runBytes("/bin/sh", ["-c", "printf '\\377\\000end'; printf err >&2"])
+        #expect(result.status == 0)
+        #expect(result.stdout == Data([255, 0, 101, 110, 100]))
+        #expect(result.stderr == Data("err".utf8))
+    }
+
+    @Test("large input can be read and echoed without a pipe deadlock")
+    func fullDuplex() async throws {
+        let input = Data(repeating: 120, count: 1_000_000)
+        let result = try await Shell.runBytes("/bin/cat", stdin: input, timeout: .seconds(5))
+        #expect(result.stdout == input)
+        #expect(result.status == 0)
+    }
+
+    @Test("a cancelled invocation reports cancellation")
+    func cancellation() async throws {
+        let task = Task { try await Shell.run("/bin/sh", ["-c", "sleep 2"], timeout: .seconds(5)) }
+        task.cancel()
+        await #expect(throws: CancellationError.self) { try await task.value }
+    }
+}

--- a/Tests/BloomCoreTests/SnapshotSummaryTests.swift
+++ b/Tests/BloomCoreTests/SnapshotSummaryTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Snapshot file summaries", .tags(.git), .scratchDirectory)
+struct SnapshotSummaryTests {
+    @Test("historical net counts include shell writes, repeated edits, newline renames and binary changes")
+    func historicalNetChanges() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        try repo.write("repeated.txt", "before\n")
+        try repo.write("old\nname.txt", "unchanged contents\n")
+        try Data([0, 1, 2]).write(to: URL(fileURLWithPath: repo.path + "/binary.bin"))
+        try await repo.commit("Before turn")
+        let session = SessionID.new()
+        let before = try await Git.captureSnapshot(in: repo.path, sessionID: session)
+
+        try await Shell.check("/bin/sh", ["-c", """
+        printf 'intermediate\nmore intermediate\n' > repeated.txt
+        printf 'after\n' > repeated.txt
+        printf 'only written by the shell\n' > shell-only.txt
+        """], cwd: repo.path)
+        try FileManager.default.moveItem(atPath: repo.path + "/old\nname.txt", toPath: repo.path + "/renamed\nname.txt")
+        try Data([0, 3, 4]).write(to: URL(fileURLWithPath: repo.path + "/binary.bin"))
+        let after = try await Git.captureSnapshot(in: repo.path, sessionID: session)
+
+        try await Shell.check("git", ["config", "diff.external", "/usr/bin/true"], cwd: repo.path)
+        let files = try await Git.snapshotFiles(from: before, to: after, in: repo.path)
+        let byPath = Dictionary(uniqueKeysWithValues: files.map { ($0.path, $0) })
+        #expect(files.count == 4)
+        #expect(byPath["repeated.txt"]?.additions == 1)
+        #expect(byPath["repeated.txt"]?.deletions == 1)
+        #expect(byPath["shell-only.txt"]?.change == .added)
+        #expect(byPath["shell-only.txt"]?.additions == 1)
+        #expect(byPath["renamed\nname.txt"]?.change == .renamed)
+        #expect(byPath["renamed\nname.txt"]?.oldPath == "old\nname.txt")
+        #expect(byPath["renamed\nname.txt"]?.additions == 0)
+        #expect(byPath["binary.bin"]?.isBinary == true)
+        #expect(files.reduce(0) { $0 + $1.additions } == 2)
+        #expect(files.reduce(0) { $0 + $1.deletions } == 1)
+
+        try repo.write("repeated.txt", "another turn\nmore work\n")
+        try repo.write("later.txt", "not this turn\n")
+        let stillHistorical = try await Git.snapshotFiles(from: before, to: after, in: repo.path)
+        #expect(stillHistorical == files)
+    }
+
+    @Test("equal snapshots have no changes and unsafe identifiers cannot become revisions")
+    func emptyAndInvalidSummary() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        let session = SessionID.new()
+        let snapshot = try await Git.captureSnapshot(in: repo.path, sessionID: session)
+        #expect(try await Git.snapshotFiles(from: snapshot, to: snapshot, in: repo.path).isEmpty)
+        let invalid = GitSnapshot(id: GitSnapshotID("../../heads/main"), sessionID: session)
+        await #expect(throws: SnapshotFailure.self) {
+            try await Git.snapshotFiles(from: invalid, to: snapshot, in: repo.path)
+        }
+    }
+}

--- a/Tests/BloomCoreTests/TerminalExcerptTests.swift
+++ b/Tests/BloomCoreTests/TerminalExcerptTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Terminal excerpts")
+struct TerminalExcerptTests {
+    @Test("An excerpt retains exact selected bytes and provenance after serialisation")
+    func snapshot() throws {
+        var liveOutput = "before\r\n```\nfailed <test>\n```\n"
+        let excerpt = try #require(TerminalExcerpt(
+            terminalID: TerminalTabID("shell-1"), workspaceID: WorkspaceID("worktree-1"), label: "Tests",
+            firstLine: 14, lastLine: 10, text: liveOutput
+        ))
+        liveOutput = "terminal cleared"
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let restored = try decoder.decode(TerminalExcerpt.self, from: Data(excerpt.attachmentText().utf8))
+        #expect(restored.text == "before\r\n```\nfailed <test>\n```\n")
+        #expect(restored.terminalID == TerminalTabID("shell-1"))
+        #expect(restored.workspaceID == WorkspaceID("worktree-1"))
+        #expect(restored.label == "Tests")
+        #expect(restored.firstLine == 10)
+        #expect(restored.lastLine == 14)
+        #expect(restored.text != liveOutput)
+    }
+
+    @Test("Blank selection does not create an attachment")
+    func empty() {
+        let excerpt = TerminalExcerpt(
+            terminalID: .new(), workspaceID: .new(), label: "Terminal", firstLine: 1, lastLine: 1, text: " \n"
+        )
+        #expect(excerpt == nil)
+    }
+}

--- a/Tests/BloomCoreTests/TranscriptRewindTests.swift
+++ b/Tests/BloomCoreTests/TranscriptRewindTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Transcript rewind", .scratchDirectory)
+struct TranscriptRewindTests {
+    private func fixture(_ store: Store) async throws -> (Session, Delivery, TurnCheckpoint) {
+        let repo = try await store.upsert(Repo(name: "rewind", path: "/tmp/rewind"))
+        let workspace = try await store.upsert(Workspace(
+            repoID: repo.id, name: "w", branch: "topic", path: "/tmp/rewind-w", baseBranch: "main"
+        ))
+        let session = try await store.upsert(Session(workspaceID: workspace.id, agentKind: .codex))
+        _ = try await store.appendNext(sessionID: session.id, kind: .notice, payload: Data("{}".utf8))
+        let delivery = Delivery(targetSessionID: session.id, body: "Fix this `.bloom/attachments/img/shot.png`")
+        _ = try await store.enqueueDelivery(delivery)
+        let claimed = try await store.claimDelivery(id: delivery.id)
+        #expect(claimed)
+        try await store.beginDeliveryDispatch(id: delivery.id)
+        try await store.acceptDelivery(id: delivery.id, providerTurnID: "provider-turn")
+        let sent = try #require(await store.delivery(id: delivery.id))
+        let seq = try #require(sent.deliveredSeq)
+        _ = try await store.appendNext(sessionID: session.id, kind: .result, payload: Data("{}".utf8))
+        var checkpoint = TurnCheckpoint(sessionID: session.id, startSeq: seq, before: GitSnapshot(sessionID: session.id))
+        checkpoint.providerTurnID = "provider-turn"
+        try await store.saveTurnCheckpoint(checkpoint)
+        return (session, sent, checkpoint)
+    }
+
+    @Test("Confirmed rewind atomically restores draft and retains a transcript backup without replaying deliveries")
+    func completeAndReopen() async throws {
+        let path = TestScratch.unique("transcript-rewind") + ".sqlite"
+        let store = try Store(path: path)
+        let (session, delivery, checkpoint) = try await fixture(store)
+        try await store.saveDraft(sessionID: session.id, body: "An existing draft")
+        _ = try await store.prepareTranscriptRewind(checkpoint)
+        var journal = CheckpointRewind(checkpoint: checkpoint, recovery: nil, restoringFiles: false)
+        try await store.saveCheckpointRewind(journal)
+        journal.stage = .providerReverted
+        try await store.saveCheckpointRewind(journal)
+        let restored = try await store.completeTranscriptRewind(sessionID: session.id)
+        #expect(restored == "An existing draft\n\n" + delivery.body)
+        #expect(try await store.messages(sessionID: session.id).map(\.seq) == [0])
+        #expect(try await store.delivery(id: delivery.id)?.state == .accepted)
+        #expect(try await store.pendingDeliveries(sessionID: session.id).isEmpty)
+        #expect(try await store.turnCheckpoints(sessionID: session.id).isEmpty)
+        #expect(try await store.retiredRewindCheckpoints(sessionID: session.id).map(\.id) == [checkpoint.id])
+        let repeated = try await store.completeTranscriptRewind(sessionID: session.id)
+        #expect(repeated == restored)
+        let reopened = try Store(path: path)
+        #expect(try await reopened.draft(sessionID: session.id) == restored)
+        let backup = try #require(await reopened.transcriptRewindBackup(sessionID: session.id))
+        #expect(backup.messages.count == 2)
+        #expect(backup.prompt == delivery.body)
+    }
+
+    @Test("Unconfirmed provider history cannot delete rows or close the recovery conversation")
+    func unconfirmed() async throws {
+        let store = try makeTestStore("rewind-unconfirmed")
+        let (session, _, checkpoint) = try await fixture(store)
+        _ = try await store.prepareTranscriptRewind(checkpoint)
+        try await store.saveCheckpointRewind(CheckpointRewind(checkpoint: checkpoint, recovery: nil, restoringFiles: false))
+        await #expect(throws: SnapshotFailure.self) { try await store.completeTranscriptRewind(sessionID: session.id) }
+        await #expect(throws: SnapshotFailure.self) { try await store.deleteSession(id: session.id) }
+        await #expect(throws: SnapshotFailure.self) {
+            _ = try await store.update(sessionID: session.id) { $0.archivedAt = Date() }
+        }
+        #expect(try await store.messages(sessionID: session.id).count == 3)
+        let workspaceID = try #require(session.workspaceID)
+        #expect(try await store.pendingCheckpointRewind(workspaceID: workspaceID)?.checkpoint.id == checkpoint.id)
+    }
+}

--- a/Tests/BloomCoreTests/TurnCheckpointTests.swift
+++ b/Tests/BloomCoreTests/TurnCheckpointTests.swift
@@ -1,0 +1,295 @@
+import Foundation
+import Testing
+@testable import BloomCore
+
+@Suite("Turn checkpoints", .tags(.git), .scratchDirectory)
+struct TurnCheckpointTests {
+    @Test("capture preserves the real index and records net shell edits")
+    func netChanges() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        try repo.write("file.txt", "one\n")
+        try await repo.commit("Initial")
+        try repo.write("file.txt", "staged\n")
+        try await Shell.check("git", ["add", "file.txt"], cwd: repo.path)
+        try repo.write("file.txt", "before\n")
+        let indexPath = repo.path + "/.git/index"
+        let index = try Data(contentsOf: URL(fileURLWithPath: indexPath))
+        let session = SessionID.new()
+        let before = try await Git.captureSnapshot(in: repo.path, sessionID: session)
+        #expect(try Data(contentsOf: URL(fileURLWithPath: indexPath)) == index)
+        try await Shell.check("/bin/sh", ["-c", "printf 'after\\n' > file.txt; printf 'new\\n' > new.txt"], cwd: repo.path)
+        let after = try await Git.captureSnapshot(in: repo.path, sessionID: session)
+        let patch = try await Git.snapshotDiff(from: before, to: after, in: repo.path)
+        #expect(patch.contains("-before"))
+        #expect(patch.contains("+after"))
+        #expect(patch.contains("+new"))
+        #expect(try Data(contentsOf: URL(fileURLWithPath: indexPath)) == index)
+        try repo.write("file.txt", "later\n")
+        #expect(try await Git.snapshotDiff(from: before, to: after, in: repo.path) == patch)
+    }
+
+    @Test("restore recovers partial staging, untracked files and preserves ignored files")
+    func restoresStaging() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        try repo.write("file.txt", "committed\n")
+        try repo.write(".gitignore", "ignored.txt\n")
+        try await repo.commit("Initial")
+        try repo.write("file.txt", "staged\n")
+        try await Shell.check("git", ["add", "file.txt"], cwd: repo.path)
+        try repo.write("file.txt", "unstaged\n")
+        try repo.write("[id].txt", "untracked\n")
+        try repo.write("ignored.txt", "ignored\n")
+        let session = SessionID.new()
+        let before = try await Git.captureSnapshot(in: repo.path, sessionID: session)
+        try repo.write("file.txt", "later\n")
+        try repo.write("[id].txt", "later\n")
+        try repo.write("new.txt", "later untracked\n")
+        let recovery = try await Git.captureSnapshot(in: repo.path, sessionID: session)
+        try await Git.restoreSnapshot(before, in: repo.path)
+        #expect(repo.read("file.txt") == "unstaged\n")
+        #expect(repo.read("[id].txt") == "untracked\n")
+        #expect(!repo.exists("new.txt"))
+        #expect(repo.read("ignored.txt") == "ignored\n")
+        let staged = try await Shell.check("git", ["show", ":file.txt"], cwd: repo.path)
+        #expect(staged.stdout == "staged\n")
+        let untracked = try await Shell.check("git", ["ls-files", "--others", "--exclude-standard"], cwd: repo.path)
+        #expect(untracked.stdout.contains("[id].txt"))
+        try await Git.restoreSnapshot(recovery, in: repo.path)
+        #expect(repo.read("new.txt") == "later untracked\n")
+    }
+
+    @Test("snapshot diffs select a literal path and bypass external diff configuration")
+    func literalDiff() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        for file in ["[id].txt", "i.txt"] { try repo.write(file, "before\n") }
+        try await repo.commit("Before")
+        let session = SessionID.new()
+        let before = try await Git.captureSnapshot(in: repo.path, sessionID: session)
+        for file in ["[id].txt", "i.txt"] { try repo.write(file, "after\n") }
+        let after = try await Git.captureSnapshot(in: repo.path, sessionID: session)
+        try await Shell.check("git", ["config", "diff.external", "/usr/bin/true"], cwd: repo.path)
+        let patch = try await Git.snapshotDiff(from: before, to: after, in: repo.path, path: "[id].txt")
+        #expect(patch.contains("+after"))
+        #expect(DiffParser.parse(patch).count == 1)
+    }
+
+    @Test("an ignored file cannot be overwritten by restore")
+    func ignoredCollision() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        try repo.write("valuable.txt", "snapshot\n")
+        let session = SessionID.new()
+        let target = try await Git.captureSnapshot(in: repo.path, sessionID: session)
+        try repo.write(".gitignore", "valuable.txt\n")
+        try repo.write("valuable.txt", "outside snapshot\n")
+        await #expect(throws: SnapshotFailure.self) { try await Git.restoreSnapshot(target, in: repo.path) }
+        #expect(repo.read("valuable.txt") == "outside snapshot\n")
+    }
+
+    @Test("checkpoint metadata and an interrupted rewind survive a Store reopen")
+    func persistence() async throws {
+        let path = TestScratch.path("checkpoints.sqlite")
+        let store = try Store(path: path)
+        let session = SessionID.new()
+        var checkpoint = TurnCheckpoint(sessionID: session, startSeq: 5, before: GitSnapshot(sessionID: session))
+        checkpoint.endSeq = 12
+        checkpoint.providerTurnID = "provider-turn"
+        try await store.saveTurnCheckpoint(checkpoint)
+        var journal = CheckpointRewind(checkpoint: checkpoint, recovery: GitSnapshot(sessionID: session), restoringFiles: true)
+        journal.stage = .filesRestored
+        try await store.saveCheckpointRewind(journal)
+        let reopened = try Store(path: path)
+        #expect(try await reopened.turnCheckpoints(sessionID: session) == [checkpoint])
+        #expect(try await reopened.checkpointRewind(sessionID: session) == journal)
+        let removed = try await reopened.removeTurnCheckpoints(sessionID: session, fromSeq: 5)
+        #expect(removed == [checkpoint])
+        #expect(try await reopened.checkpointRewind(sessionID: session) == journal)
+    }
+}
+
+extension TurnCheckpointTests {
+    @Test("intent-to-add and index flags survive restore, while snapshots read actual files")
+    func preservesIndexMetadata() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        try repo.write("assumed.txt", "committed\n")
+        try repo.write("skipped.txt", "committed\n")
+        try await repo.commit("Initial")
+        try repo.write("intent\n[id].txt", "new intent\n")
+        try await Shell.check("git", ["add", "-N", "--", "intent\n[id].txt"], cwd: repo.path)
+        try await Shell.check("git", ["update-index", "--assume-unchanged", "--", "assumed.txt"], cwd: repo.path)
+        try await Shell.check("git", ["update-index", "--skip-worktree", "--", "skipped.txt"], cwd: repo.path)
+        try repo.write("assumed.txt", "actual assumed\n")
+        try repo.write("skipped.txt", "actual skipped\n")
+        let flags = try await Shell.check("git", ["ls-files", "-v", "-z"], cwd: repo.path)
+        let staged = try await Shell.check("git", ["diff", "--cached", "--raw", "-z"], cwd: repo.path)
+        let snapshot = try await Git.captureSnapshot(in: repo.path, sessionID: .new())
+        try repo.write("assumed.txt", "later\n")
+        try repo.write("skipped.txt", "later\n")
+        try await Shell.check("git", ["add", "--", "intent\n[id].txt"], cwd: repo.path)
+        try await Git.restoreSnapshot(snapshot, in: repo.path)
+        #expect(repo.read("assumed.txt") == "actual assumed\n")
+        #expect(repo.read("skipped.txt") == "actual skipped\n")
+        #expect(try await Shell.check("git", ["ls-files", "-v", "-z"], cwd: repo.path).stdout == flags.stdout)
+        #expect(try await Shell.check("git", ["diff", "--cached", "--raw", "-z"], cwd: repo.path).stdout == staged.stdout)
+        let intent = try await Shell.check("git", ["diff", "--raw", "-z", "--", "intent\n[id].txt"], cwd: repo.path)
+        #expect(intent.stdout.contains(" A\0"))
+    }
+
+    @Test("missing snapshot index fails before changing files")
+    func missingIndexFailsBeforeMutation() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        try repo.write("file", "before")
+        let snapshot = try await Git.captureSnapshot(in: repo.path, sessionID: .new())
+        try repo.write("file", "keep this")
+        try await Shell.check("git", ["update-ref", "-d", snapshot.rawIndexRef], cwd: repo.path)
+        await #expect(throws: SnapshotFailure.self) { try await Git.restoreSnapshot(snapshot, in: repo.path) }
+        #expect(repo.read("file") == "keep this")
+    }
+
+    @Test("a missing index remains missing after restore")
+    func restoresMissingIndex() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        try repo.write("file", "untracked")
+        try FileManager.default.removeItem(atPath: repo.path + "/.git/index")
+        #expect(!repo.exists(".git/index"))
+        let snapshot = try await Git.captureSnapshot(in: repo.path, sessionID: .new())
+        try await Shell.check("git", ["add", "file"], cwd: repo.path)
+        try repo.write("file", "changed")
+        try await Git.restoreSnapshot(snapshot, in: repo.path)
+        #expect(repo.read("file") == "untracked")
+        #expect(!repo.exists(".git/index"))
+    }
+}
+
+extension TurnCheckpointTests {
+    @Test("stale journal updates cannot replace a later rewind")
+    func journalOwnership() async throws {
+        let store = try makeTestStore("rewind-journal-ownership")
+        let session = SessionID.new()
+        let checkpoint = TurnCheckpoint(sessionID: session, startSeq: 1, before: GitSnapshot(sessionID: session))
+        var first = CheckpointRewind(checkpoint: checkpoint, recovery: nil, restoringFiles: false)
+        try await store.saveCheckpointRewind(first)
+        first.stage = .complete
+        try await store.saveCheckpointRewind(first)
+        let second = CheckpointRewind(checkpoint: checkpoint, recovery: nil, restoringFiles: false)
+        try await store.saveCheckpointRewind(second)
+        await #expect(throws: SnapshotFailure.self) { try await store.saveCheckpointRewind(first) }
+        #expect(try await store.checkpointRewind(sessionID: session)?.token == second.token)
+    }
+
+    @Test("replacing a completed rewind retires its unretained recovery refs")
+    func supersededRecoveryCleanup() async throws {
+        let repo = try await TempRepo()
+        defer { repo.cleanUp() }
+        let store = try makeTestStore("rewind-recovery-cleanup")
+        let service = TurnCheckpointStore(store: store)
+        let session = SessionID.new()
+        let checkpoint = try await service.begin(sessionID: session, cwd: repo.path, startSeq: 1)
+        var first = try await service.prepareRewind(checkpoint: checkpoint, cwd: repo.path, restoringFiles: true)
+        let oldRecovery = try #require(first.recovery)
+        first.stage = .complete
+        try await service.markRewind(first)
+        _ = try await service.prepareRewind(checkpoint: checkpoint, cwd: repo.path, restoringFiles: true)
+        let old = try await Shell.run("git", ["rev-parse", "--verify", oldRecovery.rawIndexRef], cwd: repo.path)
+        #expect(!old.ok)
+        let retained = try await Shell.run("git", ["rev-parse", "--verify", checkpoint.before.rawIndexRef], cwd: repo.path)
+        #expect(retained.ok)
+    }
+}
+
+extension TurnCheckpointTests {
+    @Test("steering and workspace-free messages have no checkpoint association")
+    func absentCheckpointLink() async throws {
+        let store = try makeTestStore("checkpoint-no-association")
+        let session = SessionID.new()
+        let linked = try await store.linkTurnCheckpoint(sessionID: session, startSeq: 4, providerTurnID: "steered")
+        #expect(!linked)
+        #expect(try await store.turnCheckpoints(sessionID: session).isEmpty)
+    }
+
+    @Test("a reused message sequence after rewind belongs to the new snapshot")
+    func sequenceReuseAfterRewind() async throws {
+        let store = try makeTestStore("checkpoint-reused-sequence")
+        let session = SessionID.new()
+        let old = TurnCheckpoint(sessionID: session, startSeq: 4, before: GitSnapshot(sessionID: session))
+        try await store.saveTurnCheckpoint(old)
+        try await store.linkTurnCheckpoint(sessionID: session, startSeq: 4, providerTurnID: "old-turn")
+        try await store.removeTurnCheckpoints(sessionID: session, fromSeq: 4)
+        var replacement = TurnCheckpoint(sessionID: session, startSeq: 4, before: GitSnapshot(sessionID: session))
+        replacement.endSeq = 8
+        replacement.after = GitSnapshot(sessionID: session)
+        try await store.saveTurnCheckpoint(replacement)
+        try await store.linkTurnCheckpoint(sessionID: session, startSeq: 4, providerTurnID: "new-turn")
+        let saved = try #require(try await store.turnCheckpoints(sessionID: session).first)
+        #expect(saved.id == replacement.id)
+        #expect(saved.providerTurnID == "new-turn")
+        #expect(saved.after == replacement.after)
+    }
+
+    @Test("provider linkage survives completion and stale checkpoint writes in either order")
+    func lateProviderLinkPreservesCompletedCheckpoint() async throws {
+        for linkFirst in [false, true] {
+            let store = try makeTestStore("checkpoint-link-race")
+            let session = SessionID.new()
+            let original = TurnCheckpoint(sessionID: session, startSeq: 3, before: GitSnapshot(sessionID: session))
+            try await store.saveTurnCheckpoint(original)
+            var completed = original
+            completed.after = GitSnapshot(sessionID: session)
+            completed.endSeq = 9
+            if linkFirst { try await store.linkTurnCheckpoint(sessionID: session, startSeq: 3, providerTurnID: "turn") }
+            try await store.saveTurnCheckpoint(completed)
+            if !linkFirst { try await store.linkTurnCheckpoint(sessionID: session, startSeq: 3, providerTurnID: "turn") }
+            try await store.saveTurnCheckpoint(original)
+            let saved = try #require(await store.turnCheckpoints(sessionID: session).first)
+            #expect(saved.after == completed.after)
+            #expect(saved.endSeq == 9)
+            #expect(saved.providerTurnID == "turn")
+        }
+    }
+}
+
+extension TurnCheckpointTests {
+    @Test("unsupported file restores never create a blocking rewind journal", arguments: ["sparse", "submodule", "ignored"])
+    func rejectedRestoreDoesNotPrepareARewind(_ obstruction: String) async throws {
+        let repo = try await TempRepo()
+        let nested = try await TempRepo()
+        defer { repo.cleanUp(); nested.cleanUp() }
+        let store = try makeTestStore("rewind-preflight")
+        let session = try await store.upsert(Session(workspaceID: nil, agentKind: .codex))
+        let service = TurnCheckpointStore(store: store)
+        try repo.write("valuable.txt", "snapshot content")
+        if obstruction == "submodule" {
+            try FileManager.default.copyItem(atPath: nested.path, toPath: repo.path + "/nested")
+        }
+        let checkpoint = try await service.begin(sessionID: session.id, cwd: repo.path, startSeq: 1)
+        if obstruction == "sparse" {
+            try await Shell.check("git", ["config", "core.sparseCheckout", "true"], cwd: repo.path)
+        } else if obstruction == "ignored" {
+            try repo.write(".gitignore", "valuable.txt\n")
+        }
+        try repo.write("valuable.txt", "keep this content")
+        let index = try Data(contentsOf: URL(fileURLWithPath: repo.path + "/.git/index"))
+        let refs = try await Shell.check("git", ["for-each-ref", "--format=%(refname)", "refs/bloom/checkpoints"], cwd: repo.path)
+        await #expect(throws: SnapshotFailure.self) {
+            try await service.prepareRewind(checkpoint: checkpoint, cwd: repo.path, restoringFiles: true)
+        }
+        #expect(try await service.pendingRewind(sessionID: session.id) == nil)
+        #expect(try await store.checkpointRewind(sessionID: session.id) == nil)
+        #expect(repo.read("valuable.txt") == "keep this content")
+        #expect(try Data(contentsOf: URL(fileURLWithPath: repo.path + "/.git/index")) == index)
+        #expect(try await Shell.check("git", ["for-each-ref", "--format=%(refname)", "refs/bloom/checkpoints"], cwd: repo.path).stdout == refs.stdout)
+        _ = try await store.enqueueDelivery(Delivery(targetSessionID: session.id, body: "A later message"))
+        let waiting = try await store.pendingDeliveries(sessionID: session.id)
+        #expect(Delivery.deliverable(from: waiting, hold: .none, on: .codex).count == 1)
+        // Conversation-only rewind has no filesystem dependency and deliberately skips preflight.
+        let keepFiles = try await service.prepareRewind(checkpoint: checkpoint, cwd: repo.path, restoringFiles: false)
+        #expect(keepFiles.recovery == nil)
+        #expect(!keepFiles.restoringFiles)
+    }
+}

--- a/Tests/BloomCoreTests/WorkspaceManagerTests.swift
+++ b/Tests/BloomCoreTests/WorkspaceManagerTests.swift
@@ -325,7 +325,7 @@ struct WorkspaceManagerTests {
         #expect(stored.setupState == .failed)
         #expect(stored.setupLog.contains("seeding"))
         #expect(stored.setupLog.contains(WorkspaceManager.setupStoppedNote))
-        #expect(!TempRepo(existing: workspace.path).exists("finished.txt"))
+        #expect(!TempRepo(existing: workspace.path).exists("finished.txt"), Comment(rawValue: stored.setupLog))
     }
 
     @Test(

--- a/Tools/house-rules.sh
+++ b/Tools/house-rules.sh
@@ -334,6 +334,13 @@ id_type_allowed_lines=(
   'Sources/BloomCore/GitHub/CheckFailureHandoff.swift'       # a GitHub Actions run and job, read out of a URL gh gave us
   'Sources/BloomCore/Presentation/SearchPanelListing.swift'  # a section heading key, not a row
 )
+# External tokens carried beside typed Bloom ids. Limit each exemption to its
+# property so adding another bare internal id in the same file still fails.
+id_type_allowed_properties=(
+  'Sources/BloomCore/Agent/Delivery.swift:providerTurnID'             # the provider's accepted turn, used for recovery
+  'Sources/BloomCore/Transcript/TurnCheckpoint.swift:providerTurnID' # the same provider turn correlated with a snapshot
+  'Sources/BloomCore/Agent/PlanArtefact.swift:sourceID'               # the provider's plan item or tool-use token
+)
 # A stored property whose name ends in ID or Ids and whose type is a bare
 # String. Trailing `{` is excluded by the `$` anchor, which is what leaves
 # computed properties out.
@@ -347,6 +354,11 @@ while IFS= read -r hit; do
     [ "$file" = "$path" ] && allowed=1
   done
   for name in "${id_type_allowed_names[@]}"; do
+    case "$hit" in *" $name:"*|*" $name "*) allowed=1 ;; esac
+  done
+  for property in "${id_type_allowed_properties[@]}"; do
+    [ "$file" = "${property%:*}" ] || continue
+    name="${property##*:}"
     case "$hit" in *" $name:"*|*" $name "*) allowed=1 ;; esac
   done
   if [ "$allowed" -eq 0 ]; then

--- a/docs/CODEX.md
+++ b/docs/CODEX.md
@@ -32,6 +32,30 @@ also what Conductor drives. The reasoning is repeated in the doc comment at the 
 
 ### The protocol describes itself
 
+Schema verification on 2026-09-12 used installed `codex-cli 0.153.4`, without sending a model
+turn. Its stable schema omits `turn/start.collaborationMode`; generating with `--experimental`
+includes `{ mode: "default" | "plan", settings: { model, reasoning_effort,
+developer_instructions } }`. Bloom now declares `experimentalApi: true` at initialise so the
+Plan/Build control can use this field. Planning is independent of approval policy and sandbox.
+Null developer instructions retain Codex's defaults. Build explicitly resets the collaboration
+mode to `default` after planning.
+
+For an older server, only an explicit invalid-parameters response naming `collaborationMode`
+permits one Build retry without that field. Plan instead reports that Codex must be updated or
+the mode switched to Build. A timeout, disconnect or internal error never takes this fallback.
+Learned lack of support is persisted and disables Plan in the composer and agent settings, with
+an explanation. Check Again resets discovery without sending a turn. The next idle send starts
+a fresh app-server process so it can use an updated executable instead of the older running copy.
+Fake-peer regressions cover the handshake, payload, field rejection and retained permissions;
+no paid end-to-end Plan turn was run for this change.
+
+The same installed version supports two conversation-history contracts. Bloom reads
+`thread.historyMode` first. Paginated threads use `thread/revert` with an exact `beforeTurnId`;
+legacy threads use the deprecated `thread/rollback` after locating that exact ID in their full
+turn list. Rewind status queries treat a failed or malformed read as unavailable, never as
+evidence that a turn disappeared. These history methods affect conversation context only.
+Bloom owns the independent file/index snapshots and recovery journal.
+
 ```
 codex app-server generate-json-schema --out <dir>
 ```

--- a/docs/T3CODE-IMPLEMENTATION.md
+++ b/docs/T3CODE-IMPLEMENTATION.md
@@ -1,0 +1,92 @@
+# Git and agent reliability improvements
+
+Implementation of the recommendations in [the T3 Code investigation](T3CODE-RESEARCH.md).
+The investigation remains a record of the original source snapshots; this document describes
+the resulting Bloom behaviour and its validation.
+
+## Git operations
+
+- Single-file revert and diff treat filenames literally, including dynamic route names such as
+  `[id].tsx`. Reverting one file preserves neighbouring worktree and index changes.
+- Patch rendering disables external diff tools and text conversion, fixes the patch prefixes,
+  and distinguishes the normal `--no-index` changed-files status from a real command failure.
+- Worktree enumeration uses NUL-delimited records, retaining newline-containing paths and lock
+  reasons. Watchers include each worktree's real Git directory and shared repository metadata.
+- Refreshes acknowledge only the invalidation generation they read. A change arriving during a
+  refresh remains due, and a failed refresh remains eligible for retry.
+- Repository context distinguishes the base branch/remote from the publication branch/remote,
+  including `branch.<name>.pushRemote` and `remote.pushDefault` fork workflows.
+  A checked-out pull request ref without an explicit publication remote refuses a direct push
+  instead of guessing the contributor's repository. The normal agent-driven push remains available.
+- Submodule initialisation runs through workspace setup before the project's setup script.
+  Failures retain the workspace and use the existing setup log and retry controls.
+
+## Process and service reliability
+
+Short-lived subprocesses share byte-preserving, bounded output collection. Cancellation and
+execution deadlines cover input writes, child execution and inherited output pipes. A bounded
+termination grace allows cleanup before returning a typed failure. Structured output exceeding
+its budget fails explicitly instead of returning a truncated successful result.
+
+GitHub requests share identical in-flight reads and host-wide rate-limit cooldowns. Cancelling
+one consumer does not cancel a shared request. Missing pull requests, malformed responses and
+service failures remain distinct. The inspector retains the last successful result with an
+explanation when refresh is unavailable.
+
+## Agent interactions
+
+- Delivery records distinguish claiming a prompt from provider acceptance. Interrupted sends
+  remain visible and recoverable without automatically replaying uncertain paid work.
+- Codex Stop accounts for child turns as well as the parent, with bounded interruption of
+  unresponsive children and guards against affecting a replacement turn.
+- Presentation subscribers receive bounded updates backed by authoritative live state and
+  persisted transcript rows. Protocol ingestion remains lossless.
+- Codex has independent Plan/Build and permission controls. Queued prompts preserve the mode
+  selected when they were submitted.
+- Saved plans retain revisions and provenance. A plan can be refined, implemented in the current
+  chat, or handed to a new chat in the same worktree with the selected model and permissions.
+- A terminal selection can be added to a draft with its captured text and source. Attaching an
+  excerpt does not send it, and later scrolling or terminal closure does not change its contents.
+- Settings > Agents offers optional idle process release. It defaults to Never. Active turns,
+  pending work, questions and live children prevent release. Restarting Codex can require new
+  approval for permissions that belonged to its previous process.
+
+## Historical changes and rewind
+
+Turn snapshots use private Git indexes and hidden refs. They record worktree contents separately
+from the user's staging state. Historical diffs therefore include shell edits and net changes
+from repeated writes, and remain tied to their original contents after subsequent turns.
+Recorded turn footers use these net file counts, and their file chips open the historical patch
+instead of previewing the current file.
+Changes made by another chat or terminal during the same interval may appear in the snapshot;
+the diff describes changes during a turn, not guaranteed authorship.
+
+The most recent 200 completed turns per conversation retain snapshots. Transcript history is
+not removed by snapshot retention. Older turns can retain their existing tool-derived summaries.
+
+Conversation rewind requires provider history support and a recorded provider turn identity.
+Filesystem restore and provider history are separate operations, so rewind first records a
+recovery snapshot and a durable progress journal. An interrupted rewind must be reconciled
+before sending more work into the affected workspace. Restoring files refuses unsupported
+submodule/sparse-checkout cases and collisions with ignored files.
+
+## Validation
+
+Local validation passed: 336 regression tests in 44 suites, app compilation with warnings treated
+as errors, both house rules and SwiftLint, and shell syntax checking. The pull request runs the
+full suite and app checks in CI. No installed Bloom application or production database was used;
+live provider calls and interactive UI behaviour were not exercised.
+
+The separate standards review found lifecycle boundaries could disappear during presentation
+catch-up and checkpoint linkage could race completion. Fixes preserve lifecycle boundaries in a
+bounded temporary transport journal, replay them off the main actor without starting queued work
+inside an autonomous turn, and associate provider turns atomically through Store. Follow-up
+review also removed an unnecessary sequence-keyed cache and made absent checkpoint associations
+normal for steering and workspace-free chats.
+
+The separate specification review found setup could race rewind, plans were marked implemented
+on queue acceptance, and learned planning incompatibility was not reflected in the controls.
+Fixes add a shared workspace operation lease, mark implementation only after provider acceptance,
+and disable unavailable planning with explicit rediscovery. Restore preflight now rejects
+unsupported file restores before creating a blocking journal. The reviewers verified these
+corrections and reported no remaining findings within their targeted follow-up scopes.

--- a/docs/T3CODE-RESEARCH.md
+++ b/docs/T3CODE-RESEARCH.md
@@ -1,0 +1,406 @@
+**T3 Code investigation: Git operations and AI interactions**
+
+Investigated 12 September 2026 using three research subagents and a separate integration review. Compared [T3 Code at a43f9b4](https://github.com/pingdotgg/t3code/tree/a43f9b45ae85caf37e0be8270ad3d27365ece2bd) with [Bloom at e00870c](https://github.com/spatie/bloom/tree/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01). Recommendations below apply to these snapshots.
+
+There are worthwhile improvements, including a reproduced single-file revert that changes unrelated files, a reproduced shell deadline failure, and a source-established prompt delivery crash window. The best approach is a series of focused fixes and feature additions within Bloom's existing core/view architecture.
+
+**Recommended order**
+
+Priority reflects user impact and confidence, not the amount of machinery T3 uses. Small means a local change with focused regressions, medium crosses a few core/UI boundaries, and large needs a separate lifecycle or storage design. These are relative scopes, not time estimates.
+
+| Order | Improvement | Evidence | Scope |
+| --- | --- | --- | --- |
+| 1 | Literal filename handling in single-file revert and diff | Reproduced unrelated edits being discarded, including `[id].tsx` matching `i.tsx` and `d.tsx` | Small |
+| 2 | Recover prompts claimed before provider send | Source-established crash window; fault injection still needed | Medium |
+| 3 | End-to-end subprocess deadlines and output budgets | Actual Bloom Swift probe exceeded 200 ms deadline and returned success after 2 seconds | Medium |
+| 4 | Stable machine-readable patch output | External diff setting reproduced an empty successful patch for a changed file | Small |
+| 5 | Preserve refresh invalidations; watch actual Git metadata | Source-established race and linked-worktree coverage gap | Medium |
+| 6 | NUL-delimited worktree enumeration | Newline path format failure reproduced at command level | Small |
+| 7 | Explicit Codex child cancellation on Stop | Missing explicit guarantee; child leakage not measured | Medium |
+| 8 | Codex Plan/Build independent of permissions | T3 implements and tests collaboration mode; Bloom deliberately omits it | Medium |
+| 9 | Bound presentation event queues and coordinate GitHub cooldowns | Confirmed implementation differences; performance benefit unmeasured | Medium |
+| 10 | Terminal selection into a draft | Concrete workflow addition using existing attachment patterns | Small |
+| 11 | Historical turn diffs from snapshots | Stronger replacement for tool-derived summaries | Large |
+| 12 | Submodule readiness, publication remotes, plan handoff | Valuable extensions depending on repository/workflow needs | Medium |
+| Later | Conversation rewind and idle provider eviction | Separate lifecycle risks and product tradeoffs | Large / medium |
+
+For the first implementation batch, prioritise literal paths, delivery recovery, shell deadlines and controlled patch output. For the first feature batch, choose Codex planning and terminal excerpts. Design historical turn diffs before attempting rewind.
+
+**Evidence and limits**
+
+The Git reproductions ran in fresh temporary repositories with global/system Git configuration neutralised. They exercised Bloom's command shapes, not the app UI. The shell probe compiled three unchanged Bloom source files into a temporary executable. Existing test files in both projects were inspected, but neither full suite was run. No provider calls, paid requests, live fault injection, app launches or installations were performed. No application source changed. This report is the only repository addition.
+
+Observed reproductions, source-derived defects and proposed features are distinguished throughout. T3 implementation tests are useful regression specifications, not proof that its whole application is more reliable or faster. No end-to-end performance comparison was made.
+
+---
+
+**Git operations and worktrees**
+
+**Highest priority: literal filenames must not become Git pathspecs**
+
+**P1, command-level reproduced data loss.** Bloom uses `--` to separate paths from options, but this does not turn off Git pathspec globbing or pathspec magic. `FileRevert` uses `git checkout <base> -- <file.path>` and `git rm -f -- <file.path>` at [Sources/Bloom/Views/Inspector/FileRevert.swift:65-76](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/Views/Inspector/FileRevert.swift#L65). Its command wrapper at lines 103-105 supplies no global `--literal-pathspecs` or equivalent environment variable. Reverting a tracked file named literally `*.txt` restores all matching tracked `.txt` files, including edits the user did not ask to lose. A filename using `:(exclude)` is another dangerous variant.
+
+A follow-up isolated reproduction used the realistic route filename `[id].tsx` alongside `i.tsx` and `d.tsx`. After all three changed from `before\n` to `after\n`, `git checkout HEAD -- '[id].tsx'` restored all three to `before\n`. The command was again an argv call with no shell expansion and neutralised global/system config. This is not limited to intentionally unusual star filenames. Temp repository: `/var/folders/l4/r8h3dm6911q73cn70zxxp8z80000gn/T/bloom-route-path-repro-le2ewacu`.
+
+Bloom's per-file patch command has the same scope issue at [Sources/BloomCore/Git/Git+Diffs.swift:241-254](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Git/Git+Diffs.swift#L241). A single selected file can return a multiple-file patch. This increases the risk that the review and the confirmation do not describe the operation accurately.
+
+T3 explicitly uses `--literal-pathspecs` before `add -A -- <selected paths>` in its selected-file preparation ([apps/server/src/vcs/GitVcsDriverCore.ts:1875-1889](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L1875)) and temporary-index review assembly (`:2352-2362`). Its regression test creates the literal file `:(exclude)after.ts` and verifies that the review includes its content ([GitVcsDriverCore.test.ts:899-915](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.test.ts#L899)). This is a transferable mechanism, not evidence that every T3 Git command handles every hostile path.
+
+Source: [T3 literal selected paths](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L1875), [T3 regression](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.test.ts#L899).
+
+Recommendation: centralise literal-path command construction and apply it to per-file diff, checkout/restore and rm operations. Move the destructive operation from the app-only FileRevert helper into BloomCore so a real-repository regression can verify that a neighbouring file and index entry remain untouched. Cover `*`, `?`, brackets, `:(exclude)`, tabs, spaces, newlines and renamed paths. Do not claim `--` alone provides this guarantee.
+
+Reproduction details: Python `tempfile.mkdtemp`, fresh `git init -b main`, repository-local dummy user.name/email, `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_NOSYSTEM=1`. No user repository or global configuration was mutated. Both tracked files began with `original\n`, were committed, and both were changed to `edited\n`. Commands were invoked as argv through `subprocess.run`, so no shell expansion occurred.
+
+```text
+git diff --no-color -M HEAD -- '*.txt'
+=> diff --git a/*.txt b/*.txt
+=> diff --git a/victim.txt b/victim.txt
+
+git checkout HEAD -- '*.txt'
+=> {'*.txt': 'original\n', 'victim.txt': 'original\n'}
+
+# After editing both again:
+git --literal-pathspecs checkout HEAD -- '*.txt'
+=> {'*.txt': 'original\n', 'victim.txt': 'edited\n'}
+```
+
+Temp repository: `/var/folders/l4/r8h3dm6911q73cn70zxxp8z80000gn/T/bloom-git-repro-a02ec84v`. This reproduced the exact command shape used by Bloom, not a UI click or a compiled FileRevert invocation.
+
+**Make rendered patches independent of personal Git diff settings**
+
+**P2, empty patch reproduced.** T3's review diff commands use `--no-ext-diff`, `--no-textconv`, and explicit `--src-prefix=a/ --dst-prefix=b/` ([GitVcsDriverCore.ts:2271-2296](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L2271); prefix definition `:56-59`). Bloom's patch command sets `--no-color` only ([Git+Diffs.swift:244-254](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Git/Git+Diffs.swift#L244)). Configured external diff tools can replace the machine-readable patch entirely. Text conversion can also make displayed lines describe converted content rather than the bytes Bloom edits.
+
+In a fresh isolated repository with the same neutralised global/system config, I set repository-local `diff.external=/usr/bin/true`, changed note.txt from `before\n` to `after\n`, and ran:
+
+```text
+git diff --no-color -M HEAD -- note.txt
+=> ''
+git diff --numstat -M -z HEAD --
+=> '1\t1\tnote.txt\0'
+git diff --no-color --no-ext-diff --no-textconv HEAD -- note.txt
+=> a normal patch containing '+after'
+```
+
+Temp repository: `/var/folders/l4/r8h3dm6911q73cn70zxxp8z80000gn/T/bloom-diff-config-repro-por120qo`. This shows a changed-file list reporting an edit while the patch command succeeds with no diff.
+
+Explicit prefixes also remove configuration-dependent paths. Bloom's parser strips only `a/` and `b/` ([Sources/BloomCore/Git/DiffParser.swift:768](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Git/DiffParser.swift#L768)), and its header splitting relies on ` b/` or falls back to the first space (`:661-698`). T3 tests both `diff.noprefix=true` and `diff.mnemonicPrefix=true` ([GitVcsDriverCore.test.ts:872-897](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.test.ts#L872)). Bloom handles some prefix-less patches through `---`/`+++` lines, so do not claim all such patches fail. Mode-only/binary paths containing spaces and mnemonic prefixes are the cases to cover.
+
+Recommendation: one patch-output policy for tracked and untracked previews: literal path selection where applicable, no colour, no external diff, no text conversion, fixed prefixes, and explicit handling of nonzero exit status. Bloom currently returns stdout from untracked `--no-index` diff without distinguishing expected exit 1 from genuine errors ([Git+Diffs.swift:244-250](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Git/Git+Diffs.swift#L244)); include that small correctness fix in the same work.
+
+Source: [T3 controlled patch output](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L2271), [prefix regression](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.test.ts#L872).
+
+**Preserve file-system events that arrive during a Git refresh**
+
+**P2, source-derived race, not runtime reproduced.** In [Sources/Bloom/State/AppModel.swift:856-859](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/State/AppModel.swift#L856), file-system events insert workspace ids into `changedWorkspaceIDs`. A refresh awaits a task-group result at line 917 and clears that id at line 925, after asynchronous Git work. An event delivered during that suspension can therefore be cleared by completion of the older refresh. The comment at lines 922-924 says such events remain fresh, but the set carries no generation that could distinguish old from new events.
+
+Concrete interleaving: refresh reads file state A; external terminal writes B; watcher inserts the workspace id; the A refresh finishes; completion removes the id. A non-running background workspace can then wait until the 300-second backstop. The selected workspace has a 30-second backstop. Agent-active workspaces continue at six seconds, reducing the impact there.
+
+T3 uses repository generations for ref snapshots: reads capture a generation, and only return a snapshot if the generation still matches after the async operation ([GitVcsDriverCore.ts:2902-2926](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L2902)); invalidation advances the generation (`:2928-2945`). This is the relevant pattern, not a suggestion to transplant its whole cache.
+
+Recommendation: remove consumed invalidations before starting the refresh, letting events during the await reinsert them, or maintain per-workspace event generations and acknowledge only the generation sampled by the read. Preserve retry eligibility after a failed read. Add a deterministic delayed-reader test with a second invalidation delivered in the middle, rather than a timing-dependent FSEvents test.
+
+Source: [T3 generation guard](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L2902).
+
+**Watch the real Git metadata of linked worktrees**
+
+**P2, source-derived freshness gap; Git directory layout confirmed in isolated repo.** Bloom watches `workspaces.map(\.path)` at [Sources/Bloom/State/AppModel.swift:625](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/State/AppModel.swift#L625); `WorktreeWatcher` registers those roots ([Sources/BloomCore/System/WorktreeWatcher.swift:88-99](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/System/WorktreeWatcher.swift#L88), `:130-151`) and attributes events only under those roots (`:216-231`). In a linked worktree, `.git` is a pointer file. Its index, HEAD and reflog are in the main repository's `.git/worktrees/<name>`, while branches/remotes are in the shared Git directory. They do not live underneath the watched worktree directory.
+
+An external `git commit --allow-empty`, branch rename, or ref update need not write a tracked file underneath the workspace root. The watcher comment that `.git` is deliberately not excluded is therefore insufficient for linked worktrees. Existing tests cover a file written inside a root, root matching and teardown ([Tests/BloomCoreTests/WorktreeWatcherTests.swift:15-100](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Tests/BloomCoreTests/WorktreeWatcherTests.swift#L15)), not metadata living elsewhere.
+
+The isolated worktree above reported:
+
+```text
+git rev-parse --absolute-git-dir
+=> .../bloom-git-repro-a02ec84v/.git/worktrees/bloom-git-repro-a02ec84v-with-newline
+git rev-parse --git-common-dir
+=> .../bloom-git-repro-a02ec84v/.git
+```
+
+T3 resolves/canonicalises the common Git directory ([GitVcsDriverCore.ts:1040-1118](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L1040)), shares ref snapshots by that identity (`:2880-2894`), and coalesces network refreshes by `(gitCommonDir, remoteName)` (`:1253-1279`). T3 does not provide a like-for-like FSEvents implementation to copy here. Its shared-repository identity is the useful architectural lesson.
+
+Recommendation: resolve both per-worktree Git dir and common Git dir once, watch them too, and map shared-ref events to the affected sibling workspaces. Distinguish worktree-local index/HEAD updates from common ref changes. Reuse this identity for worktree-operation coordination and ref-list caching, while retaining worktree-specific indexes and diffs. Do not put all reads/writes from every project behind one global lock.
+
+Source: [T3 repository identity](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L1040).
+
+**Use NUL-delimited worktree enumeration**
+
+**P2 for correctness, low occurrence, command output reproduced.** Bloom's changed-file parsers already use byte-based `-z` records, but its worktree enumeration does not: [Git+Worktrees.swift:16-17](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Git/Git+Worktrees.swift#L16) invokes `worktree list --porcelain`; [WorktreeListing.swift:77-92](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Git/WorktreeListing.swift#L77) splits on newlines. A real worktree directory containing a newline is truncated into a path that does not exist. This can break branch-holder identification and stale-worktree restoration checks. It does not prove that Bloom subsequently deletes an unrelated worktree, because those paths have additional guards.
+
+T3 runs `worktree list --porcelain -z` ([GitVcsDriverCore.ts:2745](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L2745)) and splits fields on NUL (`:250-274`). A regression explicitly preserves newline-containing worktree paths ([GitVcsDriverCore.test.ts:1556-1581](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.test.ts#L1556)).
+
+In the first isolated repo, Python created a worktree whose absolute path ended with `-with\nnewline` through an argv argument to `git worktree add -b feature <path>`. Real `git worktree list --porcelain` returned:
+
+```text
+worktree .../bloom-git-repro-a02ec84v-with
+newline
+HEAD b1a6ecf4382abb269a19e25964ba541bf2c2c758
+branch refs/heads/feature
+```
+
+Bloom's parser will retain only the first line's path. Its existing real-worktree and spaces tests ([Tests/BloomCoreTests/WorktreeListingTests.swift:127-181](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Tests/BloomCoreTests/WorktreeListingTests.swift#L127)) do not cover this format break.
+
+Recommendation: adopt raw `-z` enumeration and keep all current fields, especially locked/prunable states. Do not copy T3's smaller branch-to-path projection wholesale: Bloom needs these states for safe archive/restore decisions, and T3's parser deliberately drops prunable holders.
+
+Source: [T3 NUL parser](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L250), [newline regression](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.test.ts#L1556).
+
+**Make submodule readiness part of creating a workspace**
+
+**P2 feature gap, source-verified.** `git worktree add` leaves submodule content unpopulated. T3 detects `.gitmodules` and runs `git submodule update --init --recursive` after creating the worktree; a failure is logged and the workspace survives ([GitVcsDriverCore.ts:3027-3050](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L3027)). Tests cover both populated files and an unreachable submodule ([GitVcsDriverCore.test.ts:1585-1668](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.test.ts#L1585)).
+
+Bloom's worktree helpers create/check out the worktree and return ([Git+Worktrees.swift:35-69](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Git/Git+Worktrees.swift#L35)); the manager then copies configured files and records the workspace ([WorkspaceManager.swift:218-240](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Workspace/WorkspaceManager.swift#L218), `:306-350`). Searches across Sources and tests found submodule mentions in project-init safeguards, but no automatic submodule initialisation in the creation/restore paths. A project's setup script can already initialise submodules; this is a gap in the default path, not an impossibility.
+
+Recommendation: add a bounded, cancellable readiness step when `.gitmodules` exists, before starting an agent or setup script that relies on those files. Keep the workspace on failure and surface which submodules are missing, with a retry. T3's log-only warning is weaker than Bloom's existing setup failure UX and need not be copied. Cover normal, nested, offline and local-transport-restricted cases without enabling unsafe Git transports globally.
+
+Source: [T3 initialisation](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L3027), [T3 tests](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.test.ts#L1585).
+
+**Resolve base and publication remotes separately**
+
+**P2 capability improvement, source-verified, no wrong-remote incident reproduced.** Bloom deliberately fixes `Git.remote = "origin"` ([Git+Branches.swift:32-36](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Git/Git+Branches.swift#L32)) and its direct push uses `origin HEAD:refs/heads/<branch>` ([GitHub.swift:334-348](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/GitHub/GitHub.swift#L334)). This protects against option injection and accidental pushes to an upstream base branch, but does not honour fork workflows configured through `branch.<name>.pushRemote` or `remote.pushDefault`.
+
+T3 resolves the publish remote through those Git settings before choosing its primary remote ([GitVcsDriverCore.ts:1351-1378](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L1351)). It distinguishes an upstream that is actually the feature branch's base from its intended publication target, records `branch.<name>.gh-merge-base` before retargeting upstream, and publishes with explicit `HEAD:refs/heads/<name>` (`:2047-2114`). Its tests cover a branch tracking its base and a Git-mangled alias ([GitVcsDriverCore.test.ts:2097-2189](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.test.ts#L2097)).
+
+Recommendation: introduce one repository context that carries the base remote/ref and publish remote/ref, and use it consistently in fetch, baseline, create/continue, PR lookup and direct push. Preserve Bloom's branch validation and `--` option boundary. Treat this as a coordinated improvement, not changing the one origin constant and hoping all callers agree.
+
+Qualification: Bloom's normal Commit/Push and Create PR buttons already delegate to the current agent ([Sources/Bloom/State/WorkspaceModel.swift:1961-2010](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/State/WorkspaceModel.swift#L1961), `:2014-2048`). Agents can inspect and honour a project's remotes themselves. The hardcoded direct helper limitation therefore does not mean every UI push ignores configured remotes.
+
+Source: [T3 remote resolution](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L1351), [safe base-versus-publish handling](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L2047).
+
+**What Bloom already does well and should retain**
+
+1. **Archive safety is richer than T3's raw worktree removal.** Bloom inventories uncommitted/untracked work, commits unique to the branch, detached-HEAD commits and meaningful ignored-file differences ([Git+Safety.swift:266-320](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Git/Git+Safety.swift#L266)). Ignored-file differences are informational notes, not necessarily a reason to refuse, which existing tests explicitly document. Archive refuses unsafe work unless authorised, aborts on a failing archive script, preserves a recreated non-checkout folder, only deletes a branch after finding a worktree, and updates only its own stored columns ([WorkspaceManager.swift:653-773](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Workspace/WorkspaceManager.swift#L653)). T3's core removal mostly invokes `git worktree remove` with optional force and handles already-gone paths ([GitVcsDriverCore.ts:3254-3302](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L3254)). This comparison is the core method, not a claim that no higher T3 layer has confirmation UX.
+2. **Per-repository worktree creation is already serialised.** [WorkspaceManager.swift:172-185](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Workspace/WorkspaceManager.swift#L172) wraps the complete read-name/path-then-create sequence in `WorktreeCutQueue`; the queue deliberately serialises distinct creates rather than coalescing them ([WorktreeCutQueue.swift:1-57](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Workspace/WorktreeCutQueue.swift#L1)). [WorkspaceStartTests.swift:394-418](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Tests/BloomCoreTests/WorkspaceStartTests.swift#L394) launches three simultaneous starts and checks distinct branches and sessions. No generic 'add a mutex' recommendation is warranted. Canonical common-dir identity can improve the key for aliases/imported linked worktrees, but this needs a demonstrated caller path before declaring an existing race.
+3. **Changed-file paths already use NUL-delimited bytes.** [Git+Diffs.swift:122-164](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Git/Git+Diffs.swift#L122) and `:167-215` handle tabs/newlines, renames and binary counts. [GitSafetyTests.swift:329-438](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Tests/BloomCoreTests/GitSafetyTests.swift#L329) exercises awkward paths. T3's local status still uses non-NUL porcelain v2 and newline-split numstat ([GitVcsDriverCore.ts:1626](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriverCore.ts#L1626), `:1668`, `:1728-1740`, parser `:172-190`). Do not replace Bloom's parsers with these.
+4. **Polling is already bounded and event-assisted.** Six-second ticks, four concurrent worktree reads, 30-second selected backstop and five-minute idle backstop are deliberate ([DiffRefreshSchedule.swift:41-79](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Presentation/DiffRefreshSchedule.swift#L41)). Bloom also has fingerprint-based baseline caching with single-flight resolution and a bounded patch cache. T3 cache lessons should target correctness and common-repository work, not add a second cache blindly.
+5. **Bloom already avoids optional index writes from reads.** Git's wrappers set `GIT_OPTIONAL_LOCKS=0` and disable terminal prompts ([Git.swift:31-39](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Git/Git.swift#L31), `:78-81`); raw output is drained concurrently and nonzero status does not become an empty clean diff. Preserve these properties while addressing the independent process-bound issues examined later in this report.
+6. **Agent-driven Git actions are an intentional product choice.** T3 offers a typed commit/push/PR workflow with phase events ([GitManager.ts:2566-2740](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/git/GitManager.ts#L2566)), which can inspire clearer progress. Bloom deliberately routes actions into the existing conversation, keeping project instructions and recovery reasoning available ([WorkspaceModel.swift:1961-2023](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/State/WorkspaceModel.swift#L1961)). The better improvement is structured progress/results around that model, not necessarily replacing it with a generic generated commit message workflow.
+
+**Suggested implementation order**
+
+1. Literal path selection for destructive single-file operations and patch reads, with a two-file data-loss regression.
+2. Controlled patch output and explicit `--no-index` error handling.
+3. Event acknowledgement generations, then real Git metadata watch roots.
+4. NUL worktree listing.
+5. Submodule readiness.
+6. Unified base/publication remote context if fork and non-origin workflows are important to Bloom users.
+
+The literal-path data loss, external-diff empty patch, and newline-containing worktree listing received command-level reproduction. Other statements are source/test inspection or explicitly marked design proposals. Existing tests were read, not executed.
+
+
+---
+
+**AI runtime and recovery**
+
+**1. Highest priority: distinguish a claimed prompt from a delivered prompt**
+
+**Source-established crash window, not reproduced with fault injection.** Bloom has a durable delivery queue and a correct atomic single-claimant check. However, `TranscriptModel.drain` removes the delivery from the pending set before calling the runner. `claimForDelivery` writes `delivered_at`, then awaits a queue refresh, then calls `deliver`. Runner startup and thread opening happen before the user transcript row is persisted. A process crash in this interval leaves a delivery marked delivered with neither an actual provider send nor necessarily a transcript row.
+
+Bloom evidence:
+
+- [Sources/Bloom/State/TranscriptModel.swift:764-775](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/State/TranscriptModel.swift#L764) claims before sending; `789-805` calls `markDelivered` then awaits other work; `1052-1073` calls `runner.send` and restores only after an error returned in this process.
+- [Sources/BloomCore/Persistence/Store.swift:2669-2677](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Persistence/Store.swift#L2669) only returns deliveries whose `delivered_at IS NULL`; `2719-2724` marks a delivery atomically; `2753-2757` explicitly restores it.
+- [Sources/BloomCore/Agent/Codex/CodexRunner.swift:136-153](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/Codex/CodexRunner.swift#L136) opens the connection/thread before persisting the user's message.
+- [Sources/Bloom/State/AppModel.swift:392-405](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/State/AppModel.swift#L392) resets sessions, closes stale asks and recovers setups at launch, but does not recover delivery claims. Searching all uses of `delivered_at`, `restoreDelivery`, `markDelivered`, and `deliveredSeq` found no such recovery.
+- [Tests/BloomCoreTests/AuditPersistenceTests.swift:34-58](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Tests/BloomCoreTests/AuditPersistenceTests.swift#L34) covers competing claimants and failed claim persistence. It does not cover crash after successful claim. Enqueue plus draft clear is already transactional, covered at `61-74`.
+
+T3 Code has a useful smaller lesson than adopting its whole event-sourced architecture: command IDs and durable acceptance are explicit. Its engine reads an existing receipt before accepting a retry, verifies its aggregate, and writes events, their projection and the receipt in one SQLite transaction. A retry returns the same sequence and does not append the same user message again. [Receipt lookup](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/orchestration/Layers/OrchestrationEngine.ts#L144-L171), [transaction](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/orchestration/Layers/OrchestrationEngine.ts#L273-L314), [retry test](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts#L1928-L1990).
+
+**Recommendation:** introduce explicit `pending`, `claimed`, `accepted`, and `uncertain` delivery states, with a persistent `DeliveryID` association to the transcript message and provider turn where available. Make claiming plus creating the transcript placeholder atomic. On launch, recover an unfinished claim into a visible state. Never silently replay an uncertain provider send: acceptance may have happened just before the crash and a replay can duplicate paid work or edits. An unsent prompt should remain recoverable even if nobody can prove whether the provider saw it. Keep today's optimistic bubble suppression as presentation state rather than making `delivered_at` mean both claimed and sent.
+
+Tests worth adding when implementing: crash/reopen after claim before runner start; after message persistence before provider request; after provider acceptance before recording acceptance; duplicate retry with same DeliveryID; do not automatically start paid work on relaunch. Bloom deliberately does not drain on launch or after Stop ([TranscriptModel.swift:730-738](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/State/TranscriptModel.swift#L730)), which should be preserved.
+
+**Limit on the comparison:** T3's database receipt is not a distributed transaction with the AI provider and does not prove exactly-once provider execution across a server crash. Its architecture separates accepted domain commands from provider-side effects. Borrow durable intent and reconciliation, not an unsupported exactly-once promise.
+
+**2. High priority: Stop should explicitly account for Codex child turns**
+
+**Confirmed missing explicit guarantee in Bloom; actual provider child leakage not measured.** Bloom captures the current parent turn and sends one interrupt for that thread/turn. Its `CodexSubagents` tracks known child identities and generates transcript status signals, but does not retain an active turn ID per child for cancellation.
+
+Bloom evidence: [Sources/BloomCore/Agent/Codex/CodexRunner.swift:223-227](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/Codex/CodexRunner.swift#L223), `263-276`; [Sources/BloomCore/Agent/Codex/CodexSubagents.swift:5-46](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/Codex/CodexSubagents.swift#L5). Searching Codex sources found no child-interrupt path.
+
+T3 Code explicitly handles the case where child agents are independent threads. Stop interrupts every known live child with concurrency 8, a 3-second deadline per child and 10-second overall budget, then interrupts the parent. Its fake-peer integration test deliberately leaves a child interrupt unanswered and checks that other children and the parent still receive theirs. It also tests a child whose turn-start arrived before its registration event. [Cancellation implementation](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/provider/Layers/CodexSessionRuntime.ts#L2494-L2525), [adversarial integration test](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/provider/Layers/CodexCollabRuntime.integration.test.ts#L478-L603).
+
+**Recommendation:** track owned child thread IDs with their current turn IDs, including out-of-order announcements, and define whether Stop means this conversation's entire native agent family. Apply bounded child interruption without permitting an unresponsive child to block the parent. Capture the family being stopped at the same intent/generation boundary as the parent, so Stop cannot interrupt a replacement turn. A local fake JSON-RPC peer is sufficient for regression coverage, without paid model calls.
+
+Preserve Bloom's strengths: Stop and permanent termination are intentionally different, so ordinary Stop keeps session grants alive; shutdown kills the provider process and its group. Bloom already guards delayed start responses and late stopped completions ([CodexRunner.swift:178-182](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/Codex/CodexRunner.swift#L178); [Tests/BloomCoreTests/CodexRunnerTests.swift:88](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Tests/BloomCoreTests/CodexRunnerTests.swift#L88), `130`, `450`, `574`). Killing the entire server on each Stop would discard this deliberate behaviour.
+
+**3. Medium priority: bound event fanout before the UI consumes it**
+
+**Confirmed unbounded queue, practical severity requires a load measurement.** Every Bloom `EventFanout` subscriber gets `AsyncStream(bufferingPolicy: .unbounded)`, and `yield` neither examines its result nor accounts for bytes. A consumer stalled on the main actor or database can retain arbitrary queued payloads. [Sources/BloomCore/Agent/SessionRunner.swift:114-137](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/SessionRunner.swift#L114).
+
+T3 Code limits each live subscriber to 1,000 retained items and 8 MiB of serialised data. Its budget counts queued, coalescing, and in-flight items waiting for a client acknowledgement. Overflow terminates that subscription with an instruction to resume from the last received sequence. It coalesces consecutive `tool.updated` events over 50 ms using turn plus stable tool-call identity, preserves anonymous/parallel calls, and flushes before a completion boundary. [Budget](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/orchestration/LiveStreamBudget.ts#L10-L112), [coalescer](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/orchestration/ThreadLiveEventCoalescer.ts#L18-L102), [ACK retention regression](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/orchestration/LiveStreamBudget.test.ts#L10-L44), [identity and boundary tests](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/orchestration/ThreadLiveEventCoalescer.test.ts#L93-L132).
+
+Bloom already batches text/thinking redraws every 50 ms ([TranscriptModel.swift:1706-1755](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/State/TranscriptModel.swift#L1706)) and fetches persisted transcript rows after a sequence cursor (`1665-1692`). Do not report batching or incremental reload as missing. The improvement is bounding the queue before those mechanisms can run.
+
+**Recommendation:** start with measurements and a bounded UI-specific subscription. Coalesce replaceable progress snapshots by stable identity, concatenate text deltas without dropping bytes, preserve approvals/results and lifecycle boundaries, and reload durable transcript rows from the cursor on overflow. Bloom normally does not persist every text delta ([AgentRunner.swift:129-132](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/AgentRunner.swift#L129), `537`), so changing `.unbounded` directly to `.bufferingNewest` would lose live text and potentially critical protocol events. Separate the protocol ingestion channel from presentation notifications and keep full authoritative state outside the bounded presentation queue.
+
+**Limit:** T3's own provider-ingestion queues are still unbounded ([CodexSessionRuntime.ts:1297](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/provider/Layers/CodexSessionRuntime.ts#L1297), `1351`). It is evidence for robust client fanout, not evidence that every stage of its runtime has end-to-end backpressure.
+
+**4. Medium priority: idle provider eviction with resumable sessions**
+
+**Confirmed feature difference, performance benefit not measured.** T3 Code sweeps every five minutes and stops sessions idle for thirty minutes. It checks both the binding timestamp and session-update timestamp, skips active turns, and skips live background agent/workflow/monitor work. Failures stopping one provider do not prevent the rest of the sweep. [Reaper](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/provider/Layers/ProviderSessionReaper.ts#L17-L115), [active-turn and background-work tests](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts#L272-L411).
+
+Bloom retains long-lived provider processes until permanent shutdown on close/archive/quit or a preference-driven runner replacement; ordinary Codex Stop intentionally keeps the process alive. See [TranscriptModel.swift:1215-1255](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/State/TranscriptModel.swift#L1215), `1282-1287`; no provider idle reaper found. Bloom already persists and resumes Codex thread IDs ([CodexRunner.swift:400-434](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/Codex/CodexRunner.swift#L400)), so lazy restart is an existing foundation. T3's recovery additionally resolves the provider instance, adopts an existing live runtime if possible, otherwise starts using persisted cwd, model selection and resume cursor. [Recovery](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/provider/Layers/ProviderService.ts#L1227-L1301).
+
+**Recommendation:** measure per-provider idle resident memory and session counts first. If material, add a configurable idle budget, suspend only resumable sessions with no active turns, asks, queued sends or live children, and recheck generation/state immediately before killing. Do not reuse UI busy status as the only liveness source. Account for the real tradeoff: Codex process-local approvals disappear on restart, which is why Bloom intentionally keeps the process after Stop. This makes eviction an optimisation with product consequences, not an unconditional correctness fix.
+
+**Existing Bloom behaviour to retain**
+
+- Durable pending messages, atomic queue claiming, transactional enqueue/draft clearing, FIFO order, explicit retry, and no automatic paid delivery on restart are already implemented. The claim/send crash gap above is narrower than lacking persistence.
+- Session state has an explicit transition table ([SessionLifecycle.swift:54-106](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/SessionLifecycle.swift#L54)). Process death during an unfinished turn produces a useful error even for exit code zero ([UnfinishedRun.swift:60-75](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/UnfinishedRun.swift#L60)).
+- Pending asks are settled on Stop and abandoned after restart ([CodexRunner.swift:223-238](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/Codex/CodexRunner.swift#L223); [AppModel.swift:392-398](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/State/AppModel.swift#L392)). T3 similarly identifies recovered callbacks as stale rather than pretending they can be answered. Its tests include stale Codex approval callbacks and non-resumable user-input callbacks ([ProviderCommandReactor.test.ts:3933](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts#L3933), `4028`). Neither architecture can revive an in-memory callback that died with the provider connection.
+- Bloom already has native Codex steering ([CodexRunner.swift:131-165](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/Codex/CodexRunner.swift#L131)) and provider-specific mid-turn support ([Models.swift:770-805](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Model/Models.swift#L770)). Do not propose generic steering as absent.
+- Bloom already has a 120-second Codex RPC deadline ([CodexClient.swift:252-289](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/Codex/CodexClient.swift#L252)). T3's comments explicitly identify its underlying request wait as unbounded and add targeted timeouts for child Stop, so it is not a uniformly better transport to copy.
+- Bloom already presents model overload retries and per-subagent retry signals ([AgentRetry.swift](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/AgentRetry.swift)). No evidence found that adding another application-level automatic retry loop would improve reliability. Blind retries are especially risky around turn acceptance.
+
+**Architecture judgement**
+
+T3 separates provider adapters, session directory, service routing, durable commands/events/projections and runtime ingestion. This makes remote clients, multiple configured instances of one provider, and event replay easier to support. Its adapter declares model-switch, promptless-continuation, rollback and compaction capabilities explicitly. [Adapter contract](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/provider/Services/ProviderAdapter.ts#L37-L104).
+
+Bloom already has a small `SessionRunner` seam and shared events around native Swift actors, appropriate for a local macOS app. Keep it. Adopt explicit capabilities when adding an actual new capability or a second provider instance, rather than creating a generic registry to emulate T3. The first concrete runtime work should be delivery recovery, child cancellation, and bounded presentation delivery. Full event sourcing or a transport rewrite has no demonstrated need from this investigation.
+
+
+---
+
+**AI interaction workflows**
+
+**1. Separate planning from permissions, then support Codex planning**
+
+**High-value, high-confidence improvement.** Bloom currently deliberately suppresses Plan on Codex. [Sources/BloomCore/Agent/ComposerControls.swift:101-112](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/ComposerControls.swift#L101) explains that Codex has no plan entry because approval policy crossed with sandbox has no planning setting. This correctly identifies a missing permission setting but draws an overly broad conclusion about planning capability. [Sources/BloomCore/Agent/Codex/CodexClient.swift:379-397](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/Codex/CodexClient.swift#L379) sends approvalPolicy, sandboxPolicy and approvalsReviewer on turn/start but no collaborationMode. A repository-wide Sources search found no collaborationMode or interactionMode implementation.
+
+T3 models two independent dimensions. Its [Codex turn builder](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/provider/Layers/CodexSessionRuntime.ts#L584-L654) puts `interactionMode` into `collaborationMode.mode`, carrying model, reasoning effort and developer instructions in settings, while independently setting sandbox and approval fields. Its [tests](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts#L184-L272) assert plan mode with full access, and default mode with workspace write. This proves the source implementation distinguishes the two axes. It is not proof that every older installed Codex binary supports it.
+
+Recommended Bloom shape: a core interaction mode value, `.build` / `.plan`, separate from PermissionMode; provider capability drives whether the control appears. Carry it through composer, session persistence, queued delivery and turn/start. Verify installed app-server schema or protocol fixture before enabling. Returning to Build must explicitly send default mode because protocol state can persist across turns. Do not simply expose Bloom's existing `.plan` permission case for Codex: [CodexRunner.swift:463-471](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/Codex/CodexRunner.swift#L463) maps that to read-only sandbox, which is not collaboration planning.
+
+Test targets: round-trip the new interaction mode through stored composer defaults and queued messages; assert plan/default payloads preserve the chosen approval policy; provider switching cannot leak an unsupported mode; old/missing capability has a predictable fallback.
+
+**2. Reusable plan artefacts and a clean implementation handoff**
+
+**Medium-value extension once planning is separate.** T3 turns the proposed plan into an artefact with an identity and markdown, then makes the next action specific: entering text refines the plan and keeps plan mode, while an empty composer offers Implement and moves to default mode. [Pure follow-up policy](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/proposedPlan.ts#L74-L111), [tests](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/proposedPlan.test.ts#L66-L112), [composer actions](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/components/chat/ComposerPrimaryActions.tsx#L180-L251).
+
+It additionally offers Implement in a new thread. [The handler](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/components/ChatView.tsx#L8016-L8114) creates a conversation on the existing branch/worktree, sends only the plan with selected model settings, and persists `sourceProposedPlan` with originating thread and plan IDs. This creates a clean context without requiring a new checkout. The implementation uses the app's default runtime mode for the new thread, which should not be copied blindly: Bloom should visibly preserve or explicitly choose implementation permissions.
+
+Bloom already has proper Claude ExitPlanMode handling: [Sources/Bloom/Views/Transcript/PermissionAskRowView.swift:312-347](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/Views/Transcript/PermissionAskRowView.swift#L312) offers Approve and implement, alternate permission choices and Keep planning. [Sources/BloomCore/Agent/PlanApproval.swift:8-44](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/PlanApproval.swift#L8) normalises implementation mode, stores approval choices and keeps the rejection nonterminal. This is not missing plan approval. The narrower opportunity is a backend-independent plan record and an optional new-conversation implementation action with source provenance. Bloom already has a useful creation precedent in [Sources/BloomCore/Agent/BackendChange.swift:5-28](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/BackendChange.swift#L5): switching provider on a spoken chat creates a new conversation in the same worktree.
+
+Suggested test cases: plan-only handoff carries the latest plan version, model and permission choice; source link remains after reload; failed thread creation does not mark the plan implemented; refining never starts implementation; no implicit worktree duplication.
+
+**3. Snapshot-backed turn diffs, followed by optional rewind**
+
+**High-value Git/AI crossover.** T3's changed-file section is backed by checkpoint files and opens a diff for the selected turn/file. [MessagesTimeline](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/components/chat/MessagesTimeline.tsx#L2455-L2505) consumes TurnDiffSummary, rather than reconstructing changes from tool display events. [CheckpointStore contract](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/checkpointing/CheckpointStore.ts#L51-L77) describes isolated temporary-index capture into hidden Git refs. Capture and restore semantics are examined in the shared implementation section below.
+
+Bloom does have per-turn file summaries. [Sources/Bloom/Views/Transcript/TurnScan.swift:5-79](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/Views/Transcript/TurnScan.swift#L5) scans up to 400 transcript rows and aggregates Claude Edit/Write/MultiEdit/NotebookEdit and Codex fileChange payloads. [TurnFileChip.swift:8-31](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/Views/Transcript/TurnFileChip.swift#L8) displays counts and Quick Look on the current file. This answers approximately what tools wrote, not the net repository change across the turn, and does not reconstruct the old file. Consequences inferred directly from the code: shell scripts or formatters that edit files are absent; writing a file twice accumulates operation counts; sufficiently long turns lose earlier edits; a historical chip previews current contents. This should be described as a stronger implementation of an existing feature, not a missing turn summary.
+
+Start with immutable before/after snapshots plus a turn-scoped diff accessible from the existing file chips. Capturing real worktree state can include external changes from another chat or terminal during the same time interval, so describe the result as changes during the turn rather than guaranteed authorship. Bloom can run multiple sessions per worktree, making that distinction material. Keep attributed tool activity alongside the snapshot diff where useful.
+
+T3 adds Edit from here on old user messages. [Rewind action](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/components/ChatView.tsx#L6552-L6651) gates by provider rollback capability and idle state, waits for the reverted state to project, and restores prompt plus attachments without dropping an existing draft. Its [dialog](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/components/ChatView.tsx#L9246-L9288) separately offers conversation rewind with file restore or with current files retained. Tests in [apps/web/src/components/ChatView.logic.test.ts:2280](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/components/ChatView.logic.test.ts#L2280) onward cover waiting for state projection and checkpoint failure handling; timeline tests at [MessagesTimeline.logic.test.ts:1240](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/components/chat/MessagesTimeline.logic.test.ts#L1240) cover mapping rewind counts to user rows.
+
+Bloom Sources search found no conversation rollback / turn checkpoint facility. FileRevert is a different operation. Ship the turn diff first; only then add rewind with provider capability checks, draft/attachment recovery, worktree-wide running-agent checks, a backup/recovery path and explicit semantics for index state, untracked files and edits since checkpoint. Do not present deleting transcript rows as rollback if the provider still retains them in context.
+
+**4. Terminal selection as structured prompt context**
+
+**Small, concrete quality-of-life feature.** T3 exposes Add to chat next to Copy for terminal selections, then captures terminal ID, label, line range and the exact selected text. [Menu](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/components/ThreadTerminalDrawer.tsx#L250-L284), [capture](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/components/ThreadTerminalDrawer.tsx#L566-L607). It does not rely on a later agent rereading mutable scrollback. [Structured record](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/lib/composerContextRecords.ts#L158-L170) preserves that provenance and text. [ThreadTerminalDrawer.test.ts:12-28](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/components/ThreadTerminalDrawer.test.ts#L12) covers hiding Add to chat without a target; context record tests cover expired chips and serialisation.
+
+Bloom's [Sources/Bloom/Views/Terminal/TerminalPaneMenu.swift:19-60](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/Views/Terminal/TerminalPaneMenu.swift#L19) only creates split, zoom and close items. [TerminalView.swift:222-224](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/Views/Terminal/TerminalView.swift#L222) returns that custom menu when available. Searching Sources found no terminal selection-to-composer context path. Users can copy and paste today, so this is convenience and preservation of provenance, not missing terminal access for agents.
+
+Add an action on an existing selection that stages a named terminal excerpt into the destination conversation's draft, letting the user add instructions before sending. Keep the exact snapshot even if the terminal scrolls, clears or closes. Follow Bloom's existing attachment and review-comment draft patterns; do not introduce a generic context subsystem solely for this one producer.
+
+**5. Typed context references are worth borrowing incrementally**
+
+T3 has canonical records for terminal excerpts, review comments, browser annotations and uploaded attachments, and inline references point to stable IDs. [Reference helpers](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/lib/composerContextReferences.ts#L13-L137) preserve placement, deduplicate references and scope IDs. [Record conversion](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/lib/composerContextRecords.ts#L294-L321) constructs message context from producer records. The [tests](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/lib/composerContextRecords.test.ts#L190-L275) include colliding IDs and screenshot linkage; later tests cover partial-copy selection carrying only selected backing records (:709-751).
+
+Bloom already has inline attachment tokens, copied file staging, persisted review comments, browser region capture and draft recovery. [Sources/BloomCore/Transcript/AttachmentDraft.swift:84-128](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Transcript/AttachmentDraft.swift#L84) parses attachment tokens, and [PromptAttachments.swift:12-27](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Transcript/PromptAttachments.swift#L12) puts accessible copies in ignored worktree scratch space. Review comments are stronger than bare line numbers: [ReviewComment.swift:17-58,177-224](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Transcript/ReviewComment.swift#L17) captures neighbouring text, re-finds shifted lines and explicitly marks outdated anchors. [Tests/BloomCoreTests/ReviewCommentTests.swift:67-148](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Tests/BloomCoreTests/ReviewCommentTests.swift#L67) covers edits above the anchor, deletion, indentation changes and repeated-line disambiguation. Browser UI lives in [Sources/Bloom/Views/Center/Browser/BrowserRegionCanvas.swift](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/Views/Center/Browser/BrowserRegionCanvas.swift) and [BrowserRegionCaptureView.swift](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/Views/Center/Browser/BrowserRegionCaptureView.swift).
+
+The opportunity is one typed payload boundary when adding terminal excerpts or plan artefacts, so restore/copy/recall does not have to reverse-engineer visible labels. Do not replace Bloom's content-based review anchoring with T3's diff-coordinate records or claim attachments/browser annotations are absent.
+
+**6. Areas where Bloom already meets or exceeds the relevant pattern**
+
+- **Queues and steering:** Bloom has a durable SQLite delivery queue, optimistic pending bubbles, retry, remove, edit-back-to-composer, explicit steer, and stop/relaunch rules. See [Sources/Bloom/State/TranscriptModel.swift:599-684,816-975](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/State/TranscriptModel.swift#L599), [Sources/BloomCore/Agent/DeliverySteer.swift:3-50](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/DeliverySteer.swift#L3); [Tests/BloomCoreTests/DeliveryTests.swift:224-385](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Tests/BloomCoreTests/DeliveryTests.swift#L224) covers ordering, relaunch survival, cancellation and failed start. Codex already uses native `turn/steer` with expectedTurnId in [CodexClient.swift:400-416](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/Codex/CodexClient.swift#L400). Do not recommend adding basic steering or a second queue.
+- **Permission scope:** Bloom already offers once/session/project only where the request and context can support it, explains scope and stores implementation permission choices. [PermissionScopeOffer.swift:36-64](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/PermissionScopeOffer.swift#L36), [PermissionAskRowView.swift:312-357](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/Views/Transcript/PermissionAskRowView.swift#L312). T3's provider-advertised action choices and explicit session labels are good regression fixtures, but are not a broad missing feature. See [apps/web/src/components/chat/ComposerPendingApprovalActions.test.tsx:8-45](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/components/chat/ComposerPendingApprovalActions.test.tsx#L8) and [ComposerPendingApprovalPanel.test.tsx:8-51](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/components/chat/ComposerPendingApprovalPanel.test.tsx#L8).
+- **Question drafts:** Bloom retains answer state outside recycled transcript cells in [AgentQuestionDraft.swift:3-22](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/AgentQuestionDraft.swift#L3), supports multi-select and Other, and validates completion. T3's composer-integrated question flow is a different presentation, not inherently a better fit for Bloom. No recommendation to relocate Bloom's existing question UI without user evidence.
+- **Provider-specific settings:** Bloom already dynamically loads supported reasoning efforts, filters permission choices, hides output styles outside Claude and context-window overrides outside Codex. [ComposerControls.swift:109-165](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Agent/ComposerControls.swift#L109), [Sources/Bloom/Views/Center/Composer/ComposerModelCatalog.swift:128-136](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/Views/Center/Composer/ComposerModelCatalog.swift#L128). Improve the capability contract where adding plan/rollback instead of copying T3's much broader web/mobile/provider-instance architecture.
+
+**Workflow acceptance criteria**
+
+Relative scope and minimum acceptance criteria:
+
+| Improvement | Scope | Regression criteria |
+| --- | --- | --- |
+| Codex Plan/Build | Medium | Plan/default turn payloads retain permission settings; persisted defaults and queued messages retain mode; unsupported provider/version does not expose a working-looking control; returning to Build clears planning. |
+| Snapshot-backed turn diffs | Large | Include shell edits and new files; repeated edits report net diff; historical results survive later turns and relaunch; real Git index is unchanged by capture; snapshot failure is visible; concurrent session edits are not mislabelled as certain authorship. |
+| Rewind with optional files | Large, separate from diff | Refuse with any mutating work in same worktree; server context and visible transcript converge; failure retains history and draft; restored attachments preserve existing draft; pre-existing untracked/index changes and later edits have explicit tested treatment; unsupported rollback cannot silently truncate UI history. |
+| Terminal excerpt to draft | Small | Disabled without selection/destination; immutable text survives terminal close/scroll; workspace/chat switching cannot send excerpt to wrong session; attaching never sends automatically; draft survives relaunch. |
+| Plan artefact and clean handoff | Medium | Latest plan version, source link, model and selected permissions survive creation/reload; refine stays in planning; failed start does not mark implemented; same-worktree handoff does not accidentally create a checkout. |
+
+Avoid wholesale adoption of T3's component structure. [ChatView.tsx](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/components/ChatView.tsx) is over 9,000 lines and [ChatComposer.tsx](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/web/src/components/chat/ChatComposer.tsx) over 6,000 lines at this snapshot. Their pure policy helpers and targeted regression cases are useful references; Bloom's existing BloomCore/view boundary is the better home for these decisions.
+
+
+---
+
+**Shared process handling, GitHub coordination and architectural fit**
+
+**Shared subprocess reliability**
+
+Bloom's short-lived process runner should gain an output budget and a deadline covering process exit and output collection. These are separate from the long-lived AI stream changes below.
+
+T3's `ProcessRunner` defaults to a 60-second timeout and an 8 MiB output limit per stream, exposes typed spawn/stdin/read/output-limit/timeout errors, and allows either failure or explicitly marked truncation. Its timeout wraps the scoped operation, including concurrent output collection. Those defaults are examples, not values to copy indiscriminately into Git mutation commands. See [process contract and defaults](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/processRunner.ts#L20-L160), [collection and deadline implementation](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/processRunner.ts#L197-L283), and [output-budget tests](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/processRunner.test.ts#L203-L289). T3's tests were inspected, not executed.
+
+Bloom's `Shell.run` reads both pipes with `readDataToEndOfFile`, stores all output, writes stdin before installing its timeout, sends SIGTERM on timeout, cancels the timeout after direct-child exit, then waits for both pipes to reach EOF. It returns a process status with no distinct timed-out outcome. `Git.runRaw` duplicates the unrestricted pipe collection and has no timeout argument. See [Shell.run](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/System/Shell.swift#L132-L233) and [Git.runRaw](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/Git/Git.swift#L63-L130).
+
+**Reproduced using Bloom's actual unchanged Swift sources:** compiled [Shell.swift](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/System/Shell.swift), [ExecutableSearchPath.swift](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/System/ExecutableSearchPath.swift) and [ProcessExitGate.swift](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/System/ProcessExitGate.swift) with a tiny async executable. Both calls used `Shell.run("/bin/sh", ["-c", script], timeout: .milliseconds(200))`:
+
+| Script | Observed elapsed | Returned status |
+| --- | --- | --- |
+| `sleep 2` | 0.210906542 seconds | 15 |
+| `(sleep 2) & exit 0` | 2.016809583 seconds | 0 |
+
+The second case shows that an exited parent with an inherited pipe can outlive the requested deadline and still report success. It is not a measurement of a production Git hang, and there was no app launch or access to Bloom's database. The short-lived descendants exited naturally. The probe source is reproduced here so the finding survives cleanup of `/tmp`:
+
+```swift
+import Foundation
+
+@main struct Probe {
+    static func main() async throws {
+        let clock = ContinuousClock()
+        for script in ["sleep 2", "(sleep 2) & exit 0"] {
+            let start = clock.now
+            let result = try await Shell.run(
+                "/bin/sh", ["-c", script], timeout: .milliseconds(200)
+            )
+            print(start.duration(to: clock.now), result.status)
+        }
+    }
+}
+```
+
+Compile with `swiftc -swift-version 6 -parse-as-library Sources/BloomCore/System/Shell.swift Sources/BloomCore/System/ExecutableSearchPath.swift Sources/BloomCore/System/ProcessExitGate.swift /tmp/Probe.swift -o /tmp/bloom-shell-probe`, after saving the snippet to `/tmp/Probe.swift`.
+
+Recommended scope: medium. Add byte-preserving collection policies, typed timeout/cancellation/output-limit results, and owned subprocess cleanup with a bounded final drain. Keep stderr tails bounded. Structured Git output must fail explicitly or spill to a file when too large; silently truncating status or a patch would create correctness bugs. Use purpose-specific policies for mutations and long-running hooks. Regression cases should cover a descendant holding stdout, a child ignoring SIGTERM, blocked stdin, large output, invalid UTF-8, and a normal child flushing its last bytes.
+
+Bloom already solves part of this in `StreamingProcess`: EOF quiet/hard limits and group-aware signalling are present. Reuse those lessons, while retaining the ordered drains and SIGPIPE protection. Do not claim Bloom lacks subprocess cancellation in general. See [stream shutdown](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/System/StreamingProcess.swift#L293-L320) and [bounded EOF settling](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/System/StreamingProcess.swift#L360-L400).
+
+**Coordinate GitHub backoff and distinguish stale data from missing data**
+
+T3 has a provider-and-host cooldown shared across PR operations, with provider reset times, exponential fallback from 30 seconds to 15 minutes, and generation leases so an older successful request cannot erase a newer rate limit. `PullRequestService` wraps provider calls with it. Background reads pause; explicit interactive operations can bypass the pause. Its GraphQL budget separately reserves quota for reads after observing a quota snapshot and accounts conservatively for out-of-order responses. See [cooldown](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/sourceControl/SourceControlRateLimit.ts#L63-L163), [wrapper and interactive bypass](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/pullRequest/PullRequestService.ts#L420-L525), [actual PR integration](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/pullRequest/PullRequestService.ts#L670), [GraphQL integration](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/pullRequest/GitHubPullRequestCli.ts#L1100-L1132), and [race/reset tests](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/sourceControl/SourceControlRateLimit.test.ts#L18-L121).
+
+The scoped T3 timeout is an implementation reference, not a measured hard wall-clock cleanup guarantee. Its inspected timeout tests use fake process handles; the real inherited-pipe probe above was run only against Bloom.
+
+Bloom already serialises sidebar lookups, polls at 120 seconds with a 110-second cache, skips irrelevant workspaces, and retains the last good result on failure. Its inspector has a separate freshness policy and shares displayed PR state. The improvement is a host-wide budget and explicit stale/error state, not another cache. See [sidebar polling](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/Views/Sidebar/WorkspacePullRequests.swift#L20-L33), [sequential lookup](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/Views/Sidebar/WorkspacePullRequests.swift#L94-L115), and [shared inspector result](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/Bloom/State/WorkspaceModel.swift#L1917-L1952).
+
+One concrete boundary issue: Bloom's lookup by PR number converts process failures, nonzero responses and decoding failures to cached `nil`. That conflates unavailable with absent even though a preceding request succeeding does not guarantee this one succeeds. By contrast, its branch lookup distinguishes a known not-found response from an error. See [number lookup](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/GitHub/GitHub.swift#L425-L449) and [branch lookup](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/Sources/BloomCore/GitHub/GitHub.swift#L373-L406). Existing last-good UI retention reduces visible flicker; no production loss of a PR badge was reproduced.
+
+Recommended scope: medium. Introduce typed results for present, absent, stale and unavailable; share cooldowns and in-flight requests at the GitHub boundary; preserve last-good content with a retry time. Distinguish host/account identity if multi-account support is added. Honour `Retry-After` or reset data where obtainable; use a bounded fallback for CLI error text. Do not switch to custom GraphQL solely for this feature. Regression tests should cover a 429 or CLI rate-limit response followed by another workspace poll, stale success racing a fresh rate limit, genuine not-found versus malformed JSON, and independent enterprise hosts.
+
+**Checkpoint implementation details worth preserving and changing**
+
+T3's concrete Git implementation creates a unique temporary index inside the common Git directory, reads HEAD into it if present, runs `add -A`, writes a tree, creates a parentless checkpoint commit and updates a hidden ref. Cleanup removes the temporary index. This captures the resulting worktree contents without altering the user's real index or branch history. See [capture implementation](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriver.ts#L715-L793) and [index/path preservation tests](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/checkpointing/CheckpointStore.test.ts#L307-L402).
+
+There are important limits to copying this as an Undo feature. The snapshot records worktree contents, not a separate snapshot of the user's staging choices. Restore writes the snapshot to both index and worktree, then runs `git clean -fd -- .`; that can discard later non-ignored untracked files. The reactor checks provider rollback support before touching files, which is good, but restores files before requesting the provider rollback. Those operations are not atomic. A later provider failure therefore needs recovery semantics in any Bloom implementation. See [restore implementation](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/vcs/GitVcsDriver.ts#L801-L845) and [revert ordering](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/apps/server/src/orchestration/Layers/CheckpointReactor.ts#L728-L797).
+
+For Bloom, start with read-only historical turn diffs. Before adding restore, specify staging preservation, non-ignored untracked recovery, ignored-file exclusions, nested repositories/submodules, concurrent sessions in the same workspace, ref ownership and retention. Take a recovery snapshot before changing files, and persist restore progress so a partial failure is visible and recoverable. These are design requirements inferred from the inspected implementation; T3 restore failures were not exercised live.
+
+**Architectural fit and licensing**
+
+T3 has broader product scope: server-owned execution with web, desktop and mobile clients, remote environments, and provider adapters. Its durable event log, command receipts and projected state address reconnects and multiple clients. Bloom is a native Mac application with a core actor and SQLite store; these differences explain much of T3's machinery. Copy specific contracts and failure tests before considering an event-sourcing or server/client rewrite. See [T3 architecture](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/docs/internals/overview.md) and [Bloom boundaries](https://github.com/spatie/bloom/blob/e00870ceec7cdb3c5d92a610dea0f1ac610e4d01/CLAUDE.md).
+
+GitLab, Bitbucket and Azure DevOps are supported alongside GitHub in T3. They are evidence of a useful host abstraction if Bloom needs more hosts, not sufficient reason to prioritise four new integrations now. See [source control documentation](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/docs/user/source-control.md).
+
+T3's repository is MIT licensed. If implementation code is copied rather than independently reimplemented from the behaviour, preserve the applicable copyright and permission notice. See [licence](https://github.com/pingdotgg/t3code/blob/a43f9b45ae85caf37e0be8270ad3d27365ece2bd/LICENSE).


### PR DESCRIPTION
Prevent single-file reverts from affecting neighbouring paths and preserve prompts across interrupted sends. Add reliable Git refreshes and process handling, independent Codex planning, saved plan handoffs, terminal excerpts, historical turn diffs, recoverable rewind and optional idle process release.

Includes regression coverage and a separate code-quality sweep, with all review findings corrected and rechecked. The 336 focused tests and both linters pass; the app builds with warnings treated as errors. Research and implementation notes are in docs/T3CODE-RESEARCH.md and docs/T3CODE-IMPLEMENTATION.md.
